### PR TITLE
Conditionally render Sortable item subtitles (Rails)

### DIFF
--- a/docs/app/views/examples/objects/sortable/_preview.html.erb
+++ b/docs/app/views/examples/objects/sortable/_preview.html.erb
@@ -43,12 +43,11 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">As cards</h3>
+<h3 class="t-sage-heading-6">As cards with no subtitles</h3>
 <%= sage_component SageSortable, { resource_name: "link" } do %>
   <% 3.times do %>
     <%= sage_component SageSortableItem, {
       title: "Fringilla Ullamcorper Dolor Adipiscing Ultricies",
-      subtitle: "Label Text",
       url_update: "update/endpoint",
       id: "id",
       card: true

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
@@ -8,7 +8,9 @@
 >
   <div class="sage-sortable__item-content">
     <h1 class="sage-sortable__item-title"><%= component.title %></h1>
-    <h2 class="sage-sortable__item-subtitle"><%= component.subtitle %></h2>
+    <% if component.subtitle %>
+      <h2 class="sage-sortable__item-subtitle"><%= component.subtitle %></h2>
+    <% end %>
   </div>
   <div class="sage-sortable__item-actions">
     <%= component.content %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
@@ -8,7 +8,7 @@
 >
   <div class="sage-sortable__item-content">
     <h1 class="sage-sortable__item-title"><%= component.title %></h1>
-    <% if component.subtitle %>
+    <% if component.subtitle.present? %>
       <h2 class="sage-sortable__item-subtitle"><%= component.subtitle %></h2>
     <% end %>
   </div>


### PR DESCRIPTION
## Description
Corrects an issue when using the Rails version of the Sortable item component where `H2` elements for the subtitle are output, regardless of whether a value is being provided. The benefit of this change is primarily for [accessibility](https://dequeuniversity.com/rules/axe/3.5/empty-heading).

Note: the React version of this component is not affected, since it already performs this check before being rendered.

