### PR TITLE
Dropdown - fixed string interpolation issue when multiple words present

### DIFF
--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -97,7 +97,10 @@
       value: "Delete Category",
       icon: "trash",
       style: "danger",
-      attributes: { "href": "#" },
+      attributes: { 
+        "href": "#",
+        "data-test": "test method" 
+      },
     }]
   } do %>
     <%= sage_component SageLabel, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -52,7 +52,7 @@
           >
             <a
               <% item[:attributes].each do |key, value| %>
-                <%= "#{key}=#{value}"%>
+                <%= key %>="<%= value %>"
               <% end if item[:attributes]&.is_a?(Hash) %>
               role="menuitem"
               tabindex="0"


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - resolve string interpolation issue when multiple words present

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-01-26_at_9_00_32_AM](https://user-images.githubusercontent.com/1241836/105862282-394d0400-5fb5-11eb-9a5b-496d2204a429.png)|![Screen_Shot_2021-01-26_at_8_59_19_AM](https://user-images.githubusercontent.com/1241836/105862311-3f42e500-5fb5-11eb-8aec-81d6ab72e214.png)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit dropdown sage page: http://localhost:4000/pages/object/dropdown
2. In the `SageLabel Button, with SageLabel Values, and aligned right example`, Inspect the `Delete Category` option
3. Verify that the multi word value is 2 words surrounded by quotes and not only the first word being wrapped in quotes
