### PR TITLE
Choice card custom/rich content

### DIFF
--- a/docs/app/views/examples/elements/choice/_preview.html.erb
+++ b/docs/app/views/examples/elements/choice/_preview.html.erb
@@ -38,7 +38,7 @@
 %>
 
 <h3 class="t-sage-heading-6">Graphic Variation (with link text)</h3>
-<p>Select any icon to appear to the left of the text.</p>
+<p>Provide a graphic to the left of the text.</p>
 <%= sage_component SageChoice, {
     target: "example",
     text: "Calendly",

--- a/docs/app/views/examples/elements/choice/_preview.html.erb
+++ b/docs/app/views/examples/elements/choice/_preview.html.erb
@@ -50,3 +50,18 @@
     },
   }
 %>
+
+<h3 class="t-sage-heading-6">Rich text/Customized</h3>
+<p>Choice cards can also be opened up for custom content to be composed within.</p>
+<%= sage_component SageChoice, {
+  target: "example",
+  attributes: {
+    href: "http://example.com",
+  },
+} do %>
+  <%= sage_component SageAvatar, { initials: 'PS' } %>
+  <%= sage_component SageCardBlock, {} do %>
+    <h4>Custom heading</h4>
+    <p>Custom content here...</p>
+  <% end %>
+<% end %>

--- a/docs/app/views/examples/elements/choice/_props.html.erb
+++ b/docs/app/views/examples/elements/choice/_props.html.erb
@@ -1,42 +1,42 @@
 <tr>
-  <td>active</td>
-  <td>Toggles <code>--active</code> modifier to visually indicate whether this choice is active/selected.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`active`") %></td>
+  <td><%= md("Toggles `--active` modifier to visually indicate whether this choice is active/selected.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>align_center</td>
-  <td>Toggles <code>--align-center</code> modifier to visually center the icon and text. This is only intended to be used with the "icon" type.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`align_center`") %></td>
+  <td><%= md('Toggles`--align-center` modifier to visually center the icon and text. This is only intended to be used with the "icon" type.') %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>text</td>
-  <td>Sets the content of the primary text line</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`text`") %></td>
+  <td><%= md("Sets the content of the primary text line") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
 </tr>
 <tr>
-  <td>subtext</td>
-  <td>Sets the content of the secondary text line</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`subtext`") %></td>
+  <td><%= md("Sets the content of the secondary text line") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
 </tr>
 <tr>
-  <td>type</td>
-  <td>Sets the choice graphic type. If <code>icon</code> is used here the <code>icon</code> prop must also be set.</td>
-  <td>icon | radio | arrow</td>
-  <td>radio</td>
+  <td><%= md("`type`") %></td>
+  <td><%= md("Sets the choice graphic type. If `icon` is used here the `icon` prop must also be set.") %></td>
+  <td><%= md("`icon`, `radio`, or `arrow`") %></td>
+  <td><%= md("`radio") %></td>
 </tr>
 <tr>
-  <td>icon</td>
-  <td>Provides the name of the Sage Icon to be displayed before the text content.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`icon`") %></td>
+  <td><%= md("Provides the name of the Sage Icon to be displayed before the text content.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
 </tr>
 <tr>
-  <td>target</td>
-  <td>Provides the <code>id</code> for the corresponding Tab Pane that this choice will activate.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`target`") %></td>
+  <td><%= md("Provides the `id` for the corresponding Tab Pane that this choice will activate.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
 </tr>

--- a/docs/app/views/examples/objects/tabs/_preview.html.erb
+++ b/docs/app/views/examples/objects/tabs/_preview.html.erb
@@ -207,3 +207,66 @@
 <h4>Tab Pane Style and Spacing</h4>
 
 <p>Since tabs may be employed in a variety of settings, the following modifiers may be added on panes to set their appearance and internal spacing accordingly: <code>card</code>, <code>card_spacing</code>, and <code>panel_spacing</code>. See the Properties table below for more details</p>
+
+
+<h3>Tabs/Choice with Rich/Custom Content</h3>
+<%= md("
+Choice tabs can be set up with a rich/custom content block by passing any desired markup through the `content` property or yield block.
+
+The example below demonstrates how local styles and Javascript can be paired with the Tabs component and rich content for a much more tailored component.
+") %>
+<style>
+.u-rich-choice-card__option-checkmark {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: none;
+}
+.sage-choice--active .u-rich-choice-card__option-checkmark {
+  display: block;
+}
+</style>
+<script>
+document.addEventListener("sage.tabs.change", function(evt) {
+  // Check that event occurred on special tabs
+  if (evt.detail && evt.detail.tabsId === 'example-tabs-rich') {
+    var elTargetId = evt.detail.paneId;
+    var elTarget = document.getElementById(elTargetId);
+    console.log('Selected', elTargetId, elTarget.value);
+  }
+});
+</script>
+<div class="sage-tabs-container">
+  <%= sage_component SageTabs, {
+      id: "example-tabs-rich",
+      css_classes: "u-rich-choice-card",
+      items: [
+        {
+          target: "item1",
+          content: %(
+            #{sage_component(SageAvatar, { initials: 'PS' })}
+            #{sage_component(SageCardBlock, { content: %(
+              <h4>User A</h4>
+              <p>Custom content here...</p>
+            ).html_safe})}
+            <i class="sage-icon-check-circle-lg t-sage--color-primary u-rich-choice-card__option-checkmark" aria-label="Selected"></i>
+            <input type="hidden" id="item1" name="item1" value="User A" />
+          )
+        },
+        {
+          target: "item2",
+          content: %(
+            #{sage_component(SageAvatar, { initials: 'JW' })}
+            #{sage_component(SageCardBlock, { content: %(
+              <h4>User B</h4>
+              <p>Custom content here...</p>
+            ).html_safe})}
+            <i class="sage-icon-check-circle-lg t-sage--color-primary u-rich-choice-card__option-checkmark" aria-label="Selected"></i>
+            <input type="hidden" id="item2" name="item2" value="User B" />
+          )
+        },
+      ],
+      style: "choice",
+    }
+  %>
+</div>

