### PR TITLE
Sage Form Section - updated mobile spacing in header

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_form_section.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_form_section.scss
@@ -13,6 +13,10 @@
 .sage-form-section__info {
   /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
   @extend .sage-col--md-4;
+
+  @media (max-width: sage-breakpoint(sm-max)) {
+    margin-bottom: sage-spacing(md);
+  }
 }
 
 .sage-form-section__title {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - updated spacing in the mobile header

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2020-12-11_at_9_34_55_AM](https://user-images.githubusercontent.com/1241836/101923385-efd75f80-3b94-11eb-9d53-caf34b94d384.png)|![Screen_Shot_2020-12-11_at_9_34_31_AM](https://user-images.githubusercontent.com/1241836/101923406-f665d700-3b94-11eb-83e5-6d5c3c470656.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit Form Section page on viewport < `767px`: http://localhost:4000/pages/object/form_section
