### PR TITLE
Enhance Description rails component

### DIFF
--- a/docs/app/views/examples/elements/description/_preview.html.erb
+++ b/docs/app/views/examples/elements/description/_preview.html.erb
@@ -50,7 +50,7 @@
     },
     {
       title: "Name",
-      data: %(<img src="//placehold.it/24x18?text=VISA" /> John Doe),
+      data: %(<img src="//placehold.it/24x18?text=VISA" /> John Doe).html_safe,
     }
   ],
   inline_spread: true,

--- a/docs/app/views/examples/elements/description/_preview.html.erb
+++ b/docs/app/views/examples/elements/description/_preview.html.erb
@@ -1,4 +1,59 @@
+<h2>Single item</h2>
 <%= sage_component SageDescription, {
   title: "Name",
   data: "John Doe",
 } %>
+
+<h2>Single item (title normal case)</h2>
+<%= sage_component SageDescription, {
+  title: "Name",
+  data: "John Doe",
+  allcaps_titles: false,
+} %>
+
+<h2>Mulitple items</h2>
+<%= sage_component SageDescription, {
+  items: [
+    {
+      title: "Name",
+      data: "John Doe",
+    },
+    {
+      title: "Name",
+      data: "John Doe",
+    },
+    {
+      title: "Name",
+      data: "John Doe",
+    },
+    {
+      title: "Name",
+      data: "John Doe",
+    }
+  ],
+} %>
+
+<h2>Mulitple items (inline layout)</h2>
+<%= sage_component SageDescription, {
+  items: [
+    {
+      title: "Name",
+      data: "John Doe",
+    },
+    {
+      title: "Name",
+      data: "John Doe",
+    },
+    {
+      title: "Name",
+      data: "John Doe",
+    },
+    {
+      title: "Name",
+      data: %(<img src="//placehold.it/24x18?text=VISA" /> John Doe),
+    }
+  ],
+  inline_spread: true,
+  allcaps_titles: false,
+} %>
+

--- a/docs/app/views/examples/elements/description/_preview.html.erb
+++ b/docs/app/views/examples/elements/description/_preview.html.erb
@@ -11,7 +11,7 @@
   allcaps_titles: false,
 } %>
 
