### PR TITLE
Parsley - add error state to dropdown icon

### DIFF
--- a/packages/sage-assets/lib/stylesheets/vendor/_parsley.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_parsley.scss
@@ -56,6 +56,10 @@ $-parsley-color-success: map-get($sage-field-colors, success);
     ~ .sage-select__label {
       color: $-parsley-color-error;
     }
+
+    & ~ .sage-select__arrow::before {
+      color: $-parsley-color-error;
+    }
   }
 
   &.parsley-error:focus:not(:disabled),

--- a/packages/sage-assets/lib/stylesheets/vendor/_parsley.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_parsley.scss
@@ -57,7 +57,7 @@ $-parsley-color-success: map-get($sage-field-colors, success);
       color: $-parsley-color-error;
     }
 
-    & ~ .sage-select__arrow::before {
+    ~ .sage-select__arrow::before {
       color: $-parsley-color-error;
     }
   }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - updated color of dropdown icon in the error state

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-02-17 at 9 58 22 AM](https://user-images.githubusercontent.com/1241836/108231258-31413980-7107-11eb-8d0f-994def8fdf8c.png)|![Screen Shot 2021-02-17 at 9 57 54 AM](https://user-images.githubusercontent.com/1241836/108231278-3605ed80-7107-11eb-9172-897cb08aa655.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. In the app, go to Products -> Podcasts -> New Podcast -> Click save -> Scroll down to the Podcast Categories section to view the affected area


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- 
