### PR TITLE
React Tooltips

### DIFF
--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -1,0 +1,50 @@
+import React, { Children, useState, cloneElement } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+import TooltipElement from './TooltipElement';
+
+import {
+  TOOLTIP_SIZES,
+  TOOLTIP_POSITIONS,
+  TOOLTIP_THEMES,
+} from './configs';
+
+const Tooltip = ({
+  children,
+  ...rest
+}) => {
+  const [active, setActive] = useState(false);
+  const [parentDomRect, setParentDomRect] = useState(null);
+
+  function handleMouseEnter(evt) {
+    setParentDomRect(evt.target.getBoundingClientRect());
+    setActive(true);
+  }
+
+  function handleMouseLeave() {
+    setActive(false);
+  }
+
+  return (
+    <>
+      {Children.map(children, child => {
+        return cloneElement(child, { onMouseEnter: handleMouseEnter, onMouseLeave: handleMouseLeave });
+      })}
+      {active && ReactDOM.createPortal(<TooltipElement parentDomRect={parentDomRect} {...rest} />, document.body) }
+    </>
+  );
+};
+
+Tooltip.POSITIONS = TOOLTIP_POSITIONS;
+Tooltip.SIZES = TOOLTIP_SIZES;
+Tooltip.THEMES = TOOLTIP_THEMES;
+
+Tooltip.defaultProps = {
+};
+
+Tooltip.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Tooltip;

