### PR TITLE
Sage form input property additions

### DIFF
--- a/docs/app/views/examples/elements/form_input/_preview.html.erb
+++ b/docs/app/views/examples/elements/form_input/_preview.html.erb
@@ -52,6 +52,21 @@
     has_placeholder: false
   } %>
 
+  <h3 class="t-sage-heading-6">Text (readonly)</h3>
+  <%= sage_component SageFormInput, {
+    id: "form__readonly",
+    value: "This text can't be modified by the user",
+    input_type: "text",
+    label_text: "Can't touch this",
+    placeholder: "Can't touch this",
+    required: false,
+    disabled: false,
+    readonly: true,
+    has_error: false,
+    message_text: "This is a message",
+    has_placeholder: false
+  } %>
+
   <h3 class="t-sage-heading-6">Email</h3>
   <%= sage_component SageFormInput, {
     id: "form__email",
@@ -91,6 +106,23 @@
     pattern: "[0-9]{2}",
     max: "48",
     maxlength: "2",
+    has_error: false,
+    has_placeholder: false
+  } %>
+
+  <h3 class="t-sage-heading-6">Numbers (incremented)</h3>
+  <%= sage_component SageFormInput, {
+    id: "form__num",
+    input_type: "number",
+    label_text: "Enter percentage (max 5%)",
+    placeholder: "Enter percentage (max 5%)",
+    required: true,
+    disabled: false,
+    input_mode: "numeric",
+    max: "5",
+    maxlength: "2",
+    min: "0",
+    step: "0.5",
     has_error: false,
     has_placeholder: false
   } %>

--- a/docs/app/views/examples/elements/form_input/_props.html.erb
+++ b/docs/app/views/examples/elements/form_input/_props.html.erb
@@ -1,103 +1,133 @@
 <tr>
