### PR TITLE
fix(typeahead): normalize typeahead item height to 68px

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_typeahead.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_typeahead.scss
@@ -4,6 +4,8 @@
 
 ================================================== */
 
+$-item-height: rem(68px);
+
 .sage-typeahead {
   position: relative;
 }
@@ -34,7 +36,8 @@
   display: flex;
   align-items: center;
   position: relative;
-
+  overflow: hidden;
+  height: $-item-height;
 
   &:not(:first-child) {
     border-top: sage-border();
@@ -61,7 +64,7 @@
   grid-template-rows: 1fr;
   column-gap: sage-spacing(sm);
   align-items: center;
-  padding: sage-spacing(sm);
+  padding: sage-spacing(md) sage-spacing(sm);
   text-align: left;
 
   > * {


### PR DESCRIPTION
## Description
Per design feedback

### Screenshots
![image](https://user-images.githubusercontent.com/565743/102825513-e2984d00-43ac-11eb-90e3-4b6d0070f62f.png)

## Test notes
n/a

## Related
BUILD-540