### PR TITLE
Rails Components: Attribute Schema

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: lib/sage_rails
   specs:
     sage_rails (3.4.0)
+      classy_hash
       rails
 
 GEM
@@ -47,6 +48,7 @@ GEM
     builder (3.2.4)
     bump (0.9.0)
     byebug (11.1.3)
+    classy_hash (1.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)

--- a/docs/app/views/examples/elements/_element.html.erb
+++ b/docs/app/views/examples/elements/_element.html.erb
@@ -16,6 +16,10 @@
     type: "element",
     title: @title %>
 
+  <%= render "examples/shared/props",
+    props_content: props_content,
+    title: @title %>
+
   <% if info_content[:use_legacy_html_code_source] %>
     <%= render "examples/shared/legacy_code",
       type: "element",
@@ -26,12 +30,8 @@
       title: @title %>
   <% end %>
 
-  <%= render "examples/shared/props",
-    props_content: props_content, 
-    title: @title %>
-
   <%= render "examples/shared/rules",
     do_content: do_content,
-    dont_content: dont_content, 
+    dont_content: dont_content,
     title: @title %>
 </div>

--- a/docs/app/views/examples/elements/button/_preview.html.erb
+++ b/docs/app/views/examples/elements/button/_preview.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
 demo_configs = [
   {
     heading: "Primary (regular and disabled)",
@@ -175,7 +175,7 @@ demo_configs = [
 <p>
   Regular buttons allow for a "raised" shadow treatement to be toggled on or off.
   This is on by default for "Primary" button styles and can be toggled off with "no_shadow".
-  For the other styles it is off by default but can be toggled on with "raised".  
+  For the other styles it is off by default but can be toggled on with "raised".
 </p>
 <%= sage_component SageButtonGroup, { gap: :md, spacer: { bottom: :md } } do %>
   <%= sage_component SageButton, {

--- a/docs/app/views/examples/elements/button/_preview.html.erb
+++ b/docs/app/views/examples/elements/button/_preview.html.erb
@@ -154,7 +154,7 @@ demo_configs = [
     value: "Button group: Align End",
   } %>
 <% end %>
-<%= sage_component SageButtonGroup, { gap: :md, align: "end" } do %>
+<%= sage_component SageButtonGroup, { gap: :md, align: :end } do %>
   <%= sage_component SageButton, {
     value: "Cancel",
     style: "secondary",

--- a/docs/app/views/examples/elements/button/_preview.html.erb
+++ b/docs/app/views/examples/elements/button/_preview.html.erb
@@ -1,4 +1,4 @@
-<%
+<% 
 demo_configs = [
   {
     heading: "Primary (regular and disabled)",
@@ -154,7 +154,7 @@ demo_configs = [
     value: "Button group: Align End",
   } %>
 <% end %>
-<%= sage_component SageButtonGroup, { gap: :md, align: :end } do %>
+<%= sage_component SageButtonGroup, { gap: :md, align: "end" } do %>
   <%= sage_component SageButton, {
     value: "Cancel",
     style: "secondary",
@@ -175,7 +175,7 @@ demo_configs = [
 <p>
   Regular buttons allow for a "raised" shadow treatement to be toggled on or off.
   This is on by default for "Primary" button styles and can be toggled off with "no_shadow".
-  For the other styles it is off by default but can be toggled on with "raised".
+  For the other styles it is off by default but can be toggled on with "raised".  
 </p>
 <%= sage_component SageButtonGroup, { gap: :md, spacer: { bottom: :md } } do %>
   <%= sage_component SageButton, {

--- a/docs/app/views/examples/objects/_object.html.erb
+++ b/docs/app/views/examples/objects/_object.html.erb
@@ -16,6 +16,10 @@
     type: "object",
     title: @title %>
 
+  <%= render "examples/shared/props",
+    props_content: props_content,
+    title: @title %>
+
   <% if info_content[:use_legacy_html_code_source] %>
     <%= render "examples/shared/legacy_code",
       type: "object",
@@ -25,10 +29,6 @@
       type: "object",
       title: @title %>
   <% end %>
-
-  <%= render "examples/shared/props",
-    props_content: props_content,
-    title: @title %>
 
   <%= render "examples/shared/rules",
     do_content: do_content,

--- a/docs/app/views/examples/objects/alert/_preview.html.erb
+++ b/docs/app/views/examples/objects/alert/_preview.html.erb
@@ -1,7 +1,7 @@
 
 <!-- Info -->
 <%= sage_component SageAlert, {
-  color: :info,
+  color: "info",
   title: "Our privacy policy has changed",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-info-circle",
@@ -14,7 +14,7 @@
 
 <!-- Success -->
 <%= sage_component SageAlert, {
-  color: :success,
+  color: "success",
   title: "Account settings updated",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-check-circle",
@@ -28,7 +28,7 @@
 
 <!-- Warning -->
 <%= sage_component SageAlert, {
-  color: :warning,
+  color: "warning",
   title: "Exceeded product amount limit",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",
@@ -41,7 +41,7 @@
 
 <!-- Danger -->
 <%= sage_component SageAlert, {
-  color: :danger,
+  color: "danger",
   title: "App outage tonight at 12am",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",
@@ -58,7 +58,7 @@
 
 <!-- Info -->
 <%= sage_component SageAlert, {
-  color: :info,
+  color: "info",
   title: "Our privacy policy has changed",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-info-circle",
@@ -72,7 +72,7 @@
 
 <!-- Success -->
 <%= sage_component SageAlert, {
-  color: :success,
+  color: "success",
   title: "Account settings updated",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-check-circle",
@@ -87,7 +87,7 @@
 
 <!-- Warning -->
 <%= sage_component SageAlert, {
-  color: :warning,
+  color: "warning",
   title: "Exceeded product amount limit",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",
@@ -101,7 +101,7 @@
 
 <!-- Danger -->
 <%= sage_component SageAlert, {
-  color: :danger,
+  color: "danger",
   title: "App outage tonight at 12am",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",

--- a/docs/app/views/examples/objects/alert/_preview.html.erb
+++ b/docs/app/views/examples/objects/alert/_preview.html.erb
@@ -1,7 +1,7 @@
 
 <!-- Info -->
 <%= sage_component SageAlert, {
-  color: "info",
+  color: :info,
   title: "Our privacy policy has changed",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-info-circle",
@@ -14,7 +14,7 @@
 
 <!-- Success -->
 <%= sage_component SageAlert, {
-  color: "success",
+  color: :success,
   title: "Account settings updated",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-check-circle",
@@ -28,7 +28,7 @@
 
 <!-- Warning -->
 <%= sage_component SageAlert, {
-  color: "warning",
+  color: :warning,
   title: "Exceeded product amount limit",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",
@@ -41,7 +41,7 @@
 
 <!-- Danger -->
 <%= sage_component SageAlert, {
-  color: "danger",
+  color: :danger,
   title: "App outage tonight at 12am",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",
@@ -58,7 +58,7 @@
 
 <!-- Info -->
 <%= sage_component SageAlert, {
-  color: "info",
+  color: :info,
   title: "Our privacy policy has changed",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-info-circle",
@@ -72,7 +72,7 @@
 
 <!-- Success -->
 <%= sage_component SageAlert, {
-  color: "success",
+  color: :success,
   title: "Account settings updated",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-check-circle",
@@ -87,7 +87,7 @@
 
 <!-- Warning -->
 <%= sage_component SageAlert, {
-  color: "warning",
+  color: :warning,
   title: "Exceeded product amount limit",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",
@@ -101,7 +101,7 @@
 
 <!-- Danger -->
 <%= sage_component SageAlert, {
-  color: "danger",
+  color: :danger,
   title: "App outage tonight at 12am",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-warning",

--- a/docs/app/views/examples/objects/avatar/_preview.html.erb
+++ b/docs/app/views/examples/objects/avatar/_preview.html.erb
@@ -1,6 +1,6 @@
 <div class="sage-avatar-wrapper">
   <!-- Showing default -->
-  <%= sage_component SageAvatar, { color: "", initials: "JC" } %>
+  <%= sage_component SageAvatar, { color: nil, initials: "JC" } %>
 
   <!-- Showing color variation -->
   <%= sage_component SageAvatar, { color: "purple", initials: "PS" } %>

--- a/docs/app/views/examples/shared/_code.html.erb
+++ b/docs/app/views/examples/shared/_code.html.erb
@@ -1,19 +1,38 @@
-<%= sage_component SagePanelHeader, {} do %>
-  <h2 id="<%= title %>-example-code">SageRails Code</h2>
-<% end %>
-<div class="example__code">
-  <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
-  <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
-    <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
-  </div>
-</div>
+<% component_classname = "sage_#{title}".camelize %>
 
 <%= sage_component SagePanelHeader, {} do %>
-  <h2>HTML Code</h2>
+  <h2 id="<%= title %>-example-code">SageRails Component</h2>
+  <code><%= component_classname %></code>
 <% end %>
-<div class="example__code">
-  <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
-  <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
-    <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardHeader, { title: "Preview Source" } %>
+  <div class="example__code">
+    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+    <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
+      <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
+    </div>
   </div>
-</div>
+<% end %>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardHeader, { title: "Attribute Schema"} do %>
+    <code><%= component_classname %>::ATTRIBUTE_SCHEMA</code>
+  <% end %>
+  <div class="example__code">
+    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+    <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
+      <pre class="prettyprint"><code><%= component_classname.constantize::ATTRIBUTE_SCHEMA.pretty_inspect %></code></pre>
+    </div>
+  </div>
+<% end %>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardHeader, { title: "Preview Generated HTML Code"} %>
+  <div class="example__code">
+    <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
+    <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
+      <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
+    </div>
+  </div>
+<% end %>

--- a/docs/lib/generators/sage_rails_component/sage_rails_component_generator.rb
+++ b/docs/lib/generators/sage_rails_component/sage_rails_component_generator.rb
@@ -16,7 +16,7 @@ class SageRailsComponentGenerator < Rails::Generators::NamedBase
   private
 
   def initialize_attributes
-    attributes.map { |attr| "attr_accessor :#{attr.name}" }.join("\n  ")
+    attributes.map { |attr| "#{attr.name}: [<TYPES>]" }.join("\n  ")
   end
 
   def utilize_attributes

--- a/docs/lib/generators/sage_rails_component/templates/component.rb
+++ b/docs/lib/generators/sage_rails_component/templates/component.rb
@@ -1,6 +1,12 @@
 class Sage<%= class_name %> < SageComponent
   # EXAMPLE ATTRIBUTES
-  # attr_accessor :title
-  # attr_accessor :subtitle
+  # set_attribute_schema({
+  #   title: String,
+  #   id: [:optional, String, Integer],
+  #   items: [[{
+  #     title: String,
+  #     sub_title: String,
+  #    }]],
   <%= initialize_attributes %>
+  # })>
 end

--- a/docs/lib/sage-frontend/stylesheets/docs/_example.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_example.scss
@@ -132,6 +132,7 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
 
   .prettyprint {
     margin-bottom: 0;
+    padding-bottom: sage-spacing(xl);
   }
 
   &::before {

--- a/docs/lib/sage_rails/app/helpers/sage_component_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_component_helper.rb
@@ -1,12 +1,27 @@
 module SageComponentHelper
-  def sage_component(component, props, &block)
+  def sage_component(component, attributes, &block)
+    validate_sage_component_attributes(component, attributes)
+
     component.new({
       context: self,
       content: block_given? ? capture(&block) : nil
-    }.merge(props)).render
+    }.merge(attributes)).render
   end
 
   def sage_component_section(name, &block)
     content_for "sage_#{name}".to_sym, flush: true, &block
+  end
+
+  private
+
+  def validate_sage_component_attributes(component, attributes)
+    return if Rails.env.production?
+    require "classy_hash"
+
+    begin
+      ClassyHash.validate(attributes, component::ATTRIBUTE_SCHEMA, strict: true, full: true)
+    rescue ClassyHash::SchemaViolationError => e
+      raise SageRails::SageComponentSchemaViolationError.new(component, attributes_attempted: attributes, message: e.message)
+    end
   end
 end

--- a/docs/lib/sage_rails/app/helpers/sage_component_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_component_helper.rb
@@ -21,7 +21,7 @@ module SageComponentHelper
     begin
       ClassyHash.validate(attributes, component::ATTRIBUTE_SCHEMA, strict: true, full: true)
     rescue ClassyHash::SchemaViolationError => e
-      raise SageRails::SageComponentSchemaViolationError.new(component, attributes_attempted: attributes, message: e.message)
+      raise SageRails::SageComponentAttributeSchemaViolation.new(component, attributes_attempted: attributes, message: e.message)
     end
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_alert.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_alert.rb
@@ -1,9 +1,9 @@
 class SageAlert < SageComponent
   set_attribute_schema({
-    color: Set.new([:info, :success, :warning, :danger]),
-    desc: String,
+    color: [:optional, Set.new(["info", "success", "warning", "danger"])],
+    desc: [:optional, String],
     dismissable: [:optional, TrueClass],
-    icon_name: String,
+    icon_name: [:optional, String],
     raised: [:optional, TrueClass],
     title: String,
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_alert.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_alert.rb
@@ -1,10 +1,13 @@
 class SageAlert < SageComponent
-  attr_accessor :color
-  attr_accessor :icon_name
-  attr_accessor :title
-  attr_accessor :desc
-  attr_accessor :dismissable
-  attr_accessor :raised
+  set_attribute_schema({
+    color: Set.new([:info, :success, :warning, :danger]),
+    desc: String,
+    dismissable: [:optional, TrueClass],
+    icon_name: String,
+    raised: [:optional, TrueClass],
+    title: String,
+  })
+
   def sections
     %w(alert_actions)
   end

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -1,6 +1,6 @@
 class SageAvatar < SageComponent
   set_attribute_schema({
-    color: [:optional, Set.new([nil, "purple", "sage", "yellow", "orange", "red"])],
+    color: [:optional, NilClass, Set.new(["purple", "sage", "yellow", "orange", "red"])],
     css_classes: [:optional, String],
     initials: String,
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -1,5 +1,7 @@
 class SageAvatar < SageComponent
-  attr_accessor :color
-  attr_accessor :css_classes
-  attr_accessor :initials
+  set_attribute_schema({
+    color: [:optional, Set.new([nil, "purple", "sage", "yellow", "orange", "red"])],
+    css_classes: [:optional, String],
+    initials: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_banner.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_banner.rb
@@ -1,10 +1,12 @@
 class SageBanner < SageComponent
-  attr_accessor :banner_context
-  attr_accessor :dismissable
-  attr_accessor :type
-  attr_accessor :icon
-  attr_accessor :text
-  attr_accessor :link
-  attr_accessor :id
-  attr_accessor :active
+  set_attribute_schema({
+    banner_context: [:optional, Set.new(["ladera-top", "sage-demo"])],
+    dismissable: [:optional, TrueClass],
+    type: [:optional, String],
+    icon: [:optional, String],
+    text: String,
+    link: [:optional, {name: String, attributes: Hash}],
+    id: [:optional, String],
+    active: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_billboard.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_billboard.rb
@@ -1,5 +1,7 @@
 class SageBillboard < SageComponent
-  attr_accessor :img
-  attr_accessor :title
-  attr_accessor :message
+  set_attribute_schema({
+    img: [:optional, String],
+    title: [:optional, String],
+    message: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_body.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_body.rb
@@ -1,3 +1,5 @@
 class SageBody < SageComponent
-  attr_accessor :css_classes
+  set_attribute_schema({
+    css_classes: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_breadcrumbs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_breadcrumbs.rb
@@ -6,7 +6,7 @@ class SageBreadcrumbs < SageComponent
     items: [[{
       is_current: [:optional, TrueClass],
       text: String,
-      url: String,
+      url: [:optional, String],
     }]],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_breadcrumbs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_breadcrumbs.rb
@@ -1,6 +1,12 @@
 class SageBreadcrumbs < SageComponent
-  attr_accessor :items
-  attr_accessor :is_progressbar
-  attr_accessor :css_classes
-  attr_accessor :has_back_icon
+  set_attribute_schema({
+    css_classes: [:optional, String],
+    has_back_icon: [:optional, TrueClass],
+    is_progressbar: [:optional, TrueClass],
+    items: [[{
+      is_current: [:optional, TrueClass],
+      text: String,
+      url: String,
+    }]],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button.rb
@@ -1,14 +1,16 @@
 class SageButton < SageComponent
-  attr_accessor :align
-  attr_accessor :attributes
-  attr_accessor :css_classes
-  attr_accessor :disabled
-  attr_accessor :full_width
-  attr_accessor :icon
-  attr_accessor :no_shadow
-  attr_accessor :raised
-  attr_accessor :small
-  attr_accessor :style
-  attr_accessor :subtle
-  attr_accessor :value
+  attribute_schema({
+    align:            [:optional, String],
+    attributes:       [:optional, Hash],
+    css_classes:      [:optional, [String]],
+    disabled:         [:optional, TrueClass],
+    full_width:       [:optional, TrueClass],
+    icon:             [:optional, { style: String, name: String }],
+    no_shadow:        [:optional, TrueClass],
+    raised:           [:optional, TrueClass],
+    small:            [:optional, TrueClass],
+    style:            [:optional, String],
+    subtle:           [:optional, TrueClass],
+    value:            String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button.rb
@@ -1,15 +1,15 @@
 class SageButton < SageComponent
-  attribute_schema({
+  set_attribute_schema({
     align:            [:optional, String],
     attributes:       [:optional, Hash],
     css_classes:      [:optional, [String]],
     disabled:         [:optional, TrueClass],
     full_width:       [:optional, TrueClass],
-    icon:             [:optional, { style: String, name: String }],
+    icon:             [:optional, { name: String, style: Set.new(["left", "right", "only"]) }],
     no_shadow:        [:optional, TrueClass],
     raised:           [:optional, TrueClass],
     small:            [:optional, TrueClass],
-    style:            [:optional, String],
+    style:            [:optional, Set.new(["primary", "secondary", "danger"])],
     subtle:           [:optional, TrueClass],
     value:            String,
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
@@ -1,6 +1,6 @@
 class SageButtonGroup < SageComponent
   set_attribute_schema({
-    align: [:optional, Set.new([:end])],
-    gap: Set.new([:xs, :sm, :md, :lg])
+    align: [:optional, Set.new(["end"])],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
@@ -1,4 +1,6 @@
 class SageButtonGroup < SageComponent
-  attr_accessor :align
-  attr_accessor :gap
+  set_attribute_schema({
+    align: [:optional, Set.new([:end])],
+    gap: Set.new([:xs, :sm, :md, :lg])
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card.rb
@@ -1,5 +1,7 @@
 class SageCard < SageComponent
-  attr_accessor :clear_top_padding
-  attr_accessor :clear_bottom_padding
-  attr_accessor :border_dashed
+  set_attribute_schema({
+    border_dashed: [:optional, TrueClass],
+    clear_bottom_padding: [:optional, TrueClass],
+    clear_top_padding: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_block.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_block.rb
@@ -1,4 +1,6 @@
 class SageCardBlock < SageComponent
-  attr_accessor :color
-  attr_accessor :type_block
+  set_attribute_schema({
+    color: [:optional, String],
+    type_block: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_divider.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_divider.rb
@@ -1,3 +1,5 @@
 class SageCardDivider < SageComponent
-  attr_accessor :bleed
+  set_attribute_schema({
+    bleed: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_figure.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_figure.rb
@@ -1,4 +1,6 @@
 class SageCardFigure < SageComponent
-  attr_accessor :bleed
-  attr_accessor :is_wistia
+  set_attribute_schema({
+    bleed: [:optional, TrueClass],
+    is_wistia: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_footer.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_footer.rb
@@ -1,3 +1,5 @@
 class SageCardFooter < SageComponent
-  attr_accessor :align_spread
+  set_attribute_schema({
+    align_spread: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_header.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_header.rb
@@ -1,3 +1,5 @@
 class SageCardHeader < SageComponent
-  attr_accessor :title
+  set_attribute_schema({
+    title: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_list_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_list_item.rb
@@ -1,3 +1,5 @@
 class SageCardListItem < SageComponent
-  attr_accessor :grid_template
+  set_attribute_schema({
+    grid_template: SageSchemaHelper::GRID_TEMPLATE
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
@@ -1,4 +1,6 @@
 class SageCardRow < SageComponent
-  attr_accessor :grid_template
-  attr_accessor :vertical_align
+  set_attribute_schema({
+    grid_template: SageSchemaHelper::GRID_TEMPLATE,
+    vertical_align: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_catalog_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_catalog_item.rb
@@ -1,7 +1,9 @@
 class SageCatalogItem < SageComponent
-  attr_accessor :image
-  attr_accessor :href
-  attr_accessor :title
+  set_attribute_schema({
+    href: [:optional, String],
+    image: [:optional, String],
+    title: [:optional, String],
+  })
 
   def sections
     %w(aside)

--- a/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
@@ -1,14 +1,15 @@
 class SageCheckbox < SageComponent
-  attr_accessor :css_classes
-  attr_accessor :checked
-  attr_accessor :disabled
-  attr_accessor :has_error
-  attr_accessor :id
-  attr_accessor :label_text
-  attr_accessor :name
-  attr_accessor :partial_selection
-  attr_accessor :required
-  attr_accessor :standalone
-  attr_accessor :value
+  set_attribute_schema({
+    checked: TrueClass,
+    css_classes: [:optional, String],
+    disabled: [:optional, TrueClass],
+    has_error:  [:optional, TrueClass],
+    id: String,
+    label_text: String,
+    name: [:optional, String],
+    partial_selection: [:optional, TrueClass],
+    required: [:optional, TrueClass],
+    standalone:  [:optional, TrueClass],
+    value: [:optional, String],
+  })
 end
-  

--- a/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
@@ -1,11 +1,11 @@
 class SageCheckbox < SageComponent
   set_attribute_schema({
-    checked: TrueClass,
+    checked: [:optional, TrueClass],
     css_classes: [:optional, String],
     disabled: [:optional, TrueClass],
     has_error:  [:optional, TrueClass],
-    id: String,
-    label_text: String,
+    id: [:optional, String],
+    label_text: [:optional, String],
     name: [:optional, String],
     partial_selection: [:optional, TrueClass],
     required: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -1,11 +1,13 @@
 class SageChoice < SageComponent
-  attr_accessor :target
-  attr_accessor :text
-  attr_accessor :type
-  attr_accessor :icon
-  attr_accessor :subtext
-  attr_accessor :active
-  attr_accessor :align_center
-  attr_accessor :attributes
-  attr_accessor :disabled
+  set_attribute_schema({
+    active: [:optional, TrueClass],
+    align_center: [:optional, TrueClass],
+    attributes: [:optional, Hash],
+    disabled: [:optional, TrueClass],
+    icon: [:optional, String],
+    subtext: [:optional, String],
+    target: [:optional, String],
+    text: String,
+    type: Set.new(["icon", "radio", "arrow"]),
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -1,12 +1,12 @@
 class SageChoice < SageComponent
   set_attribute_schema({
-    active: [:optional, TrueClass],
+    active: [:optional, NilClass, TrueClass],
     align_center: [:optional, TrueClass],
-    attributes: [:optional, Hash],
-    disabled: [:optional, TrueClass],
-    icon: [:optional, String],
-    subtext: [:optional, String],
-    target: [:optional, String],
+    attributes: [:optional, NilClass, Hash],
+    disabled: [:optional, NilClass, TrueClass],
+    icon: [:optional,NilClass, String],
+    subtext: [:optional, NilClass, String],
+    target: [:optional, NilClass, String],
     text: String,
     type: Set.new(["icon", "radio", "arrow"]),
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -5,12 +5,7 @@ class SageComponent
 
   ATTRIBUTE_SCHEMA = {
     html_attributes: [:optional, Hash],
-    spacer: [:optional, {
-      top: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
-      right: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
-      bottom: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
-      left: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
-    }]
+    spacer: [:optional, SageSchemaHelper::SPACER]
   }
 
   def generated_css_classes

--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -3,6 +3,11 @@ class SageComponent
   attr_accessor :context
   attr_accessor :content
 
+  SCHEMA = {
+    spacer: [:optional, Hash],
+    html_attributes: [:optional, Hash],
+  }
+
   def generated_css_classes
     @generated_css_classes ||= ""
   end
@@ -15,7 +20,7 @@ class SageComponent
     context.render(
       partial: "sage_components/#{template_path}",
       locals: { component: self }
-    ).tap { cleanup_section_vars }
+    )
   end
 
   # SageComponent Universal Spacer Attribute
@@ -25,8 +30,6 @@ class SageComponent
   #   USAGE:
   #   sage_component <CLASSNAME>, { spacer: { bottom: :lg } }
   def spacer=(spacer_hash)
-    raise ArgumentError.new("SageComponent expects :spacer to be a hash") unless spacer_hash.is_a?(Hash)
-
     spacer_hash.each do |key, value|
       generated_css_classes << " sage-spacer-#{key}#{value != :md ? "-#{value}" : ""}"
     end
@@ -38,8 +41,6 @@ class SageComponent
   #   USAGE:
   #   sage_component <CLASSNAME>, { html_attributes: { "id": "my-cool-identifier" } }
   def html_attributes=(html_attributes_hash)
-    raise ArgumentError.new("SageComponent expects :html_attributes to be a hash") unless html_attributes_hash.is_a?(Hash)
-
     html_attributes_hash.each do |key, value|
       generated_html_attributes << " #{key}=\"#{value.to_s}\""
     end
@@ -47,17 +48,12 @@ class SageComponent
 
   private
 
-  def sections
-    []
-  end
-
-  def cleanup_section_vars
-    sections.each do |section_name|
-      context.view_flow.set("sage_#{section_name}".to_sym, '')
-    end
-  end
-
   def template_path
     self.class.to_s.underscore
+  end
+
+  def self.attribute_schema(attributes)
+    attr_accessor(*attributes.keys)
+    self.const_set("SCHEMA", self.superclass::SCHEMA.deep_merge(attributes))
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -4,8 +4,13 @@ class SageComponent
   attr_accessor :content
 
   ATTRIBUTE_SCHEMA = {
-    spacer: [:optional, Hash],
     html_attributes: [:optional, Hash],
+    spacer: [:optional, {
+      top: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
+      right: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
+      bottom: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
+      left: [:optional, Set.new([:xs, :sm, :md, :lg, :xl])],
+    }]
   }
 
   def generated_css_classes

--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -3,7 +3,7 @@ class SageComponent
   attr_accessor :context
   attr_accessor :content
 
-  SCHEMA = {
+  ATTRIBUTE_SCHEMA = {
     spacer: [:optional, Hash],
     html_attributes: [:optional, Hash],
   }
@@ -20,7 +20,7 @@ class SageComponent
     context.render(
       partial: "sage_components/#{template_path}",
       locals: { component: self }
-    )
+    ).tap { cleanup_section_vars }
   end
 
   # SageComponent Universal Spacer Attribute
@@ -48,12 +48,22 @@ class SageComponent
 
   private
 
+  def sections
+    []
+  end
+
+  def cleanup_section_vars
+    sections.each do |section_name|
+      context.view_flow.set("sage_#{section_name}".to_sym, '')
+    end
+  end
+
   def template_path
     self.class.to_s.underscore
   end
 
-  def self.attribute_schema(attributes)
+  def self.set_attribute_schema(attributes)
     attr_accessor(*attributes.keys)
-    self.const_set("SCHEMA", self.superclass::SCHEMA.deep_merge(attributes))
+    self.const_set("ATTRIBUTE_SCHEMA", self.superclass::ATTRIBUTE_SCHEMA.deep_merge(attributes))
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_container.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_container.rb
@@ -1,3 +1,5 @@
 class SageContainer < SageComponent
-  attr_accessor :size
+  set_attribute_schema({
+    size: SageSchemaHelper::CONTAINER_SIZE,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_copy_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_copy_button.rb
@@ -1,4 +1,6 @@
 class SageCopyButton < SageComponent
-  attr_accessor :value
-  attr_accessor :semibold
+  set_attribute_schema({
+    semibold: [:optional, TrueClass],
+    value: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_copy_text.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_copy_text.rb
@@ -1,4 +1,6 @@
 class SageCopyText < SageComponent
-  attr_accessor :value
-  attr_accessor :semibold
+  set_attribute_schema({
+    semibold: [:optional, TrueClass],
+    value: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_copy_text_card.rb
@@ -1,4 +1,6 @@
 class SageCopyTextCard < SageComponent
-  attr_accessor :semibold
-  attr_accessor :truncate_contents
+  set_attribute_schema({
+    semibold: [:optional, TrueClass],
+    truncate_contents: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_description.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_description.rb
@@ -1,6 +1,8 @@
 class SageDescription < SageComponent
-  attr_accessor :title
-  attr_accessor :data
-  attr_accessor :link
-  attr_accessor :id 
+  set_attribute_schema({
+    title: [:optional, String],
+    data: [:optional, NilClass, String, Integer, Hash],
+    link: [:optional, String],
+    id: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -1,12 +1,23 @@
 class SageDropdown < SageComponent
-  attr_accessor :id
-  attr_accessor :align
-  attr_accessor :css_classes
-  attr_accessor :contained
-  attr_accessor :customized
-  attr_accessor :custom_modifier
-  attr_accessor :items
-  attr_accessor :trigger_type
-  attr_accessor :search
-  attr_accessor :panel_size
+  set_attribute_schema({
+    id: [:optional, String],
+    align: [:optional, Set.new(["right"])],
+    css_classes: [:optional, String],
+    contained: [:optional, TrueClass],
+    content: [:optional, String],
+    customized: [:optional, TrueClass],
+    custom_modifier: [:optional, Set.new(["actions", "sort"])],
+    items: [:optional, [[{
+      value: String,
+      icon: [:optional, NilClass, String],
+      attributes: [:optional, Hash],
+      style: [:optional, String],
+      is_heading: [:optional, TrueClass],
+      modifiers: [:optional, Array],
+      border_before: [:optional, TrueClass],
+    }]]],
+    trigger_type: [:optional, Set.new(["select", "select-labeled"])],
+    search: [:optional, TrueClass],
+    panel_size: [:optional, Set.new(["small"])],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_empty_state.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_empty_state.rb
@@ -1,6 +1,8 @@
 class SageEmptyState < SageComponent
-  attr_accessor :icon
-  attr_accessor :title
-  attr_accessor :text
-  attr_accessor :compact
+  set_attribute_schema({
+    icon: [:optional, String],
+    title: [:optional, String],
+    text: [:optional, String],
+    compact: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -1,10 +1,12 @@
 class SageFeatureToggle < SageComponent
-  attr_accessor :alt_text
-  attr_accessor :description
-  attr_accessor :image
-  attr_accessor :link_location
-  attr_accessor :link_text
-  attr_accessor :title
+  set_attribute_schema({
+    alt_text: [:optional, String],
+    description: [:optional, String],
+    image: [:optional, String],
+    link_location: [:optional, String],
+    link_text: [:optional, String],
+    title: [:optional, String],
+  })
 
   def sections
     %w(:feature_toggle_input)

--- a/docs/lib/sage_rails/app/sage_components/sage_form_section.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_section.rb
@@ -1,6 +1,8 @@
 class SageFormSection < SageComponent
-  attr_accessor :title
-  attr_accessor :subtitle
-  attr_accessor :id
-  attr_accessor :title_tag
+  set_attribute_schema({
+    id: [:optional, String],
+    subtitle: [:optional, String],
+    title_tag: [:optional, String],
+    title: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
@@ -1,4 +1,6 @@
 class SageGridCol < SageComponent
-  attr_accessor :breakpoint
-  attr_accessor :size
+  set_attribute_schema({
+    breakpoint: [:optional, Symbol, String],
+    size: [:optional, String, Integer],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_hero.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_hero.rb
@@ -1,10 +1,12 @@
 class SageHero < SageComponent
-  attr_accessor :alt_text
-  attr_accessor :button
-  attr_accessor :cta_attributes
-  attr_accessor :description
-  attr_accessor :image
-  attr_accessor :title
-  attr_accessor :title_tag
-  attr_accessor :css_classes
+  set_attribute_schema({
+    alt_text: [:optional, String],
+    button: [:optional, String],
+    cta_attributes: [:optional, Hash],
+    description: [:optional, String],
+    image: [:optional, String],
+    title: [:optional, String],
+    title_tag: [:optional, String],
+    css_classes: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
@@ -1,8 +1,10 @@
 class SageIconCard < SageComponent
-  attr_accessor :color
-  attr_accessor :css_classes
-  attr_accessor :icon
-  attr_accessor :label
-  attr_accessor :size
-  attr_accessor :style
+  set_attribute_schema({
+    color: Set.new(["draft", "published", "info", "warning", "danger"]),
+    css_classes: [:optional, String],
+    icon: String,
+    label: [:optional, String],
+    size: [:optional, SageSchemaHelper::ICON_SIZE],
+    style: [:optional, Set.new(["subtle", "bold"])],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_label.rb
@@ -1,9 +1,11 @@
 class SageLabel < SageComponent
-  attr_accessor :color
-  attr_accessor :style
-  attr_accessor :icon
-  attr_accessor :value
-  attr_accessor :html_tag
-  attr_accessor :interactive_type # TODO: Validate if :dropdown, :default, or :secondary_button
-  attr_accessor :secondary_button
+  set_attribute_schema({
+    color: Set.new(["danger", "draft", "info", "locked", "published", "success", "warning"]),
+    html_tag: [:optional, String],
+    icon: [:optional, String],
+    interactive_type: [:optional, Set.new([:dropdown, :default, :secondary_button])],
+    secondary_button: [:optional, String],
+    style: [:optional, Set.new(["subtle", "bold"])],
+    value: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_loader.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_loader.rb
@@ -1,4 +1,6 @@
 class SageLoader < SageComponent
-  attr_accessor :fill
-  attr_accessor :type
+  set_attribute_schema({
+    fill: [:optional, TrueClass],
+    type: Set.new(["bar", "spinner"]),
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -1,6 +1,8 @@
 class SageModal < SageComponent
-  attr_accessor :id
-  attr_accessor :active
-  attr_accessor :disable_close
-  attr_accessor :large
+  set_attribute_schema({
+    id: [:optional, String],
+    active: [:optional, TrueClass],
+    disable_close: [:optional, TrueClass],
+    large: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
@@ -1,5 +1,7 @@
 class SageModalContent < SageComponent
-  attr_accessor :title
+  set_attribute_schema({
+    title: [:optional, String],
+  })
 
   def sections
     %w(header footer footer_aside)

--- a/docs/lib/sage_rails/app/sage_components/sage_nav_link.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_nav_link.rb
@@ -1,8 +1,10 @@
 class SageNavLink < SageComponent
-  attr_accessor :link
-  attr_accessor :text
-  attr_accessor :type
-  attr_accessor :icon
-  attr_accessor :no_active
-  attr_accessor :method
+  set_attribute_schema({
+    link: [:optional, String],
+    text: [:optional, String],
+    type: [:optional, String],
+    icon: [:optional, String],
+    no_active: [:optional, TrueClass],
+    method: [:optional, Symbol],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_outline_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_outline_item.rb
@@ -1,9 +1,11 @@
 class SageOutlineItem < SageComponent
-  attr_accessor :title
-  attr_accessor :actions_secondary
-  attr_accessor :actions_primary
-  attr_accessor :status
-  attr_accessor :icon
-  attr_accessor :depth
-  attr_accessor :category
+  set_attribute_schema({
+    title: [:optional, String],
+    actions_secondary: [:optional, Array],
+    actions_primary: [:optional, Array],
+    status: [:optional, String],
+    icon: [:optional, String],
+    depth: [:optional, Integer],
+    category: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
@@ -1,9 +1,11 @@
 class SagePageHeading < SageComponent
-  attr_accessor :title
-  attr_accessor :secondary_text
-  attr_accessor :help_title
-  attr_accessor :help_link
-  attr_accessor :help_html
+  set_attribute_schema({
+    title: [:optional, String],
+    secondary_text: [:optional, String],
+    help_title: [:optional, String],
+    help_link: [:optional, Hash],
+    help_html: [:optional, String],
+  })
 
   def sections
     %w(breadcrumbs page_heading_toolbar page_heading_actions page_heading_intro help_content)

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -1,8 +1,10 @@
 class SagePagination < SageComponent
-  attr_accessor :items
-  attr_accessor :window
-  attr_accessor :hide_pages
-  attr_accessor :additional_params
+  set_attribute_schema({
+    items: -> (v) { SageSchemaHelper.is_active_record?(v) },
+    window: [:optional, Integer],
+    hide_pages: [:optional, TrueClass],
+    additional_params: [:optional, Hash]
+  })
 
   def initialize(attributes = {})
     super

--- a/docs/lib/sage_rails/app/sage_components/sage_panel.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel.rb
@@ -1,4 +1,6 @@
 class SagePanel < SageComponent
-  attr_accessor :clear_top_padding
-  attr_accessor :clear_bottom_padding
+  set_attribute_schema({
+    clear_top_padding: [:optional, TrueClass],
+    clear_bottom_padding: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_block.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_block.rb
@@ -1,4 +1,6 @@
 class SagePanelBlock < SageComponent
-  attr_accessor :color
-  attr_accessor :type_block
+  set_attribute_schema({
+    color: [:optional, String],
+    type_block: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -1,15 +1,42 @@
 class SagePanelControls < SageComponent
-  attr_accessor :bulk_action_items
-  attr_accessor :item_count_label
-  attr_accessor :show_bulk_actions
-  attr_accessor :show_expand_collapse
-  attr_accessor :show_pagination
-  attr_accessor :show_sort
-  attr_accessor :sort_items
-  attr_accessor :start_expanded
-  attr_accessor :target
+  set_attribute_schema({
+    bulk_action_items: [:optional, [[{
+      value: String,
+      attributes: [:optional, Hash],
+    }]]],
+    item_count_label: [:optional, TrueClass],
+    show_bulk_actions: [:optional, TrueClass],
+    show_expand_collapse: [:optional, TrueClass],
+    show_pagination: [:optional, TrueClass],
+    show_sort: [:optional, TrueClass],
+    sort_items: [:optional, [[{
+      value: String,
+      attributes: [:optional, Hash],
+    }]]],
+    start_expanded: [:optional, TrueClass],
+    target: [:optional, String],
+  })
 
   def sections
     %w(panel_controls_toolbar panel_controls_tabs)
   end
 end
+
+
+{:show_bulk_actions=>true,
+ :show_expand_collapse=>true,
+ :show_pagination=>true,
+ :show_sort=>true,
+ :bulk_action_items=>
+  [{:value=>"Delete",
+    :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},
+   {:value=>"Set marketing",
+    :attributes=>
+     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
+ :sort_items=>
+  [{:value=>"Name",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
+   {:value=>"Email",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
+   {:value=>"Join date",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_divider.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_divider.rb
@@ -1,3 +1,5 @@
 class SagePanelDivider < SageComponent
-  attr_accessor :bleed
+  set_attribute_schema({
+    bleed: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_figure.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_figure.rb
@@ -1,4 +1,6 @@
 class SagePanelFigure < SageComponent
-  attr_accessor :bleed
-  attr_accessor :is_wistia
+  set_attribute_schema({
+    bleed: [:optional, Set.new(["top", "bottom", "sides"])],
+    is_wistia: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_footer.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_footer.rb
@@ -1,3 +1,5 @@
 class SagePanelFooter < SageComponent
-  attr_accessor :align_spread
+  set_attribute_schema({
+    align_spread: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_header.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_header.rb
@@ -1,3 +1,5 @@
 class SagePanelHeader < SageComponent
-  attr_accessor :title
+  set_attribute_schema({
+    title: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_list_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_list_item.rb
@@ -1,3 +1,5 @@
 class SagePanelListItem < SageComponent
-  attr_accessor :grid_template
+  set_attribute_schema({
+    grid_template: SageSchemaHelper::GRID_TEMPLATE,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,4 +1,11 @@
 class SagePanelRow < SageComponent
-  attr_accessor :grid_template
-  attr_accessor :vertical_align
+  set_attribute_schema({
+    grid_template: Set.new([
+      "m", "o", "mm", "mo",
+      "et", "ete", "eti", "ets", "em", "eme", "emi", "ems", "eo", "eoe", "eoi", "eos",
+      "it", "ite", "iti", "its", "im", "ime", "imi", "ims", "io", "ioe", "ioi", "ios",
+      "st", "ste", "sti", "sts", "sm", "sme", "smi", "sms", "so", "soe", "soi", "sos",
+    ]),
+    vertical_align: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,11 +1,6 @@
 class SagePanelRow < SageComponent
   set_attribute_schema({
-    grid_template: Set.new([
-      "m", "o", "mm", "mo",
-      "et", "ete", "eti", "ets", "em", "eme", "emi", "ems", "eo", "eoe", "eoi", "eos",
-      "it", "ite", "iti", "its", "im", "ime", "imi", "ims", "io", "ioe", "ioi", "ios",
-      "st", "ste", "sti", "sts", "sm", "sme", "smi", "sms", "so", "soe", "soi", "sos",
-    ]),
+    grid_template: SageSchemaHelper::GRID_TEMPLATE,
     vertical_align: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_subheader.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_subheader.rb
@@ -1,3 +1,5 @@
 class SagePanelSubheader < SageComponent
-  attr_accessor :title
+  set_attribute_schema({
+    title: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_tiles.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_tiles.rb
@@ -1,3 +1,5 @@
 class SagePanelTiles < SageComponent
-  attr_accessor :tiles_in_row
+  set_attribute_schema({
+    tiles_in_row: Set.new([2, 3, 4])
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_popover.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_popover.rb
@@ -1,11 +1,13 @@
 class SagePopover < SageComponent
-  attr_accessor :body
-  attr_accessor :custom_content_class
-  attr_accessor :icon
-  attr_accessor :id
-  attr_accessor :link
-  attr_accessor :popover_position
-  attr_accessor :title
-  attr_accessor :trigger_icon_only
-  attr_accessor :trigger_value
+  set_attribute_schema({
+    body: [:optional, String],
+    custom_content_class: [:optional, String],
+    icon: [:optional, String],
+    id: [:optional, String],
+    link: [:optional, {href: String, name: String}],
+    popover_position: [:optional, String],
+    title: [:optional, String],
+    trigger_icon_only: [:optional, TrueClass],
+    trigger_value: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
@@ -1,4 +1,6 @@
 class SageProgressBar < SageComponent
-  attr_accessor :percent
-  attr_accessor :label
+  set_attribute_schema({
+    percent: 0..100,
+    label: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_property.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_property.rb
@@ -1,4 +1,6 @@
 class SageProperty < SageComponent
-  attr_accessor :icon
-  attr_accessor :value
+  set_attribute_schema({
+    icon: [:optional, String],
+    value: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_radio.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_radio.rb
@@ -1,12 +1,14 @@
 class SageRadio < SageComponent
-  attr_accessor :checked
-  attr_accessor :css_classes
-  attr_accessor :disabled
-  attr_accessor :has_error
-  attr_accessor :id
-  attr_accessor :label_text
-  attr_accessor :name
-  attr_accessor :required
-  attr_accessor :standalone
-  attr_accessor :value
+  set_attribute_schema({
+    checked: [:optional, TrueClass],
+    css_classes: [:optional, String],
+    disabled: [:optional, TrueClass],
+    has_error: [:optional, TrueClass],
+    id: String,
+    label_text: String,
+    name: String,
+    required: [:optional, TrueClass],
+    standalone: [:optional, TrueClass],
+    value: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
@@ -1,0 +1,24 @@
+module SageSchemaHelper
+  ICON_SIZE = Set.new(["xs", "sm", "md", "lg", "xl", "2xl", "2xl", "3xl", "3xl", "4xl"])
+
+  CONTAINER_SIZE = Set.new(["modal", "modal-lg", "xs", "sm", "md", "lg", "fluid"])
+
+  GRID_TEMPLATE = Set.new([
+    "m", "o", "mm", "mo", "te",
+    "et", "ete", "eti", "ets", "em", "eme", "emi", "ems", "eo", "eoe", "eoi", "eos",
+    "it", "ite", "iti", "its", "im", "ime", "imi", "ims", "io", "ioe", "ioi", "ios",
+    "st", "ste", "sti", "sts", "sm", "sme", "smi", "sms", "so", "soe", "soi", "sos",
+  ])
+
+  SPACER = {
+    top: [:optional, Set.new([:xs, :sm, :md, :lg, :xl, "xs", "sm", "md", "lg", "xl"])],
+    right: [:optional, Set.new([:xs, :sm, :md, :lg, :xl, "xs", "sm", "md", "lg", "xl"])],
+    bottom: [:optional, Set.new([:xs, :sm, :md, :lg, :xl, "xs", "sm", "md", "lg", "xl"])],
+    left: [:optional, Set.new([:xs, :sm, :md, :lg, :xl, "xs", "sm", "md", "lg", "xl"])],
+  }
+
+  # Accepts ActiveRecord descendants
+  def self.is_active_record?(value)
+    value.superclass == ActiveRecord::Base
+  end
+end

--- a/docs/lib/sage_rails/app/sage_components/sage_search.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_search.rb
@@ -1,7 +1,9 @@
 class SageSearch < SageComponent
-  attr_accessor :id
-  attr_accessor :value
-  attr_accessor :placeholder
-  attr_accessor :contained
-  attr_accessor :label_text
+  set_attribute_schema({
+    id: [:optional, String],
+    value: [:optional, String, NilClass],
+    placeholder: [:optional, String],
+    contained: [:optional, TrueClass],
+    label_text: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_sidebar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sidebar.rb
@@ -1,3 +1,5 @@
 class SageSidebar < SageComponent
-  attr_accessor :size
+  set_attribute_schema({
+    size: [:optional, Set.new(["md", "lg"])],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable.rb
@@ -1,5 +1,7 @@
 class SageSortable < SageComponent
-  attr_accessor :resource_name
+  set_attribute_schema({
+    resource_name: String
+  })
 
   def sections
     %w(empty)

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item.rb
@@ -1,8 +1,10 @@
 class SageSortableItem < SageComponent
-  attr_accessor :url_update
-  attr_accessor :title
-  attr_accessor :subtitle
-  attr_accessor :label
-  attr_accessor :id
-  attr_accessor :card
+  set_attribute_schema({
+    card: [:optional, TrueClass],
+    id: [:optional, Integer, String],
+    label: [:optional, String],
+    subtitle: [:optional, String],
+    title: String,
+    url_update: [:optional, String],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_status_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_status_icon.rb
@@ -1,4 +1,6 @@
 class SageStatusIcon < SageComponent
-  attr_accessor :value
-  attr_accessor :icon
+  set_attribute_schema({
+    value: String,
+    icon: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_switch.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_switch.rb
@@ -1,14 +1,16 @@
 class SageSwitch < SageComponent
-  attr_accessor :css_classes
-  attr_accessor :checked
-  attr_accessor :disabled
-  attr_accessor :has_error
-  attr_accessor :hide_text
-  attr_accessor :id
-  attr_accessor :label_text
-  attr_accessor :name
-  attr_accessor :message
-  attr_accessor :required
-  attr_accessor :type
-  attr_accessor :value
+  set_attribute_schema({
+    css_classes: [:optional, String],
+    checked: [:optional, TrueClass],
+    disabled: [:optional, TrueClass],
+    has_error: [:optional, TrueClass],
+    hide_text: [:optional, TrueClass],
+    id: String,
+    label_text: String,
+    name: String,
+    message: [:optional, String],
+    required: [:optional, TrueClass],
+    type: String,
+    value: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tab.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tab.rb
@@ -1,9 +1,9 @@
 class SageTab < SageComponent
   set_attribute_schema({
-    active: [:optional, TrueClass],
-    attributes: [:optional, Hash],
-    disabled: [:optional, TrueClass],
-    target: [:optional, String],
+    active: [:optional, NilClass, TrueClass],
+    attributes: [:optional, NilClass, Hash],
+    disabled: [:optional, NilClass, TrueClass],
+    target: [:optional, NilClass, String],
     text: String,
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tab.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tab.rb
@@ -1,7 +1,9 @@
 class SageTab < SageComponent
-  attr_accessor :target
-  attr_accessor :text
-  attr_accessor :active
-  attr_accessor :attributes
-  attr_accessor :disabled
+  set_attribute_schema({
+    active: [:optional, TrueClass],
+    attributes: [:optional, Hash],
+    disabled: [:optional, TrueClass],
+    target: [:optional, String],
+    text: String,
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -1,12 +1,14 @@
 class SageTable < SageComponent
-  attr_accessor :caption
-  attr_accessor :responsive
-  attr_accessor :striped
-  attr_accessor :selectable
-  attr_accessor :condensed
-  attr_accessor :sortable
-  attr_accessor :headers
-  attr_accessor :rows
-  attr_accessor :reset_above
-  attr_accessor :reset_below
+  set_attribute_schema({
+    caption: [:optional, String],
+    condensed: [:optional, TrueClass],
+    headers: [:optional, Array],
+    reset_above: [:optional, TrueClass],
+    reset_below: [:optional, TrueClass],
+    responsive: [:optional, TrueClass],
+    rows: [:optional, Array],
+    selectable: [:optional, TrueClass],
+    sortable: [:optional, TrueClass],
+    striped: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -1,9 +1,18 @@
 class SageTabs < SageComponent
-  attr_accessor :style
-  attr_accessor :stacked
-  attr_accessor :id
-  attr_accessor :items
-  attr_accessor :progressbar
-  attr_accessor :align_items_center
-  attr_accessor :navigational
+  set_attribute_schema({
+    style: [:optional, Set.new(["choice"])],
+    stacked: [:optional, TrueClass],
+    id: [:optional, String],
+    items: [[
+      text: String,
+      attributes: [:optional, Hash],
+      active: [:optional, TrueClass],
+      target: [:optional, String],
+      type: [:optional, Set.new(["radio", "arrow", "icon"])],
+      icon: [:optional, String],
+    ]],
+    progressbar: [:optional, TrueClass],
+    align_items_center: [:optional, TrueClass],
+    navigational: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs_pane.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs_pane.rb
@@ -1,6 +1,8 @@
 class SageTabsPane < SageComponent
-  attr_accessor :id
-  attr_accessor :card
-  attr_accessor :card_spacing
-  attr_accessor :panel_spacing
+  set_attribute_schema({
+    card_spacing: [:optional, TrueClass],
+    card: [:optional, TrueClass],
+    id: String,
+    panel_spacing: [:optional, TrueClass],
+  })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_toast.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_toast.rb
@@ -1,4 +1,6 @@
 class SageToast < SageComponent
-  attr_accessor :value
-  attr_accessor :style
+  set_attribute_schema({
+    style: [:optional, Set.new(["danger"])],
+    value: String,
+  })
 end

--- a/docs/lib/sage_rails/lib/sage_rails.rb
+++ b/docs/lib/sage_rails/lib/sage_rails.rb
@@ -1,4 +1,5 @@
 require "sage_rails/engine"
+require "sage_rails/exceptions"
 
 module SageRails
 end

--- a/docs/lib/sage_rails/lib/sage_rails/exceptions.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/exceptions.rb
@@ -1,0 +1,13 @@
+module SageRails
+  class SageComponentSchemaViolationError < StandardError
+    def initialize(sage_component, attributes_attempted: {}, message: "")
+      error_messages = [
+        "#{sage_component.name} Schema Violation:\n#{message}",
+        "#{sage_component.name} Schema:\n#{sage_component::ATTRIBUTE_SCHEMA.pretty_inspect}",
+        "Attributes Passed:\n#{attributes_attempted.pretty_inspect}",
+      ]
+
+      super(error_messages.join("\n\n"))
+    end
+  end
+end

--- a/docs/lib/sage_rails/lib/sage_rails/exceptions.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/exceptions.rb
@@ -1,10 +1,10 @@
 module SageRails
-  class SageComponentSchemaViolationError < StandardError
+  class SageComponentAttributeSchemaViolation < StandardError
     def initialize(sage_component, attributes_attempted: {}, message: "")
       error_messages = [
-        "#{sage_component.name} Schema Violation:\n#{message}",
-        "#{sage_component.name} Schema:\n#{sage_component::ATTRIBUTE_SCHEMA.pretty_inspect}",
-        "Attributes Passed:\n#{attributes_attempted.pretty_inspect}",
+        "#{sage_component.name}\n#{attributes_attempted.pretty_inspect}",
+        "Schema Violation Message:\n#{message}",
+        "#{sage_component.name}::ATTRIBUTE_SCHEMA:\n#{sage_component::ATTRIBUTE_SCHEMA.pretty_inspect}",
       ]
 
       super(error_messages.join("\n\n"))

--- a/docs/lib/sage_rails/sage_rails.gemspec
+++ b/docs/lib/sage_rails/sage_rails.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["docs/{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "rails"
+  s.add_runtime_dependency "classy_hash"
 
   s.add_development_dependency "pry"
 end


### PR DESCRIPTION
## ☃️ 

Validate Rails Component attributes like we do for React Props

#### Description
I’d like to make this its own Sage bump, if the crew doesn’t mind, because this touches every Rails component. The intent is to precision-add only the argument checking to each SageRails component without updating the attributes themselves to prevent any diff in Kajabi-Products. I defaulted to setting each as an optional attribute unless I was familiar with the Products usage and audited that component on the other side (in Kajabi-Products). This leaves some space for improvement to make these checks even more strict down the road.
One issue that this PR’s diff does highlight is an inconsistent use of symbols and strings for arguments with a defined set of values. (e.g. gap may only be one of [:xs, :sm, :md, :lg]). I think it would be wise for us choose one approach for predictability; however, that falls outside the scope of this PR.

#### This PR currently includes:
- Method (`set_attribute_schema({})`) to build a schema and `attr_accessor`s
- `SageSchemaHelper` module to store reusable schema values (a temporary solution until we are able to use a design tokens file)
- Usage of [classy_hash](https://github.com/deseretbook/classy_hash) which will give us powerful tools to deeply check the hash passed to `sage_component`.
  - Check whether an attr value is _one of_ many different explicit values or types
  - Ability to define custom procs for validation
  - Sets us up to refactor the React component `configs.js` pattern allowed props pattern into a global implementation that these Rails components can also consume.
  - See the [classy_hash docs for examples ](https://github.com/deseretbook/classy_hash)


------------

#### Documentation:
![image](https://user-images.githubusercontent.com/565743/103819530-9b5ebd00-5038-11eb-8451-05c3ebd70d1e.png)


#### Preview of error message:
![image](https://user-images.githubusercontent.com/565743/103927353-3bbfea80-50e8-11eb-8ec5-32c474f11a32.png)
