### PR TITLE
Update dropdown size position

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -46,7 +46,16 @@ export const Dropdown = ({
 
   const setPanelCoords = () => {
     const rect = wrapperRef.current.getBoundingClientRect();
-    updateCoords({ top: rect.bottom, left: rect.left });
+
+    updateCoords({
+      top: rect.bottom,
+      left: align !== 'right'
+        ? rect.left
+        : 'intitial',
+      right: align === 'right'
+        ? window.innerWidth - rect.right
+        : 'intitial',
+    });
   };
 
   const onUpdate = useCallback(debounce(() => setPanelCoords(), 20), []); // eslint-disable-line
@@ -59,12 +68,15 @@ export const Dropdown = ({
     if (isActive && isPinned) {
       setPanelCoords();
       window.addEventListener('scroll', onUpdate);
+      window.addEventListener('resize', onUpdate);
     } else {
       window.removeEventListener('scroll', onUpdate);
+      window.removeEventListener('resize', onUpdate);
     }
 
     return () => {
       window.removeEventListener('scroll', onUpdate);
+      window.removeEventListener('resize', onUpdate);
     };
   }, [wrapperRef, isActive, isPinned, onUpdate]);
 

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -34,6 +34,9 @@ export const Dropdown = ({
   const [coords, updateCoords] = useState(null);
   const wrapperRef = useRef(null);
 
+  const topBoxOffset = 2;
+  const inlineBoxOffset = -6;
+
   const onClickTrigger = () => {
     if (!isActive && clickTriggerHandler) {
       clickTriggerHandler();
@@ -48,12 +51,12 @@ export const Dropdown = ({
     const rect = wrapperRef.current.getBoundingClientRect();
 
     updateCoords({
-      top: rect.bottom,
+      top: rect.bottom + topBoxOffset,
       left: align !== 'right'
-        ? rect.left
+        ? rect.left + inlineBoxOffset
         : 'intitial',
       right: align === 'right'
-        ? window.innerWidth - rect.right
+        ? window.innerWidth - rect.right + inlineBoxOffset
         : 'intitial',
     });
   };

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -26,6 +26,7 @@ export const Dropdown = ({
   isPinned,
   label,
   panelModifier,
+  panelMaxWidth,
   triggerButtonSubtle,
   triggerModifier,
 }) => {
@@ -120,6 +121,7 @@ export const Dropdown = ({
       </DropdownTrigger>
       {isActive && (
         <DropdownPanel
+          maxWidth={panelMaxWidth}
           modifier={panelModifier}
           onClickScreen={onClickScreen}
           onExit={onExit}
@@ -154,6 +156,7 @@ Dropdown.defaultProps = {
   icon: null,
   isLabelVisible: true,
   isPinned: false,
+  panelMaxWidth: null,
   panelModifier: 'default',
   triggerButtonSubtle: false,
   triggerModifier: 'default',
@@ -177,6 +180,7 @@ Dropdown.propTypes = {
   isLabelVisible: PropTypes.bool,
   isPinned: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -57,7 +57,14 @@ DropdownPanel.propTypes = {
   children: PropTypes.node,
   coords: PropTypes.shape({
     top: PropTypes.number,
-    left: PropTypes.number,
+    left: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
+    right: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]),
   }),
   maxWidth: PropTypes.string,
   modifier: PropTypes.string,

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 export const DropdownPanel = ({
   children,
   coords,
+  maxWidth,
   modifier,
   onClickScreen,
   onExit,
@@ -28,7 +29,16 @@ export const DropdownPanel = ({
   const positioningCoords = { ...coords };
 
   return (
-    <div ref={menuEl} className={classNames} onClick={handlePanelClick} role="dialog" style={{ ...positioningCoords }}>
+    <div
+      ref={menuEl}
+      className={classNames}
+      onClick={handlePanelClick}
+      role="dialog"
+      style={{
+        maxWidth,
+        ...positioningCoords
+      }}
+    >
       {children && React.cloneElement(children, { onExit })}
     </div>
   );
@@ -37,6 +47,7 @@ export const DropdownPanel = ({
 DropdownPanel.defaultProps = {
   coords: null,
   children: null,
+  maxWidth: null,
   modifier: null,
   onClickScreen: (evt) => evt,
   onExit: (evt) => evt,
@@ -48,6 +59,7 @@ DropdownPanel.propTypes = {
     top: PropTypes.number,
     left: PropTypes.number,
   }),
+  maxWidth: PropTypes.string,
   modifier: PropTypes.string,
   onClickScreen: PropTypes.func,
   onExit: PropTypes.func,

--- a/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
@@ -9,6 +9,7 @@ export const OptionsDropdown = ({
   className,
   exitPanelHandler,
   isPinned,
+  panelMaxWidth,
   options,
 }) => (
   <Dropdown
@@ -19,6 +20,7 @@ export const OptionsDropdown = ({
     isLabelVisible={false}
     isPinned={isPinned}
     label="Options"
+    panelMaxWidth={panelMaxWidth}
     triggerModifier="options"
     triggerButtonSubtle={true}
   >
@@ -31,6 +33,7 @@ OptionsDropdown.defaultProps = {
   className: null,
   exitPanelHandler: (evt) => evt,
   isPinned: true,
+  panelMaxWidth: null,
   options: null,
 };
 
@@ -41,5 +44,6 @@ OptionsDropdown.propTypes = {
   className: PropTypes.string,
   exitPanelHandler: PropTypes.func,
   isPinned: PropTypes.bool,
+  panelMaxWidth: PropTypes.string,
   options: DropdownItemList.itemsPropTypes,
 };

--- a/packages/sage-react/lib/Panel/Panel.story.jsx
+++ b/packages/sage-react/lib/Panel/Panel.story.jsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 import { Grid } from '../Grid';
 import { Icon } from '../Icon';
 import { Label } from '../Label';
+import { OptionsDropdown } from '../Dropdown';
 import { SageClassnames, SageTokens } from '../configs';
 import { centerXY } from '../story-support/decorators';
 import { Panel } from './Panel';
@@ -22,14 +23,24 @@ storiesOf('Sage/Panel', module)
     <Grid container={Grid.CONTAINER_SIZES.XS}>
       <Panel loading={boolean('Loading', false)}>
         <Panel.Header title="Panel header">
-          <Button
-            color={Button.COLORS.SECONDARY}
-            icon={SageTokens.ICONS.INFO_CIRCLE}
-            iconOnly={true}
-            subtle={true}
-          >
-            Learn more
-          </Button>
+          <OptionsDropdown
+            align="right"
+            options={[
+              {
+                id: '1',
+                label: 'Option 1',
+              },
+              {
+                id: '2',
+                label: 'Option 2',
+              },
+              {
+                id: '3',
+                label: 'Option 3',
+              }
+            ]}
+            panelMaxWidth="240px"
+          />
         </Panel.Header>
         <Panel.Block sageType={true}>
           <p>


### PR DESCRIPTION
## Description

This PR adds ability to set a `max-width` for dropdown panels and fixes a positioning bug for when dropdowns and pinned and aligned right in React.

### Screenshots

![Screen Shot 2021-01-25 at 10 52 58 AM](https://user-images.githubusercontent.com/17955295/105729739-87053600-5efb-11eb-8afd-1085c2e6f877.png)


## Test notes

See storybook and `Panel` where an `OptionsDropdown` is used in context, pinned, and positioned right now with the new `max-width`.