### PR TITLE
Sage Rails Popover - added focus trapping

### DIFF
--- a/packages/sage-system/lib/popover.js
+++ b/packages/sage-system/lib/popover.js
@@ -71,6 +71,7 @@ Sage.popover = (function() {
   function closePopoverPanel(elParent) {
     elParent.querySelector(`[${SELECTOR_TRIGGER}]`).setAttribute(ATTRIBUTE_ARIA_EXPANDED, 'false');
     elParent.classList.remove(CLASS_ACTIVE);
+    elParent.removeEventListener('keydown', focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
added focus trapping to the rails implementation of sage popover

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![sage-popover-focus-trap-before](https://user-images.githubusercontent.com/1241836/100272879-79dec180-2f21-11eb-8a76-a5c2b4715c62.gif)|![sage-popover-focus-trap-after](https://user-images.githubusercontent.com/1241836/100272891-7f3c0c00-2f21-11eb-9636-f400d450efd9.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the modal sage rails page: http://localhost:4000/pages/object/popover
2. Expand the popover, either by clicking or tabbing
3. Continuously press `TAB` and verify that focus never leaves the modal until the user opts for it

