### PR TITLE
Catalog item content spacing

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
@@ -127,12 +127,6 @@ $-label-interactive-icon-size: rem(24px);
   }
 
   // Contextual modifications
-  .sage-catalog-item__content & {
-    &:not(:last-child) {
-      margin-right: sage-spacing();
-    }
-  }
-
   .sage-dropdown--contained &,
   .sage-panel-controls__toolbar .sage-dropdown__trigger &,
   .sage-panel-controls__bulk-actions .sage-dropdown__trigger & {
@@ -256,7 +250,7 @@ $-label-interactive-icon-size: rem(24px);
   .sage-panel-controls__toolbar-btn-group--expand-collapse > & {
     border-radius: sage-border(radius);
   }
-  
+
   .sage-panel-controls__toolbar > &,
   .sage-panel-controls__pagination > & {
     border-radius: sage-border(radius);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -90,8 +90,8 @@ $-image-height-mobile: rem(120px);
   align-self: flex-start;
   flex-flow: row wrap;
 
-  > *:not(:last-child) {
-    margin-right: sage-spacing();
+  > * + * {
+    margin-left: sage-spacing();
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -88,7 +88,11 @@ $-image-height-mobile: rem(120px);
   display: flex;
   grid-area: content;
   align-self: flex-start;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
+
+  > *:not(:last-child) {
+    margin-right: sage-spacing();
+  }
 }
 
 .sage-catalog-item__aside {


### PR DESCRIPTION
## Description
[Catalog items](https://sage-design-system.kajabi.com/pages/object/catalog_item) can include any combination of sub-items within the `sage-catalog-item__content` area. Because spacing between child elements is being applied specifically to buttons at present, this PR extends the margin to all child elements (see below examples for a mix of `label` and `span`).

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/103591929-66226580-4ea6-11eb-8cff-9b4ea9baf2b0.png)|![after](https://user-images.githubusercontent.com/816579/103591940-6b7fb000-4ea6-11eb-852e-7898fe7503f5.png)|


### Related
- SELL-578