### PR TITLE
Adjust panel controls subcomponents

### DIFF
--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -17,7 +17,7 @@ tabs = sage_component(SageTabs, {
   ]
 })
 
-search = sage_component(SageSearch, { placeholder: "Find..." })
+search = sage_component(SageSearch, { placeholder: "Find...", contained: true, })
 
 dropdown = sage_component(SageDropdown, {
   search: true,

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_search.scss
@@ -54,25 +54,12 @@ $-search-icon: "::before";
   &.sage-search--contained {
     position: relative;
     z-index: sage-z-index(default);
+    border-radius: sage-border(radius);
     box-shadow: map-get($sage-toolbar-button-borders, default);
     border: 0;
 
     &::after {
       display: none;
-    }
-
-    .sage-panel-controls__toolbar &:first-child {
-      border-top-left-radius: sage-border(radius);
-      border-bottom-left-radius: sage-border(radius);
-    }
-
-    .sage-panel-controls__toolbar &:last-child {
-      border-top-right-radius: sage-border(radius);
-      border-bottom-right-radius: sage-border(radius);
-    }
-
-    :not(.sage-panel-controls__toolbar) & {
-      border-radius: sage-border(radius);
     }
 
     &:hover {
@@ -83,6 +70,16 @@ $-search-icon: "::before";
     &:focus-within {
       z-index: sage-z-index(default, 2);
       box-shadow: map-get($sage-toolbar-button-borders, focus);
+    }
+
+    .sage-panel-controls__toolbar &:first-child:not(:only-child) {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    .sage-panel-controls__toolbar &:last-child:not(:only-child) {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
     }
   }
 

--- a/packages/sage-react/lib/PanelControls/PanelControls.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.jsx
@@ -93,11 +93,7 @@ const PanelControls = ({
 
   return (
     <div className={classNames}>
-      {children && (
-        <div className="sage-panel-controls__toolbar">
-          {children}
-        </div>
-      )}
+      {children}
       <div className="sage-panel-controls__default-controls">
         <PanelControlsBulkActions
           checked={selfConfigs.bulkActionsChecked}

--- a/packages/sage-react/lib/PanelControls/PanelControls.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.jsx
@@ -8,6 +8,8 @@ import {
 import { DEFAULT_NOUN, SELECTION_TYPES } from './configs';
 import PanelControlsBulkActions from './PanelControlsBulkActions';
 import PanelControlsPagination from './PanelControlsPagination';
+import PanelControlsToolbar from './PanelControlsToolbar';
+import PanelControlsToolbarButtonGroup from './PanelControlsToolbarButtonGroup';
 
 const PanelControls = ({
   children,
@@ -123,6 +125,8 @@ PanelControls.handlerUtils = {
   handleChange,
   handleSelection,
 };
+PanelControls.Toolbar = PanelControlsToolbar;
+PanelControls.ToolbarButtonGroup = PanelControlsToolbarButtonGroup;
 
 PanelControls.defaultProps = {
   children: null,

--- a/packages/sage-react/lib/PanelControls/PanelControls.story.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.story.jsx
@@ -13,7 +13,7 @@ import PanelControls from './PanelControls';
 const PanelControlsWithData = () => {
   const [selfData, setSelfData] = useState({
     // Set locally
-    articles: [],
+    items: [],
     selectedRows: [],
 
     // Panel Controls Configurations
@@ -72,7 +72,7 @@ const PanelControlsWithData = () => {
       // Bring over all existing selfData props
       ...selfData,
       // Rewrite articles to contain those returned by service
-      articles: formattedArticles,
+      items: formattedArticles,
       // Rewrite the panelControlConfigs
       panelControlConfigs: {
         // First bring over all existing props
@@ -130,7 +130,7 @@ const PanelControlsWithData = () => {
         })}
         resetAbove={true}
         resetBelow={true}
-        rows={selfData.articles}
+        rows={selfData.items}
         schema={{
           title: {
             label: 'Title',

--- a/packages/sage-react/lib/PanelControls/PanelControlsToolbar.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControlsToolbar.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PanelControlsToolbar = ({ children, className, ...rest }) => (
+  <div className={`sage-panel-controls__toolbar ${className || ''}`} {...rest}>
+    {children}
+  </div>
+);
+
+PanelControlsToolbar.defaultProps = {
+  children: null,
+  className: null,
+};
+
+PanelControlsToolbar.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default PanelControlsToolbar;

--- a/packages/sage-react/lib/PanelControls/PanelControlsToolbarButtonGroup.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControlsToolbarButtonGroup.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PanelControlsToolbarButtonGroup = ({ children, className, ...rest }) => (
+  <div className={`sage-panel-controls__toolbar-btn-group ${className || ''}`} {...rest}>
+    {children}
+  </div>
+);
+
+PanelControlsToolbarButtonGroup.defaultProps = {
+  children: null,
+  className: null,
+};
+
+PanelControlsToolbarButtonGroup.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default PanelControlsToolbarButtonGroup;

--- a/packages/sage-react/lib/PanelControls/utils.js
+++ b/packages/sage-react/lib/PanelControls/utils.js
@@ -32,7 +32,8 @@ export const handleChange = ({
   stateData,
   setStateDataFn,
   pageChangeHandlerFn,
-  mapSelectedRowsFn = ({ id }) => id
+  mapSelectedRowsFn = ({ id }) => id,
+  itemsKey = 'items',
 }) => {
   // First if a page change is requested, send for that
   if (data.page) {
@@ -46,7 +47,7 @@ export const handleChange = ({
     let selectedRows;
     switch (data.selectionType) {
       case SELECTION_TYPES.ALL:
-        selectedRows = stateData.articles.map(mapSelectedRowsFn);
+        selectedRows = stateData[itemsKey].map(mapSelectedRowsFn);
         break;
       case SELECTION_TYPES.NONE:
       default:

--- a/packages/sage-react/lib/PanelControls/utils.js
+++ b/packages/sage-react/lib/PanelControls/utils.js
@@ -80,11 +80,11 @@ export const handleSelection = ({
   const numSelectedRows = selectedRows.length;
   let selectionType;
   if (numSelectedRows === totalItems) {
-    selectionType = PanelControls.SELECTION_TYPES.ALL;
+    selectionType = SELECTION_TYPES.ALL;
   } else if (numSelectedRows > 0) {
-    selectionType = PanelControls.SELECTION_TYPES.PARTIAL;
+    selectionType = SELECTION_TYPES.PARTIAL;
   } else {
-    selectionType = PanelControls.SELECTION_TYPES.NONE;
+    selectionType = SELECTION_TYPES.NONE;
   }
 
   setStateDataFn({

--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -32,7 +32,7 @@ const TableRow = ({
 
   const onChangeSelector = (value, checked, ev) => {
     if (onSelect) {
-      onSelect(value);
+      onSelect(id);
     } else {
       setSelfSelected(!checked);
     }


### PR DESCRIPTION
## Description

This PR makes a few non-visual improvements to the Panel Controls to help with implementing them in context. 

- Selection releases the `id` rather than a checkbox value, which solves a data type conflict (checked values always emit strings that don't compare the same to `id` values for other purposes.
- Added subcomponents for tighter composition and revised `children` wrapper.
- Made a few other tweaks to utilities and the story for easier copy-and-paste of the example there.