### PR TITLE
feat(search component): migrate KJB's search.js into Sage

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -1,10 +1,12 @@
-<div
+<form
   role="search"
   class=" sage-search
   <%= "sage-search--contained" if component.contained %>
   "
   data-js-search
 
+  <%# Prevents the default Kajabi-Products Search.js from binding to this input %>
+  data-kjb-disable-search
 >
   <label for="<%= component.id %>" class="sage-search__label">
     <%= component.label_text %>
@@ -21,10 +23,13 @@
     style: "secondary",
     css_classes: "sage-search__reset-button",
     subtle: true,
+    attributes: {
+      "data-js-search-clear": ""
+    },
     icon: {
       style: "only",
       name: "remove"
     }
   } %>
 
-</div>
+</form>

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_search.scss
@@ -130,7 +130,14 @@ $-search-icon: "::before";
 
 .sage-search__reset-button {
   visibility: hidden;
-  margin-right: sage-spacing(xs);
+
+  :not(.sage-search--contained) & {
+    margin-right: sage-spacing(xs);
+  }
+
+  .sage-search--contained & {
+    margin-right: sage-spacing(sm);
+  }
 
   .sage-search--has-text & {
     visibility: visible;

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_search.scss
@@ -51,8 +51,7 @@ $-search-icon: "::before";
     }
   }
 
-  &.sage-search--contained,
-  .sage-panel-controls__toolbar & {
+  &.sage-search--contained {
     position: relative;
     z-index: sage-z-index(default);
     box-shadow: map-get($sage-toolbar-button-borders, default);
@@ -62,14 +61,18 @@ $-search-icon: "::before";
       display: none;
     }
 
-    &:first-child {
+    .sage-panel-controls__toolbar &:first-child {
       border-top-left-radius: sage-border(radius);
       border-bottom-left-radius: sage-border(radius);
     }
 
-    &:last-child {
+    .sage-panel-controls__toolbar &:last-child {
       border-top-right-radius: sage-border(radius);
       border-bottom-right-radius: sage-border(radius);
+    }
+
+    :not(.sage-panel-controls__toolbar) & {
+      border-radius: sage-border(radius);
     }
 
     &:hover {

--- a/packages/sage-react/lib/Search/Search.jsx
+++ b/packages/sage-react/lib/Search/Search.jsx
@@ -27,7 +27,7 @@ const Search = ({
         placeholder={`${placeholder}…`}
         value={value}
         // Prevents the default Kajabi-Products Search.js from binding to this input
-        data-js-disable-search
+        data-kjb-disable-search
         {...rest}
       />
     </div>

--- a/packages/sage-system/lib/search.js
+++ b/packages/sage-system/lib/search.js
@@ -3,46 +3,65 @@ Sage.search = (function() {
   // Variables
   // ==================================================
 
-  const SELECTOR_SEARCH = 'data-js-search';
-  const SELECTOR_SEARCH_INPUT = '.sage-search__input';
-  const SELECTOR_SEARCH_BUTTON = '.sage-search__reset-button';
-  const CLASS_VISIBLE = 'sage-search--has-text';
+  const SELECTOR_CLEAR_BUTTON = 'data-js-search-clear';
+  const CLASS_HAS_TEXT = 'sage-search--has-text';
 
 
   // ==================================================
   // Functions
   // ==================================================
 
-  function init(el) {
-    const elInput = el.querySelector(SELECTOR_SEARCH_INPUT);
+  function getInput(el) {
+    return el.querySelector('input');
+  }
 
-    // check the input for a value on load
-    hasValue(elInput) ? addVisibleButtonState(el) : removeVisibleButtonState(el);
-    el.addEventListener('keyup', searchOnInputHandler);
+  function init(el) {
+    el.addEventListener('submit', onSubmit);
+    el.querySelector(`[${SELECTOR_CLEAR_BUTTON}]`).addEventListener('click', onClearButtonClick);
+    getInput(el).addEventListener('keyup', onInputKeyup);
+
+    hasTextCssClassController(el);
   }
 
   function unbind(el) {
-    el.removeEventListener('keyup', searchOnInputHandler);
+    el.removeEventListener('submit', onSubmit);
+    el.querySelector(`[${SELECTOR_CLEAR_BUTTON}]`).removeEventListener('click', onClearButtonClick);
+    getInput(el).removeEventListener('keyup', onInputKeyup);
   }
 
-  function searchOnInputHandler(evt) {
-    const elParent = evt.currentTarget;
-    const elInput = elParent.querySelector(SELECTOR_SEARCH_INPUT);
-
-    hasValue(elInput) ? addVisibleButtonState(elParent) : removeVisibleButtonState(elParent);
+  function onSubmit(evt) {
+    evt.preventDefault();
+    search(getInput(evt.target).value)
   }
 
-  // check if the search value has text or not
-  function hasValue(el) {
-    return el.value.length > 0
+  function onClearButtonClick(evt) {
+    let el = evt.target.parentNode,
+        elInput = getInput(el);
+
+    elInput.value = '';
+    search(elInput.value);
+    hasTextCssClassController(el);
   }
 
-  function addVisibleButtonState(elParent) {
-    elParent.classList.add(CLASS_VISIBLE);
+  function onInputKeyup(evt) {
+    hasTextCssClassController(evt.target.parentNode);
   }
 
-  function removeVisibleButtonState(elParent) {
-    elParent.classList.remove(CLASS_VISIBLE);
+  function search(value) {
+    let searchParams = new URLSearchParams(window.location.search);
+
+    if (value == (searchParams.get('search') || "")) return;
+
+    searchParams.set('search', value);
+    window.location.search = searchParams.toString();
+  }
+
+  function hasTextCssClassController(el) {
+    if (getInput(el).value.length === 0) {
+      el.classList.remove(CLASS_HAS_TEXT);
+    } else {
+      el.classList.add(CLASS_HAS_TEXT);
+    }
   }
 
   return {


### PR DESCRIPTION
BREAKING CHANGE: Breaking change because of rename of KJB's search.js data-attr that excludes the
new Sage search fields from being bound by old script

## Description
- Migrates KJB's search.js functionality into Sage Search
- Fix broken search border-radius when it exists outside of panel-controls
- Spacing adjustment for clear button when in `contained` search field

### Screenshots
n/a

## Test notes
Ensure a query string param of `search` is updated in location bar
If value of `search` query string matches value in bar, don't reload the page.

## Related
BUILD-447 
BUILD-407
