### PR TITLE
Add toast confirmation to CopyButton

### DIFF
--- a/packages/sage-system/lib/copy-button.js
+++ b/packages/sage-system/lib/copy-button.js
@@ -15,6 +15,7 @@ Sage.copyButton = (function() {
     document.execCommand('copy');
     document.body.removeChild(el);
     ev.currentTarget.focus();
+    Sage.toast.trigger({message:'Copied to clipboard'})
   };
 
 


### PR DESCRIPTION
## Description
Adds a toast confirmation to the Sage copy button.
Jira Request: https://kajabi.atlassian.net/browse/MKT-137 

### Screenshots
<img width="1680" alt="Screen Shot 2021-01-13 at 1 33 13 PM" src="https://user-images.githubusercontent.com/1175111/104513165-14639480-55a4-11eb-8df7-1aa2ad74dd28.png">

### Steps for testing
1. Visit http://localhost:4000/pages/breakout/element/copy_text
2. Click on the copy button
3. Verify toast displays with the message **"Copied to clipboard"**

