### PR TITLE
Sage docs odd scrolling issue

### DIFF
--- a/packages/sage-assets/lib/stylesheets/layout/_page.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_page.scss
@@ -10,6 +10,7 @@ $-banner-height-offset: map-get($sage-banner-heights, default);
 .sage-page {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   height: 100%;
 
   // TODO: Determine if this is used or needed

--- a/packages/sage-assets/lib/stylesheets/layout/_page.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_page.scss
@@ -8,10 +8,7 @@
 $-banner-height-offset: map-get($sage-banner-heights, default);
 
 .sage-page {
-  display: flex;
-  flex-direction: column;
   overflow: hidden;
-  height: 100%;
 
   // TODO: Determine if this is used or needed
   &.banner-active {

--- a/packages/sage-assets/lib/stylesheets/layout/_stage.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_stage.scss
@@ -8,5 +8,6 @@
 .sage-stage {
   display: flex;
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
+  height: calc(100vh - #{$sage-assistant-height});
 }


### PR DESCRIPTION
## Description
Kept coming across odd scrolling behavior on the Sage Docs site where on the Objects and Elements pages, the page will continue to scroll for quite a ways after reaching the end of the content.

This is most likely a short-term fix since ideally the root cause should be addressed with a larger layout debug/refactor when time and manpower are available.

### Screenshots

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-15 at 4 51 49 PM](https://user-images.githubusercontent.com/1175111/102290608-3b23a200-3ef6-11eb-8776-cfd4356e779b.png)|![Screen Shot 2020-12-15 at 4 53 56 PM](https://user-images.githubusercontent.com/1175111/102290628-44147380-3ef6-11eb-8216-de173450e6fc.png)|

### Steps for testing
1. Visit the elements or objects page and verify the page no longer scroll past the content.

## Related
-  N/A
