### PR TITLE
Hero - conditionally render aria attribute

### DIFF
--- a/docs/app/views/examples/objects/hero/_preview.html.erb
+++ b/docs/app/views/examples/objects/hero/_preview.html.erb
@@ -14,6 +14,7 @@
 <h2 class="t-sage-heading-6">Sage Hero with dismiss button</h3>
 <%= sage_component SageCardBlock, {} do %>
   <%= sage_component SageHero, {
+    alt_text: "",
     cta_attributes: {
       "data-js-modaltrigger": "cool-modal",
       href: "#",

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
@@ -17,6 +17,6 @@
     <% end if component.cta_attributes&.is_a?(Hash) %>
     class="sage-hero__artwork"
   >
-    <img class="sage-hero__artwork-image" src=<%= component.image%> alt="<%= component.alt_text %>" />
+    <img class="sage-hero__artwork-image" <%= "aria-hidden=true" if component.alt_text.blank? %> src=<%= component.image%> alt="<%= component.alt_text %>" />
   </a>
 </article>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
conditionally render `aria-hidden` if `alt_text` is not present

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-01-04_at_11_08_35_AM](https://user-images.githubusercontent.com/1241836/103560414-58a4b580-4e7d-11eb-91de-84255e9574b5.png)|![Screen_Shot_2021-01-04_at_11_06_23_AM](https://user-images.githubusercontent.com/1241836/103560424-5cd0d300-4e7d-11eb-9074-7867db2024b1.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit hero page: http://localhost:4000/pages/object/hero

