### PR TITLE
Sage Docs mobile header fixes

### DIFF
--- a/docs/app/views/application/_assistant.html.erb
+++ b/docs/app/views/application/_assistant.html.erb
@@ -10,7 +10,7 @@
   <% end %>
   <div class="sage-assistant__body">
   </div>
-  <div class="sage-assistant__actions">
+  <div class="sage-assistant__actions sage-col--sm-hide">
     <div class="sage-btn-group sage-btn-group--gap-md">
       <%= link_to "💎 v#{$SAGE_VERSION_GEM}",
         $SAGE_VERSION_GEM_URL,

--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -203,6 +203,24 @@ layout_pages = [
       <ul class="sage-nav__list">
         <li><%= link_to "Sandbox", pages_sandbox_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page?(pages_sandbox_path)}" %></li>
         <li><%= link_to "Code Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+        <li class="sage-col--sm-show">
+          <%= link_to "Release Notes",
+            $SAGE_RELEASE_URL,
+            class: "sage-nav__link",
+            target: "_blank",
+            rel: "noopener noreferrer",
+            title: "Github release notes"
+          %>
+        </li>
+        <li class="sage-col--sm-show">
+            <%= link_to "Changelog",
+              "https://github.com/Kajabi/sage/releases",
+              class: "sage-nav__link",
+              target: "_blank",
+              rel: "noopener noreferrer",
+              title: "Github changelog"
+            %>
+        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
### Description
Links in the site header/assistant were breaking the layout on mobile devices and preventing the nav from displaying, so this is just a quick patch until we have a chance for a permanent fix. Header links are hidden from view, and the Release Notes and Changelog links moved to the sidebar. Also, as we're already limited on real estate in the mobile sidebar, the version numbers have been left out for the time being.
 

### Screenshots
|  Before (nav menu unreachable)   |  After  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/102427185-b1430a00-3fc5-11eb-96da-0670192cec8d.png)|![after](https://user-images.githubusercontent.com/816579/102427200-b7d18180-3fc5-11eb-8e35-efa8262937f1.png)|
