### PR TITLE
Sage Rails Dropdown - added focus trapping

### DIFF
--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -125,6 +125,7 @@ Sage.dropdown = (function() {
 
   function close(el) {
     el.setAttribute('aria-expanded', 'false');
+    el.removeEventListener('keydown', focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
added focus trapping to the rails implementation of sage dropdown

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![sage-dropdown-focus-trap-before](https://user-images.githubusercontent.com/1241836/100267012-5ebb8400-2f18-11eb-9b7e-7170ed175a0c.gif)|![sage-dropdown-focus-trap-after](https://user-images.githubusercontent.com/1241836/100267044-6aa74600-2f18-11eb-892f-3411e8d7a522.gif)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the modal sage rails page: http://localhost:4000/pages/object/modal
2. Expand the modal, either by clicking or tabbing
3. Continuously press `TAB` and verify that focus never leaves the modal until the user opts for it

