### PR TITLE
Modal content spacing and cleanup

### DIFF
--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -1,48 +1,160 @@
 <%= sage_component SagePanelBlock, {} do %>
+  <div class="sage-btn-group">
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Modal",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Large Modal",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-large",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Spaced Modal",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-spaced",
+      }
+    } %>
+  </div>
+
   <%# Standard Modal %>
-  <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal">Trigger Modal</button>
   <%= sage_component SageModal, { id: "cool-modal" } do %>
-    <header class="sage-modal__header">
-      <h1 class="t-sage-heading-4">Example Sage Modal</h1>
-      <aside class="sage-modal__header-aside">
-        <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
-          <span class="visually-hidden">Menu</span>
-        </button>
-      </aside>
-    </header>
-    <div class="sage-modal__content">
-      <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    </div>
-    <footer class="sage-modal__footer">
-      <aside class="sage-modal__footer-aside">
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
-      </aside>
-      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
-    </footer>
+    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
   <% end %>
 
   <%# Large Modal %>
-  <button class="sage-btn sage-btn--primary sage-btn--icon-right-launch" data-js-modaltrigger="cool-modal-large">Trigger Modal Large</button>
   <%= sage_component SageModal, { 
     id: "cool-modal-large",
     large: true
   } do %>
-    <header class="sage-modal__header">
-      <h1 class="t-sage-heading-4">Example Sage Modal</h1>
-      <aside class="sage-modal__header-aside">
-        <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
-          <span class="visually-hidden">Menu</span>
-        </button>
-      </aside>
-    </header>
-    <div class="sage-modal__content">
-      <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    </div>
-    <footer class="sage-modal__footer">
-      <aside class="sage-modal__footer-aside">
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
-      </aside>
-      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
-    </footer>
+    <%= sage_component SageModalContent, { title: "Example Large Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%# Spaced Modal %>
+  <%= sage_component SageModal, { 
+    id: "cool-modal-spaced",
+    large: true
+  } do %>
+    <%= sage_component SageModalContent, {
+      title: "Example Spaced Modal",
+      spacing: "panel",
+    } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <%= sage_component SagePanelBlock, {} do %>
+        <h4 class="t-sage-heading-5">Lorem ipsum dolor sit amet</h4>
+        <p class="t-sage-body">
+          Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      <% end %>
+
+      <%= sage_component SagePanelTiles, { tiles_in_row: 2 } do %>
+        <%= sage_component SageCard, {} do %>
+          <p class="t-sage-body">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </p>
+        <% end %>
+        <%= sage_component SageCard, {} do %>
+          <p class="t-sage-body">
+            Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </p>
+        <% end %>
+      <% end %>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -40,6 +40,12 @@
   <td><%= md("`nil`") %></td>
 </tr>
 <tr>
+  <td><%= md("Section: `header_aside`") %></td>
+  <td><%= md("Populates the `sage-modal__header-aside`.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
   <td><%= md("Section: `footer`") %></td>
   <td><%= md("Populates the `sage-modal__footer`.") %></td>
   <td><%= md("String") %></td>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -1,26 +1,53 @@
 <tr>
-  <td>active</td>
-  <td>Enabling this property will return the JS early to not initialize any handlers.</td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td><%= md("`active`") %></td>
+  <td><%= md("Enabling this property will return the JS early to not initialize any handlers.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`nil`") %></td>
 </tr>
 <tr>
-  <td>disable_close</td>
-  <td>Enabling this property will return the JS early to not initialize any handlers.</td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td><%= md("`disable_close`") %></td>
+  <td><%= md("Enabling this property will return the JS early to not initialize any handlers.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`nil`") %></td>
 </tr>
 <tr>
-<tr>
-  <td>id</td>
-  <td>Unique identifier for component. Should match the <code>data-js-modaltrigger</code> property on the corresponding button</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`id`") %></td>
+  <td><%= md("Unique identifier for component. Should match the <code>data-js-modaltrigger</code> property on the corresponding button") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`nil") %></td>
 </tr>
 <tr>
+  <td><%= md("`large`") %></td>
+  <td><%= md("Toggles whether to use the large variant of the modal by attaching <code>.sage-modal--large</code>") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
 <tr>
-  <td>large</td>
-  <td>Toggles whether to use the large variant of the modal by attaching <code>.sage-modal--large</code></td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td colspan="4">
+    <strong>Modal Content</strong>
+  </td>
+</tr>
+<tr>
+  <td><%= md("`title`") %></td>
+  <td><%= md("Populates the `sage-modal__header` with a heading containing the provided content") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
+  <td><%= md("`spacing`") %></td>
+  <td><%= md("Optionally enforces either a `card`- or `panel`-based spacing grid on the `sage-modal__content`.") %></td>
+  <td><%= md("`panel` or `card`") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
+  <td><%= md("Section: `footer`") %></td>
+  <td><%= md("Populates the `sage-modal__footer`.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
+  <td><%= md("Section: `footer_aside`") %></td>
+  <td><%= md("Populates the `sage-modal__footer-aside` for buttons or content set to the left of the panel footer.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`nil`") %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
@@ -5,6 +5,6 @@ class SageModalContent < SageComponent
   })
 
   def sections
-    %w(header footer footer_aside)
+    %w(header_aside footer footer_aside)
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
@@ -1,6 +1,7 @@
 class SageModalContent < SageComponent
   set_attribute_schema({
     title: [:optional, String],
+    spacing: [:optional, NilClass, Set.new(["panel", "card"])],
   })
 
   def sections

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -3,7 +3,20 @@
     <h1 class="t-sage-heading-4">
       <%= component.title %>
     </h1>
+    <% if content_for?(:sage_header_aside) %>
+      <aside class="sage-modal__header-aside">
+        <%= content_for :sage_header_aside %>
+      </aside>
+    <% end %>
   </header>
+<% else %>
+  <% if content_for?(:sage_header_aside) %>
+    <header class="sage-modal__header">
+      <aside class="sage-modal__header-aside">
+        <%= content_for :sage_header_aside %>
+      </aside>
+    </header>
+  <% end %>
 <% end %>
 
 <div class="sage-modal__content <%= "sage-modal__content--spacing-#{component.spacing}" if component.spacing.present? %>">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -6,7 +6,7 @@
   </header>
 <% end %>
 
-<div class="sage-modal__content">
+<div class="sage-modal__content <%= "sage-modal__content--spacing-#{component.spacing}" if component.spacing.present? %>">
   <%= component.content %>
 </div>
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -86,10 +86,20 @@ $-modal-padding-y: sage-spacing(md);
 
 .sage-modal__content--spacing-panel {
   @include sage-grid-panel();
+
+  // Undo clearfix
+  &::after {
+    display: none;
+  }
 }
 
 .sage-modal__content--spacing-card {
   @include sage-grid-card();
+
+  // Undo clearfix
+  &::after {
+    display: none;
+  }
 }
 
 .sage-modal__footer {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -84,6 +84,14 @@ $-modal-padding-y: sage-spacing(md);
   @include clearfix;
 }
 
+.sage-modal__content--spacing-panel {
+  @include sage-grid-panel();
+}
+
+.sage-modal__content--spacing-card {
+  @include sage-grid-card();
+}
+
 .sage-modal__footer {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Description

This PR does some work with Modals in Rails including:

- Adds a spacing parameter on `ModalContent` to allow for `panel` and `card` grid spacing.
- Implements `header_aside` section in `ModalContent`
- Updates documentation for modals to match

## Test notes

See Objects > Modal

### Steps for testing
Existing modals should be unaffected. Check the following to confirm:

- [ ] Product catalogue (Rails)
- [ ] Product outline (React)
- [ ] Contact import mapping step (React)
