### PR TITLE
Disable release version numbers in header

### DIFF
--- a/docs/app/views/application/_assistant.html.erb
+++ b/docs/app/views/application/_assistant.html.erb
@@ -19,21 +19,21 @@
         rel: "noopener noreferrer",
         title: "Open SageRails gem source"
       %>
-      <%= link_to "📦 v#{$SAGE_VERSION_REACT}",
+      <%#= link_to "📦 v#{$SAGE_VERSION_REACT}",
         $SAGE_VERSION_REACT_URL,
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",
         rel: "noopener noreferrer",
         title: "Open Sage React package source"
       %>
-      <%= link_to "🧰 v#{$SAGE_VERSION_ASSETS}",
+      <%#= link_to "🧰 v#{$SAGE_VERSION_ASSETS}",
         $SAGE_VERSION_ASSETS_URL,
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",
         rel: "noopener noreferrer",
         title: "Open Sage Assets package source"
       %>
-      <%= link_to "🤖 v#{$SAGE_VERSION_SYSTEM}",
+      <%#= link_to "🤖 v#{$SAGE_VERSION_SYSTEM}",
         $SAGE_VERSION_SYSTEM_URL,
         class: "sage-btn sage-btn--subtle sage-btn--secondary",
         target: "_blank",

--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -204,7 +204,7 @@ layout_pages = [
         <li><%= link_to "Sandbox", pages_sandbox_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page?(pages_sandbox_path)}" %></li>
         <li><%= link_to "Code Guidelines", "#{$SAGE_GITHUB_URL}", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
         <li>
-          <%= link_to "Release Notes",
+          <%= link_to "Release Notes (#{$SAGE_VERSION_GEM})",
             $SAGE_RELEASE_URL,
             class: "sage-nav__link",
             target: "_blank",

--- a/docs/config/initializers/load_sage_version.rb
+++ b/docs/config/initializers/load_sage_version.rb
@@ -1,28 +1,28 @@
-react_package_contents = JSON.parse(
-                              File.read(
-                                File.join("../packages/sage-react/", "package.json")
-                              )
-                            )
-assets_package_contents = JSON.parse(
-                              File.read(
-                                File.join("../packages/sage-assets/", "package.json")
-                              )
-                            )
-system_package_contents = JSON.parse(
-                              File.read(
-                                File.join("../packages/sage-system/", "package.json")
-                              )
-                            )
+# react_package_contents = JSON.parse(
+#                               File.read(
+#                                 File.join("../packages/sage-react/", "package.json")
+#                               )
+#                             )
+# assets_package_contents = JSON.parse(
+#                               File.read(
+#                                 File.join("../packages/sage-assets/", "package.json")
+#                               )
+#                             )
+# system_package_contents = JSON.parse(
+#                               File.read(
+#                                 File.join("../packages/sage-system/", "package.json")
+#                               )
+#                             )
 $SAGE_VERSION_GEM = SageRails::VERSION
-$SAGE_VERSION_REACT = react_package_contents["version"]
-$SAGE_VERSION_ASSETS = assets_package_contents["version"]
-$SAGE_VERSION_SYSTEM = system_package_contents["version"]
+# $SAGE_VERSION_REACT = react_package_contents["version"]
+# $SAGE_VERSION_ASSETS = assets_package_contents["version"]
+# $SAGE_VERSION_SYSTEM = system_package_contents["version"]
 
 $SAGE_GITHUB_URL = "https://github.com/Kajabi/sage-lib"
 $SAGE_GITHUB_PACKAGE_URL = "#{$SAGE_GITHUB_URL}/tree/@kajabi/sage@#{$SAGE_VERSION_GEM}/packages"
 
 $SAGE_VERSION_GEM_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-system"
-$SAGE_VERSION_REACT_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-react"
-$SAGE_VERSION_ASSETS_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-assets"
-$SAGE_VERSION_SYSTEM_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-system"
+# $SAGE_VERSION_REACT_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-react"
+# $SAGE_VERSION_ASSETS_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-assets"
+# $SAGE_VERSION_SYSTEM_URL = "#{$SAGE_GITHUB_PACKAGE_URL}/sage-system"
 $SAGE_RELEASE_URL = "#{$SAGE_GITHUB_URL}/releases/tag/@kajabi/sage@#{$SAGE_VERSION_GEM}"


### PR DESCRIPTION
## Description
Corrects an issue noted by @voodooGQ which prevents deployments of the docs site

- removes display of React, etc package versions from header (commented out for now)
- adds Gem version to sidebar for mobile view

### Related
- #130 
