### PR TITLE
Page Header - updates to grid when no secondary_text is present

### DIFF
--- a/docs/app/views/examples/objects/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/objects/page_heading/_preview.html.erb
@@ -123,7 +123,6 @@
     href: "#",
     name: "Help"
   },
-  secondary_text: "1 Email in Sequence",
 } do %>
     <% content_for :sage_breadcrumbs do %>
       <%= render "examples/elements/breadcrumbs/markup",
@@ -155,6 +154,20 @@
         icon: { name: "preview-on", style: "left" },
         value: "Preview",
       }%>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        icon: { name: "chart", style: "left" },
+        value: "Report",
+      }%>
+
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        icon: { name: "chart", style: "left" },
+        value: "Report",
+      }%>
+
       <%= sage_component SageButton, {
         style: "secondary",
         subtle: true,

--- a/docs/app/views/examples/objects/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/objects/page_heading/_preview.html.erb
@@ -123,6 +123,7 @@
     href: "#",
     name: "Help"
   },
+  secondary_text: "1 Email in Sequence",
 } do %>
     <% content_for :sage_breadcrumbs do %>
       <%= render "examples/elements/breadcrumbs/markup",
@@ -154,20 +155,6 @@
         icon: { name: "preview-on", style: "left" },
         value: "Preview",
       }%>
-      <%= sage_component SageButton, {
-        style: "secondary",
-        subtle: true,
-        icon: { name: "chart", style: "left" },
-        value: "Report",
-      }%>
-
-      <%= sage_component SageButton, {
-        style: "secondary",
-        subtle: true,
-        icon: { name: "chart", style: "left" },
-        value: "Report",
-      }%>
-
       <%= sage_component SageButton, {
         style: "secondary",
         subtle: true,

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -1,4 +1,4 @@
-<section class="sage-page-heading <%= component.generated_css_classes %>">
+<section class="sage-page-heading <%= "sage-page-heading--no-secondary-text" if component.secondary_text.blank? %> <%= component.generated_css_classes %>">
   <% if content_for? :sage_breadcrumbs %>
     <div class="sage-page-heading__crumbs">
       <%= content_for :sage_breadcrumbs %>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
@@ -9,12 +9,12 @@
 
   @media (max-width: sage-breakpoint(sm-max)) {
     grid-template-areas: 
-    "crumbs"
-    "title"
-    "intro"
-    "actions"
-    "toolbar"
-    "secondary";
+      "crumbs"
+      "title"
+      "intro"
+      "actions"
+      "toolbar"
+      "secondary";
   }
 
   @media (min-width: sage-breakpoint(md-min)) {
@@ -27,10 +27,10 @@
 
     &.sage-page-heading--no-secondary-text {
       grid-template-areas:
-      "crumbs ."
-      "title actions"
-      "intro intro"
-      "toolbar toolbar";
+        "crumbs ."
+        "title actions"
+        "intro intro"
+        "toolbar toolbar";
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
@@ -10,9 +10,17 @@
     grid-template-areas:
       "crumbs ."
       "title actions"
-      "intro ."
+      "intro intro"
       "toolbar secondary";
     grid-template-columns: 1fr auto;
+    
+    &.sage-page-heading--no-secondary-text {
+      grid-template-areas:
+      "crumbs ."
+      "title actions"
+      "intro intro"
+      "toolbar toolbar";
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
@@ -5,15 +5,26 @@
 ================================================== */
 
 .sage-page-heading {
-  @media (min-width: sage-breakpoint()) {
-    display: grid;
+  display: grid;
+
+  @media (max-width: sage-breakpoint(sm-max)) {
+    grid-template-areas: 
+    "crumbs"
+    "title"
+    "intro"
+    "actions"
+    "toolbar"
+    "secondary";
+  }
+
+  @media (min-width: sage-breakpoint(md-min)) {
     grid-template-areas:
       "crumbs ."
       "title actions"
       "intro intro"
       "toolbar secondary";
     grid-template-columns: 1fr auto;
-    
+
     &.sage-page-heading--no-secondary-text {
       grid-template-areas:
       "crumbs ."


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
* updates to grid when no secondary_text is present to removed the reserved `grid-area`
* updated `intro` portion to consistently stretch full-width within the grid
* resolve sorting issue for mobile page header

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

##### Removed reserved `grid-area` when `secondary_text` is not present
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-02 at 3 21 00 PM](https://user-images.githubusercontent.com/1241836/100935548-dad43f80-34b5-11eb-9904-8020ae7508d2.png)|![Screen Shot 2020-12-02 at 3 22 01 PM](https://user-images.githubusercontent.com/1241836/100935569-e1fb4d80-34b5-11eb-9c77-b3d8f5b04653.png)|

##### Updated intro `grid-area`, not consistently stretching full-width
|  before  |  after  |
|--------|--------|
|![Screen_Shot_2020-12-02_at_3_17_29_PM](https://user-images.githubusercontent.com/1241836/100936866-c4c77e80-34b7-11eb-9f13-0559bc5581c9.png)|![Screen_Shot_2020-12-02_at_3_19_55_PM](https://user-images.githubusercontent.com/1241836/100936881-ca24c900-34b7-11eb-888c-3c0a0f54badd.png)|

##### Fixed issue with page-header in incorrect order on small viewports
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-02 at 4 24 30 PM](https://user-images.githubusercontent.com/1241836/100938953-29d0a380-34bb-11eb-836d-18f87e2d251c.png)|![Screen Shot 2020-12-02 at 4 24 07 PM](https://user-images.githubusercontent.com/1241836/100938982-2fc68480-34bb-11eb-88ca-2e1a2bbdb15d.png)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the page heading: http://localhost:4000/pages/object/page_heading
