### PR TITLE
Dropdown - conditionally render button in dropdown item

### DIFF
--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -86,7 +86,7 @@
     panel_size: "small",
     items: [{
       value: sage_component(SageLabel, { color: "success", value: "Publish" }),
-      attributes: { "href": "#" },
+      attributes: {},
     }, {
       value: sage_component(SageLabel, { color: "info", value: "Drip" }),
       attributes: { "href": "#" },

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -72,12 +72,13 @@
                 <% end if item[:attributes]&.is_a?(Hash) %>
                 role="menuitem"
                 tabindex="0"
+                type="button"
                 class="
                   sage-dropdown__item-control
                   <%= "sage-dropdown__item-control--#{item[:style]}" if item[:style] %>
                   <%= "sage-dropdown__item-control--icon-#{item[:icon]}" if item[:icon] %>
                 ">
-                hey
+                <%= item[:value].html_safe %>
               </button>
             <% end %>
           </li>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -50,20 +50,36 @@
             "
             role="none"
           >
-            <a
-              <% item[:attributes].each do |key, value| %>
-                <%= key %>="<%= value %>"
-              <% end if item[:attributes]&.is_a?(Hash) %>
-              role="menuitem"
-              tabindex="0"
-              class="
-                sage-dropdown__item-control
-                <%= "sage-dropdown__item-control--#{item[:style]}" if item[:style] %>
-                <%= "sage-dropdown__item-control--icon-#{item[:icon]}" if item[:icon] %>
-              "
-            >
-              <%= item[:value].html_safe %>
-            </a>
+            <% if item[:attributes].nil? || item[:attributes]&.keys&.include?(:href) || item[:attributes]&.keys&.include?("href") %>
+              <a
+                <% item[:attributes].each do |key, value| %>
+                  <%= key %>="<%= value %>"
+                <% end if item[:attributes]&.is_a?(Hash) %>
+                role="menuitem"
+                tabindex="0"
+                class="
+                  sage-dropdown__item-control
+                  <%= "sage-dropdown__item-control--#{item[:style]}" if item[:style] %>
+                  <%= "sage-dropdown__item-control--icon-#{item[:icon]}" if item[:icon] %>
+                "
+              >
+                <%= item[:value].html_safe %>
+              </a>
+            <% else %>
+              <button 
+                <% item[:attributes].each do |key, value| %>
+                  <%= key %>="<%= value %>"
+                <% end if item[:attributes]&.is_a?(Hash) %>
+                role="menuitem"
+                tabindex="0"
+                class="
+                  sage-dropdown__item-control
+                  <%= "sage-dropdown__item-control--#{item[:style]}" if item[:style] %>
+                  <%= "sage-dropdown__item-control--icon-#{item[:icon]}" if item[:icon] %>
+                ">
+                hey
+              </button>
+            <% end %>
           </li>
         <% end %>
       <% end %>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Render a `<button>` in the dropdown item if its `attributes` don't contain a `href`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-01-29_at_2_07_26_PM](https://user-images.githubusercontent.com/1241836/106322581-a5409e00-623b-11eb-900d-3e51173dda3e.png)|![Screen_Shot_2021-01-29_at_10_43_40_AM](https://user-images.githubusercontent.com/1241836/106322590-aa055200-623b-11eb-9f6c-6199c027c4fc.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the dropdown page: http://localhost:4000/pages/object/dropdown
2. If the calling code Dropdown item's `item:attributes` exists but does not contain an `href` the rendered element is a `<button>`. If the Dropdown item's `item:attributes` contain an `href` or are not present, the rendered element is a `<a>`.
  
