### PR TITLE
refactor(usefocustrap): update arg names in useFocusTrap to be more indicative of their internal use

### DIFF
--- a/packages/sage-react/lib/Typeahead/Typeahead.jsx
+++ b/packages/sage-react/lib/Typeahead/Typeahead.jsx
@@ -22,7 +22,7 @@ const Typeahead = ({
   useFocusTrap({
     active: open,
     containerRef: containerRef,
-    onDeactivateCallback: () => setOpen(false),
+    onDeactivateFn: () => setOpen(false),
     // NOTE: `returnFocus` prevents the search input from being refocused when Typeahead is closed,
     //       which prevents blocking the 'scrollTo element' UX pattern that is used with this component
     returnFocus: false,

--- a/packages/sage-react/lib/common/hooks/useFocusTrap.jsx
+++ b/packages/sage-react/lib/common/hooks/useFocusTrap.jsx
@@ -5,7 +5,7 @@ import { createFocusTrap } from 'focus-trap';
 *
 * @param {Boolean} active                 - React boolean state
 * @param {ReactRef} containerRef          - React ref of containing element where focus trapping occurs
-* @param {Function} onDeactivateCallback  - Fires on deactivation, this is where you can set the state of your
+* @param {Function} onDeactivateFn        - Fires on deactivation, this is where you can set the state of your
                                             component when a click outside or `esc` happens
 * @param {Boolean} returnFocus            - Determines whether the focus trap focuses the initial element on deactivation
 *                                           this is typically turned off for context menus that scrollTo another element on the page
@@ -15,13 +15,13 @@ import { createFocusTrap } from 'focus-trap';
 export const useFocusTrap = ({
   active,
   containerRef,
-  onDeactivateCallback = () => {},
+  onDeactivateFn = () => {},
   returnFocus = true
 }) => {
   if (
     typeof active !== 'boolean'
     || containerRef === undefined
-    || typeof onDeactivateCallback !== 'function'
+    || typeof onDeactivateFn !== 'function'
     || typeof returnFocus !== 'boolean'
   ) {
     throw new Error('Sage useFocusTrap Hook: malformed args, see param documentation in hooks/useFocusTrap.jsx');
@@ -35,11 +35,11 @@ export const useFocusTrap = ({
     });
 
     const handleEscape = (evt) => {
-      if (evt.keyCode === 27) onDeactivateCallback();
+      if (evt.keyCode === 27) onDeactivateFn();
     };
 
     const handleClickOutside = (evt) => {
-      if (!containerRef.current.contains(evt.target)) onDeactivateCallback();
+      if (!containerRef.current.contains(evt.target)) onDeactivateFn();
     };
 
     const setup = () => {


### PR DESCRIPTION
## Description
Tiny PR:
refactor(usefocustrap): update arg names in useFocusTrap to be more indicative of their internal use

I just landed this yesterday, on a second look `onDeactivateCallback` was a bad name because it implies that this will fire on a deactivating event rather than this function _being the function that handles deactivation_.

## Test notes
n/a

## Related
n/a
