### PR TITLE
Sage docs link updates

### DIFF
--- a/docs/app/views/application/_assistant.html.erb
+++ b/docs/app/views/application/_assistant.html.erb
@@ -19,26 +19,26 @@
         rel: "noopener noreferrer",
         title: "Open SageRails gem source"
       %>
-      <%= link_to "📦 v#{$SAGE_VERSION_FRONTEND}",
-        $SAGE_VERSION_FRONTEND_URL,
+      <%= link_to "📦 v#{$SAGE_VERSION_REACT}",
+        $SAGE_VERSION_REACT_URL,
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",
         rel: "noopener noreferrer",
-        title: "Open Sage frontent package source"
+        title: "Open Sage React package source"
       %>
-      <%= link_to "Release Notes",
-        $SAGE_RELEASE_URL,
+      <%= link_to "🧰 v#{$SAGE_VERSION_ASSETS}",
+        $SAGE_VERSION_ASSETS_URL,
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",
         rel: "noopener noreferrer",
-        title: "Github release notes"
+        title: "Open Sage Assets package source"
       %>
-      <%= link_to "Changelog",
-        "#{$SAGE_GITHUB_URL}/releases",
+      <%= link_to "🤖 v#{$SAGE_VERSION_SYSTEM}",
+        $SAGE_VERSION_SYSTEM_URL,
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",
         rel: "noopener noreferrer",
-        title: "Github changelog"
+        title: "Open Sage System package source"
       %>
     </div>
   </div>

--- a/docs/app/views/application/_assistant.html.erb
+++ b/docs/app/views/application/_assistant.html.erb
@@ -34,7 +34,7 @@
         title: "Github release notes"
       %>
       <%= link_to "Changelog",
-        "https://github.com/Kajabi/sage/releases",
+        "#{$SAGE_GITHUB_URL}/releases",
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",
         rel: "noopener noreferrer",

--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -203,7 +203,7 @@ layout_pages = [
       <ul class="sage-nav__list">
         <li><%= link_to "Sandbox", pages_sandbox_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page?(pages_sandbox_path)}" %></li>
         <li><%= link_to "Code Guidelines", "#{$SAGE_GITHUB_URL}", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
-        <li class="sage-col--sm-show">
+        <li>
           <%= link_to "Release Notes",
             $SAGE_RELEASE_URL,
             class: "sage-nav__link",
@@ -212,7 +212,7 @@ layout_pages = [
             title: "Github release notes"
           %>
         </li>
-        <li class="sage-col--sm-show">
+        <li>
             <%= link_to "Changelog",
               "#{$SAGE_GITHUB_URL}/releases",
               class: "sage-nav__link",

--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -202,7 +202,7 @@ layout_pages = [
     <nav class="sage-nav" aria-label="Secondary">
       <ul class="sage-nav__list">
         <li><%= link_to "Sandbox", pages_sandbox_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page?(pages_sandbox_path)}" %></li>
-        <li><%= link_to "Code Guidelines", "https://github.com/Kajabi/sage/wiki", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
+        <li><%= link_to "Code Guidelines", "#{$SAGE_GITHUB_URL}", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
         <li class="sage-col--sm-show">
           <%= link_to "Release Notes",
             $SAGE_RELEASE_URL,
@@ -214,7 +214,7 @@ layout_pages = [
         </li>
         <li class="sage-col--sm-show">
             <%= link_to "Changelog",
-              "https://github.com/Kajabi/sage/releases",
+              "#{$SAGE_GITHUB_URL}/releases",
               class: "sage-nav__link",
               target: "_blank",
               rel: "noopener noreferrer",

--- a/docs/app/views/pages/getting_started.html.erb
+++ b/docs/app/views/pages/getting_started.html.erb
@@ -5,11 +5,11 @@
 
 These reusable patterns are created from flexible building blocks we call components that share consistent visual foundations like color, iconography, typography, spacing, and interactive states.
 
-This design system is not owned by any one person or group but is a collective effort across the UXD and Product Design teams at Kajabi. Each team member can make suggestions for enhancements, as well as propose new components and patterns. 
+This design system is not owned by any one person or group but is a collective effort across the UXD and Product Design teams at Kajabi. Each team member can make suggestions for enhancements, as well as propose new components and patterns.
 )) %>
 <% end %>
