### PR TITLE
Sage Feature Toggle - Add `links` prop with optional arguments

### DIFF
--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -7,6 +7,7 @@
       {
         icon: "launch",
         location: "#",
+        target: "_blank",
         text: "Learn more",
       },
       {
@@ -40,6 +41,7 @@
       {
         icon: "launch",
         location: "#",
+        target: "_blank",
         text: "Learn more",
       },
     ],

--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -2,19 +2,29 @@
   <%= sage_component SageFeatureToggle, {
     alt_text: "Text alt text",
     description: "Quickly see Segments & filter contacts with a consistent People list view.",
-    image: asset_pack_path("media/images/docs/card/card-placeholder-sm.png"), 
-    link_text: "Learn more",
-    link_location: "#",
+    image: asset_pack_path("media/images/docs/card/card-placeholder-sm.png"),
+    links: [
+      {
+        icon: "launch",
+        location: "#",
+        text: "Learn more",
+      },
+      {
+        icon: "comment",
+        location: "#",
+        text: "Feedback",
+      }
+    ],
     title: "New People list view",
     title_tag: "h5",
   } do %>
     <%= sage_component_section :feature_toggle_input do %>
       <div class="sage-switch">
-        <input 
-          type="checkbox" 
-          id="feature-toggle-id-1" 
-          class="sage-switch__input" 
-          name="feature-toggle-id" 
+        <input
+          type="checkbox"
+          id="feature-toggle-id-1"
+          class="sage-switch__input"
+          name="feature-toggle-id"
           value="feature-toggle-id"
         >
         <label for="feature-toggle-id-1" class="sage-switch__label sage-switch__label--hide-text">Label Title</label>
@@ -25,12 +35,18 @@
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {
     description: "Quickly see Segments & filter contacts with a consistent People list view.",
-    image: asset_pack_path("media/images/docs/card/card-placeholder-sm.png"), 
-    link_text: "Learn more",
+    image: asset_pack_path("media/images/docs/card/card-placeholder-sm.png"),
+    links: [
+      {
+        icon: "launch",
+        location: "#",
+        text: "Learn more",
+      },
+    ],
     title: "New People list view",
   } do %>
     <%= sage_component_section :feature_toggle_input do %>
-      <%= sage_component SageSwitch, { 
+      <%= sage_component SageSwitch, {
         type: "checkbox",
         id: "feature-toggle-id-2",
         hide_text: true,

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -18,7 +18,7 @@
 </tr>
 <tr>
   <td><code>links</code></td>
-  <td>An array of optional links that includes <code>icon</code>, <code>location</code> and <code>text</code> hash options.</td>
+  <td>An array of optional links that includes <code>icon</code>, <code>location</code>, <code>target</code> and <code>text</code> hash options.</td>
   <td>Array</td>
   <td></td>
 </tr>

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -17,15 +17,9 @@
   <td></td>
 </tr>
 <tr>
-  <td><code>link_location</code></td>
-  <td>Sets the location of the <code>href</code> for the component</td>
-  <td>String</td>
-  <td></td>
-</tr>
-<tr>
-  <td><code>link_text</code></td>
-  <td>Sets the text for the component's link</td>
-  <td>String</td>
+  <td><code>links</code></td>
+  <td>An array of optional links that includes <code>icon</code>, <code>location</code> and <code>text</code> hash options.</td>
+  <td>Array</td>
   <td></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -6,6 +6,7 @@ class SageFeatureToggle < SageComponent
     links: [:optional, [[{
       icon: [:optional, NilClass, String],
       location: [:optional, String],
+      target: [:optional, String],
       text: [:optional, String],
     }]]],
     title: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -5,6 +5,8 @@ class SageFeatureToggle < SageComponent
     image: [:optional, String],
     link_location: [:optional, String],
     link_text: [:optional, String],
+    secondary_link_location: [:optional, String],
+    secondary_link_text: [:optional, String],
     title: [:optional, String],
     title_tag: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -3,10 +3,11 @@ class SageFeatureToggle < SageComponent
     alt_text: [:optional, String],
     description: [:optional, String],
     image: [:optional, String],
-    link_location: [:optional, String],
-    link_text: [:optional, String],
-    secondary_link_location: [:optional, String],
-    secondary_link_text: [:optional, String],
+    links: [:optional, [[{
+      icon: [:optional, NilClass, String],
+      location: [:optional, String],
+      text: [:optional, String],
+    }]]],
     title: [:optional, String],
     title_tag: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -4,16 +4,28 @@
   <<%= feature_toggle_title_tag %> class="sage-feature-toggle__title"><%= component.title %></<%= feature_toggle_title_tag %>>
   <div class="sage-feature-toggle__content">
     <p><%= component.description %></p>
-    <%= sage_component SageButton, {
-      value: component.link_text,
-      style: "primary",
-      subtle: true,
-      icon: { name: "launch", style: "right" },
-      css_classes: "sage-feature-toggle__content-button",
-      attributes: component.link_location && {
-        href:  component.link_location
-      }
-    } %>
+    <div class="sage-grid-template-it">
+      <%= sage_component SageButton, {
+        value: component.link_text,
+        style: "primary",
+        subtle: true,
+        icon: { name: "launch", style: "right" },
+        css_classes: "sage-feature-toggle__content-button",
+        attributes: component.link_location && {
+          href:  component.link_location
+        }
+      } if component.link_text.present? && component.link_location.present? %>
+      <%= sage_component SageButton, {
+        value: component.secondary_link_text,
+        style: "primary",
+        subtle: true,
+        icon: { name: "comment", style: "right" },
+        css_classes: "sage-feature-toggle__content-button",
+        attributes: component.secondary_link_location && {
+          href:  component.secondary_link_location
+        }
+      } if component.secondary_link_location.present? && component.secondary_link_text.present? %>
+    </div>
   </div>
   <% if content_for?(:sage_feature_toggle_input) %>
     <div class="sage-feature-toggle__aside">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -16,6 +16,7 @@
               css_classes: "sage-feature-toggle__link-item",
               attributes: {
                 href: (link[:location] if link[:location].present?),
+                rel: ("noopener noreferrer" if link[:target].present? && link[:target] === "_blank"),
                 target: (link[:target] if link[:target].present?),
               }.compact
             } %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -4,27 +4,23 @@
   <<%= feature_toggle_title_tag %> class="sage-feature-toggle__title"><%= component.title %></<%= feature_toggle_title_tag %>>
   <div class="sage-feature-toggle__content">
     <p><%= component.description %></p>
-    <div class="sage-grid-template-it">
-      <%= sage_component SageButton, {
-        value: component.link_text,
-        style: "primary",
-        subtle: true,
-        icon: { name: "launch", style: "right" },
-        css_classes: "sage-feature-toggle__content-button",
-        attributes: component.link_location && {
-          href:  component.link_location
-        }
-      } if component.link_text.present? && component.link_location.present? %>
-      <%= sage_component SageButton, {
-        value: component.secondary_link_text,
-        style: "primary",
-        subtle: true,
-        icon: { name: "comment", style: "right" },
-        css_classes: "sage-feature-toggle__content-button",
-        attributes: component.secondary_link_location && {
-          href:  component.secondary_link_location
-        }
-      } if component.secondary_link_location.present? && component.secondary_link_text.present? %>
+    <div class="sage-feature-toggle__links">
+      <% if component.links.present? %>
+        <% component.links.each do | link | %>
+          <% if link[:location].present? %>
+            <%= sage_component SageButton, {
+              value: link[:text],
+              style: "primary",
+              subtle: true,
+              icon: { name: link[:icon], style: "right" },
+              css_classes: "sage-feature-toggle__content-button",
+              attributes: link[:location].present? && {
+                href: link[:location]
+              }
+            } %>
+          <% end %>
+        <% end %>
+      <% end %>
     </div>
   </div>
   <% if content_for?(:sage_feature_toggle_input) %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -13,10 +13,11 @@
               style: "primary",
               subtle: true,
               icon: { name: link[:icon], style: "right" },
-              css_classes: "sage-feature-toggle__content-button",
+              css_classes: "sage-feature-toggle__link-item",
               attributes: link[:location].present? && {
-                href: link[:location]
-              }
+                href: link[:location],
+                target: (link[:target] if link[:target].present?),
+              }.compact
             } %>
           <% end %>
         <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -14,8 +14,8 @@
               subtle: true,
               icon: { name: link[:icon], style: "right" },
               css_classes: "sage-feature-toggle__link-item",
