### PR TITLE
React PageHeading: upfit with secondaryText support

### DIFF
--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import uuid from 'react-uuid';
 import Breadcrumbs from '../Breadcrumbs';
+import classnames from 'classnames';
 
 const PageHeading = ({
   className,
@@ -9,9 +10,17 @@ const PageHeading = ({
   breadcrumbs,
   actionItems,
   toolbarItems,
+  secondaryText,
   ...rest
 }) => (
-  <div className={`sage-page-heading ${className}`} {...rest}>
+  <div
+    className={classnames(
+      'sage-page-heading',
+      className,
+      { 'sage-page-heading--no-secondary-text': !secondaryText }
+    )}
+    {...rest}
+  >
     {breadcrumbs
       && (
       <div className="sage-page-heading__crumbs">
@@ -36,6 +45,13 @@ const PageHeading = ({
         </div>
       )
     }
+    {secondaryText
+      && (
+        <div className="sage-page-heading__secondary">
+          {secondaryText}
+        </div>
+      )
+    }
   </div>
 );
 
@@ -44,6 +60,7 @@ PageHeading.defaultProps = {
   actionItems: null,
   toolbarItems: null,
   breadcrumbs: null,
+  secondaryText: null,
 };
 
 PageHeading.propTypes = {
@@ -52,6 +69,7 @@ PageHeading.propTypes = {
   actionItems: PropTypes.arrayOf(PropTypes.node),
   toolbarItems: PropTypes.arrayOf(PropTypes.node),
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
+  secondaryText: PropTypes.string,
 };
 
 export default PageHeading;

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -10,6 +10,7 @@ storiesOf('Sage/PageHeading', module)
   .addDecorator(centerXY)
   .add('Default', () => (
     <PageHeading
+      secondaryText={text('Secondary Text', 'Secondary text here')}
       breadcrumbs={[
         {
           label: 'Back somewhere',


### PR DESCRIPTION
## Description
Match the grid implementation in for the Rails PageHeading component. Nothing new. 👨‍💻

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/102937640-a03c4200-4478-11eb-8d05-8b085b7710b5.png)|![image](https://user-images.githubusercontent.com/565743/102937667-af22f480-4478-11eb-9cba-ff2e6d45d77b.png)|

## Test notes
Ensure React component isn't breaking

## Related
none