### PR TITLE
Catalog Item - updated padding and first item border

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -13,14 +13,10 @@ $-image-height-mobile: rem(120px);
   display: grid;
   grid-column-gap: sage-spacing(md);
   grid-row-gap: sage-spacing(xs);
-  padding: sage-spacing(sm) sage-spacing();
+  padding: sage-spacing() sage-spacing();
   margin-bottom: rem(-1px);
   border-top: sage-border(light);
   border-bottom: sage-border(light);
-
-  &:first-child {
-    border-top: 0;
-  }
 
   &:last-child {
     border-bottom: 0;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - increase the vertical padding
- [x] - add the `border-top` to the first catalog item

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-02-17_at_1_01_24_PM](https://user-images.githubusercontent.com/1241836/108254364-8a699700-7120-11eb-9e86-91d3c70146b6.png)|![Screen Shot 2021-02-17 at 1 01 36 PM](https://user-images.githubusercontent.com/1241836/108254263-67d77e00-7120-11eb-8add-8888c60acd4b.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. In the app visit the Product Index page: Home -> Products
2. Verify spacing for border