--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -17,19 +17,24 @@ const Tooltip = ({
   const [active, setActive] = useState(false);
   const [parentDomRect, setParentDomRect] = useState(null);
 
-  function handleMouseEnter(evt) {
+  function handleActivate(evt) {
     setParentDomRect(evt.target.getBoundingClientRect());
     setActive(true);
   }
 
-  function handleMouseLeave() {
+  function handleDeactivate() {
     setActive(false);
   }
 
   return (
     <>
       {Children.map(children, child => {
-        return cloneElement(child, { onMouseEnter: handleMouseEnter, onMouseLeave: handleMouseLeave });
+        return cloneElement(child, {
+          onMouseEnter: handleActivate,
+          onFocus: handleActivate,
+          onMouseLeave: handleDeactivate,
+          onBlur: handleDeactivate,
+        });
       })}
       {active && ReactDOM.createPortal(<TooltipElement parentDomRect={parentDomRect} {...rest} />, document.body) }
     </>

--- a/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
@@ -17,7 +17,7 @@ storiesOf('Sage/Tooltip', module)
         size={select('Sizes', Tooltip.SIZES, Tooltip.SIZES.DEFAULT)}
       >
         <Button>
-          I inherit MouseEnter &amp; MouseLeave events 👋
+          I inherit Mouse &amp; Focus events 👋
         </Button>
       </Tooltip>
     </div>

--- a/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { centerXY } from '../story-support/decorators';
+import Tooltip from './Tooltip';
+import Button from '../Button';
+
+storiesOf('Sage/Tooltip', module)
+  .addDecorator(withKnobs)
+  .addDecorator(centerXY)
+  .add('Default', () => (
+    <div style={{padding: 100}}>
+      <Tooltip
+        content={text('Content', 'Hi, I provide more context for this element!')}
+        position={select('Position', Tooltip.POSITIONS, Tooltip.POSITIONS.DEFAULT)}
+        theme={select('Themes', Tooltip.THEMES, Tooltip.THEMES.DEFAULT)}
+        size={select('Sizes', Tooltip.SIZES, Tooltip.SIZES.DEFAULT)}
+      >
+        <Button>
+          I inherit MouseEnter &amp; MouseLeave events 👋
+        </Button>
+      </Tooltip>
+    </div>
+  ));

--- a/packages/sage-react/lib/Tooltip/TooltipElement.jsx
+++ b/packages/sage-react/lib/Tooltip/TooltipElement.jsx
@@ -61,7 +61,12 @@ const TooltipElement = ({
   }, [tooltipRef.current]);
 
   return (
-    <div ref={tooltipRef} className={classNames} style={coordinates}>
+    <div
+      role="tooltip"
+      ref={tooltipRef}
+      className={classNames}
+      style={coordinates}
+    >
       {content}
     </div>
   );

--- a/packages/sage-react/lib/Tooltip/TooltipElement.jsx
+++ b/packages/sage-react/lib/Tooltip/TooltipElement.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useRef, useLayoutEffect } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import {
+  TOOLTIP_SIZES,
+  TOOLTIP_POSITIONS,
+  TOOLTIP_THEMES,
+} from './configs';
+
+const TooltipElement = ({
+  content,
+  parentDomRect,
+  position,
+  size,
+  theme,
+}) => {
+  const tooltipRef = useRef(null);
+  const [coordinates, setCoordinates] = useState({top: null, left: null});
+
+  const classNames = classnames(
+    'sage-tooltip',
+    {
+      [`sage-tooltip--${position}`]: position,
+      [`sage-tooltip--${size}`]: size,
+      [`sage-tooltip--${theme}`]: theme,
+    }
+  );
+
+  useLayoutEffect(() => {
+    let distance = 8,
+        left = null,
+        top = null;
+
+    switch (position) {
+      case TOOLTIP_POSITIONS.LEFT:
+        top = (parentDomRect.top + parentDomRect.bottom) / 2 - tooltipRef.current.offsetHeight / 2;
+        left = parentDomRect.left - distance - tooltipRef.current.offsetWidth;
+        if (parentDomRect.left - tooltipRef.current.offsetWidth < 0) {
+          left = distance;
+        }
+        break;
+      case TOOLTIP_POSITIONS.RIGHT:
+        top = (parentDomRect.top + parentDomRect.bottom) / 2 - tooltipRef.current.offsetHeight / 2;
+        left = parentDomRect.right + distance;
+        if (parentDomRect.right + tooltipRef.current.offsetWidth > document.documentElement.clientWidth) {
+          left =  document.documentElement.clientWidth - tooltipRef.current.offsetWidth - distance;
+        }
+        break;
+      case TOOLTIP_POSITIONS.BOTTOM:
+        top = parentDomRect.bottom + distance;
+        left = parentDomRect.left + (parentDomRect.width - tooltipRef.current.offsetWidth) / 2;
+        break;
+      case TOOLTIP_POSITIONS.TOP:
+        top = parentDomRect.top - tooltipRef.current.offsetHeight - distance;
+        left = parentDomRect.left + (parentDomRect.width - tooltipRef.current.offsetWidth) / 2;
+      break;
+    }
+
+    setCoordinates({top: top, left: left});
+  }, [tooltipRef.current]);
+
+  return (
+    <div ref={tooltipRef} className={classNames} style={coordinates}>
+      {content}
+    </div>
+  );
+};
+
+TooltipElement.defaultProps = {
+  position: TOOLTIP_POSITIONS.DEFAULT,
+  size: TOOLTIP_SIZES.DEFAULT,
+  theme: TOOLTIP_THEMES.DEFAULT,
+};
+
+TooltipElement.propTypes = {
+  content: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+  parentDomRect: PropTypes.object.isRequired,
+  position: PropTypes.oneOf(Object.values(TOOLTIP_POSITIONS)),
+  size: PropTypes.oneOf(Object.values(TOOLTIP_SIZES)),
+  theme: PropTypes.oneOf(Object.values(TOOLTIP_THEMES)),
+};
+
+export default TooltipElement;

--- a/packages/sage-react/lib/Tooltip/configs.js
+++ b/packages/sage-react/lib/Tooltip/configs.js
@@ -1,0 +1,18 @@
+export const TOOLTIP_SIZES = {
+  DEFAULT: null,
+  SMALL: 'small',
+  LARGE: 'large',
+};
+
+export const TOOLTIP_POSITIONS = {
+  DEFAULT: 'top',
+  TOP: 'top',
+  RIGHT: 'right',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+};
+
+export const TOOLTIP_THEMES = {
+  DEFAULT: null,
+  LIGHT: 'light',
+};

--- a/packages/sage-react/lib/Tooltip/index.js
+++ b/packages/sage-react/lib/Tooltip/index.js
@@ -1,0 +1,1 @@
+export { default } from './Tooltip';


### PR DESCRIPTION
## Description
Convert our Sage Tooltips to a React flavored version. These tooltips don't have a wrapping DOM element and pass mouse events to components that it wraps.

Thanks to @pixelflips for working out the original tooltip positioning math. 🤘

### Screenshots
![image](https://user-images.githubusercontent.com/565743/101074728-17b03d00-356f-11eb-8d89-398c4a981cf5.png)

## Test notes
See the storybook for example: 
http://localhost:6006/?path=/story/sage-tooltip--default

- Tooltip should Portal _outside_ of the trigger DOM location
- Check to ensure React Component is perfomant

## Related
BUILD-367