### PR TITLE
Fix Sage Storybook Deploy

### DIFF
--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -30,10 +30,11 @@
   },
   "scripts": {
     "build": "yarn build:storybook && webpack --config webpack/webpack.prod.js",
+    "build:prod": "npm run build:storybook && webpack --config webpack/webpack.prod.js",
     "build:storybook": "build-storybook -o build",
     "build:watch": "yarn build --watch",
     "storybook": "start-storybook -p 6006 --ci",
-    "preversion": "yarn install && yarn run build",
+    "preversion": "yarn install && yarn run build:prod",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
Heroku detects the build system as being NPM because no yarn.lock exists in the submodule folder for
sage-react. Because of this we cannot run `yarn run storybook` and instead need to run `npm run
storybook` when executing the `preversion` script
