### PR TITLE
Feature Toggle - conditionally render aria attributes

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button.rb
@@ -1,7 +1,7 @@
 class SageButton < SageComponent
   set_attribute_schema({
     align:            [:optional, String],
-    attributes:       [:optional, Hash],
+    attributes:       [:optional, NilClass, Hash],
     css_classes:      [:optional, [String]],
     disabled:         [:optional, TrueClass],
     full_width:       [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -20,7 +20,7 @@
       <%= content_for :sage_feature_toggle_input %>
     </div>
   <% end %>
-  <a class="sage-feature-toggle__image-link">
-    <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>"/>
+  <a class="sage-feature-toggle__image-link" <%= aria-label={component.title} if component.alt_text.blank?%> >
+    <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>" <%= aria-hidden="true" if component.alt_text.blank? %> />
   </a>
 </li>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -20,7 +20,7 @@
       <%= content_for :sage_feature_toggle_input %>
     </div>
   <% end %>
-  <a class="sage-feature-toggle__image-link" <%= aria-label={component.title} if component.alt_text.blank?%> >
-    <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>" <%= aria-hidden="true" if component.alt_text.blank? %> />
-  </a>
+  <div class="sage-feature-toggle__image-link" >
+    <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>" <%= "aria-hidden=true" if component.alt_text.blank? %> />
+  </div>
 </li>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - conditionally render aria attributes for image
- [x] - updated sageButton `attribute` to accept `nil`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-01-14_at_11_50_50_AM](https://user-images.githubusercontent.com/1241836/104629397-0e7eb980-565f-11eb-99c4-65c18139cea6.png)|![Screen_Shot_2021-01-14_at_11_48_15_AM](https://user-images.githubusercontent.com/1241836/104629404-12124080-565f-11eb-9aa6-d4ac48533f2b.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit rail Feature Toggle page: http://localhost:4000/pages/object/feature_toggle
