### PR TITLE
Webpack config changes for Sage CSS/Fonts

### DIFF
--- a/docs/config/webpack/environment.js
+++ b/docs/config/webpack/environment.js
@@ -1,3 +1,7 @@
 const { environment } = require('@rails/webpacker')
 
+environment.loaders.get("sass").use.splice(-1, 0, {
+  loader: "resolve-url-loader"
+});
+
 module.exports = environment

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -4,7 +4,6 @@
 /// @group sage
 ////
 
-
 $-body-font-path: "../fonts/inter"; // pathname of font directory
 $-body-font-version: 3.15;
 

--- a/packages/sage-assets/lib/stylesheets/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_variables.scss
@@ -4,7 +4,6 @@
 /// @group sage
 ////
 
-
 ///
 /// Active underline configuration
 ///

--- a/packages/sage-assets/webpack/webpack.prod.js
+++ b/packages/sage-assets/webpack/webpack.prod.js
@@ -35,10 +35,7 @@ module.exports = {
       },
       {
         test: /\.(woff|woff2|eot|ttf)$/,
-        loader: "url-loader",
-        options: {
-          limit: 0,
-        },
+        loader: "file-loader",
       },
       {
         test: /\.(png|svg|jpg|jpeg|gif)$/,

--- a/packages/sage-assets/webpack/webpack.prod.js
+++ b/packages/sage-assets/webpack/webpack.prod.js
@@ -25,7 +25,7 @@ module.exports = {
             loader: MiniCssExtractPlugin.loader,
             options: {
               sourceMap: true,
-              sourceMapContents: false,
+              sourceMapContents: false
             },
           },
           "css-loader",
@@ -36,6 +36,10 @@ module.exports = {
       {
         test: /\.(woff|woff2|eot|ttf)$/,
         loader: "file-loader",
+        options: {
+          outputPath: './fonts',
+          publicPath: './fonts'
+        }
       },
       {
         test: /\.(png|svg|jpg|jpeg|gif)$/,

--- a/packages/sage-assets/webpack/webpack.prod.js
+++ b/packages/sage-assets/webpack/webpack.prod.js
@@ -37,7 +37,7 @@ module.exports = {
         test: /\.(woff|woff2|eot|ttf)$/,
         loader: "url-loader",
         options: {
-          limit: Infinity,
+          limit: 0,
         },
       },
       {


### PR DESCRIPTION
## Description
This PR is an attempt at moving the Sage fonts out of the stylesheet and what impact that might have. This came out of discussions that were taking place in `dev-js` about how to reduce Sage CSS.

There are probably better/alternative ways to do this, but this seemed the simplest to get things started.

### ! UPDATE !
@voodooGQ was able to update the webpack config to fix the issue with font exporting. Please pull down this branch and test with `kajabi-products` AND Sage Docs.

### Docs
https://webpack.js.org/loaders/url-loader/
https://webpack.js.org/loaders/file-loader/

### Screenshots
I've attached some shots to see the before/after of the stylesheet/font sizes within Kajabi Products:

| |Before|After|
|-|------|------|
|**Stylesheeet**|<img width="1791" alt="Before - Stylesheet" src="https://user-images.githubusercontent.com/7331038/106810922-9abb4580-663b-11eb-8faa-5a971dc7ab9b.png">|<img width="1791" alt="After - Stylesheet" src="https://user-images.githubusercontent.com/7331038/106810951-a4dd4400-663b-11eb-9c23-8ba34eaa4ff9.png">|
|**Fonts**|<img width="1791" alt="Before - Fonts" src="https://user-images.githubusercontent.com/7331038/106811759-cbe84580-663c-11eb-9759-347387ee2af2.png">|<img width="1791" alt="After - Fonts" src="https://user-images.githubusercontent.com/7331038/106811110-d8b86980-663b-11eb-9697-acfaa8fb7fae.png">|

### Testing
1. Checkout `jed_sage_assets_webpack_config`
2. Run `yarn build`
3. Once the assets are compiled, run Kajabi Products AND Sage docs to ensure that the fonts are appearing as they should
4. Check the `Network` tab in your browser and ensure that you are seeing reduced payloads outlined in the After screenshots