### PR TITLE
Do not render a dropdown panel when a dropdown is closed

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -121,7 +121,6 @@ const Dropdown = ({
       </DropdownTrigger>
       {isActive && (
         <DropdownPanel
-          isActive={isActive}
           modifier={panelModifier}
           onClickScreen={onClickScreen}
           onExit={onExit}

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -119,15 +119,17 @@ const Dropdown = ({
       >
         {customTrigger}
       </DropdownTrigger>
-      <DropdownPanel
-        isActive={isActive}
-        modifier={panelModifier}
-        onClickScreen={onClickScreen}
-        onExit={onExit}
-        coords={coords}
-      >
-        {children}
-      </DropdownPanel>
+      {isActive && (
+        <DropdownPanel
+          isActive={isActive}
+          modifier={panelModifier}
+          onClickScreen={onClickScreen}
+          onExit={onExit}
+          coords={coords}
+        >
+          {children}
+        </DropdownPanel>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description
It doesn't render dropdown options when dropdown is about to be closed. It allows to avoid strange effect when dropdown panel is closed but options are visible for some time.

### Screenshots

|  before  |  after  |
|--------|--------|
|![dropdown_before](https://user-images.githubusercontent.com/6203637/101417825-46951e80-38a1-11eb-8930-df2e4a1ac339.gif)|![dropdown_after](https://user-images.githubusercontent.com/6203637/101417852-50b71d00-38a1-11eb-9e68-b790e799400a.gif)|


## Test notes
A Dropdown component is used in OptionsDropdown and SelectDropdown components.
- Make sure Dropdown component works as expected

### Kajabi-products test
- Verify that dropdowns/filters works as expected on the 'People' page (`:show_peoples_segment_filter` feature flag)
- Verify that dropdowns works as expected on the 'Import Contact' page (`:show_new_imports_ui` feature flag)