### PR TITLE
Add attributes to radio buttons

### DIFF
--- a/docs/app/views/examples/elements/checkbox/_props.html.erb
+++ b/docs/app/views/examples/elements/checkbox/_props.html.erb
@@ -13,7 +13,13 @@
 </tr>
 <tr>
   <td>Disabled</td>
-  <td>Sets the state to disabled</td>
+  <td>Prevents all user interaction with the control. Be aware that when combining a disabled checkbox with a default "checked" state, the value of the checkbox <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.</td>
   <td>String</td>
+  <td>null</td>
+</tr>
+<tr>
+  <td>Attributes</td>
+  <td>For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes</td>
+  <td>Hash</td>
   <td>null</td>
 </tr>

--- a/docs/app/views/examples/elements/radio/_preview.html.erb
+++ b/docs/app/views/examples/elements/radio/_preview.html.erb
@@ -34,7 +34,7 @@
     disabled: true
   } %>
 
-  <!-- Errror -->
+  <!-- Error -->
   <%= sage_component SageRadio, {
     id: "r5",
     name: "radio4",

--- a/docs/app/views/examples/elements/radio/_props.html.erb
+++ b/docs/app/views/examples/elements/radio/_props.html.erb
@@ -6,19 +6,31 @@
 </tr>
 <tr>
   <td>Name</td>
-  <td>Using a singular name groups radio buttons together, allowing the user to toggle between them (see Default example above)</td>
+  <td>Using a singular name groups radio buttons together, allowing the user to toggle between them (see Option 1 and Option 2 examples above)</td>
   <td>String</td>
   <td>null</td>
 </tr>
 <tr>
   <td>Checked</td>
-  <td>Sets the state to "checked" by default</td>
-  <td>String</td>
+  <td>Sets the state of the radio button to "checked" by default</td>
+  <td>Boolean</td>
   <td>null</td>
 </tr>
 <tr>
   <td>Required</td>
   <td>Adding this attribute allows basic HTML form validation on this field</td>
-  <td>String</td>
+  <td>Boolean</td>
+  <td>null</td>
+</tr>
+<tr>
+  <td>Disabled</td>
+  <td>Prevents all user interaction with the control. Be aware that when combining a disabled radio button with a default "checked" state, the value of the radio button <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.</td>
+  <td>Boolean</td>
+  <td>null</td>
+</tr>
+<tr>
+  <td>Attributes</td>
+  <td>For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes</td>
+  <td>Hash</td>
   <td>null</td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_radio.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_radio.rb
@@ -1,5 +1,6 @@
 class SageRadio < SageComponent
   set_attribute_schema({
+    attributes: [:optional, Hash],
     checked: [:optional, TrueClass],
     css_classes: [:optional, String],
     disabled: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -1,19 +1,22 @@
 <% if component.standalone %>
-  <input 
-    id="<%= component.id %>" 
-    type="radio" 
+  <input
+    id="<%= component.id %>"
+    type="radio"
     class="
       sage-radio
       sage-radio--standalone
       <%= component.has_error ? "sage-radio--error" : "" %>
       <%= component.css_classes if component.css_classes.present? %>
     "
+    name="<%= component.name %>"
+    value="<%= component.value %>"
+    <% component.attributes.each do |key, value| %>
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
     <%= "checked" if component.checked %>
     <%= "disabled" if component.disabled %>
     <%= "required" if component.required %>
     aria-label="<%= component.label_text %>"
-    name="<%= component.name %>"
-    value="<%= component.value %>"
   />
 <% else %>
   <div class="
@@ -22,12 +25,15 @@
       <%= component.css_classes if component.css_classes.present? %>
     "
   >
-    <input 
-      id="<%= component.id %>" 
-      type="radio" 
-      class="sage-radio__input" 
-      name="<%= component.name %>" 
+    <input
+      id="<%= component.id %>"
+      type="radio"
+      class="sage-radio__input"
+      name="<%= component.name %>"
       value="<%= component.value %>"
+      <% component.attributes.each do |key, value| %>
+        <%= "#{key}=\"#{value}\"".html_safe %>
+      <% end if component.attributes&.is_a?(Hash) %>
       <%= "checked" if component.checked %>
       <%= "disabled" if component.disabled %>
       <%= "required" if component.required %>


### PR DESCRIPTION
## Description
Applies attributes to radio buttons. Similar to checkboxes, the most frequent use for this will be with `data` attributes.

Also fixes a small typo and adds some documentation for checkbox properties.
