### PR TITLE
Interactive Label - responsive updates

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -16,7 +16,9 @@
     <%= 'type="button"' if component.interactive_type %>
     <%= component.generated_html_attributes %>
   />
-    <%= component.value.html_safe %>
+    <span class="sage-label__value-text">
+      <%= component.value.html_safe %>
+    </span>
   </<%= label_content_tag %>>
   <%= component.content %>
   <%= component.secondary_button if component.interactive_type === :secondary_button %>

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
@@ -42,7 +42,7 @@ $-label-inset-border: 0 0 0 1px inset;
 }
 
 .sage-label__value-text {
-  .sage-label--interactive-right-cta-affordance & {
+  .sage-label--interactive-right-cta-affordance[class*="sage-label--icon-"] & {
     @media (max-width: sage-breakpoint(sm-max)) {
       @include visually-hidden();
     }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
@@ -139,7 +139,6 @@ $-label-inset-border: 0 0 0 1px inset;
     &.sage-label--interactive-right-cta-affordance .sage-label__decor-icon::before {
       @media (max-width: sage-breakpoint(sm-max)) {
         width: sage-spacing(md);
-        font-size: rem(6px);
       }
     }
   }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
@@ -24,10 +24,10 @@ $-label-inset-border: 0 0 0 1px inset;
 .sage-label__value {
   @extend %t-sage-body-small-semi;
 
-  min-height: $-label-interactive-icon-size;
   appearance: none;
   display: flex;
   align-items: center;
+  min-height: $-label-interactive-icon-size;
   padding: $-label-padding;
   white-space: nowrap;
   border-radius: $-label-border-radius;
@@ -139,6 +139,7 @@ $-label-inset-border: 0 0 0 1px inset;
     &.sage-label--interactive-right-cta-affordance .sage-label__decor-icon::before {
       @media (max-width: sage-breakpoint(sm-max)) {
         width: sage-spacing(md);
+        font-size: rem(6px);
       }
     }
   }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_label.scss
@@ -24,6 +24,7 @@ $-label-inset-border: 0 0 0 1px inset;
 .sage-label__value {
   @extend %t-sage-body-small-semi;
 
+  min-height: $-label-interactive-icon-size;
   appearance: none;
   display: flex;
   align-items: center;
@@ -37,6 +38,14 @@ $-label-inset-border: 0 0 0 1px inset;
   &:focus,
   &:active {
     outline: none;
+  }
+}
+
+.sage-label__value-text {
+  .sage-label--interactive-right-cta-affordance & {
+    @media (max-width: sage-breakpoint(sm-max)) {
+      @include visually-hidden();
+    }
   }
 }
 
@@ -75,7 +84,6 @@ $-label-inset-border: 0 0 0 1px inset;
     }
 
     .sage-label__value {
-
       @include sage-focus-outline();
       @include sage-focus-outline--update-color( sage-color-combo($-color-name, default, foreground) );
 
@@ -125,6 +133,12 @@ $-label-inset-border: 0 0 0 1px inset;
 
       &.sage-btn--tag::before {
         font-size: sage-font-size(md);
+      }
+    }
+
+    &.sage-label--interactive-right-cta-affordance .sage-label__decor-icon::before {
+      @media (max-width: sage-breakpoint(sm-max)) {
+        width: sage-spacing(md);
       }
     }
   }

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -40,7 +40,9 @@ const Label = ({
         type={interactiveType ? 'button' : null}
         {...rest}
       >
-        {value}
+        <span className="sage-label__value-text">
+          {value}
+        </span>
       </TagName>
       {
         interactiveType === LABEL_INTERACTIVE_TYPES.SECONDARY_BUTTON


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
* hide text for interactive labels on smaller viewports

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

##### sage
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-21 at 11 32 58 AM](https://user-images.githubusercontent.com/1241836/102805945-9daaf100-4381-11eb-9553-98083a08e826.png)|![Screen Shot 2020-12-21 at 11 33 50 AM](https://user-images.githubusercontent.com/1241836/102805954-a1d70e80-4381-11eb-81a0-ba44d227330e.png)|

##### preview of products page
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-21 at 11 32 36 AM](https://user-images.githubusercontent.com/1241836/102805887-85d36d00-4381-11eb-9009-d8a14f2ccccf.png)|![Screen Shot 2020-12-21 at 11 34 31 AM](https://user-images.githubusercontent.com/1241836/102805905-8ec43e80-4381-11eb-848e-402594ee8900.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the sage label page on viewport < `767px`: http://localhost:4000/pages/element/label


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- [BUILD-537](https://kajabi.atlassian.net/browse/BUILD-537)
