### PR TITLE
CLI: Display bridge status `bridge:kajabi-products:status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Proxy for the Lerna [bootstrap](https://github.com/lerna/lerna/tree/master/comma
 
 Creates a local "bridge" between your local Sage packages and the Kajabi Products repo. Use this bridge when you want to be able to locally edit changes in Sage and see them live in Kajabi Products.
 
+### `bridge:kajabi-products:status`
+
+Displays the status of the local bridge link
+
 ### `bridge:kajabi-products:destroy` :star:
 
 Destroys the bridge created by `bridge:kajabi-products`
@@ -308,4 +312,3 @@ See [CICD.md](readme/CICD.md)
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "bootstrap": "yarn lerna bootstrap",
     "bridge:kajabi-products": "bin/bridge.sh true",
+    "bridge:kajabi-products:status": "bin/bridge.sh status",
     "bridge:kajabi-products:destroy": "bin/bridge.sh false",
     "build": "yarn npm-run-all --parallel build:*",
     "build:assets": "cd packages/sage-assets && yarn build",


### PR DESCRIPTION
## Description
```
bridge:kajabi-products:status
```

This was already built in, we just didn't have a command to access.

@voodooGQ Would love to have a nicer format for displaying the package symlinks, any recommendations on how I could do that?

Right now it looks like:
```
( ls -l node_modules ; ls -l node_modules/@* ) | grep ^l
```

### Screenshots
![image](https://user-images.githubusercontent.com/565743/101837288-d8549400-3b0c-11eb-92f8-60ee0da6f3f8.png)

## Test notes
n/a

## Related
n/a
