### PR TITLE
Corrections to Rails generator file creation paths

### DIFF
--- a/docs/lib/generators/sage_element/USAGE
+++ b/docs/lib/generators/sage_element/USAGE
@@ -1,8 +1,16 @@
 Description:
-    Explain the generator
+  Elements are the basic building blocks. Applied to web interfaces, elements are our HTML tags, such as a form label, an input or a button.
 
 Example:
-    rails generate sage_element Thing
+  rails generate sage_element <new_element_name>
 
-    This will create:
-        what/will/it/create
+  This will create:
+    <root>/docs/app/views/examples/elements/<new_element_name>/_preview.html.erb (documentation preview and description)
+    <root>/docs/app/views/examples/elements/<new_element_name>/_props.html.erb (element property documentation)
+    <root>/docs/app/views/examples/elements/<new_element_name>/_rules_do.html.erb ("do" quick usage tips for element)
+    <root>/docs/app/views/examples/elements/<new_element_name>/_rules_dont.html.erb ("don't" quick usage tips for element)
+    <root>/packages/sage-assets/lib/stylesheets/patterns/elements/_<new_element_name>.scss (stylesheet for element)
+
+  This will update:
+    <root>/docs/app/helpers/elements_helper.rb (element registry)
+    <root>/packages/sage-assets/lib/stylesheets/index.scss (imports element stylesheet)

--- a/docs/lib/generators/sage_element/sage_element_generator.rb
+++ b/docs/lib/generators/sage_element/sage_element_generator.rb
@@ -3,8 +3,8 @@ class SageElementGenerator < Rails::Generators::NamedBase
   def create_sage_element
 
     # Style Variables
-    style_file = "lib/sage-frontend/stylesheets/system/patterns/elements_#{file_name}.scss"
-    style_include_file = "lib/sage-frontend/stylesheets/system/index.scss"
+    style_file = "../packages/sage-assets/lib/stylesheets/patterns/elements/_#{file_name}.scss"
+    style_include_file = "../packages/sage-assets/lib/stylesheets/index.scss"
     style_include_line = "// Elements"
     # Create Style File
     template "style.scss", style_file

--- a/docs/lib/generators/sage_object/USAGE
+++ b/docs/lib/generators/sage_object/USAGE
@@ -1,8 +1,16 @@
 Description:
-    Explain the generator
+  Objects are groups of elements bonded together. These Objects take on their own properties and serve as the backbone of our design systems.
 
 Example:
-    rails generate sage_component Thing
+  rails generate sage_component <new_object_name>
 
-    This will create:
-        what/will/it/create
+  This will create:
+    <root>/docs/app/views/examples/objects/<new_object_name>/_preview.html.erb (documentation preview and description)
+    <root>/docs/app/views/examples/objects/<new_object_name>/_props.html.erb (object property documentation)
+    <root>/docs/app/views/examples/objects/<new_object_name>/_rules_do.html.erb ("do" quick usage tips for object)
+    <root>/docs/app/views/examples/objects/<new_object_name>/_rules_dont.html.erb ("don't" quick usage tips for object)
+    <root>/packages/sage-assets/lib/stylesheets/patterns/objects/_<new_object_name>.scss (stylesheet for object)
+
+  This will update:
+    <root>/docs/app/helpers/objects_helper.rb (objects registry)
+    <root>/packages/sage-assets/lib/stylesheets/index.scss (imports object stylesheet)

--- a/docs/lib/generators/sage_object/sage_object_generator.rb
+++ b/docs/lib/generators/sage_object/sage_object_generator.rb
@@ -5,7 +5,7 @@ class SageObjectGenerator < Rails::Generators::NamedBase
     # Style Variables
     style_file = "../packages/sage-assets/lib/stylesheets/patterns/objects/_#{file_name}.scss"
     style_include_file = "../packages/sage-assets/lib/stylesheets/index.scss"
-    style_include_line = "// Objects"\
+    style_include_line = "// Objects"
     # Create Style File
     template "style.scss", style_file
     # Include Style File

--- a/docs/lib/generators/sage_object/sage_object_generator.rb
+++ b/docs/lib/generators/sage_object/sage_object_generator.rb
@@ -3,9 +3,9 @@ class SageObjectGenerator < Rails::Generators::NamedBase
   def create_sage_element
 
     # Style Variables
-    style_file = "lib/sage-frontend/stylesheets/system/patterns/objects_#{file_name}.scss"
-    style_include_file = "lib/sage-frontend/stylesheets/system/index.scss"
-    style_include_line = "// Objects"
+    style_file = "../packages/sage-assets/lib/stylesheets/patterns/objects/_#{file_name}.scss"
+    style_include_file = "../packages/sage-assets/lib/stylesheets/index.scss"
+    style_include_line = "// Objects"\
     # Create Style File
     template "style.scss", style_file
     # Include Style File

--- a/docs/lib/generators/sage_page/USAGE
+++ b/docs/lib/generators/sage_page/USAGE
@@ -1,8 +1,8 @@
 Description:
-    Explain the generator
+  Pages refer to the pages of the Sage Design System Gem. Before creating a new page, make sure that what you are documenting would not be a better fit in the gem wiki.
 
 Example:
-    rails generate sage_page Thing
+  rails generate sage_page <new_page_name>
 
