### PR TITLE
Fix table unselect one from all

### DIFF
--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -171,7 +171,10 @@ export const Table = ({
     }
 
     const rowsSelected = updatedArray.includes(data);
-    updatedArray = rowsSelected ? removeFromList(data, updatedArray) : addToList(data, updatedArray);
+    updatedArray = rowsSelected
+      ? removeFromList(data, updatedArray)
+      : addToList(data, updatedArray);
+
     setSelfSelectedRows(updatedArray);
 
     if (onSelectRowHook) {

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -158,21 +158,20 @@ export const Table = ({
     setSelfSelectedRows(selectedRows);
   }, [selectedRows]);
 
-  const removeFromList = (data) => selfSelectedRows.filter((each) => each !== data);
+  const removeFromList = (data, list) => list.filter((each) => each !== data);
 
-  const addToList = (data) => [...selfSelectedRows, data];
+  const addToList = (data, list) => [...list, data];
 
   const onSelectRow = (data) => {
     let updatedArray;
-
     if (selfSelectedRows === SELECTION_TYPES.ALL) {
       updatedArray = rows.map(({ id }) => id);
     } else {
       updatedArray = selfSelectedRows;
     }
 
-    const rowsSelected = selfSelectedRows.includes(data);
-    updatedArray = rowsSelected ? removeFromList(data) : addToList(data);
+    const rowsSelected = updatedArray.includes(data);
+    updatedArray = rowsSelected ? removeFromList(data, updatedArray) : addToList(data, updatedArray);
     setSelfSelectedRows(updatedArray);
 
     if (onSelectRowHook) {


### PR DESCRIPTION
## Description

This PR fixes an issue with handlining selections: When you select all and then deslect one item the selection should switch to all on the current page except the one you just deselected.

## Test notes
N/A
