### PR TITLE
Patch card highlight

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_card_highlight.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_card_highlight.scss
@@ -14,10 +14,14 @@
 
 .sage-card-highlight--right {
   right: 0;
+  border-top-right-radius: sage-border(radius);
+  border-bottom-right-radius: sage-border(radius);
 }
 
 .sage-card-highlight--left {
   left: 0;
+  border-top-left-radius: sage-border(radius);
+  border-bottom-left-radius: sage-border(radius);
 }
 
 .sage-card-highlight--top,
@@ -29,10 +33,14 @@
 
 .sage-card-highlight--top {
   top: 0;
+  border-top-left-radius: sage-border(radius);
+  border-top-right-radius: sage-border(radius);
 }
 
 .sage-card-highlight--bottom {
   bottom: 0;
+  border-bottom-left-radius: sage-border(radius);
+  border-bottom-right-radius: sage-border(radius);
 }
 
 @each $-color-name, $-color-sliders in $sage-colors {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_card.scss
@@ -9,7 +9,6 @@
   @include sage-card();
 
   position: relative;
-  overflow: hidden;
   width: 100%;
 }
 


### PR DESCRIPTION
## Description

Current implementation of card highlight simply (and erroneously) relied on `overflow: hidden` to clip the border. This was short-sighted and caused issues with panels that appear within cards.

This fix adds a little more complexity to card highlights so that the overflow setting is no longer needed.

### Screenshots

No visual change.

## Test notes
1. See Card Highlight is still working
2. See that panels that appear within cards such as on Input Group password meter are no longer clipped by erroneous overflow setting.
