### PR TITLE
Feature Toggle - added flexibility to component title heading level

### DIFF
--- a/docs/app/helpers/objects_helper.rb
+++ b/docs/app/helpers/objects_helper.rb
@@ -125,7 +125,7 @@ module ObjectsHelper
       {
         title: "feature_toggle",
         description: "Feature toggle",
-        use_legacy_html_code_source: true,
+        use_legacy_html_code_source: false,
         scss: "done",
         docs: "done",
         rails: "done",

--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -6,17 +6,18 @@
     link_text: "Learn more",
     link_location: "#",
     title: "New People list view",
+    title_tag: "h5",
   } do %>
     <%= sage_component_section :feature_toggle_input do %>
       <div class="sage-switch">
         <input 
           type="checkbox" 
-          id="feature-toggle-id" 
+          id="feature-toggle-id-1" 
           class="sage-switch__input" 
           name="feature-toggle-id" 
           value="feature-toggle-id"
         >
-        <label for="feature-toggle-id" class="sage-switch__label sage-switch__label--hide-text">Label Title</label>
+        <label for="feature-toggle-id-1" class="sage-switch__label sage-switch__label--hide-text">Label Title</label>
       </div>
     <% end %>
   <% end %>
@@ -31,7 +32,7 @@
     <%= sage_component_section :feature_toggle_input do %>
       <%= sage_component SageSwitch, { 
         type: "checkbox",
-        id: "feature-toggle-id",
+        id: "feature-toggle-id-2",
         hide_text: true,
         label_text: "Label Title",
         message: "",

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -1,6 +1,42 @@
 <tr>
   <td><code>alt_text</code></td>
-  <td>Sets the <code>alt</code> text for the Feature Toggle's image image</td>
+  <td>Sets the <code>alt</code> text for the components's image.</td>
   <td>String</td>
   <td></td>
+</tr>
+<tr>
+  <td><code>description</code></td>
+  <td>Sets the description text for the component.</td>
+  <td>String</td>
+  <td></td>
+</tr>
+<tr>
+  <td><code>image</code></td>
+  <td>Sets the <code>src</code> for the component's image</td>
+  <td>String</td>
+  <td></td>
+</tr>
+<tr>
+  <td><code>link_location</code></td>
+  <td>Sets the location of the <code>href</code> for the component</td>
+  <td>String</td>
+  <td></td>
+</tr>
+<tr>
+  <td><code>link_text</code></td>
+  <td>Sets the text for the component's link</td>
+  <td>String</td>
+  <td></td>
+</tr>
+<tr>
+  <td><code>title</code></td>
+  <td>Sets the sets the title text for the component</td>
+  <td>String</td>
+  <td></td>
+</tr>
+<tr>
+  <td><code>title_tag</code></td>
+  <td>Sets the heading tag (<code>h1</code> - <code>h6</code>) for the component's title tag</td>
+  <td>String</td>
+  <td>h3</td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -6,6 +6,7 @@ class SageFeatureToggle < SageComponent
     link_location: [:optional, String],
     link_text: [:optional, String],
     title: [:optional, String],
+    title_tag: [:optional, String],
   })
 
   def sections

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -1,3 +1,5 @@
+<% html_tag = component.title_tag ? component.title_tag : "h3" %>
+
 <li class="sage-feature-toggle">
   <h3 class="sage-feature-toggle__title"><%= component.title %></h3>
   <div class="sage-feature-toggle__content">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -1,7 +1,7 @@
-<% html_tag = component.title_tag ? component.title_tag : "h3" %>
+<% feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3" %>
 
 <li class="sage-feature-toggle">
-  <h3 class="sage-feature-toggle__title"><%= component.title %></h3>
+  <<%= feature_toggle_title_tag %> class="sage-feature-toggle__title"><%= component.title %></<%= feature_toggle_title_tag %>>
   <div class="sage-feature-toggle__content">
     <p><%= component.description %></p>
     <%= sage_component SageButton, {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - added flexibility to the title's heading level
- [x] - added rails code to docs site
- [x] - resolve a11y issue in demo
- [x] - added properties for component in docs site

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-01-14_at_10_56_54_AM](https://user-images.githubusercontent.com/1241836/104622942-7cbf7e00-5657-11eb-8e60-6a5647f5cc54.png)|![Screen_Shot_2021-01-14_at_10_55_58_AM](https://user-images.githubusercontent.com/1241836/104622967-80eb9b80-5657-11eb-8abb-da61dbebdb53.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit Feature Toggle rails page: http://localhost:4000/pages/object/feature_toggle