--- a/docs/app/views/examples/objects/tabs/_props.html.erb
+++ b/docs/app/views/examples/objects/tabs/_props.html.erb
@@ -1,48 +1,47 @@
 <tr>
-  <td>active</td>
-  <td>Tabs use a <code>--active</code> modifier to visually indicate which tab or related content is actively being viewed.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`style`") %></td>
+  <td><%= md("What kind of tab style to use. A simple style is default, but the `choice` setting enables a more complex Choice style (See Tab versus Choice components)") %></td>
+  <td><%= md("`nil` or `choice`") %></td>
+  <td><%= md("`nil`") %></td>
 </tr>
 <tr>
-  <td>stacked</td>
-  <td>Tabs use a <code>--stacked</code> modifier to visually display tab options on top of each other.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`stacked`") %></td>
+  <td><%= md("Whether or not the tab set should be laid out in a stack versus inline (default) fashion.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>style</td>
-  <td>Tabs use a <code>--style</code> modifier to visually display either a tab or choice button.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`id`") %></td>
+  <td><%= md("Unique identifier for this tab set.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`nil`") %></td>
 </tr>
 <tr>
-  <td>progressbar</td>
-  <td>Tabs use a <code>--progressbar</code> modifier to visually display regular tabs in a progressional fashion.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`items`") %></td>
+  <td><%= md("
+    A set of items that render as tabs.
+    Values for each item must conform to the properties available
+    for either Tab or Choice components,
+    depending on the `style` setting used here.
+  ") %></td>
+  <td><%= md("`Array<{See Choice or Tab component properties}>`") %></td>
+  <td><%= md("") %></td>
 </tr>
 <tr>
-  <td>align_items_center</td>
-  <td>Toggles whether the contents of tab items should center; intended only to be used with icon-style choices.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`progressbar`") %></td>
+  <td><%= md("Whether or not to display tabs in a Progress bar layoutu with carets separating each.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>card</td>
-  <td>styles the pane as a Sage Card altogether. All examples on this page use this modifier.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`align_items_center`") %></td>
+  <td><%= md("Whether or not to center the content in each tab.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>card_spacing</td>
-  <td>applies the internal Card grid settings but no padding or border.</td>
-  <td>Boolean</td>
-  <td>false</td>
-</tr>
-<tr>
-  <td>panel_spacing</td>
-  <td>applies the internal Panel grid settings but no padding or box shadow.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`navigational`") %></td>
+  <td><%= md("Whether or not the tab set acts functionally as a navigation set for pages such as in a progressbar fashion.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -9,7 +9,7 @@ class SageChoice < SageComponent
     link_text: [:optional, NilClass, String],
     subtext: [:optional, NilClass, String],
     target: [:optional, NilClass, String],
-    text: String,
-    type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
+    text: [:optional, NilClass, String],
+    type: [:optional, NilClass, Set.new(["arrow", "graphic", "icon", "radio"])]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -4,7 +4,7 @@ class SageTabs < SageComponent
     style: [:optional, Set.new(["choice"])],
     stacked: [:optional, TrueClass],
     id: [:optional, String],
-    items: [[
+    items: [:optional, [[
       active: [:optional, NilClass, TrueClass],
       align_center: [:optional, TrueClass],
       attributes: [:optional, NilClass, Hash],
@@ -17,7 +17,7 @@ class SageTabs < SageComponent
       target: [:optional, NilClass, String],
       text: [:optional, NilClass, String],
       type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])]
-    ]],
+    ]]],
     progressbar: [:optional, TrueClass],
     align_items_center: [:optional, TrueClass],
     navigational: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -1,5 +1,6 @@
 class SageTabs < SageComponent
   set_attribute_schema({
+    css_classes: [:optional, String],
     style: [:optional, Set.new(["choice"])],
     stacked: [:optional, TrueClass],
     id: [:optional, String],
@@ -14,8 +15,8 @@ class SageTabs < SageComponent
       link_text: [:optional, NilClass, String],
       subtext: [:optional, NilClass, String],
       target: [:optional, NilClass, String],
-      text: String,
-      type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
+      text: [:optional, NilClass, String],
+      type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])]
     ]],
     progressbar: [:optional, TrueClass],
     align_items_center: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -6,7 +6,6 @@ html_tag = is_button ? (component.content.present? ? "div" : "button") : "a"
 
 <<%= html_tag %>
   <%= "type=button" if is_button and !component.content.present? %>
