### PR TITLE
Dropdown - trigger label will contain recently selected option text onload

### DIFF
--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -121,6 +121,7 @@
   items: [{
     value: "-- None --"
   }, {
+    selected: true,
     value: "Option 1",
    }, {
     value: "Option 2",

--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -15,6 +15,7 @@ class SageDropdown < SageComponent
       is_heading: [:optional, TrueClass],
       modifiers: [:optional, Array],
       border_before: [:optional, TrueClass],
+      selected: [:optional, TrueClass],
     }]]],
     trigger_type: [:optional, Set.new(["select", "select-labeled"])],
     search: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -38,6 +38,7 @@
               sage-dropdown__item--heading
             "
             role="none"
+            <%= "aria-selected=true" if item[:selected] %>
           >
             <%= item[:value] %>
           </li>
@@ -49,6 +50,7 @@
               <% end %>
             "
             role="none"
+            <%= "aria-selected=true" if item[:selected] %>
           >
             <% if item[:attributes].nil? || item[:attributes]&.keys&.include?(:href) || item[:attributes]&.keys&.include?("href") %>
               <a

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -27,18 +27,16 @@ Sage.dropdown = (function() {
   // Several variations exist for triggers in selection mode; this is a grouped selector to grab any of them
   const triggerSelectClasses = '.sage-dropdown__trigger--select-labeled, .sage-dropdown__trigger--select';
 
-  const dropdownItemAriaSelectedClass = '.sage-dropdown__panel .sage-dropdown__item[aria-selected="true"]';
-  const dropdownItemControlClass = '.sage-dropdown__item-control';
-  const dropdownClass = '.sage-dropdown';
-  const dropdownTriggerLabelClass = '.sage-dropdown__trigger-label';
-
-
-
   // The element in which to show the selected value when dropdown is in selection mode
   const triggerSelectedValueClass = '.sage-dropdown__trigger-selected-value .sage-btn__truncate-text';
 
   const SELECTOR_FOCUSABLE_ELEMENTS = '.sage-dropdown__panel a, .sage-dropdown__panel button, .sage-dropdown__panel textarea, .sage-dropdown__panel input[type="text"], .sage-dropdown__panel input[type="radio"], .sage-dropdown__panel input[type="checkbox"], .sage-dropdown__panel input[type="search"], .sage-dropdown__panel select';
   let SELECTOR_LAST_FOCUSED;
+
+  const dropdownItemAriaSelectedClass = '.sage-dropdown__panel .sage-dropdown__item[aria-selected="true"]';
+  const dropdownItemControlClass = '.sage-dropdown__item-control';
+  const dropdownClass = '.sage-dropdown';
+  const dropdownTriggerLabelClass = '.sage-dropdown__trigger-label';
 
   // ==================================================
   // Functions

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -27,6 +27,13 @@ Sage.dropdown = (function() {
   // Several variations exist for triggers in selection mode; this is a grouped selector to grab any of them
   const triggerSelectClasses = '.sage-dropdown__trigger--select-labeled, .sage-dropdown__trigger--select';
 
+  const dropdownItemAriaSelectedClass = '.sage-dropdown__panel .sage-dropdown__item[aria-selected="true"]';
+  const dropdownItemControlClass = '.sage-dropdown__item-control';
+  const dropdownClass = '.sage-dropdown';
+  const dropdownTriggerLabelClass = '.sage-dropdown__trigger-label';
+
+
+
   // The element in which to show the selected value when dropdown is in selection mode
   const triggerSelectedValueClass = '.sage-dropdown__trigger-selected-value .sage-btn__truncate-text';
 
@@ -39,6 +46,7 @@ Sage.dropdown = (function() {
 
   function init(el) {
     buildA11y(el);
+    checkSelected(el);
     el.addEventListener('click', handleClick);
     el.addEventListener('keyup', handleKeyAction);
   }
@@ -136,6 +144,16 @@ Sage.dropdown = (function() {
   function buildA11y(el) {
     el.setAttribute('aria-haspopup', true);
     el.setAttribute('aria-expanded', false);
+  }
+
+  function checkSelected(el) {
+    let selectedItem = el.querySelector(dropdownItemAriaSelectedClass); 
+    
+    if (selectedItem != null) {
+      let selectedItemValue = selectedItem.querySelector(dropdownItemControlClass).innerHTML;
+      let selectedParent = selectedItem.closest(dropdownClass);
+      selectedParent.querySelector(dropdownTriggerLabelClass).innerHTML = selectedItemValue;
+    }
   }
 
   function focusTrap(evt) {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - add `selected` property to the `items` array
- [x] - updated trigger label to contain `selected` text on pageload

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-02-03 at 3 08 53 PM](https://user-images.githubusercontent.com/1241836/106810468-99d1e600-6632-11eb-9f4d-f8f3609ecc8f.png)|![Screen_Shot_2021-02-03_at_3_05_17_PM](https://user-images.githubusercontent.com/1241836/106810436-8c1c6080-6632-11eb-88d9-d5b814de3937.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Pending


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- 
