### PR TITLE
Page headings help link missing href

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.3.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@3.2.3...@kajabi/sage@3.3.0) (2020-12-22)
+
+
+### Bug Fixes
+
+* **label:** update dropdown labels to new icon, tighten up right spacing a bit ([f6dd468](https://github.com/Kajabi/sage-lib/commit/f6dd468333f7a6d065e94b54cfaebd0564ffe917))
+* **sage-outline:** update focus-within to show background-color ([51a95a9](https://github.com/Kajabi/sage-lib/commit/51a95a9ce0204fc02d5c6f0029028658dd5d16a8))
+* **tabs:** updated choice tabs to stack at specific breakpoint ([7170ff2](https://github.com/Kajabi/sage-lib/commit/7170ff25ebc156577658816c45c528c4b50affa6))
+
+
+### Features
+
+* **rails pagination:** add :hide_pages attribute, enable :spacer support ([8b226fa](https://github.com/Kajabi/sage-lib/commit/8b226fa0a227c8fc54ace50a9aab0e5612c52592))
+
+
+
+
+
 ## [3.2.3](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@3.2.2...@kajabi/sage@3.2.3) (2020-12-22)
 
 **Note:** Version bump only for package @kajabi/sage

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.1](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@3.3.0...@kajabi/sage@3.3.1) (2020-12-23)
+
+**Note:** Version bump only for package @kajabi/sage
+
+
+
+
+
 # [3.3.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@3.2.3...@kajabi/sage@3.3.0) (2020-12-22)
 
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (3.2.3)
+    sage_rails (3.3.0)
       rails
 
 GEM

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (3.3.0)
+    sage_rails (3.3.1)
       rails
 
 GEM

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -11,10 +11,10 @@
   <% end %>
   <h1 class="sage-page-heading__title">
     <%= component.title %>
-    <% if component.help_link.present? && component.help_html.blank? %> 
-      <a href="<%= component.help_link[:url] %>" 
-        class="sage-link--no-launch sage-link--help-icon-only" 
-        target="_blank" 
+    <% if component.help_link.present? && component.help_html.blank? %>
+      <a href="<%= component.help_link[:href] %>"
+        class="sage-link--no-launch sage-link--help-icon-only"
+        target="_blank"
         referrer="no-referrer"
       >
         <span class="visually-hidden">

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "3.2.3"
+  VERSION = "3.3.0"
 end

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "3.3.0"
+  VERSION = "3.3.1"
 end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^0.0.127",
+    "@kajabi/sage-packs": "^0.0.128",
     "@rails/webpacker": "4.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^0.0.126",
+    "@kajabi/sage-packs": "^0.0.127",
     "@rails/webpacker": "4.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/packages/sage-assets/CHANGELOG.md
+++ b/packages/sage-assets/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.14.4](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-assets@0.14.3...@kajabi/sage-assets@0.14.4) (2020-12-22)
+
+
+### Bug Fixes
+
+* **focus-outline:** updated mixin to reduce impact appwide ([4294c1c](https://github.com/Kajabi/sage-lib/commit/4294c1cc688042a37dbe6f560c815b3dee251b5e))
+* **label:** update dropdown labels to new icon, tighten up right spacing a bit ([f6dd468](https://github.com/Kajabi/sage-lib/commit/f6dd468333f7a6d065e94b54cfaebd0564ffe917))
+* **sage-outline:** linter ([b0a35cb](https://github.com/Kajabi/sage-lib/commit/b0a35cb58c2efd636519210e0cfb4dffc776c778))
+* **sage-outline:** update focus-within to show background-color ([51a95a9](https://github.com/Kajabi/sage-lib/commit/51a95a9ce0204fc02d5c6f0029028658dd5d16a8))
+* **sage-outline:** update focus-within to show outline ([31cbdfd](https://github.com/Kajabi/sage-lib/commit/31cbdfd9f4ee871d068d2805ebce47e405d2043b))
+* **tabs:** linter ([4a41dfe](https://github.com/Kajabi/sage-lib/commit/4a41dfe53d869009506136938cd22557511d5a1e))
+* **tabs:** removed a default flexbox property ([5ac2c0e](https://github.com/Kajabi/sage-lib/commit/5ac2c0eb66564906c7cce54065da8664579693fa))
+* **tabs:** update responsive styles ([46b4942](https://github.com/Kajabi/sage-lib/commit/46b4942ba0a20f6881007f8508d9c0dc19087bff))
+* **tabs:** updated choice tabs to stack at specific breakpoint ([7170ff2](https://github.com/Kajabi/sage-lib/commit/7170ff25ebc156577658816c45c528c4b50affa6))
+
+
+
+
+
 ## [0.14.3](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-assets@0.14.2...@kajabi/sage-assets@0.14.3) (2020-12-22)
 
 

--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-assets",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Assets",
   "main": "dist/main.css",
   "repository": {

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.127](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.0.126...@kajabi/sage-packs@0.0.127) (2020-12-22)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [0.0.126](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.0.125...@kajabi/sage-packs@0.0.126) (2020-12-22)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.128](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.0.127...@kajabi/sage-packs@0.0.128) (2020-12-23)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [0.0.127](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.0.126...@kajabi/sage-packs@0.0.127) (2020-12-22)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -27,8 +27,8 @@
     "url": "https://github.com/Kajabi/sage-lib/issues"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^0.14.3",
-    "@kajabi/sage-react": "^0.19.3",
+    "@kajabi/sage-assets": "^0.14.4",
+    "@kajabi/sage-react": "^0.20.0",
     "@kajabi/sage-system": "^0.2.1"
   }
 }

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@kajabi/sage-assets": "^0.14.4",
-    "@kajabi/sage-react": "^0.20.0",
+    "@kajabi/sage-react": "^0.21.0",
     "@kajabi/sage-system": "^0.2.1"
   }
 }

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.21.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.20.0...@kajabi/sage-react@0.21.0) (2020-12-23)
+
+
+### Features
+
+* **react pageheading:** upfit react pageheading to match the rails component grid implementation ([6b691b3](https://github.com/Kajabi/sage-lib/commit/6b691b3b7ec91f6d8a0a49935ba50fe7e29d2b7d))
+
+
+
+
+
 # [0.20.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.19.3...@kajabi/sage-react@0.20.0) (2020-12-22)
 
 

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.20.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.19.3...@kajabi/sage-react@0.20.0) (2020-12-22)
+
+
+### Bug Fixes
+
+* **label:** update dropdown labels to new icon, tighten up right spacing a bit ([f6dd468](https://github.com/Kajabi/sage-lib/commit/f6dd468333f7a6d065e94b54cfaebd0564ffe917))
+* **sage-react:** remove console log from service ([5cd0a13](https://github.com/Kajabi/sage-lib/commit/5cd0a135f3f559ca481acfdcf89eb81e82402e46))
+
+
+### Features
+
+* **panel-controls:** add panel controls MVP in React ([d3ac0d3](https://github.com/Kajabi/sage-lib/commit/d3ac0d354070212b033674aca4af0e7446069bb7))
+* **panel-controls:** refactor common handlers into public utils ([1606331](https://github.com/Kajabi/sage-lib/commit/1606331cefa8ae17679abb152f342e348a6a92d3))
+* **sage-react:** add news api service for testing ([d91aac9](https://github.com/Kajabi/sage-lib/commit/d91aac9ec9db3de51e1f55657990a8a50e1a2c06))
+* **table:** improve interactivity of table ([5999c59](https://github.com/Kajabi/sage-lib/commit/5999c5907d542ace7b2e69bf364109b3e101a23a))
+
+
+
+
+
 ## [0.19.3](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.19.2...@kajabi/sage-react@0.19.3) (2020-12-22)
 
 **Note:** Version bump only for package @kajabi/sage-react

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import uuid from 'react-uuid';
 import Breadcrumbs from '../Breadcrumbs';
+import classnames from 'classnames';
 
 const PageHeading = ({
   className,
@@ -9,9 +10,17 @@ const PageHeading = ({
   breadcrumbs,
   actionItems,
   toolbarItems,
+  secondaryText,
   ...rest
 }) => (
-  <div className={`sage-page-heading ${className}`} {...rest}>
+  <div
+    className={classnames(
+      'sage-page-heading',
+      className,
+      { 'sage-page-heading--no-secondary-text': !secondaryText }
+    )}
+    {...rest}
+  >
     {breadcrumbs
       && (
       <div className="sage-page-heading__crumbs">
@@ -36,6 +45,13 @@ const PageHeading = ({
         </div>
       )
     }
+    {secondaryText
+      && (
+        <div className="sage-page-heading__secondary">
+          {secondaryText}
+        </div>
+      )
+    }
   </div>
 );
 
@@ -44,6 +60,7 @@ PageHeading.defaultProps = {
   actionItems: null,
   toolbarItems: null,
   breadcrumbs: null,
+  secondaryText: null,
 };
 
 PageHeading.propTypes = {
@@ -52,6 +69,7 @@ PageHeading.propTypes = {
   actionItems: PropTypes.arrayOf(PropTypes.node),
   toolbarItems: PropTypes.arrayOf(PropTypes.node),
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
+  secondaryText: PropTypes.string,
 };
 
 export default PageHeading;

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -10,6 +10,7 @@ storiesOf('Sage/PageHeading', module)
   .addDecorator(centerXY)
   .add('Default', () => (
     <PageHeading
+      secondaryText={text('Secondary Text', 'Secondary text here')}
       breadcrumbs={[
         {
           label: 'Back somewhere',

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "React Components",
   "keywords": [
     "react",

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "description": "React Components",
   "keywords": [
     "react",
@@ -62,7 +62,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^0.14.3",
+    "@kajabi/sage-assets": "^0.14.4",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "focus-trap": "^6.2.2",


### PR DESCRIPTION
## Description
Help icons/links within page headings are not linking to the correct location due to missing href. 
This seems due to `:url` being used/passed in instead of `:href`

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screen Shot 2021-01-04 at 10 35 01 AM](https://user-images.githubusercontent.com/1175111/103567432-ab2fa300-4e78-11eb-9f58-6cae56ee8fe9.png)|![Screen Shot 2021-01-04 at 10 35 36 AM](https://user-images.githubusercontent.com/1175111/103567441-b08ced80-4e78-11eb-8311-560cd92663a1.png)| 

### Steps for testing

1. Visit: http://localhost:4000/pages/object/page_heading
2. Verify within the "Page Heading with Help Link" that the icon links to the expected location.
