### PR TITLE
Fix tooltip map

### DIFF
--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -26,7 +26,7 @@ export const Tooltip = ({
 
   return (
     <>
-      {Children.map((_children, child) => cloneElement(child, {
+      {Children.map(children, (child) => cloneElement(child, {
         onMouseEnter: handleActivate,
         onFocus: handleActivate,
         onMouseLeave: handleDeactivate,


### PR DESCRIPTION
## Description

While linting, I misunderstood where the parenthesis needed to go in this map function and unnecessarily renamed the `children` variable.