### PR TITLE
Adjust popover to allow default styles and customization

### DIFF
--- a/docs/app/views/examples/objects/popover/_preview.html.erb
+++ b/docs/app/views/examples/objects/popover/_preview.html.erb
@@ -16,12 +16,10 @@
     name: "Learn more about a thing",
   }
 } do %>
-  <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-    <p>This is a block of content.</p>
-    <p>This is a block of content.</p>
-    <p>This is a block of content.</p>
-    <p>This is a block of content.</p>
-  </div>
+  <p>This is a block of content.</p>
+  <p>This is a block of content.</p>
+  <p>This is a block of content.</p>
+  <p>This is a block of content.</p>
 <% end %>
 
 <%= sage_component SageCardBlock, {} do %>
@@ -48,6 +46,23 @@
     <p>This is a block of content.</p>
     <p>This is a block of content.</p>
   </div>
+<% end %>
+
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Standalone Popover with Customized Content Panel",
+    html_tag: "h3"
+  } %>
+<% end %>
+
+<%= sage_component SagePopover, {
+  custom_content_class: "u-popover-customized",
+  icon: "question-circle",
+  trigger_value: "Open Menu",
+  trigger_icon_only: true,
+} do %>
+  <p>I can put whatever content I want in here and use the cusotm class as a hook to style it like a good 'ol BEM mixin!</p>
 <% end %>
 
 <%= sage_component SageCardBlock, {} do %>

--- a/docs/app/views/examples/objects/popover/_props.html.erb
+++ b/docs/app/views/examples/objects/popover/_props.html.erb
@@ -1,0 +1,58 @@
+<tr>
+  <td><code>body</code></td>
+  <td>The content to display inside the popover panel</td>
+  <td>String</td>
+  <td><code></code></td>
+</tr>
+<tr>
+  <td><code>custom_content_class</code></td>
+  <td>
+    A class to add to the panel's content contianer for cusotm styling.
+    When present, <code>sage-popover__content--custom</code> is also added,
+    and default styling on the content panel is disabled.
+  </td>
+  <td>String</td>
+  <td><code></code></td>
+</tr>
+<tr>
+  <td><code>icon</code></td>
+  <td>Which icon to display in the panel trigger button.</td>
+  <td>String</td>
+  <td><code></code></td>
+</tr>
+<tr>
+  <td><code>id</code></td>
+  <td>Id attribute for the panel.</td>
+  <td>String</td>
+  <td><code></code></td>
+</tr>
+<tr>
+  <td><code>link</code></td>
+  <td>If provided, this turns on the actions area with a link that points to the provided URL.</td>
+  <td>String</td>
+  <td><code>nil</code></td>
+</tr>
+<tr>
+  <td><code>popover_position</code></td>
+  <td>Where to position the popover panel in relation to the trigger button.</td>
+  <td>String</td>
+  <td><code>right</code></td>
+</tr>
+<tr>
+  <td><code>title</code></td>
+  <td>The heading to show at the top of the popover.</td>
+  <td>String</td>
+  <td><code>nil</code></td>
+</tr>
+<tr>
+  <td><code>trigger_icon_only</code></td>
+  <td>Whether or not the trigger button should only show an icon and not a label</td>
+  <td>Boolean</td>
+  <td><code>true</code></td>
+</tr>
+<tr>
+  <td><code>trigger_value</code></td>
+  <td>The text label to show on the trigger</td>
+  <td>String</td>
+  <td><code>nil</code></td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_popover.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_popover.rb
@@ -1,10 +1,11 @@
 class SagePopover < SageComponent
-  attr_accessor :id
-  attr_accessor :title
   attr_accessor :body
-  attr_accessor :link
+  attr_accessor :custom_content_class
   attr_accessor :icon
+  attr_accessor :id
+  attr_accessor :link
+  attr_accessor :popover_position
+  attr_accessor :title
   attr_accessor :trigger_icon_only
   attr_accessor :trigger_value
-  attr_accessor :popover_position
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_popover.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_popover.html.erb
@@ -39,27 +39,33 @@
   <div class="sage-popover__overlay" data-js-popover--overlay></div>
 
   <div class="sage-popover__panel">
