### PR TITLE
React Modal Updates

### DIFF
--- a/packages/sage-react/lib/Modal/ModalBody.jsx
+++ b/packages/sage-react/lib/Modal/ModalBody.jsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { MODAL_CONTENT_SPACINGS } from './configs';
 
 export const ModalBody = ({
   children,
   className,
+  spacing,
   ...rest
 }) => {
   const classNames = classnames(
     'sage-modal__content',
     className,
+    {
+      [`sage-modal__content--spacing-${spacing}`]: spacing,
+    }
   );
 
   return (
@@ -19,12 +24,16 @@ export const ModalBody = ({
   );
 };
 
+ModalBody.SPACINGS = MODAL_CONTENT_SPACINGS;
+
 ModalBody.defaultProps = {
   children: null,
   className: '',
+  spacing: MODAL_CONTENT_SPACINGS.DEFAULT,
 };
 
 ModalBody.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  spacing: PropTypes.oneOf(Object.values(MODAL_CONTENT_SPACINGS)),
 };

--- a/packages/sage-react/lib/Modal/ModalHeader.jsx
+++ b/packages/sage-react/lib/Modal/ModalHeader.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ModalHeaderAside } from './ModalHeaderAside';
+import { SageClassnames } from '../configs';
 
 export const ModalHeader = ({
+  aside,
   children,
   className,
+  title,
   ...rest
 }) => {
   const classNames = classnames(
@@ -15,7 +18,9 @@ export const ModalHeader = ({
 
   return (
     <header className={classNames} {...rest}>
+      {title && <h5 className={SageClassnames.TYPE.HEADING_4}>{title}</h5>}
       {children}
+      {aside && <ModalHeaderAside>{aside}</ModalHeaderAside>}
     </header>
   );
 };
@@ -23,11 +28,15 @@ export const ModalHeader = ({
 ModalHeader.Aside = ModalHeaderAside;
 
 ModalHeader.defaultProps = {
+  aside: null,
   children: null,
-  className: '',
+  className: null,
+  title: null,
 };
 
 ModalHeader.propTypes = {
+  aside: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.string,
+  title: PropTypes.string,
 };

--- a/packages/sage-react/lib/Modal/configs.js
+++ b/packages/sage-react/lib/Modal/configs.js
@@ -1,0 +1,5 @@
+export const MODAL_CONTENT_SPACINGS = {
+  CARD: 'card',
+  DEFAULT: null,
+  PANEL: 'panel',
+};


### PR DESCRIPTION
## Description

This PR syncs up the React Modal components to some improvements made recently to the Rails components.

- ModalBody now allows a `spacing` prop to enforce `card` or `panel` spacing therein.
- ModalHeader now allows
  - a `title` to be passed in to automate rendering the modal title consistently. A custom one can still be provided as `children` if preferred.
  - an `aside` for simplifying populating the contents of a HeaderAside. As above a custom one with additional configurations can still be provided as `children`.

### Screenshots
No visual changes to the component.

## Test notes

Verify in Storybook > Modal that component displays as expected with no errors.

### Steps for testing
1. React-based Modals should not be impacted but now have features that make them easier to compose headers and to space the body of the modal. Verify existing React-based Modals behave as expected:
    - [ ] New Contact Imports > Mapping step (map columns modals)
    - [ ] Product outline editor (any modals)