### PR TITLE
Outline-focus - followup for better style isolation

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -148,9 +148,16 @@
       opacity: 1;
     }
   }
+}
 
+///
+/// Sets the background-color focus outline to an interactive element's parent.
+///
+/// @param {color} $focus-within-background-color Hex color to be used for the background-color
+///
+@mixin sage-focus-outline--focus-within($focus-within-background-color: sage-color(primary, 100)) {
   &:focus-within:not(:disabled):not([aria-disabled="true"]) {
-    background-color: sage-color(primary, 100);
+    background-color: $focus-within-background-color;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_outline_item.scss
@@ -20,6 +20,7 @@ $-collapse-breakpoint-key: lg-max;
 .sage-outline-item {
   @include sage-focus-outline($outline-offset-block: -6px, $outline-offset-inline: -6px, $outline-animation-speed: 0.05s);
   @include sage-focus-outline--update-color(transparent);
+  @include sage-focus-outline--focus-within();
 
   display: grid;
   align-items: stretch;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
* create new mixin instead of updated existing widely used mixin

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

##### outline-focus - unaffected
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-22 at 1 51 24 PM](https://user-images.githubusercontent.com/1241836/102927571-d8358c00-445c-11eb-85aa-6cf3250a0274.png)|![Screen Shot 2020-12-22 at 1 47 05 PM](https://user-images.githubusercontent.com/1241836/102927595-e2578a80-445c-11eb-8547-3596cd929616.png)|

##### button focus - regression resolved
|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-22 at 1 51 04 PM](https://user-images.githubusercontent.com/1241836/102927629-f0a5a680-445c-11eb-9280-4c21265d9999.png)|![Screen Shot 2020-12-22 at 1 46 55 PM](https://user-images.githubusercontent.com/1241836/102927651-f69b8780-445c-11eb-8aca-1fc3b76ac64a.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the button page and click the primary button and verify focused state: http://localhost:4000/pages/element/button
2. Visit the outline-item page and click any of the icons and verify focused state on the row: http://localhost:4000/pages/element/button
