### PR TITLE
Toast adjustments to fix bootstrap styling conflicts

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_toast.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_toast.scss
@@ -74,6 +74,8 @@ $-toast-viewport-spacing-bottom: sage-spacing();
 
 .sage-toast__value {
   margin-right: sage-spacing(xs);
+  padding: 0;
   color: sage-color(white);
   line-height: sage-line-height(2xs);
+  font-size: sage-font-size(md);
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_toast.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_toast.scss
@@ -77,5 +77,5 @@ $-toast-viewport-spacing-bottom: sage-spacing();
   padding: 0;
   color: sage-color(white);
   line-height: sage-line-height(2xs);
-  font-size: sage-font-size(md);
+  @extend %t-sage-body-med;
 }

--- a/packages/sage-system/lib/toast.js
+++ b/packages/sage-system/lib/toast.js
@@ -34,7 +34,7 @@ Sage.toast = (function () {
     toast.classList.add('sage-toast--style-'+ config.type);
     toast.innerHTML = `
     <i class="sage-toast__icon sage-icon-${config.icon}"></i>
-    <output aria-live="assertive" aria-atomic="true"><p class="sage-toast__value">${config.message}</p></output>
+    <output class="sage-toast__value" aria-live="assertive" aria-atomic="true">${config.message}</output>
     <button type="button" data-js-toast-close class="sage-toast__close sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove"><span class="visually-hidden">Close</span></button>`;
 
     document.body.appendChild(toast);


### PR DESCRIPTION
## Description
The toast component when used within `kajabi-products` is clashing ⚔️   with some bootstrap styles related to the `output` element.

These adjustments will provide the additional properties (font-size and padding) needed to override the bootstrap defaults and prevent this issue.

### Screenshots

|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-01-22 at 9 00 54 AM](https://user-images.githubusercontent.com/1175111/105522255-d8aa8800-5c91-11eb-8fc7-15b736b73201.png) |![Screen Shot 2021-01-22 at 9 01 19 AM](https://user-images.githubusercontent.com/1175111/105522283-e102c300-5c91-11eb-9620-45c37a9aa4d5.png)|


## Test notes
There will be no visual changes within Sage but see screenshots above for how the appearance will change in `kajabi-products`.
