### PR TITLE
Panel size prop react

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -236,7 +236,7 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown__menu {
   overflow: auto;
   min-width: $-dropdown-width;
-  width: 100%;
+  width: auto;
   max-height: $-panel-max-height;
   padding: sage-spacing(xs) 0;
 
@@ -263,7 +263,7 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   // transform: rotate3d(1, 0, 0, -90deg);
   transform-origin: top center;
   min-width: $-dropdown-width;
-  width: 100%;
+  width: auto;
   border-radius: sage-border(radius);
   background-color: sage-color(white);
   box-shadow: sage-shadow(md);

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -8,7 +8,7 @@ import { DropdownItemList } from './DropdownItemList';
 import { DropdownItemSearch } from './DropdownItemSearch';
 import { DropdownPanel } from './DropdownPanel';
 import { DropdownTrigger } from './DropdownTrigger';
-import { DROPDOWN_ITEM_COLORS } from './configs';
+import { DROPDOWN_ITEM_COLORS, DROPDOWN_PANEL_SIZES } from './configs';
 
 export const Dropdown = ({
   align,
@@ -27,6 +27,7 @@ export const Dropdown = ({
   label,
   panelModifier,
   panelMaxWidth,
+  panelSize,
   triggerButtonSubtle,
   triggerModifier,
 }) => {
@@ -111,10 +112,11 @@ export const Dropdown = ({
     {
       [`sage-dropdown--anchor-${align}`]: align,
       'sage-dropdown--active': isActive,
+      'sage-dropdown--contained': contained,
+      'sage-dropdown--customized': customized,
       'sage-dropdown--disabled': disabled,
       'sage-dropdown--pinned': isPinned,
-      'sage-dropdown--customized': customized,
-      'sage-dropdown--contained': contained,
+      [`sage-dropdown--${panelSize}`]: panelSize,
     }
   );
 
@@ -156,6 +158,7 @@ Dropdown.Panel = DropdownPanel;
 Dropdown.Trigger = DropdownTrigger;
 
 Dropdown.ITEM_COLORS = DROPDOWN_ITEM_COLORS;
+Dropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
 
 Dropdown.defaultProps = {
   align: null,
@@ -173,6 +176,7 @@ Dropdown.defaultProps = {
   isPinned: false,
   panelMaxWidth: null,
   panelModifier: 'default',
+  panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   triggerButtonSubtle: false,
   triggerModifier: 'default',
   label: null
@@ -197,6 +201,7 @@ Dropdown.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
+  panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
 import { DropdownItemList } from './DropdownItemList';
+import { DROPDOWN_PANEL_SIZES } from './configs';
 
 export const OptionsDropdown = ({
   align,
@@ -10,6 +11,7 @@ export const OptionsDropdown = ({
   exitPanelHandler,
   isPinned,
   panelMaxWidth,
+  panelSize,
   options,
 }) => (
   <Dropdown
@@ -21,6 +23,7 @@ export const OptionsDropdown = ({
     isPinned={isPinned}
     label="Options"
     panelMaxWidth={panelMaxWidth}
+    panelSize={panelSize}
     triggerModifier="options"
     triggerButtonSubtle={true}
   >
@@ -28,12 +31,15 @@ export const OptionsDropdown = ({
   </Dropdown>
 );
 
+OptionsDropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
+
 OptionsDropdown.defaultProps = {
   align: null,
   className: null,
   exitPanelHandler: (evt) => evt,
   isPinned: true,
   panelMaxWidth: null,
+  panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   options: null,
 };
 
@@ -45,5 +51,6 @@ OptionsDropdown.propTypes = {
   exitPanelHandler: PropTypes.func,
   isPinned: PropTypes.bool,
   panelMaxWidth: PropTypes.string,
+  panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
   options: DropdownItemList.itemsPropTypes,
 };

--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -6,6 +6,7 @@ import uuid from 'react-uuid';
 import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
 import { DropdownTriggerSelect } from './DropdownTriggerSelect';
+import { DROPDOWN_PANEL_SIZES } from './configs';
 
 export const SelectDropdown = ({
   allowMultiselect,
@@ -25,6 +26,7 @@ export const SelectDropdown = ({
   onDeselect,
   onSearch,
   onSelect,
+  panelSize,
   resetToken,
   searchable,
   searchPlaceholder,
@@ -188,6 +190,7 @@ export const SelectDropdown = ({
       exitPanelHandler={changeValue}
       label={emptySelectedValue}
       panelModifier="select"
+      panelSize={panelSize}
       triggerModifier="select"
     >
       <Dropdown.ItemList
@@ -203,6 +206,8 @@ export const SelectDropdown = ({
     </Dropdown>
   );
 };
+
+SelectDropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
 
 SelectDropdown.defaultProps = {
   allowMultiselect: false,
@@ -222,6 +227,7 @@ SelectDropdown.defaultProps = {
   onDeselect: null,
   onSelect: (evt) => evt,
   onSearch: (evt) => evt,
+  panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   resetToken: null,
   searchable: false,
   searchPlaceholder: 'Find',
@@ -257,6 +263,7 @@ SelectDropdown.propTypes = {
   onDeselect: PropTypes.func,
   onSearch: PropTypes.func,
   onSelect: PropTypes.func,
+  panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
   resetToken: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]),
   searchable: PropTypes.bool,
   searchPlaceholder: PropTypes.string,

--- a/packages/sage-react/lib/Dropdown/configs.js
+++ b/packages/sage-react/lib/Dropdown/configs.js
@@ -4,3 +4,8 @@ export const DROPDOWN_ITEM_COLORS = {
   PRIMARY: 'primary',
   DEFAULT: null,
 };
+
+export const DROPDOWN_PANEL_SIZES = {
+  DEFAULT: false,
+  SMALL: 'small',
+};


### PR DESCRIPTION
## Description

This PR incorporates the existing `--small` modifier on Dropdowns in React and makes size adjustments on panel sizes easier by revising their widths from `100%` to `auto`.

## Test notes
See Dropdown in Storybook for no change in presentation.

### Steps for testing

In `products`, Dropdowns should continue to behave as expected. For example:
  - [ ] Dropdowns in People panel controls all size and behave correctly
  - [ ] Dropdowns in Product catalogue and outline all size and behave correctly
  - [ ] General perusal of other Sage dropdowns should demonstrate they remain unaffected

## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- 
