### PR TITLE
React toast default state

### DIFF
--- a/packages/sage-react/lib/Toast/Toast.jsx
+++ b/packages/sage-react/lib/Toast/Toast.jsx
@@ -15,7 +15,7 @@ const Toast = ({
   timeout,
   title,
 }) => {
-  const [isDismissed, setDismissed] = useState(false);
+  const [isDismissed, setDismissed] = useState(!isActive);
 
   const dismiss = (dismissed) => {
     if (dismissed) {


### PR DESCRIPTION
## Description

This small patch ensures React Toast is synchronized with the value passed to `isActive` right from the start. This solves a blinking Toast issue in some browsers.
