### PR TITLE
Breadcrumb link icon spacing fix

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_breadcrumbs.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_breadcrumbs.scss
@@ -11,6 +11,10 @@ $-breadcrumb-disabled-color: sage-color(grey, 500);
 .sage-breadcrumbs__icon {
   display: inline-flex;
   align-items: center;
+
+  .sage-breadcrumbs__link & {
+    margin-right: sage-spacing(xs);
+  }
 }
 
 .sage-breadcrumbs__item {
@@ -35,7 +39,6 @@ $-breadcrumb-disabled-color: sage-color(grey, 500);
 .sage-breadcrumbs__link {
   display: inline-flex;
   align-items: center;
-  gap: rem(8px);
   color: sage-color(charcoal, 100);
 
   &:hover,


### PR DESCRIPTION
## Description
Replaces `gap` property used on `sage-breadcrumbs__link` which has limited support in flex containers outside of Chrome and Firefox. As seen below, this results in the arrow icon collapsing against the "Settings" text.

Unfortunately it isn't yet possible to use `@supports` to detect `gap` support in flexbox, though [a few suggestions are in consideration](https://github.com/w3c/csswg-drafts/issues/3559#issuecomment-621032156).

### Screenshots

|  before  |  after  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/103844824-a244fa00-504f-11eb-8c91-2a91ea627ce0.png)|![after](https://user-images.githubusercontent.com/816579/103844835-a5d88100-504f-11eb-88d2-7d0480fc39fa.png)|



## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- closes #159