### PR TITLE
SageCardStack: Add spacer: "form" modifier

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_panel_stack.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_stack.rb
@@ -1,2 +1,5 @@
 class SagePanelStack < SageComponent
+  set_attribute_schema({
+    spacing: [:optional, Set.new(["form"])],
+  })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_stack.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_stack.html.erb
@@ -1,5 +1,9 @@
 <div
-  class="sage-panel__stack <%= component.generated_css_classes %>"
+  class="
+    sage-panel__stack
+    <%= "sage-panel__stack--spacing-form" if component.spacing === "form" %>
+    <%= component.generated_css_classes %>
+  "
   <%= component.generated_html_attributes.html_safe %>
 >
   <%= component.content %>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel.scss
@@ -130,6 +130,11 @@
   @include sage-grid-stack();
 }
 
+.sage-panel__stack--spacing-form {
+  justify-items: stretch;
+  gap: sage-spacing(card);
+}
+
 .sage-panel__subtitle {
   @extend %t-sage-heading-6;
 }


### PR DESCRIPTION
## Description
Adds a `spacing` modifier that accepts a value of `"form"` to `SageCardStack` rails Sage component. This adds support for form element spacing.

Slack conversation context:
https://kajabi.slack.com/archives/CU5JG6N2E/p1611864458032400

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/106198349-ee341c00-6181-11eb-9108-9fffd1a356b1.png)|![image](https://user-images.githubusercontent.com/565743/106198397-fb510b00-6181-11eb-8152-0ac52115d7e3.png)|


## Test notes
n/a


## Related
BUILD-693
