### PR TITLE
TinyMCE(mobile) - added overflow property for smaller displays

### DIFF
--- a/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
@@ -11,8 +11,8 @@
   border-radius: sage-border(radius);
 
   .mce-panel {
-    border: unset !important; /* stylelint-disable-line declaration-no-important */
     overflow-x: scroll;
+    border: unset !important; /* stylelint-disable-line declaration-no-important */
 
     &.mce-toolbar-grp {
       border-bottom: sage-border() !important; /* stylelint-disable-line declaration-no-important */


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
added overflow to the tinymce toolbar to resolve a mobile issue where it's currently being cut off

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-02 at 10 21 56 AM](https://user-images.githubusercontent.com/1241836/100901745-cbd79800-3489-11eb-9993-7f55803e285f.png)|![tinymcs-responsive](https://user-images.githubusercontent.com/1241836/100901777-d4c86980-3489-11eb-9c00-8514914b5f3c.gif)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. In the app, you'll have to visit a post edit page: something like http://www.kajabi.test:3000/admin/posts/51/edit
