### PR TITLE
Adding .slugignore to docs/, temporarily turning off sassdocs/storybook deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
       - node/with-cache:
           steps:
             - run: yarn docs:deploy
-            - run: yarn storybook:deploy
-            - run: yarn sassdocs:deploy
+            # - run: yarn storybook:deploy
+            # - run: yarn sassdocs:deploy
 workflows:
     lint-test-build:
       jobs:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@ The Sage Design System (SDS) is our single source of truth, providing everything
 
 [Visit Sage Design System Documentation →](https://sage-lib-documentation.herokuapp.com)
 
-[Visit Sage Storybook Documentation →](https://sage-lib-storybook.herokuapp.com)
-
-[Visit Sage SASSDocs Documentation →](https://sage-lib-sassdocs.herokuapp.com)
-
-
 ## Structure
 
 There are 5 total packages in the monorepo:

--- a/docs/.slugignore
+++ b/docs/.slugignore
@@ -3,3 +3,6 @@
 /node_modules
 /.cache/yarn
 /README.md
+/CHANGELOG.md
+/.stylelintrc.json
+/MIT-LICENSE

--- a/docs/.slugignore
+++ b/docs/.slugignore
@@ -1,0 +1,5 @@
+/spec
+/tmp/cache
+/node_modules
+/.cache/yarn
+/README.md


### PR DESCRIPTION
Deployments of the main docs site were failing due to a large slug size. Added a slugignore and set:config on NPM_MODULES_CACHE to false in Heroku.

Temporarily turning off SassDocs/Storybook deploys. They are failing due to dependency issues and I'm not sure how to address at this time. Once I have a little more time I'll speak with the others in PE about fixing. Turning them off for the time being will have us seeing green builds again.