-  <td><%= md('`disabled`') %></td>
-  <td><%= md('Enabling this property adds the `disabled` attribute to the component.') %></td>
+  <td><%= md('`autocomplete`') %></td>
+  <td><%= md('Enables the browser to autofill values from saved fields or password managers. Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete" target="_blank" rel="nofollow">the allowed values for acceptable properties</a>.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('nil') %></td>
+</tr>
+<tr>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Enabling this property adds the `disabled` attribute to the component. Note that `disabled` input fields will not be submitted in forms.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('nil') %></td>
 </tr>
 <tr>
   <td><%= md('`has_error`') %></td>
   <td><%= md('Enabling this property adds the `.sage-input--error` class to the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`has_placeholder`') %></td>
   <td><%= md('Enabling this property adds the `.sage-input--showplaceholder` class to the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`id`') %></td>
   <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`input_mode`') %></td>
   <td><%= md('Hints at the type of data to be entered. Primarily intended for mobile devices, this can influence the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode" rel="nofollow" target="_blank"> type of control displayed</a>, for example a numeric input keypad instead of a standard text keyboard.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`input_type`') %></td>
   <td><%= md('Sets the `type` attribute for the component') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`label_text`') %></td>
   <td><%= md('Sets the label text for the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`max`') %></td>
   <td><%= md('Sets the maximum numerical value for a form field.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`maxlength`') %></td>
   <td><%= md('Sets the maximum character length for a form field.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`message_text`') %></td>
   <td><%= md('Sets the message text for the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`min`') %></td>
+  <td><%= md('Sets the minimum value for a numeric form field (ex. `number` or `datetime-local` input types)') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('nil') %></td>
 </tr>
 <tr>
   <td><%= md('`minlength`') %></td>
   <td><%= md('Sets the minimum character length for a form field.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`pattern`') %></td>
-  <td><%= md('Sets form\'s validation pattern.') %></td>
+  <td><%= md('Specifies a form field\'s validation pattern using regex. Ignored with `number` input types (use `min` and `max` instead). <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern" target="_blank" rel="nofollow">See MDN for usage</a>.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('nil') %></td>
 </tr>
 <tr>
   <td><%= md('`placeholder`') %></td>
   <td><%= md('Inserts content to be displayed inside a default (empty) field.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`prefix`') %></td>
   <td><%= md('Sets prefix text to be prepended to the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`required`') %></td>
   <td><%= md('Adding this attribute allows basic HTML form validation on this field.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`readonly`') %></td>
+  <td><%= md('Enabling this property adds the `readonly` attribute, preventing the user from editing the field, but allowing manipulation of the value via Javascript. Unlike with `disabled`, `readonly` values will be submitted in a form.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('nil') %></td>
+</tr>
+<tr>
+  <td><%= md('`required`') %></td>
+  <td><%= md('Adding this attribute allows basic HTML form validation on this field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('nil') %></td>
+</tr>
+<tr>
+  <td><%= md('`step`') %></td>
+  <td><%= md('When applied to a numeric (`number`, `date`, `month`, etc) form field, this allows the browser control to be increase or decrease the value in defined increments') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('nil') %></td>
 </tr>
 <tr>
   <td><%= md('`suffix`') %></td>
   <td><%= md('Sets suffix text to be appended to the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('nil') %></td>
 </tr>
 <tr>
   <td><%= md('`value`') %></td>
   <td><%= md('Sets the value for the component.') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`nill`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 

--- a/docs/app/views/examples/elements/form_input/_rules_do.html.erb
+++ b/docs/app/views/examples/elements/form_input/_rules_do.html.erb
@@ -1,7 +1,7 @@
 <%= md("
 - Use of text inputs without a corresponding label is possible, but **not recommended**
-- Make sure that the label element follows the input in the HTML
-- Use **unique** ID and name values for each field
+- Ensure that the label element follows the input in the HTML in order to properly apply the \"floating label\" effect
+- Use **unique** `id` and `name` values for each field
 - Match the placeholder and label text precisely, or the \"floating label\" effect may appear jarring
 - Take advantage of [HTML client-side validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
   for basic fields &ndash; baked-in with most browsers

--- a/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
@@ -1,5 +1,6 @@
 class SageFormInput < SageComponent
   set_attribute_schema({
+    autocomplete: [:optional, TrueClass],
     css_classes: [:optional, String],
     disabled: [:optional, TrueClass],
     has_error: [:optional, TrueClass],
@@ -11,12 +12,15 @@ class SageFormInput < SageComponent
     max: [:optional, String],
     maxlength: [:optional, String],
     message_text: [:optional, String],
+    min: [:optional, String],
     minlength: [:optional, String],
     pattern: [:optional, String],
     placeholder: [:optional, String],
     prefix: [:optional, String],
+    readonly: [:optional, TrueClass],
     required: [:optional, TrueClass],
+    step: [:optional, String],
     suffix: [:optional, String],
-    value: [:optional, String],
+    value: [:optional, String]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -12,14 +12,18 @@
     class="sage-input__field"
     name="<%= component.id %>"
     placeholder="<%= component.placeholder -%>"
+    value="<%= component.value -%>"
     <%= "required" if component.required %>
     <%= "inputmode=#{component.input_mode}" if component.input_mode.present? -%>
+    <%= "autocomplete=#{component.autocomplete}" if component.autocomplete.present? -%>
     <%= "pattern=#{component.pattern}" if component.pattern.present? -%>
+    <%= "min=#{component.min}" if component.min.present? -%>
     <%= "max=#{component.max}" if component.max.present? -%>
     <%= "minlength=#{component.minlength}" if component.minlength.present? -%>
     <%= "maxlength=#{component.maxlength}" if component.maxlength.present? -%>
-    <%= "value=#{component.value}" if component.value.present? -%>
-    <%= "disabled" if component.disabled%>
+    <%= "step=#{component.step}" if component.step.present? -%>
+    <%= "readonly" if component.readonly -%>
+    <%= "disabled" if component.disabled %>
   >
   <label for="<%= component.id %>" class="sage-input__label">
     <%= component.label_text %>


### PR DESCRIPTION
## Description
This branch came about due to work in COMM-629, needing a `number` field to increment and preventing negative values.

- Updates Sage form input to allow use of `autocomplete`, `min`, `readonly`, and `step` values
- Documentation revised to match
- Fixes an issue with `value`, where setting a string with special characters like apostrophes or spaces would truncate prematurely


## Test notes
(MEDIUM) No known uses of `input_type: "number"` in the app at present. However, the change in output of `value` should be monitored. Some examples include:
- [x] Offer detail view:
  - [x] Affiliate settings (After Purchase panel)
  - [x] Days of Access (Product Access panel)
- [x] New coupon setup view (`app/views/admin/coupons/_form.html.erb`)

## Related
- COMM-629

Pending merge conflict from #323 