### PR TITLE
accordian-panel.js clean up/keyboard support updates.

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_expandable_card.scss
@@ -53,7 +53,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
   &::before {
     justify-content: center;
     margin-right: rem(4px);
-    font-size: rem(4px);
+    font-size: rem(8px);
     transition: transform 0.2s linear;
   }
   &[aria-expanded="true"]::before {

--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -37,7 +37,7 @@ Sage.accordion = (function () {
     // Toggle target
     const toggle = el.getAttribute('aria-expanded') === 'true';
     el.setAttribute('aria-expanded', !toggle);
-    el.nextElementSibling.hidden = false;
+    el.nextElementSibling.hidden = toggle;
   }
 
   function init(el) {

--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -5,8 +5,6 @@ Sage.accordion = (function () {
 
   const JS_ACCORDION_ROOT = 'data-js-accordion';
   const JS_ACCORDION_BODY = 'body';
-  const JS_ACCORDION_HEADER = 'header';
-  const JS_ACCORDION_SOLO_TOGGLE = 'group-toggle-solo';
   const JS_ACCORDION_ID_BODY_PREFIX = 'accordion-body';
   const JS_ACCORDION_ID_HEADER_PREFIX = 'accordion-header';
 
@@ -36,20 +34,10 @@ Sage.accordion = (function () {
       return false;
     }
 
-    // Check for other items in an exclusive panel group to toggler off
-    const grandparent = el.parentNode.parentNode;
-    if (grandparent.dataset.jsAccordion && grandparent.dataset.jsAccordion === JS_ACCORDION_SOLO_TOGGLE) {
-      const allHeaders = grandparent.querySelectorAll(`[${JS_ACCORDION_ROOT}="${JS_ACCORDION_HEADER}"]`);
-      allHeaders.forEach(header => {
-        if (header.getAttribute('id') !== el.getAttribute('id')) {
-          header.setAttribute('aria-expanded', false);
-        }
-      });
-    }
-
     // Toggle target
     const toggle = el.getAttribute('aria-expanded') === 'true';
     el.setAttribute('aria-expanded', !toggle);
+    el.nextElementSibling.hidden = false;
   }
 
   function init(el) {
@@ -73,6 +61,7 @@ Sage.accordion = (function () {
     if (!bodyId) {
       bodyId = generateId(JS_ACCORDION_ID_BODY_PREFIX);
       body.setAttribute('id', bodyId);
+      body.hidden = true;
     }
 
     // Add a11y attributes

--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -26,6 +26,7 @@ Sage.accordion = (function () {
   }
 
   function handleAccordionClick(ev) {
+
     const el = ev.currentTarget;
 
     // Ensure relevant events before proceding
@@ -82,12 +83,12 @@ Sage.accordion = (function () {
 
     // Add listeners
     header.addEventListener('click', handleAccordionClick);
-    header.addEventListener('keypress', handleAccordionClick);
+    header.addEventListener('keydown', handleAccordionClick);
   }
 
   function unbind(el) {
     header.removeEventListener('click', handleAccordionClick);
-    header.removeEventListener('keypress', handleAccordionClick);
+    header.removeEventListener('keydown', handleAccordionClick);
   }
 
   return {


### PR DESCRIPTION
## Description
This is a follow up to the new expandable card adjustments #297 and includes the following adjustments:

- Removes code related to the `group-toggle-solo` check. 
This will no longer be needed with the latest updates to the expandable card.
- Improves keyboard support for the rails component.
`enter` and `space` keys should now expand and collapse the body properly.
If multiple expandable cards appear on the page, tabbing will navigate to each trigger if the body is not expanded.
If the body is expanded the child elements will receive focus/navigation as expected

Keyboard navigation updates based on:
 https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit http://localhost:4000/pages/breakout/object/expandable_card
2. Tab to the expandable card trigger (Expand)
3. Verify pressing `space` and `enter` expand/collapse the body.

--

1. Visit http://localhost:4000/pages/breakout/object/expandable_card
2. Collapse all cards
3. Verify pressing `tab` &  `shift+tab` navigates between triggers
Previously hidden children elements would receive focus even if not visible.

## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- N/A
