### PR TITLE
Page heading popover cleanup

### DIFF
--- a/docs/app/views/examples/objects/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/objects/page_heading/_preview.html.erb
@@ -45,7 +45,7 @@
   help_html: "<p class=\"t-sage-body-small\">This is a block of content.</p>",
   help_link: {
     href: "#",
-    name: "Help"
+    name: "Learn more about cool things"
   },
 } %>
 
@@ -121,7 +121,7 @@
   help_html: "<p class=\"t-sage-body-small\">This is a block of content.</p>",
   help_link: {
     href: "#",
-    name: "Help"
+    name: "Learn more about cool things"
   },
   secondary_text: "1 Email in Sequence",
 } do %>

--- a/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
@@ -1,7 +1,5 @@
 class SagePageHeading < SageComponent
   attr_accessor :title
-  attr_accessor :link_text
-  attr_accessor :link_url
   attr_accessor :secondary_text
   attr_accessor :help_title
   attr_accessor :help_link

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -28,10 +28,7 @@
         icon: "question-circle",
         trigger_value: "Open Menu",
         trigger_icon_only: true,
-        link: {
-          href: component.help_link,
-          name: "Learn more about a thing",
-        }
+        link: component.help_link,
       } do %>
         <%= component.help_html.html_safe %>
       <% end %>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
@@ -66,6 +66,10 @@
   grid-area: actions;
   align-items: flex-start;
 
+  > a {
+    max-width: 100%;
+  }
+
   @media (max-width: sage-breakpoint(sm-max)) {
     flex-wrap: wrap;
     justify-content: flex-start;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_page_heading.scss
@@ -66,10 +66,6 @@
   grid-area: actions;
   align-items: flex-start;
 
-  > a {
-    max-width: 100%;
-  }
-
   @media (max-width: sage-breakpoint(sm-max)) {
     flex-wrap: wrap;
     justify-content: flex-start;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_popover.scss
@@ -18,6 +18,10 @@ $-popover-panel-offset-left: sage-spacing(md);
 
 .sage-popover__actions {
   margin-top: sage-spacing(card);
+
+  > a {
+    max-width: 100%;
+  }
 }
 
 .sage-popover__panel {

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -31,9 +31,9 @@ const PageHeading = ({
     }
     {actionItems
       && (
-      <div className="sage-page-heading__actions">
-        {actionItems.map(action => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
-      </div>
+        <div className="sage-page-heading__actions">
+          {actionItems.map(action => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
+        </div>
       )
     }
   </div>

--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -10,6 +10,7 @@ const Popover = ({
   children,
   customContentClassName,
   moreLinkURL,
+  moreLinkText,
   title,
 }) => {
   const [selfActive, setSelfActive] = useState(false);
@@ -79,7 +80,7 @@ const Popover = ({
               iconPosition={Button.ICON_POSITIONS.RIGHT}
               subtle={true}
             >
-              Learn more
+              {moreLinkText}
             </Button>
           </div>
         )}
@@ -93,6 +94,7 @@ Popover.defaultProps = {
   children: null,
   customContentClassName: null,
   moreLinkURL: null,
+  moreLinkText: 'Learn more',
   title: null,
 };
 
@@ -101,6 +103,7 @@ Popover.propTypes = {
   children: PropTypes.node,
   customContentClassName: PropTypes.string,
   moreLinkURL: PropTypes.string,
+  moreLinkText: PropTypes.string,
   title: PropTypes.string,
 };
 


### PR DESCRIPTION
## Description

A previous effort with Page Heading left some loose ends:

- link_url and link_text were not fully deprecated or clarified to have been deprecated. Most occurrences of this are in `super_admin` so the patchwork to repair is not as urgent.
- Lear more link text in Popovers in Page Headings had some placeholder text that needed to be customizable. 
- Learn more links needed to allow truncation.
