### PR TITLE
fix(sage-react): fix proptypes change that broke build

### DIFF
--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -174,6 +174,7 @@ DropdownItem.defaultProps = {
   onExit: null,
   options: null,
   payload: null,
+  to: null,
 };
 
 DropdownItem.propTypes = {

--- a/packages/sage-react/lib/Dropdown/DropdownItemList.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItemList.jsx
@@ -77,7 +77,10 @@ const DropdownItemList = ({
 };
 
 const itemsPropTypes = PropTypes.arrayOf(
-  DropdownItem.propTypes,
+  PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  })
 );
 
 DropdownItemList.itemsPropTypes = itemsPropTypes;


### PR DESCRIPTION
## Description

In a previous merge we updated `PropTypes` for the `items` in `DropdownItemList` attempting to the `propTypes` of `DropdownItem` directly. This perhaps caused challeges with variable references so we're reverting this change.