### PR TITLE
Breadcrumb icon repair

### DIFF
--- a/docs/app/views/examples/elements/breadcrumbs/_preview.html.erb
+++ b/docs/app/views/examples/elements/breadcrumbs/_preview.html.erb
@@ -28,7 +28,6 @@
   } %>
 <% end %>
 <%= sage_component SageBreadcrumbs, {
-  has_back_icon: true,
   items: [
     {
       text: 'Settings',

--- a/docs/app/views/examples/objects/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/objects/page_heading/_preview.html.erb
@@ -13,7 +13,6 @@
 } do %>
     <% content_for :sage_breadcrumbs do %>
       <%= sage_component SageBreadcrumbs, {
-        has_back_icon: true,
         items: [
           {
             text: 'Back to Something',
@@ -128,12 +127,17 @@
     <% content_for :sage_breadcrumbs do %>
       <%= render "examples/elements/breadcrumbs/markup",
         klass: "sage-page-heading__back",
-        has_back_icon: true,
         items: [{
-        text: "Back to Something",
-        url: "#"
-      }]
-    %>
+          text: "Back to Something",
+          url: "#"
+        }, {
+          text: "Back to Something",
+          url: "#"
+        }, {
+          text: "Back to Something",
+          url: "#"
+        }]
+      %>
     <% end %>
     <% content_for :sage_page_heading_actions do %>
       <%= sage_component SageButton, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
@@ -1,4 +1,7 @@
-<% is_progressbar = component.is_progressbar.present? && component.is_progressbar %>
+<%
+has_back_icon = component.has_back_icon.present? ? component.has_back_icon : component.items.length() == 1
+is_progressbar = component.is_progressbar.present? && component.is_progressbar
+%>
 <nav
   aria-label="Breadcrumbs"
   class="
@@ -19,7 +22,7 @@
             "
             <%= "aria-disabled=true" if item[:disabled]  %>
           >
-            <% if i == 0 && defined?(has_back_icon) && has_back_icon %>
+            <% if i == 0 && has_back_icon %>
               <i class="sage-breadcrumbs__icon sage-icon-arrow-left" aria-hidden="true"></i>
             <% end %>
             <%= item[:text] %>
@@ -30,7 +33,7 @@
   <% else %>
   <p class="sage-breadcrumbs__item">
     <a href="<%= component.items[0][:url] %>" class="sage-breadcrumbs__link" aria-current="page">
-      <% if component.has_back_icon.present? && component.has_back_icon %>
+      <% if has_back_icon %>
         <i class="sage-breadcrumbs__icon sage-icon-arrow-left" aria-hidden="true"></i>
       <% end %>
       <%= component.items[0][:text] %>

--- a/packages/sage-react/lib/Breadcrumbs/Breadcrumbs.jsx
+++ b/packages/sage-react/lib/Breadcrumbs/Breadcrumbs.jsx
@@ -39,7 +39,7 @@ export const Breadcrumbs = ({
         tag={linkTag}
         {...otherProps}
       >
-        {(icon && i === 0) && (
+        {(icon && items.length === 1 && i === 0) && (
           <Icon className="sage-breadcrumbs__icon" icon={icon} />
         )}
         {label}

--- a/packages/sage-react/lib/Breadcrumbs/Breadcrumbs.story.jsx
+++ b/packages/sage-react/lib/Breadcrumbs/Breadcrumbs.story.jsx
@@ -19,7 +19,6 @@ storiesOf('Sage/Breadcrumbs', module)
   ))
   .add('Multiple items', () => (
     <Breadcrumbs
-      icon={null}
       items={[
         {
           label: 'First place',
@@ -38,7 +37,6 @@ storiesOf('Sage/Breadcrumbs', module)
   ))
   .add('Progressbar Style', () => (
     <Breadcrumbs
-      icon={null}
       isProgressbar={true}
       items={[
         {


### PR DESCRIPTION
## Description

This PR adjusts functionality to exclude the "back icon" whenever there are more than 1 items in the breadcrumbs.

### Screenshots

No visual change.

## Test notes

See Elements > Breadcrumbs
See Storybook > Breadcrumbs

### Steps for testing
1. Verify existing uses of rails breadcrumbs (all in page headings) behave as expected:
    - [ ] Settings > Domain .... should have back icon with Settings link in header.
    - [ ] Settings > Domain, setup process... steps should not have back icon next to first link in header.
2. New contact import process... verify this (react) use of breadcrumbs in header does have back link next to "People" or "Exit import" (depending on the step)