### PR TITLE
Typeahead enhancements

### DIFF
--- a/packages/sage-react/lib/Typeahead/Typeahead.jsx
+++ b/packages/sage-react/lib/Typeahead/Typeahead.jsx
@@ -10,6 +10,7 @@ const A11Y_ID = uuid();
 export const Typeahead = ({
   contained,
   items,
+  searchFn,
   maxResults,
   placeholder,
   ...rest
@@ -28,13 +29,17 @@ export const Typeahead = ({
     returnFocus: false,
   });
 
-  useDebounceEffect(() => {
-    const _value = searchValue.toUpperCase(),
-      _results = [];
-    items.forEach((item) => {
-      if (_results.length >= maxResults) return;
-      if (item.title.toUpperCase().includes(_value)) _results.push(item);
-    });
+  useDebounceEffect(async () => {
+    const _value = searchValue.toUpperCase();
+    let _results = [];
+    if (searchFn) {
+      _results = await searchFn(_value);
+    } else {
+      items.forEach((item) => {
+        if (_results.length >= maxResults) return;
+        if (item.title.toUpperCase().includes(_value)) _results.push(item);
+      });
+    }
     setSearchResults(_results);
   }, [searchValue], 200);
 
@@ -90,8 +95,9 @@ export const Typeahead = ({
 Typeahead.defaultProps = {
   contained: true,
   items: [],
+  maxResults: 5,
   placeholder: 'Find',
-  maxResults: 5
+  searchFn: null,
 };
 
 Typeahead.propTypes = {
@@ -99,4 +105,5 @@ Typeahead.propTypes = {
   items: TypeaheadPanel.propTypes.items,
   maxResults: PropTypes.number,
   placeholder: PropTypes.string,
+  searchFn: PropTypes.func,
 };

--- a/packages/sage-react/lib/Typeahead/Typeahead.jsx
+++ b/packages/sage-react/lib/Typeahead/Typeahead.jsx
@@ -8,6 +8,7 @@ import { TypeaheadPanel } from './TypeaheadPanel';
 const A11Y_ID = uuid();
 
 export const Typeahead = ({
+  contained,
   items,
   maxResults,
   placeholder,
@@ -65,7 +66,7 @@ export const Typeahead = ({
       {...rest}
     >
       <Search
-        contained={true}
+        contained={contained}
         placeholder={placeholder}
         value={searchValue}
         onChange={onSearchInteraction}
@@ -87,12 +88,14 @@ export const Typeahead = ({
 };
 
 Typeahead.defaultProps = {
+  contained: true,
   items: [],
   placeholder: 'Find',
   maxResults: 5
 };
 
 Typeahead.propTypes = {
+  contained: PropTypes.bool,
   items: TypeaheadPanel.propTypes.items,
   maxResults: PropTypes.number,
   placeholder: PropTypes.string,

--- a/packages/sage-react/lib/Typeahead/Typeahead.story.jsx
+++ b/packages/sage-react/lib/Typeahead/Typeahead.story.jsx
@@ -1,11 +1,49 @@
-import React from 'react';
+import React, { useState } from 'react';
 import uuid from 'react-uuid';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, number } from '@storybook/addon-knobs';
 import { centerXY } from '../story-support/decorators';
-import { Button } from '../Button';
 import { SageTokens } from '../configs';
+import { Button } from '../Button';
+import { Panel } from '../Panel';
 import { Typeahead } from './Typeahead';
+import { searchNews } from '../services/newsapi';
+
+const TypeaheadWithAPI = () => {
+  const [items, setItems] = useState([]);
+  const [selectedArticle, setSelectedArticle] = useState(null);
+
+  const searchFn = async (value) => {
+    const news = await searchNews(value);
+    if (!news || !news.articles) {
+      return;
+    }
+
+    setItems(news.articles.map(({ title, author, link }) => ({
+      icon: SageTokens.ICONS.URL,
+      onClick: () => setSelectedArticle({ title, author, link }),
+      subtitle: author || '',
+      title,
+    })));
+  };
+
+  return (
+    <Panel.Stack>
+      <Typeahead
+        filterFn={null}
+        items={items}
+        maxResults={5}
+        searchFn={searchFn}
+        onClearHook={() => setSelectedArticle(null)}
+      />
+      {selectedArticle && (
+        <a href={selectedArticle.link} rel="noopener noreferrer" target="_blank">
+          {selectedArticle.title}
+        </a>
+      )}
+    </Panel.Stack>
+  );
+};
 
 const itemActions = [
   <Button
@@ -75,5 +113,10 @@ storiesOf('Sage/Typeahead', module)
           <span key={uuid()}><br />{item.title}</span>
         )}
       </p>
+    </div>
+  ))
+  .add('With API', () => (
+    <div style={{ width: 500 }}>
+      <TypeaheadWithAPI />
     </div>
   ));

--- a/packages/sage-react/lib/services/newsapi.js
+++ b/packages/sage-react/lib/services/newsapi.js
@@ -1,18 +1,37 @@
 import axios from 'axios';
 
+const headers = {
+  'x-rapidapi-key': 'API_KEY_GOES_HERE', // Get an api key at https://rapidapi.com/newscatcher-api-newscatcher-api-default/api/newscatcher
+  'x-rapidapi-host': 'newscatcher.p.rapidapi.com'
+};
+
+const standardError = (error) => {
+  console.warn(error); // eslint-disable-line
+  console.warn('You likely need to set up an API key with Newscatcher.'); // eslint-disable-line
+};
+
 export const getNews = (page = 1) => {
   const options = {
+    headers,
     method: 'GET',
-    url: 'https://newscatcher.p.rapidapi.com/v1/search_free',
     params: { q: 'Star Wars', lang: 'en', page, page_size: '25', media: 'True' },
-    headers: {
-      'x-rapidapi-key': 'API_KEY_GOES_HERE', // Get an api key at https://rapidapi.com/newscatcher-api-newscatcher-api-default/api/newscatcher
-      'x-rapidapi-host': 'newscatcher.p.rapidapi.com'
-    }
+    url: 'https://newscatcher.p.rapidapi.com/v1/search_free',
   };
 
-  return axios.request(options).then((response) => response.data).catch((error) => {
-    console.warn(error); // eslint-disable-line
-    console.warn('You likely need to set up an API key with Newscatcher.'); // eslint-disable-line
-  });
+  return axios.request(options).then((response) => response.data).catch(standardError);
+};
+
+export const searchNews = (q, page = 1) => {
+  if (!q) {
+    return [];
+  }
+
+  const options = {
+    headers,
+    method: 'GET',
+    params: { q, page, page_size: '25', lang: 'en', media: 'True' },
+    url: 'https://newscatcher.p.rapidapi.com/v1/search_free',
+  };
+
+  return axios.request(options).then((response) => response.data).catch(standardError);
 };


### PR DESCRIPTION
## Description

This PR adds a few small enhancements to Typeahead:

- Allows for a searchFn callback to override local items for the case where a type ahead's items should come from an API
- Allows for `contained` setting to be passed through to the inner Search (`true`) remains default.

### Screenshots

No visual changes


## Test notes

No changes to functionality to date.

### Steps for testing
1. [ ] (Low) Adds features to Typeahead. Only existing use of this component is in the search header on Product Outline manager. Ensure this still works as expected.