### PR TITLE
Rails Tabs Spacer Support

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -5,8 +5,10 @@
     <%= "sage-tabs--progressbar" if component.progressbar.present? && component.progressbar == true %>
     <%= "sage-tabs--align-items-center" if component.align_items_center.present? && component.align_items_center == true %>
     <%= "sage-tabs--choice" if component.style.present? && component.style === "choice" %>
+    <%= component.generated_css_classes %>
   "
   role="tablist"
+  <%= component.generated_html_attributes %>
 >
   <% component.items.each do |item| %>
     <% if component.style.present? && component.style === "choice" %>


### PR DESCRIPTION
## Description
Add Spacer support to Rails Tabs via `generated_css_classes` pattern...also added `generated_html_attributes` for good measure. :)

### Screenshots
n/a


## Test notes
Ensure no breakages

## Related
https://github.com/Kajabi/kajabi-products/pull/17323