-    <div class="sage-popover__title">
-      <%= component.title %>
-    </div>
-    <div class="sage-popover__content">
+    <% if component.title.present? %>
+      <div class="sage-popover__title">
+        <%= component.title %>
+      </div>
+    <% end %>
+    <div class="
+        sage-popover__content
+        <%= "sage-popover__content--custom #{component.custom_content_class}" if component.custom_content_class.present? %>
+      "
+    >
       <%= component.content %>
     </div>
     <% if component.link %>
-    <div class="sage-popover__actions">
-      <%= sage_component SageButton, {
-        value: component.link[:name],
-        style: "primary",
-        subtle: true,
-        icon: {
-          style: "right",
-          name: "launch"
-        },
-        attributes: {
-          href: component.link[:href]
-        }
-      } %>
-    </div>
+      <div class="sage-popover__actions">
+        <%= sage_component SageButton, {
+          value: component.link[:name],
+          style: "primary",
+          subtle: true,
+          icon: {
+            style: "right",
+            name: "launch"
+          },
+          attributes: {
+            href: component.link[:href]
+          }
+        } %>
+      </div>
     <% end %>
   </div>
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_popover.scss
@@ -16,6 +16,10 @@ $-popover-panel-offset-left: sage-spacing(md);
   position: relative;
 }
 
+.sage-popover__actions {
+  margin-top: sage-spacing(card);
+}
+
 .sage-popover__panel {
   visibility: hidden;
   z-index: sage-z-index(modal);
@@ -40,6 +44,13 @@ $-popover-panel-offset-left: sage-spacing(md);
   position: relative;
 }
 
+.sage-popover__content:not(.sage-popover__content--custom) {
+  @extend %t-sage-body-small;	
+  @include sage-grid-stack();	
+
+  color: sage-color(charcoal, 100);
+}
+
 .sage-popover__overlay {
   visibility: hidden;
   z-index: $-overlay-z-index;
@@ -54,5 +65,6 @@ $-popover-panel-offset-left: sage-spacing(md);
 
 .sage-popover__title {
   @extend %t-sage-heading-5;
-  margin-bottom: sage-spacing(xs);
+
+  margin-bottom: sage-spacing(card);
 }

--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -5,7 +5,13 @@ import uuid from 'react-uuid';
 import Button from '../Button';
 import { SageTokens } from '../configs';
 
-const Popover = ({ className, children, moreLinkURL, title }) => {
+const Popover = ({
+  className,
+  children,
+  customContentClassName,
+  moreLinkURL,
+  title,
+}) => {
   const [selfActive, setSelfActive] = useState(false);
 
   const handleExpandClick = () => {
@@ -27,6 +33,14 @@ const Popover = ({ className, children, moreLinkURL, title }) => {
     className,
     {
       'sage-popover--is-expanded': selfActive,
+    }
+  );
+
+  const contentClassNames = classnames(
+    'sage-popover__content',
+    customContentClassName,
+    {
+      'sage-popover__content--custom': customContentClassName,
     }
   );
 
@@ -52,7 +66,7 @@ const Popover = ({ className, children, moreLinkURL, title }) => {
         {title && (
           <h5 className="sage-popover__title">{title}</h5>
         )}
-        <div className="sage-popover__content">
+        <div className={contentClassNames}>
           {children}
         </div>
         {moreLinkURL && (
@@ -77,6 +91,7 @@ const Popover = ({ className, children, moreLinkURL, title }) => {
 Popover.defaultProps = {
   className: null,
   children: null,
+  customContentClassName: null,
   moreLinkURL: null,
   title: null,
 };
@@ -84,6 +99,7 @@ Popover.defaultProps = {
 Popover.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  customContentClassName: PropTypes.string,
   moreLinkURL: PropTypes.string,
   title: PropTypes.string,
 };


### PR DESCRIPTION
- Restores default styling for content in popovers but adds a `sage-popover__content--custom` modifier that turns off default styling.
- Adds `custom_content_class` and logic in Rails for an open, customizable content panel and updates documentation of this setting.
- Adds `customContentClassName` and logic in React for the same.