### PR TITLE
Hero - added background-color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_hero.scss
@@ -18,6 +18,7 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   grid-row-gap: sage-spacing(md);
   overflow: hidden;
   min-height: $-hero-min-height;
+  background-color: sage-color(white);
   border-radius: sage-border(radius);
   box-shadow: sage-shadow(sm);
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
* added `background-color` to the hero

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-15 at 4 47 11 PM](https://user-images.githubusercontent.com/1241836/102281875-56da7880-3ef5-11eb-8e72-ab913bbf255c.png)|![Screen Shot 2020-12-15 at 4 47 53 PM](https://user-images.githubusercontent.com/1241836/102281890-5e018680-3ef5-11eb-8c75-3e10a36b3f8e.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Verify that the hero has a standalone background-color independent of the panel behind it

