### PR TITLE
fix(sage-react): forcing full code compilation for debugging

### DIFF
--- a/packages/sage-react/webpack/webpack.prod.js
+++ b/packages/sage-react/webpack/webpack.prod.js
@@ -4,6 +4,9 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
+  optimization: {
+    minimize: false
+  },
   entry: {
     main: [
       './lib/index.js'


### PR DESCRIPTION
Require full code compilation (no-minification) for sage-react. Debugging.