### PR TITLE
fix(react label): add locked color option

### DIFF
--- a/packages/sage-react/lib/Label/configs.js
+++ b/packages/sage-react/lib/Label/configs.js
@@ -1,9 +1,10 @@
 export const LABEL_COLORS = {
+  DANGER: 'danger',
   DRAFT: 'draft',
   INFO: 'info',
+  LOCKED: 'locked',
   PUBLISHED: 'published',
   WARNING: 'warning',
-  DANGER: 'danger',
 };
 
 export const LABEL_STYLES = {


### PR DESCRIPTION
## Description
Follow up to https://github.com/Kajabi/sage-lib/pull/84
I overlooked the `locked` color option within React Sage Label
Alphabetized the color config params

### Screenshots
n/a

## Test notes
n/a

## Related
#84
