### PR TITLE
Splitting out deploy job from release for better ci tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,32 +17,47 @@ jobs:
             - run: yarn lint
             - run: yarn test
             - run: yarn build
-  release-and-deploy:
-      docker:
-        - image: circleci/ruby:2.4.9-node
-      resource_class: small
-      steps:
-        - checkout
-        - node/with-cache:
-            steps:
-              - add_ssh_keys:
-                  fingerprints:
-                    - "0a:4d:3f:bd:33:18:a3:42:24:6a:8f:39:3e:e0:70:ca"
-              - run: npm config set '//npm.pkg.github.com/:_authToken' '${GH_TOKEN}'
-              - run: git config user.email "dev+github-bot@kajabi.com"
-              - run: git config user.name "Kajabi Automation Bot"
-              - run: npx lerna bootstrap --ci
-              - run: npx lerna publish --registry github --yes
-              - run: yarn docs:deploy
-              - run: yarn storybook:deploy
-              - run: yarn sassdocs:deploy
+  release:
+    docker:
+      - image: circleci/ruby:2.4.9-node
+    resource_class: small
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - add_ssh_keys:
+                fingerprints:
+                  - "0a:4d:3f:bd:33:18:a3:42:24:6a:8f:39:3e:e0:70:ca"
+            - run: npm config set '//npm.pkg.github.com/:_authToken' '${GH_TOKEN}'
+            - run: git config user.email "dev+github-bot@kajabi.com"
+            - run: git config user.name "Kajabi Automation Bot"
+            - run: npx lerna bootstrap --ci
+            - run: npx lerna publish --registry github --yes
+  deploy:
+    docker:
+      - image: circleci/ruby:2.4.9-node
+    resource_class: small
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: yarn docs:deploy
+            - run: yarn storybook:deploy
+            - run: yarn sassdocs:deploy
 workflows:
     lint-test-build:
       jobs:
         - lint-test-build
-        - release-and-deploy:
+        - release:
             filters:
               branches:
                 only: master
             requires:
               - lint-test-build
+        - deploy:
+            filters:
+              branches:
+                only: master
+            requires:
+              - lint-test-build
+              - release


### PR DESCRIPTION
Separates the release and deploy steps on CircleCI to more easily distinguish where the failures are happening.