-<h2>Mulitple items</h2>
+<h2>Multiple items</h2>
 <%= sage_component SageDescription, {
   items: [
     {

--- a/docs/app/views/examples/elements/description/_props.html.erb
+++ b/docs/app/views/examples/elements/description/_props.html.erb
@@ -1,12 +1,52 @@
 <tr>
-  <td>title</td>
-  <td>The "title" or term for the element.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`title`') %></td>
+  <td><%= md('The "title" or term for the element.') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('`null`') %></td>
 </tr>
 <tr>
-  <td>data</td>
-  <td>The "data" or description for the element.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`data`') %></td>
+  <td><%= md('The "data" or description for the element.') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('`null`') %></td>
+</tr>
+<tr>
+  <td><%= md('`link`') %></td>
+  <td><%= md('URL for a link to be wrapped around the `data` value.') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('`null`') %></td>
+</tr>
+<tr>
+  <td><%= md('`id`') %></td>
+  <td><%= md('A unique `id` attribute to be applied to the root `dl` element for this description or description set.') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('`null`') %></td>
+</tr>
+<tr>
+  <td><%= md('`items`') %></td>
+  <td><%= md('
+    An array of items to create a set of `title`: `description` pairs.
+    If this is provided, standalone `title` and `data` properties are ignored in favor of rendering this set of items.
+  ') %></td>
+  <td><%= md('```
+Array<{
+  data: String,
+  title: String,
+  link: String
+}>
+```
+(see corresponding properties above)') %></td>
+  <td><%= md('`null`') %></td>
+</tr>
+<tr>
+  <td><%= md('`inline_spread`') %></td>
+  <td><%= md('If `true` the title/data pairs will render in line with each other and spread apart, with the `title` left-aligned and the `data` right-aligned.') %></td>
+  <td><%= md('`Boolean`') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`allcaps_titles`') %></td>
+  <td><%= md('If `false` the titles will render in the casing provided rather than being forced to all caps (default).') %></td>
+  <td><%= md('`Boolean`') %></td>
+  <td><%= md('`true`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_description.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_description.rb
@@ -1,8 +1,17 @@
 class SageDescription < SageComponent
+  # TODO: simplify to items only (remove data, link, title from root)
+  # once instances are converted to the lists format.
   set_attribute_schema({
-    title: [:optional, String],
     data: [:optional, NilClass, String, Integer, Hash],
-    link: [:optional, String],
     id: [:optional, String],
+    inline_spread: [:optional, TrueClass],
+    link: [:optional, String],
+    title: [:optional, String],
+    allcaps_titles: [:optional, TrueClass],
+    items: [:optional, [[{
+      data: [:optional, NilClass, String, Integer, Hash],
+      link: [:optional, String],
+      title: [:optional, String],
+    }]]]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_description.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_description.html.erb
@@ -1,14 +1,44 @@
-<dl <%= component.id ? "id=#{component.id}" : "" %> class="sage-description">
-  <% if component.title.present? %>
-    <dt class="sage-description__title"><%= component.title %></dt>
-  <% end %>
-  <% if component.data.present? %>
-    <% if component.link.present? %>
-      <%= link_to component.link do %>
-        <dd class="sage-description__data"><%= component.data %></dd>
+<%
+# ensure default is to treat titles with all caps; `allcaps_titles` must be set to false to change this
+normalcase_titles = component.allcaps_titles == false ? true : false
+%>
+<dl
+  <%= component.id ? "id=#{component.id}" : "" %>
+  class="
+    sage-description
+    <%= "sage-description--inline-spread" if component.inline_spread.present? && component.inline_spread %>
+    <%= "sage-description--normalcase-titles" if normalcase_titles %>
+  "
+>
+  <% if component.items.present? %>
+    <% component.items.each do | item | %>
+      <div class="sage-description__term-group">
+        <% if item[:title] %>
+          <dt class="sage-description__title"><%= item[:title].html_safe %></dt>
+        <% end %>
+        <% if item[:data] %>
+          <% if item[:link] %>
+            <%= link_to item[:link] do %>
+              <dd class="sage-description__data"><%= item[:data].html_safe %></dd>
+            <% end %>
+          <% else %>
+            <dd class="sage-description__data"><%= item[:data].html_safe %></dd>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <% if component.title.present? %>
+      <dt class="sage-description__title"><%= component.title.html_safe %></dt>
+    <% end %>
+    <% if component.data.present? %>
+      <% if component.link.present? %>
+        <%= link_to component.link do %>
+          <dd class="sage-description__data"><%= component.data.html_safe %></dd>
+        <% end %>
+      <% else %>
+        <dd class="sage-description__data"><%= component.data.html_safe %></dd>
       <% end %>
-    <% else %>
-      <dd class="sage-description__data"><%= component.data %></dd>
     <% end %>
   <% end %>
   <%= component.content %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_description.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_description.html.erb
@@ -14,30 +14,30 @@ normalcase_titles = component.allcaps_titles == false ? true : false
     <% component.items.each do | item | %>
       <div class="sage-description__term-group">
         <% if item[:title] %>
-          <dt class="sage-description__title"><%= item[:title].html_safe %></dt>
+          <dt class="sage-description__title"><%= item[:title] %></dt>
         <% end %>
         <% if item[:data] %>
           <% if item[:link] %>
             <%= link_to item[:link] do %>
-              <dd class="sage-description__data"><%= item[:data].html_safe %></dd>
+              <dd class="sage-description__data"><%= item[:data] %></dd>
             <% end %>
           <% else %>
-            <dd class="sage-description__data"><%= item[:data].html_safe %></dd>
+            <dd class="sage-description__data"><%= item[:data] %></dd>
           <% end %>
         <% end %>
       </div>
     <% end %>
   <% else %>
     <% if component.title.present? %>
-      <dt class="sage-description__title"><%= component.title.html_safe %></dt>
+      <dt class="sage-description__title"><%= component.title %></dt>
     <% end %>
     <% if component.data.present? %>
       <% if component.link.present? %>
         <%= link_to component.link do %>
-          <dd class="sage-description__data"><%= component.data.html_safe %></dd>
+          <dd class="sage-description__data"><%= component.data %></dd>
         <% end %>
       <% else %>
-        <dd class="sage-description__data"><%= component.data.html_safe %></dd>
+        <dd class="sage-description__data"><%= component.data %></dd>
       <% end %>
     <% end %>
   <% end %>

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_description.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_description.scss
@@ -12,12 +12,45 @@
   }
 }
 
+.sage-description__data {
+  @extend %t-sage-body;
+
+  .sage-description--inline-spread & {
+    flex: 1;
+    text-align: right;
+  }
+}
+
+.sage-description--inline-spread {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+}
+
+.sage-description__term-group {
+  margin-bottom: sage-spacing(2xs);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
+  .sage-description--inline-spread & {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+}
+
 .sage-description__title {
   @extend %t-sage-body-small-semi;
   color: sage-color(charcoal, 300);
-  text-transform: uppercase;
-}
 
-.sage-description__data {
-  @extend %t-sage-body;
+  .sage-description:not(.sage-description--normalcase-titles) & {
+    text-transform: uppercase;
+  }
+
+  .sage-description--inline-spread & {
+    flex: 1;
+    transform: translateY(rem(3px));
+  }
 }


### PR DESCRIPTION
## Description

This PR enhances the Description Rails component as follows:

- Add ability to adjust layout of description to inline
- Add ability to adjust title to match provided casing
- Add ability to provide a set of items. **NOTE:** This begins a process to sunset the direct `title` and `data` properties in lieu of a set-based `items` approach. However, enough implementations of the current approach exist in the app that it seems reasonable to allow both for a time and trim down/weed out the standalone uses before switching fully to the set-based approach.
- Updates documentation to match

### Screenshots

![Screen Shot 2021-02-01 at 12 11 57 PM](https://user-images.githubusercontent.com/17955295/106493975-d57c7c80-6487-11eb-913f-b88bcd00e058.png)


## Test notes

See Elements > Description

### Steps for testing in app
Existing implementations of Description should work as expected (no change) such as:
  - [ ] (super admin) Accounts > Select an account > See the property/value pairs throughout this page appear and work as expected
  - [ ] (super admin) Sites > Select a site > See the property/value pairs throughout this page appear and work as expected
