### PR TITLE
Adjust deselect functionality

### DIFF
--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -8,6 +8,7 @@ import { Dropdown } from './Dropdown';
 import { DropdownTriggerSelect } from './DropdownTriggerSelect';
 
 export const SelectDropdown = ({
+  allowDeselect,
   allowMultiselect,
   className,
   closePanelOnExit,
@@ -89,7 +90,7 @@ export const SelectDropdown = ({
       }
 
       // Selecting same item as currently selected deselects it
-      if (selectedValue === configs.selectedValue) {
+      if (allowDeselect && selectedValue === configs.selectedValue) {
         deselectValue();
         return;
       }
@@ -205,6 +206,7 @@ export const SelectDropdown = ({
 };
 
 SelectDropdown.defaultProps = {
+  allowDeselect: false,
   allowMultiselect: false,
   className: null,
   closePanelOnExit: true,
@@ -229,6 +231,7 @@ SelectDropdown.defaultProps = {
 };
 
 SelectDropdown.propTypes = {
+  allowDeselect: PropTypes.bool,
   allowMultiselect: PropTypes.bool,
   className: PropTypes.string,
   closePanelOnExit: PropTypes.bool,


### PR DESCRIPTION
## Description

This PR allows for `SelectDropdown`s to use the `allowDeselect` property to control whether an item within a dropdown can be deselected by clicking it a second time. This is not default behavior standard HTML `select` either, but it can now be enacted when desired in this component rather than forced as a default. 

## Test notes

No changes should occur in Rails. React uses of the `SelectDropdown` component must now set `allowDeselect` to `true` in order to retain the prior setup. No existing implementations of this component in `products` need the prior setup as a default.