### PR TITLE
Avatar center and sizing

### DIFF
--- a/docs/app/views/examples/objects/avatar/_preview.html.erb
+++ b/docs/app/views/examples/objects/avatar/_preview.html.erb
@@ -13,8 +13,8 @@
   <%= sage_component SageAvatar, { color: "orange", initials: "KJ", css_classes: "my-custom-class" } %>
 </div>
 
-<h3>Avatar centered</h3>
-<%= sage_component SageAvatar, { color: nil, centered: true, initials: "JC" } %>
+<h3>Avatar centered + custom size</h3>
+<%= sage_component SageAvatar, { color: nil, centered: true, initials: "JC", size: "128px" } %>
 
 <h3>Avatar Groups</h3>
 <div class="sage-avatar-wrapper">

--- a/docs/app/views/examples/objects/avatar/_preview.html.erb
+++ b/docs/app/views/examples/objects/avatar/_preview.html.erb
@@ -1,3 +1,4 @@
+<h3>Sample Avatars</h3>
 <div class="sage-avatar-wrapper">
   <!-- Showing default -->
   <%= sage_component SageAvatar, { color: nil, initials: "JC" } %>
@@ -12,6 +13,10 @@
   <%= sage_component SageAvatar, { color: "orange", initials: "KJ", css_classes: "my-custom-class" } %>
 </div>
 
+<h3>Avatar centered</h3>
+<%= sage_component SageAvatar, { color: nil, centered: true, initials: "JC" } %>
+
+<h3>Avatar Groups</h3>
 <div class="sage-avatar-wrapper">
   <%= sage_component SageAvatarGroup, {
     items: [

--- a/docs/app/views/examples/objects/avatar/_props.html.erb
+++ b/docs/app/views/examples/objects/avatar/_props.html.erb
@@ -10,6 +10,14 @@
   <td><%= md("`null` (primary color)") %></td>
 </tr>
 <tr>
+  <td><%= md("`centered`") %></td>
+  <td><%= md("
+    Formats the avatar to be centered by setting side `margin` to `auto`.
+  ") %></td>
+  <td><%= md("`Boolean`") %></td>
+  <td><%= md("`false`") %></td>
+</tr>
+<tr>
   <td><%= md("`initials`") %></td>
   <td><%= md("
     The initials to display in the avatar circle

--- a/docs/app/views/examples/objects/avatar/_props.html.erb
+++ b/docs/app/views/examples/objects/avatar/_props.html.erb
@@ -26,6 +26,16 @@
   <td><%= md("`required`") %></td>
 </tr>
 <tr>
+  <td><%= md("`size`") %></td>
+  <td><%= md("
+    A size setting to customize the Avatar's width and height inline.
+    **NOTE:** Fixed settings such as `px`, `rem`, or `vw` are most reliable
+    as scalable values such as `%` may lead to a squished appearance.
+  ") %></td>
+  <td><%= md("`String`") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
   <td colspan="4">
     <strong>Avatar Group</strong>
   </td>

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -4,5 +4,6 @@ class SageAvatar < SageComponent
     color: [:optional, NilClass, Set.new(["purple", "sage", "yellow", "orange", "red"])],
     css_classes: [:optional, String],
     initials: String,
+    size: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -1,5 +1,6 @@
 class SageAvatar < SageComponent
   set_attribute_schema({
+    centered: [:optional, TrueClass],
     color: [:optional, NilClass, Set.new(["purple", "sage", "yellow", "orange", "red"])],
     css_classes: [:optional, String],
     initials: String,

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,6 +1,6 @@
 class SagePanelRow < SageComponent
   set_attribute_schema({
     grid_template: SageSchemaHelper::GRID_TEMPLATE,
-    vertical_align: [:optional, TrueClass],
+    vertical_align: [:optional, Set.new(["start"])],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -5,6 +5,9 @@
     <%= "sage-avatar--centered" if component.centered.present? && component.centered %>
     <%= component.css_classes %>
   "
+  <% if component.size.present? %>
+    style="width: <%= component.size %>; height: <%= component.size %>;"
+  <% end %>
 >
   <svg class="sage-avatar__initials" viewBox="0 0 32 32">
     <text x="16" y="20"><%= component.initials %></text>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -1,4 +1,11 @@
-<div class="sage-avatar<%= component.color != "" ? " sage-avatar--#{component.color}" : "" %> <%= component.css_classes %>">
+<div
+  class="
+    sage-avatar
+    <%= "sage-avatar--#{component.color}" if component.color.present? %>
+    <%= "sage-avatar--centered" if component.centered.present? && component.centered %>
+    <%= component.css_classes %>
+  "
+>
   <svg class="sage-avatar__initials" viewBox="0 0 32 32">
     <text x="16" y="20"><%= component.initials %></text>
   </svg>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_avatar.scss
@@ -117,6 +117,10 @@ $-avatar-group-item-sizes: (
   }
 }
 
+.sage-avatar--centered {
+  margin: 0 auto;
+}
+
 // Documentation-specific styles
 .sage-avatar-wrapper {
   display: flex;

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -5,20 +5,30 @@ import { AVATAR_COLORS } from './configs';
 
 export const Avatar = ({
   className,
+  centered,
   color,
   initials,
+  size,
   ...rest
 }) => {
   const classNames = classnames(
     'sage-avatar',
     className,
     {
-      [`sage-avatar--${color}`]: color
+      'sage-avatar--centered': centered,
+      [`sage-avatar--${color}`]: color,
     }
   );
 
+  const style = {};
+
+  if (size) {
+    style.width = size;
+    style.height = size;
+  }
+
   return (
-    <div className={classNames} {...rest}>
+    <div className={classNames} style={style} {...rest}>
       <svg className="sage-avatar__initials" viewBox="0 0 32 32">
         <text x="16" y="20">{initials}</text>
       </svg>
@@ -29,13 +39,17 @@ export const Avatar = ({
 Avatar.COLORS = AVATAR_COLORS;
 
 Avatar.defaultProps = {
+  centered: false,
   className: '',
   color: AVATAR_COLORS.DEFAULT,
-  initials: ''
+  initials: '',
+  size: null,
 };
 
 Avatar.propTypes = {
+  centered: PropTypes.bool,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(AVATAR_COLORS)),
-  initials: PropTypes.string
+  initials: PropTypes.string,
+  size: PropTypes.string,
 };

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -13,6 +13,8 @@ export const Default = Template.bind({});
 Default.args = {
   initials: 'QJ',
   color: Avatar.COLORS.SAGE,
+  size: null,
+  centered: true,
 };
 
 export const Group = () => (


### PR DESCRIPTION
## Description

This PR adds ability to center an Avatar in its layout space and to provide a custom size for the Avatar.

Bonus: Fixes a schema validation error on `PanelRow` rails component.

### Screenshots

![Screen Shot 2021-02-01 at 1 10 31 PM](https://user-images.githubusercontent.com/17955295/106499773-00b69a00-648f-11eb-8a4c-469ef72e6bc8.png)

## Test notes

See Objects > Avatar

### Steps for testing in app

Avatar is not used in any production contexts to validate and these changes do not affect default implementations.

Bonus: SagePanelRow examples can be checked in the following instances and they should all behave as they have to date:
- [ ] Dashboard "Here's what's happening" cards
- [ ] Product catalog > row below search bar showing number of products and sort options