-  <%= "role=button" if is_button and component.content.present? %>
   <% component.attributes.each do |key, value| %>
     <%= "#{key}='#{value}'".html_safe %>
   <% end if component.attributes&.is_a?(Hash) %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -1,11 +1,12 @@
 <%
 css_active_class = "sage-choice--active" 
 is_button = !component.attributes&.has_key?(:href)
-html_tag = is_button ? "button" : "a"
+html_tag = is_button ? (component.content.present? ? "div" : "button") : "a"
 %>
 
 <<%= html_tag %>
-  <%= "type=button" if is_button %>
+  <%= "type=button" if is_button and !component.content.present? %>
+  <%= "role=button" if is_button and component.content.present? %>
   <% component.attributes.each do |key, value| %>
     <%= "#{key}='#{value}'".html_safe %>
   <% end if component.attributes&.is_a?(Hash) %>
@@ -34,13 +35,14 @@ html_tag = is_button ? "button" : "a"
       <%= component.graphic.html_safe %>
     </div>
   <% end %>
-  <div class="sage-choice__content">
+  <div class="sage-choice__content <%= "sage-choice__content--custom" if component.content.present? %>">
     <% if component.text.present? %>
       <em class="sage-choice__text"><%= component.text.html_safe %></em>
     <% end %>
     <% if component.subtext.present? %>
       <span class="sage-choice__subtext" aria-hidden="true"><%= component.subtext.html_safe %></span>
     <% end %>
+    <%= component.content if component.content.present? %>
   </div>
   <% if component.link_text.present? %>
     <div class="sage-choice__link-text">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -34,6 +34,6 @@
         disabled: item[:disabled]
       %>
     <% end %>
-  <% end %>
+  <% end  if component.items.present? %>
   <%= component.content if component.content.present? %>
 </nav>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -35,4 +35,5 @@
       %>
     <% end %>
   <% end %>
+  <%= component.content if component.content.present? %>
 </nav>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -5,6 +5,7 @@
     <%= "sage-tabs--progressbar" if component.progressbar.present? && component.progressbar == true %>
     <%= "sage-tabs--align-items-center" if component.align_items_center.present? && component.align_items_center == true %>
     <%= "sage-tabs--choice" if component.style.present? && component.style === "choice" %>
+    <%= component.css_classes %>
     <%= component.generated_css_classes %>
   "
   role="tablist"
@@ -12,7 +13,7 @@
 >
   <% component.items.each do |item| %>
     <% if component.style.present? && component.style === "choice" %>
-      <%= sage_component SageChoice,
+      <%= sage_component SageChoice, {
         target: item[:target],
         text: item[:text],
         subtext: item[:subtext],
@@ -21,7 +22,9 @@
         icon: item[:icon],
         attributes: item[:attributes],
         disabled: item[:disabled]
-      %>
+      } do %>
+        <%= item[:content].html_safe if defined?(item[:content]) and item[:content] %>
+      <% end %>
     <% else %>
       <%= sage_component SageTab,
         target: item[:target],

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
@@ -170,6 +170,10 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   }
 }
 
