### PR TITLE
Sage Rails Modal - added focus trapping

### DIFF
--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -92,6 +92,7 @@ Sage.modal = (function() {
   function closeModal(el) {
     el.classList.remove('sage-modal--active');
     el.removeAttribute("open");
+    el.removeEventListener('keydown', focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
added focus trapping to the rails implementation of sage modal 

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![sage-modal-before](https://user-images.githubusercontent.com/1241836/100257500-98d25900-2f0b-11eb-9cf9-cd4e28ac0cce.gif)|![sage-modal-after](https://user-images.githubusercontent.com/1241836/100258063-39c11400-2f0c-11eb-880b-9bc6b0269617.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the modal sage rails page: http://localhost:4000/pages/object/modal
2. Expand the modal, either by clicking or tabbing
3. Continuously press `TAB` and verify that focus never leaves the modal until the user opts for it