-<%= md(" 
-## How It Works 
+<%= md("
+## How It Works
 The UI of the Kajabi Core application is a combination of Rails Components, React Components and a custom SCSS Framework called Sage that applies a uniform style to both.
 ", use_sage_type: true) %>
 <%= sage_component SageGridRow, {} do %>
@@ -42,7 +42,7 @@ The UI of the Kajabi Core application is a combination of Rails Components, Reac
     </div>
   <% end %>
 <% end %>
-<%= md(" 
+<%= md("
 We think of our approach to UI at Kajabi in this way: We default to using Rails Components and a classic Rails approach to most problems and move to React where it counts.
 
 Rails does many things very well and gives us the ability to move quickly and solve complex problems with very simple, tried and true, code solutions. With that said, sometimes we come across a problem that we want to solve that the standard rails approach will just not be enough ( Think complex interactions with many versions of state ). In this case we move to React as our default approach to solving complex, Javascript heavy problems.
@@ -51,7 +51,7 @@ Rails does many things very well and gives us the ability to move quickly and so
 <hr>
 <%= sage_component SageGridRow, {} do %>
   <%= sage_component SageGridCol, { breakpoint: :lg, size: "7" } do %>
-<%= md(" 
+<%= md("
 
 Because our system contains two different approaches to UI creation, we utilize a SCSS Design System to provide the styles to both types of components (Think Bootstrap, but customized for our products). Our Design System provides the styles for the core components that make up the UI of our product.
 
@@ -65,9 +65,9 @@ Because our system contains two different approaches to UI creation, we utilize 
   <% end %>
 <% end %>
 <hr>
-<%= md(" 
+<%= md("
 
-This system is a work of shared ownership and we encourage any member of the Kajabi team to feel empowered to participate in its ongoing improvement. Understanding and contributing to the system are the keys to the system's longevity. We encourage anyone planning on contributing to the system to first read over our Guides: 
+This system is a work of shared ownership and we encourage any member of the Kajabi team to feel empowered to participate in its ongoing improvement. Understanding and contributing to the system are the keys to the system's longevity. We encourage anyone planning on contributing to the system to first read over our Guides:
 
-[Code Guidelines](https://github.com/Kajabi/sage/wiki).
+[Code Guidelines](https://github.com/Kajabi/sage-lib/wiki).
 ", use_sage_type: true) %>

--- a/docs/app/views/pages/index.html.erb
+++ b/docs/app/views/pages/index.html.erb
@@ -17,12 +17,12 @@ to give teams the ability to ship high-quality products faster.
     <p>Getting started with Sage is meant to be easy and approachable. Check out these practical developer guides to understand how to get up and running with the Sage Design System quickly.</p>
     <div class="sage-row">
       <div class="sage-col-6 sage-type">
-        <p><a href="https://github.com/Kajabi/sage/wiki/Setup">Getting up and running</a></p>
-        <p><a href="https://github.com/Kajabi/sage/wiki/Working-with-our-codebase">Our Git workflow</a></p>
+        <p><a href="https://github.com/Kajabi/sage-lib/wiki/Setup">Getting up and running</a></p>
+        <p><a href="https://github.com/Kajabi/sage-lib/wiki/Working-with-our-codebase">Our Git workflow</a></p>
       </div>
       <div class="sage-col-6 sage-type">
-        <p><a href="https://github.com/Kajabi/sage#local-development-kajabi-products">Working with Sage locally</a></p>
-        <p><a href="https://github.com/Kajabi/sage/wiki/Setup">Cutting a new version</a></p>
+        <p><a href="https://github.com/Kajabi/sage-lib#local-development-kajabi-products">Working with Sage locally</a></p>
+        <p><a href="https://github.com/Kajabi/sage-lib/wiki/Setup">Cutting a new version</a></p>
       </div>
     </div>
   </div>

--- a/docs/config/initializers/load_sage_version.rb
+++ b/docs/config/initializers/load_sage_version.rb
@@ -1,15 +1,28 @@
-frontend_package_contents = JSON.parse(
+react_package_contents = JSON.parse(
                               File.read(
-                                File.join(Rails.root, 'package.json')
+                                File.join("../packages/sage-react/", "package.json")
                               )
                             )
-
+assets_package_contents = JSON.parse(
+                              File.read(
+                                File.join("../packages/sage-assets/", "package.json")
+                              )
+                            )
+system_package_contents = JSON.parse(
+                              File.read(
+                                File.join("../packages/sage-system/", "package.json")
+                              )
+                            )
 $SAGE_VERSION_GEM = SageRails::VERSION
-$SAGE_VERSION_FRONTEND = frontend_package_contents["version"]
+$SAGE_VERSION_REACT = react_package_contents["version"]
+$SAGE_VERSION_ASSETS = assets_package_contents["version"]
+$SAGE_VERSION_SYSTEM = system_package_contents["version"]
 
 $SAGE_GITHUB_URL = "https://github.com/Kajabi/sage-lib"
+$SAGE_GITHUB_PACKAGE_URL = "#{$SAGE_GITHUB_URL}/tree/@kajabi/sage@#{$SAGE_VERSION_GEM}/packages"
 
-$SAGE_VERSION_GEM_URL = "#{$SAGE_GITHUB_URL}/tree/v#{$SAGE_VERSION_GEM}/lib/sage_rails"
-$SAGE_VERSION_FRONTEND_URL = "#{$SAGE_GITHUB_URL}/tree/v#{$SAGE_VERSION_FRONTEND}/lib/sage-frontend"
-
-$SAGE_RELEASE_URL = "#{$SAGE_GITHUB_URL}/releases/tag/v#{$SAGE_VERSION_FRONTEND}"
+$SAGE_VERSION_GEM_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-system"
+$SAGE_VERSION_REACT_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-react"
+$SAGE_VERSION_ASSETS_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-assets"
+$SAGE_VERSION_SYSTEM_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-system"
+$SAGE_RELEASE_URL = "#{$SAGE_GITHUB_URL}/releases/tag/@kajabi/sage@#{$SAGE_VERSION_GEM}"

--- a/docs/config/initializers/load_sage_version.rb
+++ b/docs/config/initializers/load_sage_version.rb
@@ -7,7 +7,9 @@ frontend_package_contents = JSON.parse(
 $SAGE_VERSION_GEM = SageRails::VERSION
 $SAGE_VERSION_FRONTEND = frontend_package_contents["version"]
 
-$SAGE_VERSION_GEM_URL = "https://github.com/Kajabi/sage/tree/v#{$SAGE_VERSION_GEM}/lib/sage_rails"
-$SAGE_VERSION_FRONTEND_URL = "https://github.com/Kajabi/sage/tree/v#{$SAGE_VERSION_FRONTEND}/lib/sage-frontend"
+$SAGE_GITHUB_URL = "https://github.com/Kajabi/sage-lib"
 
-$SAGE_RELEASE_URL = "https://github.com/Kajabi/sage/releases/tag/v#{$SAGE_VERSION_FRONTEND}"
+$SAGE_VERSION_GEM_URL = "#{$SAGE_GITHUB_URL}/tree/v#{$SAGE_VERSION_GEM}/lib/sage_rails"
+$SAGE_VERSION_FRONTEND_URL = "#{$SAGE_GITHUB_URL}/tree/v#{$SAGE_VERSION_FRONTEND}/lib/sage-frontend"
+
+$SAGE_RELEASE_URL = "#{$SAGE_GITHUB_URL}/releases/tag/v#{$SAGE_VERSION_FRONTEND}"


### PR DESCRIPTION
## Description
Revises links in documentation to point to the new Github repo path(s):
- moves "Release Notes" and "Changelog" links permanently to sidebar
- updates versions and package links in header/assistant
- open to any and all suggestions on emoji replacements 😀

~~NOTE: Not sure what happened, but it looks like a rebase I did added a bunch of unrelated files from the version bump on `master`~~


|  Before   |  After  |
|--------|--------|
|<img width="1478" alt="before" src="https://user-images.githubusercontent.com/816579/102677936-f304b980-4159-11eb-8acd-c9ae94c06f58.png">|<img width="1478" alt="after" src="https://user-images.githubusercontent.com/816579/102677944-fc8e2180-4159-11eb-9324-a51dfd83a91d.png">|


Closes #128 
