### PR TITLE
Pagination - add option to hide page count

### DIFF
--- a/docs/app/helpers/objects_helper.rb
+++ b/docs/app/helpers/objects_helper.rb
@@ -223,7 +223,7 @@ module ObjectsHelper
       {
         title: "pagination",
         description: "Pagination is used for splitting up results into several pages and provides controls for navigating to the next or previous page.",
-        use_legacy_html_code_source: true,
+        use_legacy_html_code_source: false,
         scss: "done",
         docs: "done",
         rails: "todo",

--- a/docs/app/views/examples/objects/pagination/_markup.html.erb
+++ b/docs/app/views/examples/objects/pagination/_markup.html.erb
@@ -1,5 +1,8 @@
-<nav class="sage-pagination" aria-label="pagination">
-  <span class="sage-pagination__count"><strong><%= total_count %></strong> Records</span>
+<% hide_counter ||= false %>
+<nav class="sage-pagination<% if hide_counter %> sage-pagination--no-counter<% end %>" aria-label="pagination">
+  <% unless hide_counter %>
+    <span class="sage-pagination__count"><strong><%= total_count %></strong> Records</span>
+  <% end %>
   <ul class="sage-pagination__pages">
     <% pagination_items.each do |item| %>
       <li class="sage-pagination__item">

--- a/docs/app/views/examples/objects/pagination/_preview.html.erb
+++ b/docs/app/views/examples/objects/pagination/_preview.html.erb
@@ -1,5 +1,108 @@
+<h3 class="t-sage-heading-6">Default</h3>
 <%= render "examples/objects/pagination/markup",
   total_count: "32",
+  pagination_items: [
+    {
+      # prev link
+      is_link: true,
+      is_gap: false,
+      is_prev: true,
+      is_next: false,
+      page_number: "",
+      link_url: "#",
+      is_disabled: true,
+      is_current: false
+    },
+    {
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: false,
+      page_number: "1",
+      link_url: "#",
+      is_disabled: false,
+      is_current: true
+    },
+    {
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: false,
+      page_number: "2",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+    {
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: false,
+      page_number: "3",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+    {
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: false,
+      page_number: "4",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+    {
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: false,
+      page_number: "5",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+    {
+      # gap
+      is_link: false,
+      is_gap: true,
+      is_prev: false,
+      is_next: false,
+      page_number: "",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+    {
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: false,
+      page_number: "20",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+    {
+      # next link
+      is_link: true,
+      is_gap: false,
+      is_prev: false,
+      is_next: true,
+      page_number: "",
+      link_url: "#",
+      is_disabled: false,
+      is_current: false
+    },
+  ]
+%>
+
+<h3 class="t-sage-heading-6">Page count disabled</h3>
+<%= render "examples/objects/pagination/markup",
+  total_count: "32",
+  hide_counter: true,
+  hide_pages: true,
   pagination_items: [
     {
       # prev link

--- a/docs/app/views/examples/objects/pagination/_preview.html.erb
+++ b/docs/app/views/examples/objects/pagination/_preview.html.erb
@@ -98,7 +98,7 @@
   ]
 %>
 
-<h3 class="t-sage-heading-6">Page count disabled</h3>
+<h3 class="t-sage-heading-6">Record count disabled</h3>
 <%= render "examples/objects/pagination/markup",
   total_count: "32",
   hide_counter: true,

--- a/docs/app/views/examples/objects/pagination/_props.html.erb
+++ b/docs/app/views/examples/objects/pagination/_props.html.erb
@@ -1,4 +1,16 @@
 <tr>
+  <td><code>hide_pages</code></td>
+  <td>When set to <code>true</code>, links to individual pages will not be rendered, leaving only the "Back" and "Next" links visible.</td>
+  <td>Boolean</td>
+  <td>false</td>
+</tr>
+<tr>
+  <td><code>hide_counter</code></td>
+  <td>When set to <code>true</code>, the page count will not be displayed.</td>
+  <td>Boolean</td>
+  <td>false</td>
+</tr>
+<tr>
   <td>current</td>
   <td>Pagination uses a <code>--current</code> modifier to visually indicate which page is currently being viewed.</td>
   <td>String</td>

--- a/docs/app/views/examples/objects/pagination/_props.html.erb
+++ b/docs/app/views/examples/objects/pagination/_props.html.erb
@@ -6,7 +6,7 @@
 </tr>
 <tr>
   <td><code>hide_counter</code></td>
-  <td>When set to <code>true</code>, the page count will not be displayed.</td>
+  <td>When set to <code>true</code>, the record count will not be displayed.</td>
   <td>Boolean</td>
   <td>false</td>
 </tr>

--- a/docs/app/views/examples/objects/pagination/_props.html.erb
+++ b/docs/app/views/examples/objects/pagination/_props.html.erb
@@ -1,30 +1,36 @@
 <tr>
-  <td><code>hide_pages</code></td>
-  <td>When set to <code>true</code>, links to individual pages will not be rendered, leaving only the "Back" and "Next" links visible.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`items`") %></td>
+  <td><%= md("Maps records to create page link items") %></td>
+  <td><%= md("Object") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td><code>hide_counter</code></td>
-  <td>When set to <code>true</code>, the record count will not be displayed.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md("`hide_pages`") %></td>
+  <td><%= md("When set to `true`, links to individual pages will not be rendered, leaving only the 'Back' and 'Next' links visible.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>current</td>
-  <td>Pagination uses a <code>--current</code> modifier to visually indicate which page is currently being viewed.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("`hide_counter`") %></td>
+  <td><%= md("When set to `true`, the record count will not be displayed.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`false`") %></td>
 </tr>
 <tr>
-  <td>disabled</td>
-  <td>Pagination uses a <code>--disabled</code> modifier to disable a link to prevent navigation. For example, when a user has reached the last page, the Next link should be disabled since there are no other pages/results to navigate to.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("current") %></td>
+  <td><%= md("Pagination uses a `--current` modifier to visually indicate which page is currently being viewed.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
 </tr>
 <tr>
-  <td>gap</td>
-  <td>When there are many pages, a <code>--gap</code> modifier along with an ellipsis (&hellip;) can be used to truncate the pagination list items. Should be used in conjunction with <code>sage-pagination__page</code></td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md("disabled") %></td>
+  <td><%= md("Pagination uses a `--disabled` modifier to disable a link to prevent navigation. For example, when a user has reached the last page, the Next link should be disabled since there are no other pages/results to navigate to.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
+</tr>
+<tr>
+  <td><%= md("gap") %></td>
+  <td><%= md("When there are many pages, a `--gap` modifier along with an ellipsis (&hellip;) can be used to truncate the pagination list items. Should be used in conjunction with `sage-pagination__page`") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("`null`") %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -3,6 +3,7 @@ class SagePagination < SageComponent
     items: -> (v) { SageSchemaHelper.is_active_record?(v) },
     window: [:optional, Integer],
     hide_pages: [:optional, TrueClass],
+    hide_counter: [:optional, TrueClass],
     additional_params: [:optional, Hash]
   })
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -1,15 +1,19 @@
-<% if component.items.total_pages > 1 %>
+<%- if component.items.total_pages > 1 -%>
   <nav
     class="
       sage-pagination
+      <% if component.hide_counter %>sage-pagination--no-counter<% end %>
       <%= component.generated_css_classes %>
     "
+    role="pagination"
     aria-label="Pagination Navigation"
   >
-    <span class="sage-pagination__count"><%= component.page_count component.items %></span>
+    <% if !component.hide_counter %>
+      <span class="sage-pagination__count"><%= component.page_count component.items %></span>
+    <% end %>
 
     <ul class="sage-pagination__pages">
-      <% if component.items.first_page?  %>
+      <% if component.items.first_page? %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
           <%= component.prev_text %>
@@ -25,7 +29,7 @@
         <%= paginate component.items, outer_window: component.window, theme: "sage_theme" %>
       <% end %>
 
-      <% if component.items.last_page?  %>
+      <% if component.items.last_page? %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
           <%= component.next_text %>
@@ -45,8 +49,10 @@
       <%= component.generated_css_classes %>
     "
   >
-    <span class="sage-pagination__count sage-pagination__count--solo">
-      <%= component.page_count component.items %>
-    </span>
+    <% unless component.hide_counter %>
+      <span class="sage-pagination__count sage-pagination__count--solo">
+        <%= component.page_count component.items %>
+      </span>
+    <% end %>
   </div>
 <% end -%>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -20,6 +20,10 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   align-items: center;
 }
 
+.sage-pagination--no-counter {
+  justify-content: flex-end;
+}
+
 .sage-pagination__pages {
   display: flex;
   flex-flow: row wrap;


### PR DESCRIPTION
## Description
This update to the Sage Pagination component is in response to performance issues we've encountered when calculating the item count. For a site with large numbers of records in its database, this can end up causing a long lookup time, eventually resulting in a timeout and making the view inaccessible.

**The impact on current use should be minimal since this is an optional attribute, but views listed below should still be checked.**

Changes:
- attribute `hide_counter` has been added to prevent the counter from rendering
- modified CSS to force pagination link alignment when the counter is disabled
- added documentation around `hide_pages` and `hide_counter`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
![pagination-counter](https://user-images.githubusercontent.com/816579/107722378-a8a04480-6c93-11eb-92de-55a708759745.png)

### Change impact: low
Affected locations (listed by view)
- [x] Coupons index: `app/views/admin/coupons/_new_coupons_list.html.erb`
- [x] Offer list:
  - [x] `app/views/admin/offers/_table.html.erb`
  - [x] `app/views/admin/offers/index.html.erb`
- [x] Payment transactions: `app/views/admin/payments/_transactions.html.erb`
- [ ] Podcasts: `app/views/admin/podcasts/show.html.erb`
- [ ] Product Offers: `app/views/admin/product_offers/index.html.erb`
- [x] Products: `app/views/admin/products/index.html.erb`
- [ ] SuperAdmin:
  - [ ] Search: `app/views/super_admin/shared/_dropdown_search.html.erb`
  - [ ] Users: `app/views/super_admin/users/index.html.erb`