### PR TITLE
BUILD-729 - modal - remove contents on close

### DIFF
--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -65,7 +65,8 @@
   <%# Large Modal %>
   <%= sage_component SageModal, { 
     id: "cool-modal-large",
-    large: true
+    large: true,
+    remove_content_on_close: true
   } do %>
     <%= sage_component SageModalContent, { title: "Example Large Modal" } do %>
       <% content_for :sage_header_aside do %>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -23,6 +23,12 @@
   <td><%= md("`nil`") %></td>
 </tr>
 <tr>
+  <td><%= md("`remove_content_on_close`") %></td>
+  <td><%= md("Toggles whether to delete the `innerHTML` when closing the modal.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
   <td colspan="4">
     <strong>Modal Content</strong>
   </td>

--- a/docs/app/views/examples/objects/modal/_rules_dont.html.erb
+++ b/docs/app/views/examples/objects/modal/_rules_dont.html.erb
@@ -1,0 +1,2 @@
+<%= md("
+- **DO NOT** use the `remove_content_on_close` property if your modal's content is not populated using JavaScript. The modal will not have content the next time it's triggered") %>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -4,5 +4,6 @@ class SageModal < SageComponent
     active: [:optional, TrueClass],
     disable_close: [:optional, TrueClass],
     large: [:optional, TrueClass],
+    remove_content_on_close: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -5,6 +5,7 @@
     <%= "sage-modal--large" if component.large %>
   "
   <%= "data-js-modal-disable-close" if component.disable_close %>
+  <%= "data-js-modal-remove-content-on-close" if component.remove_content_on_close %>
   data-js-modal="<%= component.id %>"
 >
   <section class="sage-modal__container" data-js-modal-container>

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -7,7 +7,7 @@ Sage.modal = (function() {
   const SELECTOR_MODAL = 'data-js-modal';
   const SELECTOR_MODAL_CONTAINER = '.sage-modal__container';
   const SELECTOR_MODAL_DISABLE_CLOSE = 'data-js-modal-disable-close';
-  const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = 'data-js-modal-remove-contents-on-close';
+  const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = 'data-js-modal-remove-content-on-close';
   const SELECTOR_MODAL_CLOSE = 'data-js-modal-close';
   const SELECTOR_MODALTRIGGER = 'data-js-modaltrigger';
   const SELECTOR_FOCUSABLE_ELEMENTS = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])';
@@ -100,8 +100,10 @@ Sage.modal = (function() {
   }
 
   function removeModalContents(el) {
-    let elContainer = el.querySelector(`${SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE}`);
-    elContainer.innerHTML = "";
+    if ( el.hasAttribute(SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE) ) {
+      let elContainer = el.querySelector(`${SELECTOR_MODAL_CONTAINER}`);
+      elContainer.innerHTML = "";
+    }
   }
 
   function eventHandlerCloseAll() {

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -5,7 +5,9 @@ Sage.modal = (function() {
   // ==================================================
 
   const SELECTOR_MODAL = 'data-js-modal';
+  const SELECTOR_MODAL_CONTAINER = '.sage-modal__container';
   const SELECTOR_MODAL_DISABLE_CLOSE = 'data-js-modal-disable-close';
+  const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = 'data-js-modal-remove-contents-on-close';
   const SELECTOR_MODAL_CLOSE = 'data-js-modal-close';
   const SELECTOR_MODALTRIGGER = 'data-js-modaltrigger';
   const SELECTOR_FOCUSABLE_ELEMENTS = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])';
@@ -94,6 +96,12 @@ Sage.modal = (function() {
     el.removeAttribute("open");
     el.removeEventListener('keydown', focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
+    removeModalContents(el);
+  }
+
+  function removeModalContents(el) {
+    let elContainer = el.querySelector(`${SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE}`);
+    elContainer.innerHTML = "";
   }
 
   function eventHandlerCloseAll() {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- added prop to remove modal contents on close

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|https://user-images.githubusercontent.com/1241836/107992028-79444d00-6f9d-11eb-95e0-2fb71c8834d0.mov|https://user-images.githubusercontent.com/1241836/107992054-88c39600-6f9d-11eb-80d2-801146de85df.mov|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. In the app create 2 separate posts that have an audio type
2. Go to first lesson: open stats modal, close modal
3. Go to second lesson: open stats modal –> content of first lesson flashes before new content loaded
