### PR TITLE
fix(modal): add large attribute

### DIFF
--- a/docs/app/views/examples/objects/modal/_markup1.html.erb
+++ b/docs/app/views/examples/objects/modal/_markup1.html.erb
@@ -1,4 +1,4 @@
-<dialog class="sage-modal sage-modal--large" data-js-modal="cool-modal-1" aria-modal="true">
+<dialog class="sage-modal sage-modal--large" data-js-modal="cool-modal-large" aria-modal="true">
   <section class="sage-modal__container">
     <header class="sage-modal__header">
       <h1 class="t-sage-heading-4">Example Sage Modal</h1>

--- a/docs/app/views/examples/objects/modal/_markup1.html.erb
+++ b/docs/app/views/examples/objects/modal/_markup1.html.erb
@@ -1,0 +1,21 @@
+<dialog class="sage-modal sage-modal--large" data-js-modal="cool-modal-1" aria-modal="true">
+  <section class="sage-modal__container">
+    <header class="sage-modal__header">
+      <h1 class="t-sage-heading-4">Example Sage Modal</h1>
+      <aside class="sage-modal__header-aside">
+        <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
+          <span class="visually-hidden">Menu</span>
+        </button>
+      </aside>
+    </header>
+    <div class="sage-modal__content">
+      <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+    <footer class="sage-modal__footer">
+      <aside class="sage-modal__footer-aside">
+        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
+      </aside>
+      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
+    </footer>
+  </section>
+</dialog>

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -1,4 +1,6 @@
 <%= sage_component SagePanelBlock, {} do %>
   <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal">Trigger Modal</button>
   <%= render "examples/objects/modal/markup" %>
+  <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal-1">Trigger Modal Large</button>
+  <%= render "examples/objects/modal/markup1" %>
 <% end %>

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -1,6 +1,6 @@
 <%= sage_component SagePanelBlock, {} do %>
   <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal">Trigger Modal</button>
   <%= render "examples/objects/modal/markup" %>
-  <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal-1">Trigger Modal Large</button>
+  <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal-large">Trigger Modal Large</button>
   <%= render "examples/objects/modal/markup1" %>
 <% end %>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td>large</td>
+  <td>Toggles whether to use the large variant of the modal by attaching <code>.sage-modal--large</code></td>
+  <td>Boolean</td>
+  <td>null</td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -2,4 +2,5 @@ class SageModal < SageComponent
   attr_accessor :id
   attr_accessor :active
   attr_accessor :disable_close
+  attr_accessor :large
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -2,6 +2,7 @@
   class="
     sage-modal
     <%= "sage-modal--active" if component.active %>
+    <%= "sage-modal--large" if component.large %>
   "
   <%= "data-js-modal-disable-close" if component.disable_close %>
   data-js-modal="<%= component.id %>"

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -60,7 +60,7 @@ $-modal-padding-y: sage-spacing(md);
   }
 
   .sage-modal--large & {
-    max-width: sage-container(modalLg);
+    max-width: sage-container(modal-lg);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -58,10 +58,10 @@ $-modal-padding-y: sage-spacing(md);
     visibility: visible;
     display: block;
   }
-}
 
-.sage-modal--large & {
-  max-width: sage-container(modalLg);
+  .sage-modal--large & {
+    max-width: sage-container(modalLg);
+  }
 }
 
 .sage-modal__header {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -60,6 +60,10 @@ $-modal-padding-y: sage-spacing(md);
   }
 }
 
+.sage-modal--large & {
+  max-width: sage-container(modalLg);
+}
+
 .sage-modal__header {
   display: flex;
   align-items: baseline;

--- a/packages/sage-assets/lib/stylesheets/tokens/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_container.scss
@@ -10,7 +10,7 @@
 ///
 $sage-containers: (
   modal: rem(500px),
-  modalLg: rem(900px),
+  modal-lg: rem(900px),
   xs: rem(760px),
   sm: rem(900px),
   md: rem(1200px),

--- a/packages/sage-assets/lib/stylesheets/tokens/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_container.scss
@@ -10,6 +10,7 @@
 ///
 $sage-containers: (
   modal: rem(500px),
+  modalLg: rem(900px),
   xs: rem(760px),
   sm: rem(900px),
   md: rem(1200px),

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -11,6 +11,7 @@ const Modal = ({
   active,
   children,
   className,
+  large,
   containerClassName,
   onExit,
   ...rest
@@ -20,6 +21,7 @@ const Modal = ({
     className,
     {
       'sage-modal--active': active,
+      'sage-modal--large': large,
     }
   );
 
@@ -65,6 +67,7 @@ Modal.defaultProps = {
   children: null,
   containerClassName: null,
   className: '',
+  large: false,
   onExit: a => a,
 };
 
@@ -73,6 +76,7 @@ Modal.propTypes = {
   children: PropTypes.node,
   containerClassName: PropTypes.string,
   className: PropTypes.string,
+  large: PropTypes.bool,
   onExit: PropTypes.func,
 };
 

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { centerXY } from '../story-support/decorators';
 import { SageTokens, SageClassnames } from '../configs';
 import Modal from '../Modal';
@@ -22,7 +22,11 @@ const ModalWithState = () => {
       >
         Take An Action
       </Button>
-      <Modal active={active} onExit={onExit}>
+      <Modal
+        active={active}
+        onExit={onExit}
+        large={boolean('Large', false)}
+      >
         <Modal.Header>
           <h1 className={SageClassnames.TYPE.HEADING_1}>Example Sage Modal</h1>
           <Modal.HeaderAside>


### PR DESCRIPTION
## Description
Adds a `:large` attribute to modals. 

### Screenshots

|  before  |  after  |
|--------|--------|
|![Screen Shot 2020-12-22 at 4 46 50 PM](https://user-images.githubusercontent.com/234225/102936097-82211280-4475-11eb-800d-1ce45714a2f1.png)|![Screen Shot 2020-12-22 at 4 45 49 PM](https://user-images.githubusercontent.com/234225/102936138-9c5af080-4475-11eb-90ce-e37a9fc2dbb4.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Locally, you can go to http://localhost:6006/?path=/story/sage-modal--default
2. Check the `Large` knob and watch it grow 🌱 


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- 
