### PR TITLE
Sage-focus-outline -  update focus-within to show background-color

### DIFF
--- a/docs/app/views/examples/objects/outline_item/_preview.html.erb
+++ b/docs/app/views/examples/objects/outline_item/_preview.html.erb
@@ -4,7 +4,12 @@
     icon: "folder",
     depth: 0,
     category: true,
-    status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+    status: sage_component(SageLabel, {
+      color: "draft",
+      value: "Draft",
+      icon: "draft",
+      interactive_type: :dropdown
+    }),
     actions_primary: [sage_component(SageButton, {
       value: "Add Content",
       style: "primary",
@@ -34,7 +39,12 @@
       icon: "video-on",
       depth: 1,
       category: false,
-      status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+      status: sage_component(SageLabel, {
+        color: "draft",
+        value: "Draft",
+        icon: "draft",
+        interactive_type: :dropdown
+      }),
       actions_primary: [sage_component(SageButton, {
         value: "Add Content",
         style: "primary",
@@ -64,7 +74,12 @@
     icon: "arrow-corner",
     depth: 1,
     category: true,
-    status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+    status: sage_component(SageLabel, {
+      color: "draft",
+      value: "Draft",
+      icon: "draft",
+      interactive_type: :dropdown
+    }),
     actions_primary: [sage_component(SageButton, {
       value: "Add Content",
       style: "primary",
@@ -94,7 +109,12 @@
       icon: "video-on",
       depth: 2,
       category: false,
-      status: sage_component(SageLabel, { value: "Draft", color: "draft" }),
+      status: sage_component(SageLabel, {
+        color: "draft",
+        value: "Draft",
+        icon: "draft",
+        interactive_type: :dropdown
+      }),
       actions_primary: [sage_component(SageButton, {
         value: "Add Content",
         style: "primary",

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -148,7 +148,8 @@
       opacity: 1;
     }
   }
-  &:focus-within:not(:disabled):not([aria-disabled="true"]){
+
+  &:focus-within:not(:disabled):not([aria-disabled="true"]) {
     background-color: sage-color(primary, 100);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -142,12 +142,14 @@
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),
-  &:focus-within:not(:disabled):not([aria-disabled="true"]),
   &:active:not(:disabled):not([aria-disabled="true"]) {
     &::after {
       transform: translate3d(-50%, -50%, 0) scale(1);
       opacity: 1;
     }
+  }
+  &:focus-within:not(:disabled):not([aria-disabled="true"]){
+    background-color: sage-color(primary, 100);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -142,6 +142,7 @@
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),
+  &:focus-within:not(:disabled):not([aria-disabled="true"]),
   &:active:not(:disabled):not([aria-disabled="true"]) {
     &::after {
       transform: translate3d(-50%, -50%, 0) scale(1);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
@@ -19,7 +19,7 @@ $-collapse-breakpoint-key: lg-max;
 
 .sage-outline-item {
   @include sage-focus-outline($outline-offset-block: -6px, $outline-offset-inline: -6px, $outline-animation-speed: 0.05s);
-  @include sage-focus-outline--update-color(sage-color(primary));
+  @include sage-focus-outline--update-color(transparent);
 
   display: grid;
   align-items: stretch;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
@@ -18,6 +18,9 @@
 $-collapse-breakpoint-key: lg-max;
 
 .sage-outline-item {
+  @include sage-focus-outline($outline-offset-block: -6px, $outline-offset-inline: -6px, $outline-animation-speed: 0.05s);
+  @include sage-focus-outline--update-color(sage-color(primary));
+
   display: grid;
   align-items: stretch;
   grid-template-rows: repeat(auto-fit, auto);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - update `sage-focus-outline` mixin to show `background-color` on `:focus-within`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-17 at 11 31 29 AM](https://user-images.githubusercontent.com/1241836/102522122-74c1ed80-405b-11eb-8784-e8ad75bf73b0.png)|![Screen Shot 2020-12-18 at 3 27 46 PM](https://user-images.githubusercontent.com/1241836/102663356-51c03800-4146-11eb-99cd-3ff5330c2266.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the sage outline page:   http://localhost:4000/pages/object/outline_item
2. Tab through the page and ensure that the outline row is highlighted when it's child has focus


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- [BUILD-535](https://kajabi.atlassian.net/browse/BUILD-535)
