### PR TITLE
Updated yarn-check to not override commit message

### DIFF
--- a/bin/yarn-check.sh
+++ b/bin/yarn-check.sh
@@ -17,5 +17,4 @@ else
   cd $sage_repo_path
   yarn bootstrap
   git add yarn.lock
-  git commit -m "chore(monorepo): updating yarn.lock for repository"
 fi;


### PR DESCRIPTION
Previously commit messages were being overridden by the chore when adding the `yarn.lock` file during the lefthook pre-commit process.

This should allow us to add the `yarn.lock` without overriding.