-    This will create:
-        what/will/it/create
+  This will create:
+    <root>/docs/app/views/pages/<new_page_name>.html.erb

--- a/docs/lib/generators/sage_token/USAGE
+++ b/docs/lib/generators/sage_token/USAGE
@@ -1,8 +1,13 @@
 Description:
-    Explain the generator
+  Design tokens are the visual design atoms of the design system—specifically, they are named entities that store visual design attributes. We use them in place of hard-coded values (such as hex values for color or pixel values for spacing) in order to maintain a scalable and consistent visual system for UI development.
 
 Example:
-    rails generate sage_token Thing
+  rails generate sage_token <new_token_name>
 
-    This will create:
-        what/will/it/create
+  This will create:
+    <root>/packages/sage-assets/lib/stylesheets/tokens/_<new_token_name>.scss (stylesheet for token)
+
+  This will update:
+    <root>/packages/sage-assets/lib/stylesheets/tokens/_index.scss (imports new token stylesheet)
+
+  Note that <root>/docs/app/helpers/tokens_helper.rb will *not* be updated and must be manually updated.

--- a/docs/lib/generators/sage_token/sage_token_generator.rb
+++ b/docs/lib/generators/sage_token/sage_token_generator.rb
@@ -5,7 +5,7 @@ class SageTokenGenerator < Rails::Generators::NamedBase
     # Style Variables
     style_file = "../packages/sage-assets/lib/stylesheets/tokens/_#{file_name}.scss"
     style_include_file = "../packages/sage-assets/lib/stylesheets/tokens/_index.scss"
-    style_include_line = "// Variable Tokens"\
+    style_include_line = "// Variable Tokens"
     # Create Style File
     template "style.scss", style_file
     # Include Style File

--- a/docs/lib/generators/sage_token/sage_token_generator.rb
+++ b/docs/lib/generators/sage_token/sage_token_generator.rb
@@ -3,14 +3,14 @@ class SageTokenGenerator < Rails::Generators::NamedBase
   def create_sage_token
 
     # Style Variables
-    style_file = "lib/sage-frontend/stylesheets/system/tokens/_#{file_name}.scss"
-    style_include_file = "lib/sage-frontend/stylesheets/system/index.scss"
-    style_include_line = "// Variable Tokens"
+    style_file = "../packages/sage-assets/lib/stylesheets/tokens/_#{file_name}.scss"
+    style_include_file = "../packages/sage-assets/lib/stylesheets/tokens/_index.scss"
+    style_include_line = "// Variable Tokens"\
     # Create Style File
     template "style.scss", style_file
     # Include Style File
     gsub_file style_include_file, /(#{Regexp.escape(style_include_line)})/mi do |match|
-      "#{match}\n@import \"tokens/#{file_name}\";"
+      "#{match}\n@import \"#{file_name}\";"
     end
 
     # Markup Variables

--- a/docs/lib/generators/sage_utility/USAGE
+++ b/docs/lib/generators/sage_utility/USAGE
@@ -1,8 +1,13 @@
 Description:
-    Explain the generator
+  Utilities are classes be used to accomplish specific styling needs and _should be used sparingly_, these limited use classes are designed to give the system flexibility but not meant to contribute to inconsistency.
 
 Example:
-    rails generate sage_utility Thing
+  rails generate sage_utility <new_utility_name>
 
-    This will create:
-        what/will/it/create
+  This will create:
+    <root>/docs/app/views/examples/utilities/<new_utility_name>/_preview.html.erb (documentation preview and description)
+    <root>/packages/sage-assets/lib/stylesheets/utilities/_<new_utility_name>.scss (stylesheet for new utility)
+
+  This will update:
+    <root>/docs/app/helpers/utilities_helper.rb (utility registry)
+    <root>/packages/sage-assets/lib/stylesheets/index.scss (imports utility stylesheet)

--- a/docs/lib/generators/sage_utility/sage_utility_generator.rb
+++ b/docs/lib/generators/sage_utility/sage_utility_generator.rb
@@ -3,8 +3,8 @@ class SageUtilityGenerator < Rails::Generators::NamedBase
   def create_sage_utility
 
     # Style Variables
-    style_file = "lib/sage-frontend/stylesheets/system/utilities/_#{file_name}.scss"
-    style_include_file = "lib/sage-frontend/stylesheets/system/index.scss"
+    style_file = "../packages/sage-assets/lib/stylesheets/utilities/_#{file_name}.scss"
+    style_include_file = "../packages/sage-assets/lib/stylesheets/index.scss"
     style_include_line = "// Utilities"
     # Create Style File
     template "style.scss", style_file

--- a/packages/sage-assets/lib/stylesheets/tokens/_index.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_index.scss
@@ -1,3 +1,4 @@
+// Variable Tokens
 @import "color_palette";
 @import "color_combos";
 @import "border";


### PR DESCRIPTION
## Description
The URLS for the Rails element/object/token file generators are out-of-date and throw errors when run. This update fixes the paths and fills out some missing documentation.

## Test notes

### Steps for testing
1. From the command-line, navigate to `docs` from the root directory
2. Run one of the [Sage generators from the wiki](https://github.com/Kajabi/sage-lib/wiki/Contributing) and confirm that the associated files are correctly output
3. Repeat step 2 with a different generator


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- closes #150 
