### PR TITLE
Feature Toggle - updated image to allow cropping within the parent

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -71,8 +71,7 @@ $-image-height-mobile: rem(120px);
   border-radius: sage-border(radius);
   
   @media (min-width: sage-breakpoint(md-min)) {
-    align-self: center;
     width: 100%;
-    height: auto;
+    object-fit: cover;
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
* allow the feature toggle image to use `object-fit: cover`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-15 at 4 45 07 PM](https://user-images.githubusercontent.com/1241836/102282222-e2540980-3ef5-11eb-8153-4b457505bbef.png)|![Screen Shot 2020-12-15 at 4 44 15 PM](https://user-images.githubusercontent.com/1241836/102282234-e7b15400-3ef5-11eb-96cd-1d6d2c462a22.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. when using a rectangular image, the image be smaller than expected   http://localhost:4000/pages/object/feature_toggle