-              attributes: link[:location].present? && {
-                href: link[:location],
+              attributes: {
+                href: (link[:location] if link[:location].present?),
                 target: (link[:target] if link[:target].present?),
               }.compact
             } %>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -48,6 +48,10 @@ $-image-height-mobile: rem(120px);
   }
 }
 
+.sage-feature-toggle__links {
+  display: flex;
+}
+
 .sage-feature-toggle__aside {
   grid-area: aside;
   padding-right: sage-spacing(xs);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -52,14 +52,14 @@ $-image-height-mobile: rem(120px);
   display: flex;
 }
 
+.sage-feature-toggle__link-item {
+  margin-top: sage-spacing(xs);
+  margin-right: sage-spacing(sm);
+}
+
 .sage-feature-toggle__aside {
   grid-area: aside;
   padding-right: sage-spacing(xs);
-}
-
-.sage-feature-toggle__content-button {
-  margin-top: sage-spacing(xs);
-  margin-right: sage-spacing(sm);
 }
 
 .sage-feature-toggle__image-link {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -13,7 +13,7 @@ $-image-height-mobile: rem(120px);
   display: grid;
   grid-column-gap: sage-spacing(md);
   grid-row-gap: sage-spacing(sm);
-  
+
   @media (max-width: sage-breakpoint(md-min)) {
     grid-template-columns: 1fr min-content;
     grid-template-rows: $-image-height-mobile auto auto;
@@ -55,6 +55,7 @@ $-image-height-mobile: rem(120px);
 
 .sage-feature-toggle__content-button {
   margin-top: sage-spacing(xs);
+  margin-right: sage-spacing(sm);
 }
 
 .sage-feature-toggle__image-link {
@@ -69,7 +70,7 @@ $-image-height-mobile: rem(120px);
   width: auto;
   height: 100%;
   border-radius: sage-border(radius);
-  
+
   @media (min-width: sage-breakpoint(md-min)) {
     width: 100%;
     object-fit: cover;


### PR DESCRIPTION
## Description
This PR adds the ability to pass `links` to the Sage Feature Toggle.

The `links` prop can be specified as such:

```
links: [
  {
    icon: "launch",
    location: "/",
    target: "_blank",
    text: "Learn more",
  },
  {
    icon: "comment",
    location: "/feedback",
    text: "Feedback",
  }
]
```

This work is being requested as a part of [COMM-671](https://github.com/Kajabi/kajabi-products/pull/17612).

### Screenshots
|Before|After|
|------|-----|
|<img width="1791" alt="Before" src="https://user-images.githubusercontent.com/7331038/106804225-22508680-6633-11eb-8a98-13cce1c9545a.png">|<img width="1791" alt="After" src="https://user-images.githubusercontent.com/7331038/106804135-0220c780-6633-11eb-9555-56c45f6a557d.png">|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Please see https://github.com/Kajabi/kajabi-products/pull/17612 for testing information.