### PR TITLE
Storybook Deployment adjustments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - node/with-cache:
           steps:
             - run: yarn docs:deploy
-            #- run: yarn storybook:deploy
+            - run: yarn storybook:deploy
             - run: yarn sassdocs:deploy
 workflows:
     lint-test-build:

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "build-storybook -o build && webpack --config webpack/webpack.prod.js",
     "build:watch": "build-storybook -o build && webpack --config webpack/webpack.prod.js --watch",
-    "heroku-prebuild": "yarn add react@16.13.1 react-dom@16.13.1 react-router-dom@5.1.0",
+    "heroku-prebuild": "npm install react@16.13.1 react-dom@16.13.1 react-router-dom@5.1.0",
     "lint": "yarn run eslint \"lib/**/*.{js,jsx}\"",
     "storybook": "start-storybook -p 6006 --ci",
     "preversion": "yarn install && yarn run build",

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -77,7 +77,8 @@
     "html-react-parser": "^0.14.2",
     "prop-types": "^15.7.2",
     "react-sortablejs": "^6.0.0",
-    "react-uuid": "^1.0.2"
+    "react-uuid": "^1.0.2",
+    "sortablejs": "^1.12.0"
   },
   "peerDependencies": {
     "react": ">=16.13.1",

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "build-storybook -o build && webpack --config webpack/webpack.prod.js",
     "build:watch": "build-storybook -o build && webpack --config webpack/webpack.prod.js --watch",
-    "heroku-prebuild": "npm install react@16.13.1 react-dom@16.13.1 react-router-dom@5.1.0",
+    "heroku-prebuild": "npm install react@16.13.1 react-dom@16.13.1 react-router-dom@5.1.0 --no-package-lock",
     "lint": "yarn run eslint \"lib/**/*.{js,jsx}\"",
     "storybook": "start-storybook -p 6006 --ci",
     "preversion": "yarn install && yarn run build",

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "build-storybook -o build && webpack --config webpack/webpack.prod.js",
     "build:watch": "build-storybook -o build && webpack --config webpack/webpack.prod.js --watch",
+    "heroku-prebuild": "yarn add react@16.13.1 react-dom@16.13.1 react-router-dom@5.1.0",
     "lint": "yarn run eslint \"lib/**/*.{js,jsx}\"",
     "storybook": "start-storybook -p 6006 --ci",
     "preversion": "yarn install && yarn run build",


### PR DESCRIPTION
Adds a `heroku-prebuild` script to the `sage-react:storybook` build. This will install react/react-dom/react-router-dom in lieu of adding to the `devDependencies`. When adding to the `devDependencies` an error occurs due to multiple versions of React. This should address the failing deploy without impacting other areas of the application.

## Testing

I'm not as familiar with the ins-outs of working through Sage on a daily basis, so I'm hoping the reviewer can test this for me. Ideally you should be able to download, run the local instance of Sage without error, as well as create a bridge with Kajabi Products without error.

## Notes

Due to the way Heroku handles installation of engines `yarn` is not available during the `heroku-prebuild` script. Using `npm` instead to install the dependencies.