### PR TITLE
Input affix render bug

### DIFF
--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -62,7 +62,7 @@ export const Input = ({
     if (affixUpdatesNeeded) {
       updateStyles(newInputStyles);
     }
-  }, [inputStyles, prefix, prefixRef, suffix, suffixRef]);
+  }, [prefix, suffix]);
 
   return (
     <div className={classNames}>

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Label } from '../Label';
 
 export const Input = ({
   className,
@@ -81,22 +82,22 @@ export const Input = ({
         </label>
       )}
       {prefix && (
-        <span
-          ref={prefixRef}
-          className="sage-input__affix sage-input__affix--prefix sage-label sage-label--draft"
+        <Label
           aria-label={`Prefixed with ${prefix}`}
-        >
-          {prefix}
-        </span>
+          className="sage-input__affix sage-input__affix--prefix"
+          color={Label.COLORS.DRAFT}
+          ref={prefixRef}
+          value={prefix}
+        />
       )}
       {suffix && (
-        <span
-          ref={suffixRef}
-          className="sage-input__affix sage-input__affix--suffix sage-label sage-label--draft"
+        <Label
           aria-label={`Suffixed with ${suffix}`}
-        >
-          {suffix}
-        </span>
+          className="sage-input__affix sage-input__affix--suffix"
+          color={Label.COLORS.DRAFT}
+          ref={suffixRef}
+          value={suffix}
+        />
       )}
       {message && (
         <div className="sage-input__message">{message}</div>

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -10,7 +10,6 @@ import {
 } from './configs';
 
 export const Label = React.forwardRef(({
-  children,
   className,
   color,
   icon,
@@ -60,7 +59,6 @@ Label.STYLES = LABEL_STYLES;
 Label.INTERACTIVE_TYPES = LABEL_INTERACTIVE_TYPES;
 
 Label.defaultProps = {
-  children: null,
   className: null,
   color: LABEL_COLORS.DRAFT,
   icon: null,
@@ -72,7 +70,6 @@ Label.defaultProps = {
 };
 
 Label.propTypes = {
-  children: PropTypes.node,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(LABEL_COLORS)),
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -9,7 +9,7 @@ import {
   LABEL_INTERACTIVE_TYPES,
 } from './configs';
 
-export const Label = ({
+export const Label = React.forwardRef(({
   children,
   className,
   color,
@@ -21,7 +21,7 @@ export const Label = ({
   style,
   value,
   ...rest
-}) => {
+}, ref) => {
   const TagName = interactiveType ? 'button' : 'span';
 
   const classNames = classnames(
@@ -37,7 +37,7 @@ export const Label = ({
   );
 
   return (
-    <span className={classNames}>
+    <span className={classNames} ref={ref}>
       <TagName
         className="sage-label__value"
         type={interactiveType ? 'button' : null}
@@ -53,7 +53,7 @@ export const Label = ({
       )}
     </span>
   );
-};
+});
 
 Label.COLORS = LABEL_COLORS;
 Label.STYLES = LABEL_STYLES;

--- a/packages/sage-react/lib/Panel/Panel.story.jsx
+++ b/packages/sage-react/lib/Panel/Panel.story.jsx
@@ -339,7 +339,7 @@ storiesOf('Sage/Panel', module)
               Molestie libero vel
             </p>
           </Panel.Block>
-          <Label color={Label.COLORS.WARNING}>In progress</Label>
+          <Label color={Label.COLORS.WARNING} value="In progress" />
           <Button
             icon={SageTokens.ICONS.PEN}
             subtle={true}


### PR DESCRIPTION
## Description

Fixes bug in Input with suffix/prefix that was rendering indefinitely.
- Updates label to use `forwardRef` and removes unused `children` prop
- Updates Input to use this Label and removes exhaustive dependencies.

### Screenshots
No visual changes.

## Test notes

Test in Storybook by adding `prefix` or `suffix` values to see expected behavior and no infinite rerenders in console.