+.sage-choice__content--custom {
+  @include sage-grid-card;
+}
+
 .sage-choice__graphic {
   overflow: hidden;
   width: rem(48px);

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -48,7 +48,7 @@ export const Tabs = ({
   return (
     <div className={`sage-tabs-container ${className || ''}`}>
       <div className={tabsClassNames} {...rest}>
-        {tabs.map(({ disabled, id, label, tabChoiceIcon, tabChoiceType, subtext }) => (
+        {tabs.map(({ disabled, id, label, tabDetails, tabChoiceIcon, tabChoiceType, subtext }) => (
           <TabsItem
             disabled={disabled}
             icon={tabChoiceIcon}
@@ -60,7 +60,9 @@ export const Tabs = ({
             label={label}
             subtext={subtext}
             type={tabChoiceType}
-          />
+          >
+            {tabDetails}
+          </TabsItem>
         ))}
       </div>
       {useSeparator && (

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -7,6 +7,43 @@ import { SageTokens } from '../configs';
 import { Tabs } from './Tabs';
 import TabsNotes from './TabsNotes.md';
 
+const ChoiceTabsWithRichContent = () => {
+  return (
+    <Tabs
+      tabs={[
+        {
+          id: 'tab-1',
+          tabDetails: (
+            <>
+              <h4>Tab 1 content.</h4>
+              <p>Lorem ipsum dolor sit amut consectitor.</p>
+            </>
+          ),
+        },
+        {
+          id: 'tab-2',
+          tabDetails: (
+            <>
+              <h4>Tab 2 content.</h4>
+              <p>Lorem ipsum dolor sit amut consectitor.</p>
+            </>
+          ),
+        },
+        {
+          id: 'tab-3',
+          tabDetails: (
+            <>
+              <h4>Tab 3 content.</h4>
+              <p>Lorem ipsum dolor sit amut consectitor.</p>
+            </>
+          ),
+        },
+      ]}
+      tabStyle="choice"
+    />
+  );
+};
+
 const TabsWithState = () => {
   const [initialActiveId, setDefaultActiveId] = useState(null);
   const buttonConfigs = {
@@ -86,4 +123,7 @@ storiesOf('Sage/Tabs', module)
     <TabsWithState />
   ), {
     notes: { markdown: TabsNotes }
-  });
+  })
+  .add('Rich content', () => (
+    <ChoiceTabsWithRichContent />
+  ));

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -7,42 +7,40 @@ import { SageTokens } from '../configs';
 import { Tabs } from './Tabs';
 import TabsNotes from './TabsNotes.md';
 
-const ChoiceTabsWithRichContent = () => {
-  return (
-    <Tabs
-      tabs={[
-        {
-          id: 'tab-1',
-          tabDetails: (
-            <>
-              <h4>Tab 1 content.</h4>
-              <p>Lorem ipsum dolor sit amut consectitor.</p>
-            </>
-          ),
-        },
-        {
-          id: 'tab-2',
-          tabDetails: (
-            <>
-              <h4>Tab 2 content.</h4>
-              <p>Lorem ipsum dolor sit amut consectitor.</p>
-            </>
-          ),
-        },
-        {
-          id: 'tab-3',
-          tabDetails: (
-            <>
-              <h4>Tab 3 content.</h4>
-              <p>Lorem ipsum dolor sit amut consectitor.</p>
-            </>
-          ),
-        },
-      ]}
-      tabStyle="choice"
-    />
-  );
-};
+const ChoiceTabsWithRichContent = () => (
+  <Tabs
+    tabs={[
+      {
+        id: 'tab-1',
+        tabDetails: (
+          <>
+            <h4>Tab 1 content.</h4>
+            <p>Lorem ipsum dolor sit amut consectitor.</p>
+          </>
+        ),
+      },
+      {
+        id: 'tab-2',
+        tabDetails: (
+          <>
+            <h4>Tab 2 content.</h4>
+            <p>Lorem ipsum dolor sit amut consectitor.</p>
+          </>
+        ),
+      },
+      {
+        id: 'tab-3',
+        tabDetails: (
+          <>
+            <h4>Tab 3 content.</h4>
+            <p>Lorem ipsum dolor sit amut consectitor.</p>
+          </>
+        ),
+      },
+    ]}
+    tabStyle="choice"
+  />
+);
 
 const TabsWithState = () => {
   const [initialActiveId, setDefaultActiveId] = useState(null);

--- a/packages/sage-react/lib/Tabs/TabsItem.jsx
+++ b/packages/sage-react/lib/Tabs/TabsItem.jsx
@@ -7,6 +7,7 @@ import { TAB_STYLES, CHOICE_TYPES } from './configs';
 
 export const TabsItem = ({
   alignCenter,
+  children,
   className,
   disabled,
   graphic,
@@ -23,7 +24,11 @@ export const TabsItem = ({
 }) => {
   const { to, href } = rest;
   const isLink = to || href;
-  const TagName = isLink ? Link : 'button';
+  const TagName = isLink 
+    ? Link
+    : children
+      ? 'div'
+      : 'button';
   const itemStyleProtected = itemStyle === TAB_STYLES.PROGRESSBAR ? TAB_STYLES.TAB : itemStyle;
   const isChoice = itemStyle === TAB_STYLES.CHOICE;
   const isIconType = type && type === CHOICE_TYPES.ICON;
@@ -57,8 +62,11 @@ export const TabsItem = ({
       ...attrs,
       disabled,
       onClick: () => onClick(panelId),
-      type: 'button',
     };
+
+    if (!children) {
+      attrs.type = 'button';
+    }
   }
 
   return (
@@ -70,15 +78,18 @@ export const TabsItem = ({
               {graphic}
             </span>
           )}
-          <span className="sage-choice__content">
-            <em className="sage-choice__text">
-              {label}
-            </em>
+          <span className={`sage-choice__content ${children && 'sage-choice__content--custom'}`}>
+            {label && (
+              <em className="sage-choice__text">
+                {label}
+              </em>
+            )}
             {subtext && (
               <span className="sage-choice__subtext">
                 {subtext}
               </span>
             )}
+            {children}
           </span>
           {linkText && (
             <span className="sage-choice__link-text">
@@ -95,6 +106,7 @@ TabsItem.CHOICE_TYPES = CHOICE_TYPES;
 
 TabsItem.defaultProps = {
   alignCenter: false,
+  children: null,
   className: null,
   disabled: false,
   graphic: null,
@@ -109,6 +121,7 @@ TabsItem.defaultProps = {
 
 TabsItem.propTypes = {
   alignCenter: PropTypes.bool,
+  children: PropTypes.node,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   graphic: PropTypes.node,

--- a/packages/sage-react/lib/Tabs/TabsItem.jsx
+++ b/packages/sage-react/lib/Tabs/TabsItem.jsx
@@ -24,11 +24,12 @@ export const TabsItem = ({
 }) => {
   const { to, href } = rest;
   const isLink = to || href;
-  const TagName = isLink 
+  let TagName = children
+    ? 'div'
+    : 'button';
+  TagName = isLink
     ? Link
-    : children
-      ? 'div'
-      : 'button';
+    : TagName;
   const itemStyleProtected = itemStyle === TAB_STYLES.PROGRESSBAR ? TAB_STYLES.TAB : itemStyle;
   const isChoice = itemStyle === TAB_STYLES.CHOICE;
   const isIconType = type && type === CHOICE_TYPES.ICON;


### PR DESCRIPTION
## Description

This PR updates Choice components (and Tabs as a result) to allow for larger blocks of custom/rich content in lieu of the out-of-the-box styling. This is useful for situations such as in the upcoming Merge contacts modal where a choice card is used to present two richly-formated cards with more data than the out-of-the-box component allows.

### Screenshots

![Screen Shot 2021-02-01 at 3 48 56 PM](https://user-images.githubusercontent.com/17955295/106516436-03bc8500-64a5-11eb-8c02-f3afbdb1c6cc.png)

## Test notes

See Elements > Choice and Objects > Tabs

### Steps for testing in app
This adds new abilities to Tabs and Choice that should not interfere with existing implementations of these components. Confirm this is the case by inspecting the following existing uses of Choice and Tabs:

- [ ] Website > Pages: (Rails: standard tabs) see tabs across top of the page
- [ ] Settings > Domain: (Rails: choice tabs) see radio choice tabs in the new set up a custom domain flow
- [ ] People > Import:
  - [ ] (React: choice tabs) first page of the import process features the existing choice tabs
  - [ ] (React: progressbar tabs) following pages include a progressbar style tab/navigation across the top of the page
