### PR TITLE
Patch tabs choice schema

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -10,6 +10,6 @@ class SageChoice < SageComponent
     subtext: [:optional, NilClass, String],
     target: [:optional, NilClass, String],
     text: String,
-    type: Set.new(["arrow", "graphic", "icon", "radio"]),
+    type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -15,7 +15,7 @@ class SageTabs < SageComponent
       subtext: [:optional, NilClass, String],
       target: [:optional, NilClass, String],
       text: String,
-      type: Set.new(["arrow", "graphic", "icon", "radio"]),
+      type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
     ]],
     progressbar: [:optional, TrueClass],
     align_items_center: [:optional, TrueClass],


### PR DESCRIPTION
## Description

This PR patches the schemas for tabs and choices to ensure they're flexible with each other. In the end, the `type` property is not necessary for choices.