### PR TITLE
Feature Toggle - image sizing to not stretch

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -85,17 +85,17 @@ $-image-height-mobile: rem(120px);
   display: flex;
   position: relative;
   grid-area: img;
+
+  @media (min-width: sage-breakpoint(md-min)) {
+    align-self: flex-start;
+  }
 }
 
 .sage-feature-toggle__image {
   align-self: flex-start;
   max-width: rem(140px);
-  width: auto;
-  height: 100%;
+  width: $-image-width;
+  height: $-image-width;
   border-radius: sage-border(radius);
-
-  @media (min-width: sage-breakpoint(md-min)) {
-    width: 100%;
-    object-fit: cover;
-  }
+  object-fit: cover;
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - resolve image stretching issue

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-02-12 at 7 47 14 AM](https://user-images.githubusercontent.com/1241836/107776099-c8bd1b80-6d06-11eb-99dc-f0ff877553b3.png)|![Screen Shot 2021-02-12 at 7 42 38 AM](https://user-images.githubusercontent.com/1241836/107776132-cf4b9300-6d06-11eb-8d26-d386056af46b.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. In the app visit the Beta Features page: http://www.kajabi.test:3000/admin/sites/1/beta_features
2. Verify that the long copy doesn't cause the image to stretch
