### PR TITLE
refactor(rails searchjs): delete search query string param if user clears search

### DIFF
--- a/packages/sage-system/lib/search.js
+++ b/packages/sage-system/lib/search.js
@@ -48,11 +48,17 @@ Sage.search = (function() {
   }
 
   function search(value) {
-    let searchParams = new URLSearchParams(window.location.search);
+    const searchParams = new URLSearchParams(window.location.search);
+    const currentSearchValue = searchParams.get('search') || '';
 
-    if (value == (searchParams.get('search') || "")) return;
+    if (value === currentSearchValue) {
+      return; // no-op
+    } else if (value.length === 0) {
+      searchParams.delete('search');
+    } else {
+      searchParams.set('search', value);
+    }
 
-    searchParams.set('search', value);
     window.location.search = searchParams.toString();
   }
 


### PR DESCRIPTION
## Description
Rails searchjs update:
Previously when search was cleared we would clear the query string param value but not the query string param key, now we clear both.

@pixelflips and I paired on this to resolve an issue with searching in the Market domain. 

### Screenshots
n/a

## Test notes
When search is cleared ensure the query string key is also deleted


## Related
n/a
