### PR TITLE
Sortable Component: image support

### DIFF
--- a/docs/app/views/examples/objects/sortable/_preview.html.erb
+++ b/docs/app/views/examples/objects/sortable/_preview.html.erb
@@ -84,3 +84,33 @@
     } %>
   <% end %>
 <% end %>
+
+<h3 class="t-sage-heading-6">As cards with images and without subtitles</h3>
+<%= sage_component SageSortable, { resource_name: "link" } do %>
+  <% 3.times do %>
+    <%= sage_component SageSortableItem, {
+      title: "Fringilla Ullamcorper Dolor Adipiscing Ultricies",
+      url_update: "update/endpoint",
+      image: "http://placehold.it/150",
+      id: "id",
+      card: true
+    } do %>
+      <%= sage_component SageButton, {
+        attributes: {
+          "data-js-tooltip": "Preview"
+        },
+        style: "secondary",
+        subtle: true,
+        icon: { name: "preview-on", style: "only" },
+        value: "Preview"
+      } %>
+    <% end %>
+  <% end %>
+
+  <%= sage_component_section :empty do %>
+    <%= sage_component SageEmptyState, {
+      title: "Empty State Title",
+      text: "Empty state text",
+    } %>
+  <% end %>
+<% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item.rb
@@ -2,6 +2,7 @@ class SageSortableItem < SageComponent
   set_attribute_schema({
     card: [:optional, TrueClass],
     id: [:optional, Integer, String],
+    image: [:optional, String],
     label: [:optional, String],
     subtitle: [:optional, String],
     title: String,

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
@@ -6,6 +6,14 @@
   data-js-sortable-update-url="<%= component.url_update %>"
   <%= "id=#{component.id}" if component.id %>
 >
+  <% if component.image.present? %>
+    <div class="sage-sortable__item-image">
+      <img
+        src="<%= component.image %>"
+        alt="Cover for <%= component.title %>"
+      />
+    </div>
+  <% end %>
   <div class="sage-sortable__item-content">
     <h1 class="sage-sortable__item-title"><%= component.title %></h1>
     <% if component.subtitle.present? %>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_sortable.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_sortable.scss
@@ -5,13 +5,16 @@
 
 ================================================== */
 
+$-image-width: rem(82px);
+$-image-height: rem(48px);
+
 .sage-sortable {
   /* stylelint-disable-line block-no-empty */
 }
 
 .sage-sortable__item {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: min-content minmax(0, min-content) auto auto;
   gap: sage-spacing(card);
   align-items: center;
   padding: sage-spacing(xs) sage-spacing(panel);
@@ -63,6 +66,23 @@
   }
 }
 
+.sage-sortable__item-image {
+  position: relative;
+  overflow: hidden;
+  height: $-image-height;
+  width: $-image-width;
+  background: sage-color(grey, 200);
+  border-radius: sage-border(radius);
+  border: sage-border();
+
+  img {
+    position: absolute;
+    transform: translateY(-50%);
+    top: 50%;
+    width: 100%;
+  }
+}
+
 .sage-sortable__item-content {
   z-index: sage-z-index();
   overflow: hidden;
@@ -82,4 +102,9 @@
 .sage-sortable__item-subtitle {
   @extend %t-sage-body-xsmall;
   color: sage-color(charcoal, 100);
+}
+
+.sage-sortable__item-actions {
+  grid-column-start: 4;
+  justify-self: end;
 }

--- a/packages/sage-react/lib/Sortable/SortableItem.jsx
+++ b/packages/sage-react/lib/Sortable/SortableItem.jsx
@@ -7,6 +7,7 @@ export const SortableItem = ({
   title,
   subtitle,
   actionItems,
+  image,
   type,
   ...rest
 }) => {
@@ -22,6 +23,14 @@ export const SortableItem = ({
       {...rest}
       className={className}
     >
+      {image && (
+        <div className="sage-sortable__item-image">
+          <img
+            src={image}
+            alt={`Cover for ${title}`}
+          />
+        </div>
+      )}
       <div className="sage-sortable__item-content">
         <h1 className="sage-sortable__item-title">
           {title}
@@ -46,6 +55,7 @@ SortableItem.TYPES = SORTABLE_ITEM_TYPES;
 SortableItem.defaultProps = {
   actionItems: null,
   subtitle: null,
+  image: null,
   type: SORTABLE_ITEM_TYPES.DEFAULT,
 };
 
@@ -53,5 +63,6 @@ SortableItem.propTypes = {
   actionItems: PropTypes.arrayOf(PropTypes.node),
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string,
+  image: PropTypes.string,
   type: PropTypes.oneOf(Object.values(SORTABLE_ITEM_TYPES)),
 };


### PR DESCRIPTION
BUILD-717

## Description
Adds an optional image to the Sortable component. The image sets its height and min-width to be 45px per the spec, the image width flexes to fill the available space on desktop displays.

### Screenshots

|  mobile  |  wide  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/106656264-75113c00-6568-11eb-9a87-4bc136946b3d.png)|![image](https://user-images.githubusercontent.com/565743/106656223-662a8980-6568-11eb-830f-1847c1590e8b.png)|


## Test notes
Component location in docs: http://localhost:4000/pages/object/sortable

## Related
BUILD-717
