### PR TITLE
fix(outline): allow for more space in outline status column

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
@@ -42,7 +42,7 @@ $-collapse-breakpoint-key: lg-max;
 
   @media (min-width: sage-breakpoint($-collapse-breakpoint-key)) {
     // Using static column values to ensure alignment
-    grid-template-columns: min-content 1fr max-content min-content rem(140px) rem(24px);
+    grid-template-columns: min-content 1fr max-content min-content rem(170px) rem(24px);
     grid-template-areas: "handle-drag title actions-secondary actions-primary status handle-collapse";
   }
 


### PR DESCRIPTION
## Description
Fix Outline Status container width to account for new Labels

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/101512131-c9bd7f80-3948-11eb-90a3-c2dcdf12eff6.png)|![image](https://user-images.githubusercontent.com/565743/101513180-e1e1ce80-3949-11eb-94b6-ccb6513e9629.png)|


## Test notes
n/a

## Related
n/a
