### PR TITLE
Status Icon - add rails demo code and updated props

### DIFF
--- a/docs/app/helpers/elements_helper.rb
+++ b/docs/app/helpers/elements_helper.rb
@@ -234,12 +234,12 @@ module ElementsHelper
       {
         title: "status_icon",
         description: "Display the status of an item",
-        use_legacy_html_code_source: true,
+        use_legacy_html_code_source: false,
         scss: "done",
         docs: "done",
         rails: "done",
         react: "todo",
-        a11y: "todo"
+        a11y: "done"
       },
       {
         title: "switch",

--- a/docs/app/views/examples/elements/status_icon/_preview.html.erb
+++ b/docs/app/views/examples/elements/status_icon/_preview.html.erb
@@ -1,21 +1,21 @@
 <%= sage_component SagePanelBlock, {} do %>
-  <%= render "examples/elements/status_icon/markup",
-    icon_name: "preview-on",
-    content: "Preview is active"
-  %>
+  <%= sage_component SageStatusIcon, {
+    icon: "preview-on",
+    value: "Preview is active"
+  } %>
 
-  <%= render "examples/elements/status_icon/markup",
-    icon_name: "lock",
-    content: "This has been locked"
-  %>
+  <%= sage_component SageStatusIcon, {
+    icon: "lock",
+    value: "This has been locked"
+  } %>
 
-  <%= render "examples/elements/status_icon/markup",
-    icon_name: "warning",
-    content: "Danger danger!"
-  %>
+  <%= sage_component SageStatusIcon, {
+    icon: "warning",
+    value: "Danger danger!"
+  } %>
 
-  <%= render "examples/elements/status_icon/markup",
-    icon_name: "info-circle",
-    content: "Good information here :)"
-  %>
+  <%= sage_component SageStatusIcon, {
+    icon: "info-circle",
+    value: "Good information here :)"
+  } %>
 <% end %>

--- a/docs/app/views/examples/elements/status_icon/_props.html.erb
+++ b/docs/app/views/examples/elements/status_icon/_props.html.erb
@@ -1,6 +1,12 @@
 <tr>
-  <td>--icon-[name]</td>
-  <td>The name of the icon to display</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`name`") %></td>
+  <td><%= md("The name of the icon to display.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("null") %></td>
+</tr>
+<tr>
+  <td><%= md("`value`") %></td>
+  <td><%= md("The hidden text value of the conponent.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("null") %></td>
 </tr>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - updated rails demo code and doc props

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit rails status icon page: http://localhost:4000/pages/element/status_icon
2. Verify demo and docs

