### PR TITLE
Elements/Objects Props Updates

### DIFF
--- a/docs/app/views/examples/elements/breadcrumbs/_props.html.erb
+++ b/docs/app/views/examples/elements/breadcrumbs/_props.html.erb
@@ -1,27 +1,31 @@
 <tr>
-  <td><pre>has_back_icon</pre></td>
-  <td>Whether or not to show the back icon before the first item.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`has_back_icon`') %></td>
+  <td><%= md('Whether or not to show the back icon before the first item.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><pre>is_progressbar</pre></td>
-  <td>Whether or not to show the breadcrumbs in a progress like fashion.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`is_progressbar`') %></td>
+  <td><%= md('Whether or not to show the breadcrumbs in a progress like fashion.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><pre>items</pre></td>
-  <td>The set of items to display.</td>
-  <td>Array of items following schema</td>
+  <td><%= md('`items`') %></td>
   <td>
-    <strong>Schema:</strong>
-    <pre>
-{
-  url: {string},
-  text: {string},
-  is_current: {boolean},
-}
-    </pre>  
+    <%= md('
+      The set of items to display.
+      Array of items following schema
+    ') %>
   </td>
+  <td>
+  <%= md('```
+    Array<{
+      url: String,
+      text: String,
+      is_current: String
+    }>
+    ') %>
+  </td>
+  <td><%= md('`nill`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/button/_props.html.erb
+++ b/docs/app/views/examples/elements/button/_props.html.erb
@@ -1,72 +1,79 @@
 <tr>
-  <td>align</td>
-  <td>Aligns a button to the "right" rather than its default position</td>
-  <td>String: [ null | "end" ]</td>
-  <td>null</td>
+  <td><%= md('`align`') %></td>
+  <td><%= md('Aligns a button to the "right" rather than its default position.') %></td>
+  <td><%= md('String: [ nil | "end" ]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>disabled</td>
+  <td><%= md('`disabled`') %></td>
   <td>
-    Toggles whether or not the button is disabled.
-    On <code>button</code> this implements the "disabled" HTML attribute
-    but on hyperlinks it enables the <code>aria-disabled="true"</code>.
+    <%= md('
+      Toggles whether or not the button is disabled.
+      On `button` this implements the "disabled" HTML attribute
+      but on hyperlinks it enables the `aria-disabled="true"`.
+    ') %>
   </td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>full_width</td>
-  <td>Forces a button to 100% the width of its container.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`full_width`') %></td>
+  <td><%= md('Forces a button to 100% the width of its container.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>icon</td>
-  <td>Allows for configurations for an and its placement to be provided.</td>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Allows for configurations for an icon and its placement to be provided.') %>
+  </td>
   <td>
-<pre><code>icon: {
-  name: &lt;String: name of Sage icon, see Icons&gt;,
-  style: &lt;String: [ "left" | "right" | "only" ]&gt;
-}</code></pre>
+  <%= md('```
+    icon: {
+      name: String,
+      style: String [ "left" | "right" | "only" ],
+    }
+    ') %>
   </td>
-  <td>null</td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>no_shadow</td>
-  <td>Toggles the "raised" effect off of Buttons that are of the "primary" type.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`no_shadow`') %></td>
+  <td><%= md('Disables default shadow for "Primary" buttons.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>raised</td>
-  <td>Toggles "raised" shadows effect onto the "secondar" or "danger" types.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`raised`') %></td>
+  <td><%= md('Toggles the "raised" effect off of Buttons that are of the "primary" type.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>small</td>
-  <td>Toggles whether buttons in the "subtle" format can be display in a regular (default) and small size using this property.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`small`') %></td>
+  <td><%= md('Toggles whether buttons in the "subtle" format can be display in a regular (default) and small size using this property.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>style</td>
-  <td>Buttons have three different "styles" that affect color appearance to create a "primary", "secondary", and "danger" variation.</td>
-  <td>String: [ "primary" | "secondary" | "danger" ]</td>
-  <td>"primary"</td>
+  <td><%= md('`style`') %></td>
+  <td><%= md('Buttons have three different "styles" that affect color appearance to create a "primary", "secondary", and "danger" variation.') %></td>
+  <td><%= md('String: [ "primary" | "secondary" | "danger" ]') %></td>
+  <td><%= md('`primary`') %></td>
 </tr>
 <tr>
-  <td>subtle</td>
-  <td>Whether or not to render the button in the "subtle" format.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`subtle`') %></td>
+  <td><%= md('Whether or not to render the button in the "subtle" format.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>value</td>
+  <td><%= md('`value`') %></td>
   <td>
-    The value to show on the button.
-    If the "only" style is set for "icon", this label is visually hidden.
+    <%= md('
+      The value to show on the button.
+      If the "only" style is set for "icon", this label is visually hidden.
+    ') %>
   </td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/button/_props.html.erb
+++ b/docs/app/views/examples/elements/button/_props.html.erb
@@ -74,6 +74,6 @@
       If the "only" style is set for "icon", this label is visually hidden.
     ') %>
   </td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`false`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/button/_props.html.erb
+++ b/docs/app/views/examples/elements/button/_props.html.erb
@@ -44,7 +44,7 @@
 </tr>
 <tr>
   <td><%= md('`raised`') %></td>
-  <td><%= md('Toggles the "raised" effect off of Buttons that are of the "primary" type.') %></td>
+  <td><%= md('Toggles "raised" shadows effect onto the "secondary" or "danger" types.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/card_highlight/_props.html.erb
+++ b/docs/app/views/examples/elements/card_highlight/_props.html.erb
@@ -1,25 +1,25 @@
 
 <tr>
   <td><%= md('`color`') %></td>
-  <td>Provide a color from within the Sage color system.</td>
+  <td><%= md('Provide a color from within the Sage color system.') %></td>
   <td><%= md('One of the system colors: `primary`, `grey`, `charcoal`, etc.') %></td>
   <td><%= md('`primary`') %></td>
 </tr>
 <tr>
   <td><%= md('`custom_color`') %></td>
-  <td>Provide a custom css color value (hex, rgb, rgba, etc.) for the highlight instead of a system color.</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Provide a custom css color value (hex, rgb, rgba, etc.) for the highlight instead of a system color.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`position`') %></td>
-  <td>The highlight can be applied to any of the four sides of the card.</td>
+  <td><%= md('The highlight can be applied to any of the four sides of the card.') %></td>
   <td><%= md('One of the following: `top`, `right`, `bottom`, or `left`.') %></td>
   <td><%= md('`left`') %></td>
 </tr>
 <tr>
   <td><%= md('`value`') %></td>
   <td><%= md('Sets the value to be used for `aria-label` if provided. Otherwise `aria-hidden` is set to `true`.') %></td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/checkbox/_props.html.erb
+++ b/docs/app/views/examples/elements/checkbox/_props.html.erb
@@ -12,7 +12,7 @@
 </tr>
 <tr>
   <td><%= md('`disabled`') %></td>
-  <td><%= md('Prevents all user interaction with the control. Be aware that when combining a disabled checkbox with a default "checked" state, the value of the checkbox [will not be included when its parent form is submitted!](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions). Likewise, setting Required will not have any effect.') %></td>
+  <td><%= md('Prevents all user interaction with the control. Be aware that when combining a disabled checkbox with a default "checked" state, the value of the checkbox <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/checkbox/_props.html.erb
+++ b/docs/app/views/examples/elements/checkbox/_props.html.erb
@@ -1,25 +1,24 @@
-
 <tr>
-  <td>ID</td>
-  <td>Unique identifier for the checkbox. Should match the "for" attribute on the corresponding label</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for the checkbox. Should match the "for" attribute on the corresponding label') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Checked</td>
-  <td>Sets the state to "checked" by default</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`checked`') %></td>
+  <td><%= md('Sets the state to "checked" by default') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Disabled</td>
-  <td>Prevents all user interaction with the control. Be aware that when combining a disabled checkbox with a default "checked" state, the value of the checkbox <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Prevents all user interaction with the control. Be aware that when combining a disabled checkbox with a default "checked" state, the value of the checkbox [will not be included when its parent form is submitted!](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions). Likewise, setting Required will not have any effect.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Attributes</td>
-  <td>For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes</td>
-  <td>Hash</td>
-  <td>null</td>
+  <td><%= md('`attributes`') %></td>
+  <td><%= md('For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/choice/_props.html.erb
+++ b/docs/app/views/examples/elements/choice/_props.html.erb
@@ -1,42 +1,42 @@
 <tr>
-  <td><%= md("`active`") %></td>
-  <td><%= md("Toggles `--active` modifier to visually indicate whether this choice is active/selected.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`active`') %></td>
+  <td><%= md('Toggles `--active` modifier to visually indicate whether this choice is active/selected.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`align_center`") %></td>
-  <td><%= md('Toggles`--align-center` modifier to visually center the icon and text. This is only intended to be used with the "icon" type.') %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`align_center`') %></td>
+  <td><%= md('Toggles `--align-center` modifier to visually center the icon and text. This is only intended to be used with the \'icon\' type.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`text`") %></td>
-  <td><%= md("Sets the content of the primary text line") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('`text`') %></td>
+  <td><%= md('Sets the content of the primary text line') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`subtext`") %></td>
-  <td><%= md("Sets the content of the secondary text line") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('`subtext`') %></td>
+  <td><%= md('Sets the content of the secondary text line') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`type`") %></td>
-  <td><%= md("Sets the choice graphic type. If `icon` is used here the `icon` prop must also be set.") %></td>
-  <td><%= md("`icon`, `radio`, or `arrow`") %></td>
-  <td><%= md("`radio") %></td>
+  <td><%= md('`type`') %></td>
+  <td><%= md('Sets the choice graphic type. If `icon` is used here the `icon` prop must also be set.') %></td>
+  <td><%= md('`icon`, `radio`, or `arrow`') %></td>
+  <td><%= md('`radio`') %></td>
 </tr>
 <tr>
-  <td><%= md("`icon`") %></td>
-  <td><%= md("Provides the name of the Sage Icon to be displayed before the text content.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Provides the name of the Sage Icon to be displayed before the text content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`target`") %></td>
-  <td><%= md("Provides the `id` for the corresponding Tab Pane that this choice will activate.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('`target`') %></td>
+  <td><%= md('Provides the `id` for the corresponding Tab Pane that this choice will activate.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/copy_text/_props.html.erb
+++ b/docs/app/views/examples/elements/copy_text/_props.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= md('`align`') %></td>
+  <td><%= md('`semibold`') %></td>
   <td><%= md('Whether or not the whole block should be set at the Semibold weight, since a number of implementations use this.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>

--- a/docs/app/views/examples/elements/copy_text/_props.html.erb
+++ b/docs/app/views/examples/elements/copy_text/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td>semibold</td>
-  <td>Wether or not the whole block should be set at the Semibold weight, since a number of implementations use this.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`align`') %></td>
+  <td><%= md('Whether or not the whole block should be set at the Semibold weight, since a number of implementations use this.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/description/_props.html.erb
+++ b/docs/app/views/examples/elements/description/_props.html.erb
@@ -2,25 +2,25 @@
   <td><%= md('`title`') %></td>
   <td><%= md('The "title" or term for the element.') %></td>
   <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`data`') %></td>
   <td><%= md('The "data" or description for the element.') %></td>
   <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`link`') %></td>
   <td><%= md('URL for a link to be wrapped around the `data` value.') %></td>
   <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`id`') %></td>
   <td><%= md('A unique `id` attribute to be applied to the root `dl` element for this description or description set.') %></td>
   <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`items`') %></td>
@@ -36,7 +36,7 @@ Array<{
 }>
 ```
 (see corresponding properties above)') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`inline_spread`') %></td>

--- a/docs/app/views/examples/elements/form_input/_props.html.erb
+++ b/docs/app/views/examples/elements/form_input/_props.html.erb
@@ -1,103 +1,103 @@
 <tr>
-  <td><%= md("`disabled`") %></td>
-  <td><%= md("Enabling this property adds the `disabled` attribute to the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Enabling this property adds the `disabled` attribute to the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`has_error`") %></td>
-  <td><%= md("Enabling this property adds the `.sage-input--error` class to the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`has_error`') %></td>
+  <td><%= md('Enabling this property adds the `.sage-input--error` class to the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`has_placeholder`") %></td>
-  <td><%= md("Enabling this property adds the `.sage-input--showplaceholder` class to the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`has_placeholder`') %></td>
+  <td><%= md('Enabling this property adds the `.sage-input--showplaceholder` class to the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`id`") %></td>
-  <td><%= md("Unique identifier for this input field. Should match the `for` property on the corresponding label.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`input_mode`") %></td>
-  <td><%= md("Hints at the type of data to be entered. Primarily intended for mobile devices, this can influence the <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode\" rel=\"nofollow\"> type of control displayed</a>, for example a numeric input keypad instead of a standard text keyboard.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`input_mode`') %></td>
+  <td><%= md('Hints at the type of data to be entered. Primarily intended for mobile devices, this can influence the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode" rel="nofollow" target="_blank"> type of control displayed</a>, for example a numeric input keypad instead of a standard text keyboard.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`input_type`") %></td>
-  <td><%= md("Sets the `type` attribute for the component") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`input_type`') %></td>
+  <td><%= md('Sets the `type` attribute for the component') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`label_text`") %></td>
-  <td><%= md("Sets the label text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`label_text`') %></td>
+  <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`max`") %></td>
-  <td><%= md("Sets the maximum numerical value for a form field.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`max`') %></td>
+  <td><%= md('Sets the maximum numerical value for a form field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`maxlength`") %></td>
-  <td><%= md("Sets the maximum character length for a form field.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`maxlength`') %></td>
+  <td><%= md('Sets the maximum character length for a form field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`message_text`") %></td>
-  <td><%= md("Sets the message text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`message_text`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`minlength`") %></td>
-  <td><%= md("Sets the minimum character length for a form field.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`minlength`') %></td>
+  <td><%= md('Sets the minimum character length for a form field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`pattern`") %></td>
-  <td><%= md("Sets form field's validation pattern.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`pattern`') %></td>
+  <td><%= md('Sets form\'s validation pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`placeholder`") %></td>
-  <td><%= md("Inserts content to be displayed inside a default (empty) field.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`placeholder`') %></td>
+  <td><%= md('Inserts content to be displayed inside a default (empty) field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`prefix`") %></td>
-  <td><%= md("Sets prefix text to be prepended to the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`prefix`') %></td>
+  <td><%= md('Sets prefix text to be prepended to the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`required`") %></td>
-  <td><%= md("Adding this attribute allows basic HTML form validation on this field.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`required`') %></td>
+  <td><%= md('Adding this attribute allows basic HTML form validation on this field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`suffix`") %></td>
-  <td><%= md("Sets suffix text to be appended to the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`suffix`') %></td>
+  <td><%= md('Sets suffix text to be appended to the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 <tr>
-  <td><%= md("`value`") %></td>
-  <td><%= md("Sets the value for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`value`') %></td>
+  <td><%= md('Sets the value for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nill`') %></td>
 </tr>
 

--- a/docs/app/views/examples/elements/form_select/_props.html.erb
+++ b/docs/app/views/examples/elements/form_select/_props.html.erb
@@ -1,24 +1,24 @@
 <tr>
-  <td><%= md("`has_error`") %></td>
-  <td><%= md("Enabling this property adds the `.sage-input--error` class to the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`has_error`') %></td>
+  <td><%= md('Enabling this property adds the `.sage-input--error` class to the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`message`") %></td>
-  <td><%= md("Sets the message text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`message`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`name`") %></td>
-  <td><%= md("Unique identifier for this component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`name`') %></td>
+  <td><%= md('Unique identifier for this component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`select_options`") %></td>
-  <td><%= md("An array of items that will serve as the `<select>`'s `<option>`s") %></td>
-  <td><%= md("Array") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`select_options`') %></td>
+  <td><%= md('An array of items that will serve as the `<select>`\'s `<option>`s') %></td>
+  <td><%= md('Array') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/form_textarea/_props.html.erb
+++ b/docs/app/views/examples/elements/form_textarea/_props.html.erb
@@ -1,42 +1,42 @@
 <tr>
-  <td><%= md("`content`") %></td>
-  <td><%= md("Sets the content of the textarea.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`content`') %></td>
+  <td><%= md('Sets the content of the textarea.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`disabled`") %></td>
-  <td><%= md("Enabling this property adds the `disabled` attribute to the component.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Enabling this property adds the `disabled` attribute to the component.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`has_error`") %></td>
-  <td><%= md("Enabling this property adds the `.sage-textarea--error` class to the component.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`has_error`') %></td>
+  <td><%= md('Enabling this property adds the `.sage-textarea--error` class to the component.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`id`") %></td>
-  <td><%= md("Unique identifier for this input field. Should match the `for` property on the corresponding label.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`label_text`") %></td>
-  <td><%= md("Sets the label text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`label_text`') %></td>
+  <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`message_text`") %></td>
-  <td><%= md("Sets the message text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`message_text`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`placeholder`") %></td>
-  <td><%= md("Inserts content to be displayed inside a default (empty) textarea.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`placeholder`') %></td>
+  <td><%= md('Inserts content to be displayed inside a default (empty) textarea.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/icon_card/_props.html.erb
+++ b/docs/app/views/examples/elements/icon_card/_props.html.erb
@@ -8,7 +8,7 @@
   <td><%= md('`icon`') %></td>
   <td><%= md('The Sage icon to show inside the card.') %></td>
   <td><%= md('`String`') %></td>
-  <td>See Sage Icons</td>
+  <td><%= md('See Sage Icons.') %></td>
 </tr>
 <tr>
   <td><%= md('`size`') %></td>

--- a/docs/app/views/examples/elements/indicator/_props.html.erb
+++ b/docs/app/views/examples/elements/indicator/_props.html.erb
@@ -1,18 +1,18 @@
 <tr>
-  <td><%= md("`current_item`") %></td>
-  <td><%= md("The item that is \"selected\" in the indicator list.") %></td>
-  <td><%= md("Integer") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`current_item`') %></td>
+  <td><%= md('The item that is "selected" in the indicator list.') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`label`") %></td>
-  <td><%= md("The label to prepend in front of the number for the indicator in visually-hidden text.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`label`') %></td>
+  <td><%= md('The label to prepend in front of the number for the indicator in visually-hidden text.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`num_items`") %></td>
-  <td><%= md("The total number of items to display.") %></td>
-  <td><%= md("Integer") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`num_items`') %></td>
+  <td><%= md('The total number of items to display.') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/label/_props.html.erb
+++ b/docs/app/views/examples/elements/label/_props.html.erb
@@ -1,42 +1,42 @@
 <tr>
-  <td><%= md("`color`") %></td>
-  <td><%= md("
+  <td><%= md('`color`') %></td>
+  <td><%= md('
     Sets the color for the label.
-  ") %></td>
+  ') %></td>
   <td><%= md('`"danger"`, `"draft"`, `"info"`, `"locked"`, `"published"`, `"success"`, or `"warning"`') %></td>
-  <td><%= md("Required") %></td>
+  <td><%= md('Required') %></td>
 </tr>
 <tr>
-  <td><%= md("`icon`") %></td>
-  <td><%= md("
+  <td><%= md('`icon`') %></td>
+  <td><%= md('
     Specifies an icon to display with the value.
     Note that if the `interactive_type` is set to `:dropdown`
     then a small down caret icon is automatically displayed
     to the right of the value in addition to any icon provided here.
-  ") %></td>
+  ') %></td>
   <td><%= md('See Icon options') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`secondary_button`") %></td>
-  <td><%= md("
+  <td><%= md('`secondary_button`') %></td>
+  <td><%= md('
     Specifies the form of an optional secondary button.
     If a string is passed it is treated as HTML content.
     If `true` is passed then a `LabelSecondaryButton` is rendered with default configurations.
     If a hash is passed it is treated as configurations for the prepackaged `LabelSecondaryButton` (see below).
-  ") %></td>
+  ') %></td>
   <td><%= md('`String`, `true`, or has with configurations for `LabelSecondaryButton` (see below)') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`style`") %></td>
-  <td><%= md("Modifies the appearance of the label from the default to a more subtle style or a bolder style.") %></td>
+  <td><%= md('`style`') %></td>
+  <td><%= md('Modifies the appearance of the label from the default to a more subtle style or a bolder style.') %></td>
   <td><%= md('`"subtle`" or `"bold"`') %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`value`") %></td>
-  <td><%= md("The text to use as the label's content") %></td>
+  <td><%= md('`value`') %></td>
+  <td><%= md('The text to use as the label\'s content') %></td>
   <td><%= md('`String`') %></td>
   <td><%= md('Required') %></td>
 </tr>
@@ -44,13 +44,13 @@
   <td colspan="4"><strong>LabelSecondaryButton</strong></td>
 </tr>
 <tr>
-  <td><%= md("`attributes`") %></td>
+  <td><%= md('`attributes`') %></td>
   <td><%= md('Additional attributes such as to provide `data-` bindings or actions.') %></td>
   <td><%= md('`String`') %></td>
   <td><%= md('`"Remove"`') %></td>
 </tr>
 <tr>
-  <td><%= md("`icon`") %></td>
+  <td><%= md('`icon`') %></td>
   <td><%= md('
     Incidates which icon to use for the button.
     Default value is based on the common use of a "remove" button with Label values.
@@ -59,7 +59,7 @@
   <td><%= md('`"remove"`') %></td>
 </tr>
 <tr>
-  <td><%= md("`value`") %></td>
+  <td><%= md('`value`') %></td>
   <td><%= md('
     Incidates which accessible label to use for this button.
     Note that this will render as an `icon-only` button,

--- a/docs/app/views/examples/elements/link/_props.html.erb
+++ b/docs/app/views/examples/elements/link/_props.html.erb
@@ -1,36 +1,36 @@
 <tr>
-  <td><%= md("`external`") %></td>
-  <td><%= md("When set to `true`, `target=\"_blank\"` will be added to the link.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`external`') %></td>
+  <td><%= md('When set to `true`, `target="_blank"` will be added to the link.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`help_link`") %></td>
-  <td><%= md("When set to `true`, the `help` icon will accompany the link text.") %></td>
-  <td><%= md("Booean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`help_link`') %></td>
+  <td><%= md('When set to `true`, the `help` icon will accompany the link text.') %></td>
+  <td><%= md('Booean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`label`") %></td>
-  <td><%= md("Sets the text for the link.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`label`') %></td>
+  <td><%= md('Sets the text for the link.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`launch`") %></td>
-  <td><%= md("When set to `true`, the `launch` icon will accompany the link text.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`launch`') %></td>
+  <td><%= md('When set to `true`, the `launch` icon will accompany the link text.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`show_label`") %></td>
-  <td><%= md("When set to `true`, the link text is visible; otherwise it exists in the DOM but is visually hidden.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`show_label`') %></td>
+  <td><%= md('When set to `true`, the link text is visible; otherwise it exists in the DOM but is visually hidden.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`url`") %></td>
-  <td><%= md("Sets the destination `url` for the link.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`url`') %></td>
+  <td><%= md('Sets the destination `url` for the link.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/lists/_props.html.erb
+++ b/docs/app/views/examples/elements/lists/_props.html.erb
@@ -1,30 +1,30 @@
 <tr>
-  <td><%= md("`Inline`") %></td>
-  <td><%= md("Inline lists will wrap by default.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("false") %></td>
+  <td><%= md('`inline`') %></td>
+  <td><%= md('Inline lists will wrap by default.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`Non-wrapping`") %></td>
-  <td><%= md("Indicates whether or not to wrap the items in the list. Only relevant when <code>inline</code> is true and when viewport is larger than 768px.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("false") %></td>
+  <td><%= md('`non-wrapping`') %></td>
+  <td><%= md('Indicates whether or not to wrap the items in the list. Only relevant when `inline` is true and when viewport is larger than 768px.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`Compact`") %></td>
-  <td><%= md("Indicates whether items are spaced out (false) or compacted together (true). Only relevant when `inline` is true.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("false") %></td>
+  <td><%= md('`compact`') %></td>
+  <td><%= md('Indicates whether items are spaced out (false) or compacted together (true). Only relevant when `inline` is true.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td colspan="4">
-    <%= md("Note that these three booleans are set up with stacked modifiers:") %>
+    <%= md('Note that these three booleans are set up with stacked modifiers:') %>
     <ul>
-      <li><%= md("Default -- `sage-list`") %></li>
-      <li><%= md("Inline, wrapping, spaced -- `sage-list--inline`") %></li>
-      <li><%= md("Inline, wrapping, compact -- `sage-list--inline-compact`") %></li>
-      <li><%= md("Inline, non-wrapping, spaced -- `sage-list--inline-fit`") %></li>
-      <li><%= md("Inline, non-wrapping, compact -- `sage-list--inline-fit-compact`") %></li>
+      <li><%= md('Default -- `sage-list`') %></li>
+      <li><%= md('Inline, wrapping, spaced -- `sage-list--inline`') %></li>
+      <li><%= md('Inline, wrapping, compact -- `sage-list--inline-compact`') %></li>
+      <li><%= md('Inline, non-wrapping, spaced -- `sage-list--inline-fit`') %></li>
+      <li><%= md('Inline, non-wrapping, compact -- `sage-list--inline-fit-compact`') %></li>
     </ul>
   </td>
 </tr>

--- a/docs/app/views/examples/elements/loader/_props.html.erb
+++ b/docs/app/views/examples/elements/loader/_props.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td>data-loading</td>
-  <td>Determines visibility. Loader will not display/animate unless this value is set to "true"</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`data-loading`') %></td>
+  <td><%= md('Determines visibility. Loader will not display/animate unless this value is set to `true`') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>type</td>
-  <td>Determines which loader will be used. We currently support a type of "bar" and "spinner"</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`type`') %></td>
+  <td><%= md('Determines which loader will be used. We currently support a type of `bar` and `spinner`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/meter/_props.html.erb
+++ b/docs/app/views/examples/elements/meter/_props.html.erb
@@ -1,56 +1,56 @@
 <tr>
-  <td><%= md("`high_value_text`") %></td>
-  <td><%= md("Sets the high value of the meter, indicating that a satisfactory value has been reached.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`high_value_text`') %></td>
+  <td><%= md('Sets the high value of the meter, indicating that a satisfactory value has been reached.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`id`") %></td>
-  <td><%= md("Unique identifier for this input field. Should match the `for` property on the corresponding label.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`label`") %></td>
-  <td><%= md("Sets the label text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`label`') %></td>
+  <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`low_value_text`") %></td>
-  <td><%= md("Sets the low value of the meter indicating that an unsatisfactory has been reached.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`low_value_text`') %></td>
+  <td><%= md('Sets the low value of the meter indicating that an unsatisfactory has been reached.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`max_value`") %></td>
-  <td><%= md("Assigns a maximum value to the meter. Required for updated styles to function.") %></td>
-  <td><%= md("Integer") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`max_value`') %></td>
+  <td><%= md('Assigns a maximum value to the meter. Required for updated styles to function.') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`max_value_text`") %></td>
-  <td><%= md("This property sets text for the maximum meter value.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`max_value_text`') %></td>
+  <td><%= md('This property sets text for the maximum meter value.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`med_value_text`") %></td>
-  <td><%= md("Sets the medium value of the meter indicating that a medium satisfactory has been reached.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`med_value_text`') %></td>
+  <td><%= md('Sets the medium value of the meter indicating that a medium satisfactory has been reached.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`optimum_value`") %></td>
-  <td><%= md("Sets the optimal value of the meter, indicating that a satisfactory value has been reached.") %></td>
-  <td><%= md("Integer") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`optimum_value`') %></td>
+  <td><%= md('Sets the optimal value of the meter, indicating that a satisfactory value has been reached.') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`value`") %></td>
-  <td><%= md("The current meter value.") %></td>
-  <td><%= md("Integer") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`value`') %></td>
+  <td><%= md('The current meter value.') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 
 

--- a/docs/app/views/examples/elements/nav_link/_props.html.erb
+++ b/docs/app/views/examples/elements/nav_link/_props.html.erb
@@ -1,36 +1,36 @@
 <tr>
-  <td><%= md("`icon`") %></td>
-  <td><%= md("Allows for configurations for an and its placement to be provided.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Allows for configurations for an and its placement to be provided.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`link`") %></td>
-  <td><%= md("This sets the `href` for the link.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`link`') %></td>
+  <td><%= md('This sets the `href` for the link.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`method`") %></td>
-  <td><%= md("Allows for configuration for custom link methods") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`method`') %></td>
+  <td><%= md('Allows for configuration for custom link methods') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`no_active`") %></td>
-  <td><%= md("When enabled, this will remove the active link styles for the current page's link.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`no_active`') %></td>
+  <td><%= md('When enabled, this will remove the active link styles for the current page\'s link.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`text`") %></td>
-  <td><%= md("The text for the link.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`text`') %></td>
+  <td><%= md('The text for the link.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`type`") %></td>
-  <td><%= md("Setting the link to `sub` creates a submenu link.") %></td>
-  <td><%= md("String: [ `sub` ]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`type`') %></td>
+  <td><%= md('Setting the link to `sub` creates a submenu link.') %></td>
+  <td><%= md('String: [ `sub` ]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/progress_bar/_props.html.erb
+++ b/docs/app/views/examples/elements/progress_bar/_props.html.erb
@@ -1,0 +1,12 @@
+<tr>
+  <td><%= md('`percent`') %></td>
+  <td><%= md('Sets `value`, `aria-valuenow` and inline `width` style of progress bar.') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`label`') %></td>
+  <td><%= md('Sets `aria-valuetext` and content text for `<progress>` element.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/elements/property/_props.html.erb
+++ b/docs/app/views/examples/elements/property/_props.html.erb
@@ -1,0 +1,12 @@
+<tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('The Sage icon to show in the property.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('See Sage Icons.') %></td>
+</tr>
+<tr>
+  <td><%= md('`value`') %></td>
+  <td><%= md('Text to show in the property.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/elements/radio/_props.html.erb
+++ b/docs/app/views/examples/elements/radio/_props.html.erb
@@ -1,36 +1,37 @@
 <tr>
-  <td>ID</td>
-  <td>Unique identifier for this input field. Should match the "for" property on the corresponding label</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Name</td>
-  <td>Using a singular name groups radio buttons together, allowing the user to toggle between them (see Option 1 and Option 2 examples above)</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`name`') %></td>
+  <td><%= md('Using a singular name groups radio buttons together, allowing the user to toggle between them (see Option 1 and Option 2 examples above)') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Checked</td>
-  <td>Sets the state of the radio button to "checked" by default</td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td><%= md('`checked`') %></td>
+  <td><%= md('Sets the state of the radio button to `checked` by default') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Required</td>
-  <td>Adding this attribute allows basic HTML form validation on this field</td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td><%= md('`required`') %></td>
+  <td><%= md('Adding this attribute allows basic HTML form validation on this field') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Disabled</td>
-  <td>Prevents all user interaction with the control. Be aware that when combining a disabled radio button with a default "checked" state, the value of the radio button <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.</td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Prevents all user interaction with the control. Be aware that when combining a disabled radio button with a default `checked` state, the value of the radio button <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Attributes</td>
-  <td>For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes</td>
-  <td>Hash</td>
-  <td>null</td>
+  <td><%= md('`attributes`') %></td>
+  <td><%= md('For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
+

--- a/docs/app/views/examples/elements/search/_props.html.erb
+++ b/docs/app/views/examples/elements/search/_props.html.erb
@@ -1,30 +1,30 @@
 <tr>
-  <td>id</td>
-  <td>Unique identifier for the search. Should match the "for" attribute on the corresponding label.</td>
-  <td>String</td>
-  <td></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for the search. Should match the `for` attribute on the corresponding label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>value</td>
-  <td>The value of the search input.</td>
-  <td>String</td>
-  <td></td>
+  <td><%= md('`value`') %></td>
+  <td><%= md('The value of the search input.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>placeholder</td>
-  <td>Search null-state text.</td>
-  <td>string</td>
-  <td></td>
+  <td><%= md('`placeholder`') %></td>
+  <td><%= md('Search null-state text.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>contained</td>
-  <td>Is in the context of a "search toolbar" area.</td>
-  <td>Boolean</td>
-  <td></td>
+  <td><%= md('`contained`') %></td>
+  <td><%= md('Is in the context of a "search toolbar" area.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>label_text</td>
-  <td>The value of the search label.</td>
-  <td>String</td>
-  <td></td>
+  <td><%= md('`label_text`') %></td>
+  <td><%= md('The value of the search label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/status_icon/_props.html.erb
+++ b/docs/app/views/examples/elements/status_icon/_props.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td><%= md("`name`") %></td>
-  <td><%= md("The name of the icon to display.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`name`') %></td>
+  <td><%= md('The name of the icon to display.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('See Sage Icons.') %></td>
 </tr>
 <tr>
-  <td><%= md("`value`") %></td>
-  <td><%= md("The hidden text value of the conponent.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`value`') %></td>
+  <td><%= md('The hidden text value of the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/switch/_props.html.erb
+++ b/docs/app/views/examples/elements/switch/_props.html.erb
@@ -1,24 +1,24 @@
 <tr>
-  <td>ID</td>
-  <td>Unique identifier for this input field. Should match the "for" property on the corresponding label</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Checked</td>
-  <td>Sets the state to "checked" by default</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`checked`') %></td>
+  <td><%= md('Sets the state to "checked" by default.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Required</td>
-  <td>Adding this attribute allows basic HTML form validation on this field</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`required`') %></td>
+  <td><%= md('Adding this attribute allows basic HTML form validation on this field.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>hide_text</td>
-  <td>This will visually hide the text but will remain accessible for assistive technologies</td>
-  <td>Boolean</td>
-  <td>null</td>
+  <td><%= md('`hide_text`') %></td>
+  <td><%= md('This will visually hide the text but will remain accessible for assistive technologies.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/tab/_props.html.erb
+++ b/docs/app/views/examples/elements/tab/_props.html.erb
@@ -1,18 +1,18 @@
 <tr>
-  <td>active</td>
-  <td>Toggles <code>--active</code> modifier to visually indicate whether this tab is active/selected.</td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`active`') %></td>
+  <td><%= md('Toggles `--active` modifier to visually indicate whether this tab is active/selected.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>text</td>
-  <td>Sets the content of the text</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`text`') %></td>
+  <td><%= md('Sets the content of the text.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>target</td>
-  <td>Provides the <code>id</code> for the corresponding Tab Pane that this tab will activate.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`target`') %></td>
+  <td><%= md('Provides the `id` for the corresponding Tab Pane that this tab will activate.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/table/_props.html.erb
+++ b/docs/app/views/examples/elements/table/_props.html.erb
@@ -1,30 +1,30 @@
 <tr>
-  <td>Responsive tables</td>
-  <td>Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: the parent with class <code>.sage-table-wrapper</code>, and a child with class <code>.sage-table-wrapper__overflow</code></td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('Responsive tables') %></td>
+  <td><%= md('Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: the parent with class `.sage-table-wrapper`, and a child with class `.sage-table-wrapper__overflow`.') %></td>
+  <td><%= md('String:') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Striped tables</td>
-  <td><code>.sage-table--striped</code> adds a background color to odd-numbered rows</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('Striped table') %></td>
+  <td><%= md('`.sage-table--striped` adds a background color to odd-numbered rows.') %></td>
+  <td><%= md('String:') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Highlighted rows</td>
-  <td><code>.sage-table--selectable</code> adds a background color when a user hovers over rows</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('Highlighted rows') %></td>
+  <td><%= md('`.sage-table--selectable` adds a background color when a user hovers over rows.') %></td>
+  <td><%= md('String:') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Block cells</td>
-  <td><code>.sage-table-cell__block</code> creates vertical block layouts within table cells. These layouts can include <code>.sage-table-cell__heading</code> and <code>.sage-table-cell__body</code> content areas.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('Block cells') %></td>
+  <td><%= md('`.sage-table-cell__block` creates vertical block layouts within table cells. These layouts can include `.sage-table-cell__heading` and `.sage-table-cell__body` content areas.') %></td>
+  <td><%= md('String:') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>Truncated cells</td>
-  <td><code>.sage-table-cell--truncate</code> on individual cells truncates their content at smaller viewport sizes, displaying ellipses (&hellip;) in place of overflowing content. Take care not to use this with important pieces of information that should be displayed to users at all times.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('Truncated cells') %></td>
+  <td><%= md('`.sage-table-cell--truncate` on individual cells truncates their content at smaller viewport sizes, displaying ellipses (&hellip;) in place of overflowing content. Take care not to use this with important pieces of information that should be displayed to users at all times.') %></td>
+  <td><%= md('String:') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/toast/_props.html.erb
+++ b/docs/app/views/examples/elements/toast/_props.html.erb
@@ -6,13 +6,13 @@
 </tr>
 <tr>
   <td><%= md('`message`') %></td>
-  <td><%= md('The message to be displayed displayed in the toast.') %></td>
+  <td><%= md('The message to be displayed in the toast.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`icon`') %></td>
-  <td><%= md('The icon to be displayed displayed in the toast.') %></td>
+  <td><%= md('The icon to be displayed in the toast.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`check`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/toast/_props.html.erb
+++ b/docs/app/views/examples/elements/toast/_props.html.erb
@@ -1,24 +1,24 @@
 <tr>
-  <td>type</td>
-  <td>Assign a type/style, options include: <code>notice</code> <code>danger</code></td>
-  <td>String</td>
-  <td><code>notice</code></td>
+  <td><%= md('`type`') %></td>
+  <td><%= md('Assign a type/style, options include: `notice` `danger`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`notice`') %></td>
 </tr>
 <tr>
-  <td>message</td>
-  <td>The message to be displayed</td>
-  <td>String</td>
-  <td><code>null</code></td>
+  <td><%= md('`message`') %></td>
+  <td><%= md('The message to be displayed displayed in the toast.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>icon</td>
-  <td>Icon to be displayed</td>
-  <td>String</td>
-  <td><code>check</code></td>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('The icon to be displayed displayed in the toast.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`check`') %></td>
 </tr>
 <tr>
-  <td>timer</td>
-  <td>Time toast should be displayed</td>
-  <td>Number</td>
-  <td><code>4000</code></td>
+  <td><%= md('`timer`') %></td>
+  <td><%= md('Time in milliseconds that toast should be displayed') %></td>
+  <td><%= md('Integer') %></td>
+  <td><%= md('`4000`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/tooltip/_props.html.erb
+++ b/docs/app/views/examples/elements/tooltip/_props.html.erb
@@ -1,24 +1,24 @@
 <tr>
-  <td><%= md("`position`") %></td>
-  <td><%= md("Set this property to position the tooltip.") %></td>
-  <td><%= md("String: [\"top\", \"right\", \"bottom\", \"left\"]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`position`') %></td>
+  <td><%= md('Set this property to position the tooltip.') %></td>
+  <td><%= md('String: ["top", "right", "bottom", "left"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`size`") %></td>
-  <td><%= md("Set this property to assign tooltip size. Choose between small (decreased horizontal padding) and <code>large</code> (increased maximum width). When empty, defaults to a maximum width of 200px.") %></td>
-  <td><%= md("String: [\"small\", \"large\"]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`size`') %></td>
+  <td><%= md('Set this property to assign tooltip size. Choose between `small` (decreased horizontal padding) and `large` (increased maximum width). When empty, defaults to a maximum width of 200px.') %></td>
+  <td><%= md('String: ["small", "large"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`text`") %></td>
-  <td><%= md("Text that will be displayed within the tooltip.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`text`') %></td>
+  <td><%= md('Text that will be displayed within the tooltip.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`theme`") %></td>
-  <td><%= md("Sets a light theme on tooltip. If empty, defaults to \"dark\".") %></td>
-  <td><%= md("String: [\"dark\", \"light\"]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`theme`') %></td>
+  <td><%= md('Sets a light theme on tooltip. If empty, defaults to `dark`.') %></td>
+  <td><%= md('String: ["dark", "light"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/alert/_props.html.erb
+++ b/docs/app/views/examples/objects/alert/_props.html.erb
@@ -1,0 +1,36 @@
+<tr>
+  <td><%= md('`color`') %></td>
+  <td><%= md('Applies color to alert. Options include `info`, `success`, `warning`, `danger` ') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Title text to be displayed.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`desc`') %></td>
+  <td><%= md('Description text to be displayed.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`icon_name`') %></td>
+  <td><%= md('Icon to be displayed in alert.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('See Sage Icons.') %></td>
+</tr>
+<tr>
+  <td><%= md('`raised`') %></td>
+  <td><%= md('Sets styling to the raised variant which includes a subtle shadow.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`dismissable`') %></td>
+  <td><%= md('Adds close icon and functionality to allow alert to be closed') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/objects/assistant/_props.html.erb
+++ b/docs/app/views/examples/objects/assistant/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td><%= md("`menu_button`") %></td>
-  <td><%= md("Enables menu button to be displayed. (below medium breakpoint)") %></td>
-  <td><%= md("`Boolean`") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`menu_button`') %></td>
+  <td><%= md('Enables menu button to be displayed. (below medium breakpoint)') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/avatar/_props.html.erb
+++ b/docs/app/views/examples/objects/avatar/_props.html.erb
@@ -1,39 +1,39 @@
 <tr>
-  <td><%= md("`color`") %></td>
-  <td><%= md("
+  <td><%= md('`color`') %></td>
+  <td><%= md('
     This component uses the `--color` modifier to change the default
     color set to the provided color. For example `sage-avatar--orange`
     sets the initials color and background color to variants of the
-    system's orange swatch.
-  ") %></td>
-  <td><%= md("`String`") %></td>
-  <td><%= md("`null` (primary color)") %></td>
+    system\'s orange swatch.
+  ') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil` (primary color)') %></td>
 </tr>
 <tr>
-  <td><%= md("`centered`") %></td>
-  <td><%= md("
+  <td><%= md('`centered`') %></td>
+  <td><%= md('
     Formats the avatar to be centered by setting side `margin` to `auto`.
-  ") %></td>
-  <td><%= md("`Boolean`") %></td>
-  <td><%= md("`false`") %></td>
+  ') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`initials`") %></td>
-  <td><%= md("
+  <td><%= md('`initials`') %></td>
+  <td><%= md('
     The initials to display in the avatar circle
-  ") %></td>
-  <td><%= md("`String`") %></td>
-  <td><%= md("`required`") %></td>
+  ') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`required`') %></td>
 </tr>
 <tr>
-  <td><%= md("`size`") %></td>
-  <td><%= md("
-    A size setting to customize the Avatar's width and height inline.
+  <td><%= md('`size`') %></td>
+  <td><%= md('
+    A size setting to customize the Avatar\'s width and height inline.
     **NOTE:** Fixed settings such as `px`, `rem`, or `vw` are most reliable
     as scalable values such as `%` may lead to a squished appearance.
-  ") %></td>
-  <td><%= md("`String`") %></td>
-  <td><%= md("`nil`") %></td>
+  ') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td colspan="4">
@@ -41,10 +41,10 @@
   </td>
 </tr>
 <tr>
-  <td><%= md("`items`") %></td>
-  <td><%= md("
+  <td><%= md('`items`') %></td>
+  <td><%= md('
     A set of items following the Avatar schema above to be displayed. Only the first four items will be rendered.
-  ") %></td>
-  <td><%= md("`Array<Avatar>`") %></td>
-  <td><%= md("`[]`") %></td>
+  ') %></td>
+  <td><%= md('Array<Avatar>') %></td>
+  <td><%= md('`[]`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/banner/_props.html.erb
+++ b/docs/app/views/examples/objects/banner/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td><code>.sage-banner--active</code></td>
-  <td>This class enables the banner, and through the associated script adjusts the page body to compensate.</td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`.sage-banner--active`') %></td>
+  <td><%= md('This class enables the banner, and through the associated script adjusts the page body to compensate.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/billboard/_props.html.erb
+++ b/docs/app/views/examples/objects/billboard/_props.html.erb
@@ -1,24 +1,24 @@
 <tr>
-  <td><%= md("`img`") %></td>
-  <td><%= md("Sets the `src` attribute for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`img`') %></td>
+  <td><%= md('Sets the `src` attribute for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`message`") %></td>
-  <td><%= md("Sets the message text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`message`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`title`") %></td>
-  <td><%= md("Sets the title for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Sets the title for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`title_tag`") %></td>
-  <td><%= md("Sets the heading tag (`h1` - `h6`) for the component's title tag") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`title_tag`') %></td>
+  <td><%= md('Sets the heading tag (`h1` - `h6`) for the component\'s title tag') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/card/_props.html.erb
+++ b/docs/app/views/examples/objects/card/_props.html.erb
@@ -1,27 +1,27 @@
 <tr>
   <td><%= md('`clear_bottom_padding`') %></td>
-  <td>Erases padding on bottom of the Card for tighter alignment of child items.</td>
-  <td>Boolean</td>
+  <td><%= md('Erases padding on bottom of the Card for tighter alignment of child items.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`clear_top_padding`') %></td>
-  <td>Erases padding on top of the Card for tighter alignment of child items.</td>
-  <td>Boolean</td>
-  <td><%= md('`false`') %></code></td>
-</tr>
-<tr>
-  <td><%= md('`border_dashed`') %></td>
-  <td>Uses our Sage dashed border styles</td>
-  <td>Boolean</td>
+  <td><%= md('Erases padding on top of the Card for tighter alignment of child items.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td colspan="4"><strong>Card List</strong></td>
+  <td><%= md('`border_dashed`') %></td>
+  <td><%= md('Uses our Sage dashed border styles.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td colspan="4"><%= md('**Card List**') %></td>
 </tr>
 <tr>
   <td><%= md('`block_spacing`') %></td>
-  <td>Adjusts the default spacing settings on top and bottom of items inside the list</td>
+  <td><%= md('Adjusts the default spacing settings on top and bottom of items inside the list.') %></td>
   <td><%= md('Optionally: `"sm"`') %></td>
-  <td><%= md('--') %></td>
+  <td><%= md('`--`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/catalog_item/_props.html.erb
+++ b/docs/app/views/examples/objects/catalog_item/_props.html.erb
@@ -1,0 +1,18 @@
+<tr>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Title text of the catalog item') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`image`') %></td>
+  <td><%= md('Image for the catalog item') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`href`') %></td>
+  <td><%= md('Applies link to the `title`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/objects/data_card/_props.html.erb
+++ b/docs/app/views/examples/objects/data_card/_props.html.erb
@@ -1,32 +1,31 @@
-
 <tr>
-  <td><%= md("`body`") %></td>
-  <td><%= md("Sets the body copy for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`body`') %></td>
+  <td><%= md('Sets the body copy for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`color`") %></td>
-  <td><%= md("This component uses the `--color` modifier to change the default
-    color set to the provided color.") %></td>
-  <td><%= md("String: [\"danger\", \"muted\"]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`color`') %></td>
+  <td><%= md('This component uses the `--color` modifier to change the default
+    color set to the provided color.') %></td>
+  <td><%= md('String: ["danger", "muted"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`header_aside`") %></td>
-  <td><%= md("Sets the message text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`header_aside`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`title`") %></td>
-  <td><%= md("Sets the title for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Sets the title for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`title_tag`") %></td>
-  <td><%= md("Sets the heading tag (`h1` - `h6`) for the component's title tag") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`title_tag`') %></td>
+  <td><%= md('Sets the heading tag (`h1` - `h6`) for the component\'s title tag') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/dropdown/_props.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_props.html.erb
@@ -1,9 +1,7 @@
 <tr>
-  <td>small</td>
-  <td>
-    This component uses the <code>--small</code> modifier to change the default
-    minimum width of the dropdown menu.
-  </td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('`small`') %></td>
+  <td><%= md('This component uses the `--small` modifier to change the default
+    minimum width of the dropdown menu.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/empty_state/_props.html.erb
+++ b/docs/app/views/examples/objects/empty_state/_props.html.erb
@@ -1,12 +1,30 @@
 <tr>
-  <td>compact</td>
-  <td>Adjusts the vertical padding of component for smaller contexts</td>
-  <td>boolean</td>
-  <td><code>false</code></td>
+  <td><%= md('`compact`') %></td>
+  <td><%= md('Adjusts the vertical padding of component for smaller contexts.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>icon</td>
-  <td>Adds an icon above the content</td>
-  <td>String</td>
-  <td><code>null | icon-name</code></td>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Adds an icon above the content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil | icon-name`') %></td>
+</tr>
+<tr>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Title for empty state.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`text`') %></td>
+  <td><%= md('Text for empty state.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`graphic`') %></td>
+  <td><%= md('Adds a graphic above the content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/expandable_card/_props.html.erb
+++ b/docs/app/views/examples/objects/expandable_card/_props.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td><%= md("`trigger_label`") %></td>
-  <td><%= md("Sets the text for the trigger button.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`trigger_label`') %></td>
+  <td><%= md('Sets the text for the trigger button.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`body_bordered`") %></td>
-  <td><%= md("Adds border and background to body.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`body_bordered`') %></td>
+  <td><%= md('Adds border and background to body.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -1,38 +1,38 @@
 <tr>
-  <td><%= md("`alt_text`") %></td>
-  <td><%= md("Sets the `alt` text for the components's image.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`alt_text`') %></td>
+  <td><%= md('Sets the `alt` text for the components\'s image.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`description`") %></td>
-  <td><%= md("Sets the description text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`description`') %></td>
+  <td><%= md('Sets the description text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`image`") %></td>
-  <td><%= md("Sets the `src` for the component\'s image.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`image`') %></td>
+  <td><%= md('Sets the `src` for the component\'s image.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`links`") %></td>
-  <td><%= md("An array of optional links that includes `icon`, `location`, `target` and `text` hash options.") %></td>
-  <td><%= md("Array") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`links`') %></td>
+  <td><%= md('An array of optional links that includes `icon`, `location`, `target` and `text` hash options.') %></td>
+  <td><%= md('Array') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`title`") %></td>
-  <td><%= md("Sets the sets the title text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Sets the sets the title text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`title_tag`") %></td>
-  <td><%= md("Sets the heading tag (`h1` - `h6`) for the component's title tag.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`title_tag`') %></td>
+  <td><%= md('Sets the heading tag (`h1` - `h6`) for the component\'s title tag.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 
 

--- a/docs/app/views/examples/objects/form_section/_props.html.erb
+++ b/docs/app/views/examples/objects/form_section/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td><code>title_tag</code></td>
-  <td>Sets the heading tag (<code>h1</code> - <code>h6</code>) for the Form Section's header tag</td>
-  <td>String</td>
-  <td>"h5"</td>
+  <td><%= md('`title_tag`') %></td>
+  <td><%= md('Sets the heading tag (`h1` - `h6`) for the Form Section\'s header tag.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`h5`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/hero/_props.html.erb
+++ b/docs/app/views/examples/objects/hero/_props.html.erb
@@ -1,12 +1,42 @@
 <tr>
-  <td><code>alt_text</code></td>
-  <td>Sets the (<code>alt</code>) text for the Hero's artwork image</td>
-  <td>String</td>
-  <td>"h2"</td>
+  <td><%= md('`alt_text`') %></td>
+  <td><%= md('Sets the (`alt`) text for the Hero\'s artwork image.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>title_tag</code></td>
-  <td>Sets the heading tag (<code>h1</code> - <code>h6</code>) for the Hero's title</td>
-  <td>String</td>
-  <td>"h2"</td>
+  <td><%= md('`description`') %></td>
+  <td><%= md('Title text for the Hero.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`title_tag`') %></td>
+  <td><%= md('Sets the heading tag (`h1` - `h6`) for the Hero\'s title') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`h2`') %></td>
+</tr>
+<tr>
+  <td><%= md('`button`') %></td>
+  <td><%= md('Adds button to the Hero.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`cta_attributes`') %></td>
+  <td><%= md('Allows for adding attributes to the Hero CTA artwork') %></td>
+  <td><%= md('Array') %></td>
+  <td><%= md('') %></td>
+</tr>
+<tr>
+  <td><%= md('`description`') %></td>
+  <td><%= md('Sets description text for the Hero') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`image`') %></td>
+  <td><%= md('Image for the Hero.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/icon_list/_props.html.erb
+++ b/docs/app/views/examples/objects/icon_list/_props.html.erb
@@ -1,14 +1,14 @@
 <tr>
   <td><%= md('`items`') %></td>
-  <td><%= md('
-    An array of items to create a an icon list.
-  ') %></td>
-  <td><%= md('```
-Array<{
-  bullet: String,
-  bullet_type: String,
-  body: String
-}>
-') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('An array of items to create a an icon list.') %></td>
+  <td>
+    <%= md('```
+      Array<{
+        bullet: String,
+        bullet_type: String,
+        body: String
+      }>
+    ') %>
+  </td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/input_group/_props.html.erb
+++ b/docs/app/views/examples/objects/input_group/_props.html.erb
@@ -1,78 +1,78 @@
 <tr>
-  <td><%= md("`group_id`") %></td>
-  <td><%= md("Unique identifier for this component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_id`') %></td>
+  <td><%= md('Unique identifier for this component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`has_button`") %></td>
-  <td><%= md("When set to `true`, displays a button next to the text input.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`has_button`') %></td>
+  <td><%= md('When set to `true`, displays a button next to the text input.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`has_hint`") %></td>
-  <td><%= md("When set to `true`, the `SageInputHelper` is visible upon field interaction.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`has_hint`') %></td>
+  <td><%= md('When set to `true`, the `SageInputHelper` is visible upon field interaction.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_icon`") %></td>
-  <td><%= md("Accepts classname of icon using the button icon syntax, ex. `sage-btn--icon-left-gear`.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_icon`') %></td>
+  <td><%= md('Accepts classname of icon using the button icon syntax, ex. `sage-btn--icon-left-gear`.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_label`") %></td>
-  <td><%= md("Sets the label text for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_label`') %></td>
+  <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_style`") %></td>
-  <td><%= md("Can be styled using `sage-btn` classes. When left empty (default), displays an \"unstyled\" button (see password reveal example above).") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_style`') %></td>
+  <td><%= md('Can be styled using `sage-btn` classes. When left empty (default), displays an "unstyled" button (see password reveal example above).') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_text`") %></td>
-  <td><%= md("Text label for the button. Recommended use for screen readers only (see `group_button_text_hidden` below). Ideal maximum length is 6-8 characters.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_text`') %></td>
+  <td><%= md('Text label for the button. Recommended use for screen readers only (see `group_button_text_hidden` below). Ideal maximum length is 6-8 characters.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_text_hidden`") %></td>
-  <td><%= md("(Recommended) Visually hides button text from view, displaying only to assistive technology users, such as screen reader devices.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_text_hidden`') %></td>
+  <td><%= md('(Recommended) Visually hides button text from view, displaying only to assistive technology users, such as screen reader devices.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_tooltip`") %></td>
-  <td><%= md("When set to `true`, this will display the available `group_button_tooltip_text`.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_tooltip`') %></td>
+  <td><%= md('When set to `true`, this will display the available `group_button_tooltip_text`.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_type`") %></td>
-  <td><%= md("This can be any allowed value from the list of types specified for the <a href=\"#element-form_input\" rel=\"nofollow\">input element</a>.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_type`') %></td>
+  <td><%= md('This can be any allowed value from the list of types specified for the <a href=\"#element-form_input\" rel=\"nofollow\">input element</a>.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_tooltip_text`") %></td>
-  <td><%= md("Sets the text for the `tooltip`.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_tooltip_text`') %></td>
+  <td><%= md('Sets the text for the `tooltip`.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_tooltip_position`") %></td>
-  <td><%= md("Can be styled using `sage-tooltip--` classes to apply to desired position of the `tooltip` text") %></td>
-  <td><%= md("String: [\"top\", \"right\", \"bottom\", \"left\"]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_tooltip_position`') %></td>
+  <td><%= md('Can be styled using `sage-tooltip--` classes to apply to desired position of the `tooltip` text') %></td>
+  <td><%= md('String: ["top", "right", "bottom", "left"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`group_button_tooltip_size`") %></td>
-  <td><%= md("Sets the size of the tooltip.") %></td>
-  <td><%= md("String: [\"small\", \"large\"]") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`group_button_tooltip_size`') %></td>
+  <td><%= md('Sets the size of the tooltip.') %></td>
+  <td><%= md('String: ["small", "large"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/input_helper/_props.html.erb
+++ b/docs/app/views/examples/objects/input_helper/_props.html.erb
@@ -1,24 +1,24 @@
 <tr>
-  <td><%= md("`helper_id`") %></td>
-  <td><%= md("Unique identifier for this component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`helper_id`') %></td>
+  <td><%= md('Unique identifier for this component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`helper_target`") %></td>
-  <td><%= md("Sets the value of `[data-js-modaltrigger]`") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`helper_target`') %></td>
+  <td><%= md('Sets the value of `[data-js-modaltrigger]`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`description`") %></td>
-  <td><%= md("Sets the description for the component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`description`') %></td>
+  <td><%= md('Sets the description for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`hints`") %></td>
-  <td><%= md("An array of hint items") %></td>
-  <td><%= md("Hash Array") %></td>
-  <td><%= md("null") %></td>
+  <td><%= md('`hints`') %></td>
+  <td><%= md('An array of hint items') %></td>
+  <td><%= md('Hash Array') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -1,32 +1,32 @@
 <tr>
-  <td><%= md("`active`") %></td>
-  <td><%= md("Enabling this property will return the JS early to not initialize any handlers.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`active`') %></td>
+  <td><%= md('Enabling this property will return the JS early to not initialize any handlers.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`disable_close`") %></td>
-  <td><%= md("Enabling this property will return the JS early to not initialize any handlers.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`disable_close`') %></td>
+  <td><%= md('Enabling this property will return the JS early to not initialize any handlers.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`id`") %></td>
-  <td><%= md("Unique identifier for component. Should match the <code>data-js-modaltrigger</code> property on the corresponding button") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil") %></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for component. Should match the `data-js-modaltrigger` property on the corresponding button') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil') %></td>
 </tr>
 <tr>
-  <td><%= md("`large`") %></td>
-  <td><%= md("Toggles whether to use the large variant of the modal by attaching <code>.sage-modal--large</code>") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`large`') %></td>
+  <td><%= md('Toggles whether to use the large variant of the modal by attaching `.sage-modal--large`') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`remove_content_on_close`") %></td>
-  <td><%= md("Toggles whether to delete the `innerHTML` when closing the modal.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`remove_content_on_close`') %></td>
+  <td><%= md('Toggles whether to delete the `innerHTML` when closing the modal.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td colspan="4">
@@ -34,32 +34,32 @@
   </td>
 </tr>
 <tr>
-  <td><%= md("`title`") %></td>
-  <td><%= md("Populates the `sage-modal__header` with a heading containing the provided content") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Populates the `sage-modal__header` with a heading containing the provided content') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`spacing`") %></td>
-  <td><%= md("Optionally enforces either a `card`- or `panel`-based spacing grid on the `sage-modal__content`.") %></td>
-  <td><%= md("`panel` or `card`") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`spacing`') %></td>
+  <td><%= md('Optionally enforces either a `card`- or `panel`-based spacing grid on the `sage-modal__content`.') %></td>
+  <td><%= md('`panel` or `card`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("Section: `header_aside`") %></td>
-  <td><%= md("Populates the `sage-modal__header-aside`.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('Section: `header_aside`') %></td>
+  <td><%= md('Populates the `sage-modal__header-aside`.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("Section: `footer`") %></td>
-  <td><%= md("Populates the `sage-modal__footer`.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('Section: `footer`') %></td>
+  <td><%= md('Populates the `sage-modal__footer`.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("Section: `footer_aside`") %></td>
-  <td><%= md("Populates the `sage-modal__footer-aside` for buttons or content set to the left of the panel footer.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('Section: `footer_aside`') %></td>
+  <td><%= md('Populates the `sage-modal__footer-aside` for buttons or content set to the left of the panel footer.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/nav/_props.html.erb
+++ b/docs/app/views/examples/objects/nav/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td><%= md("`aria_label`") %></td>
-  <td><%= md("Sets the `aria-label` for the nav component.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("Default") %></td>
+  <td><%= md('`aria_label`') %></td>
+  <td><%= md('Sets the `aria-label` for the nav component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/null_view/_props.html.erb
+++ b/docs/app/views/examples/objects/null_view/_props.html.erb
@@ -1,30 +1,30 @@
 <tr>
   <td><%= md('`title`') %></td>
-  <td>Title text to be displayed</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Title text to be displayed.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`text`') %></td>
-  <td>Text description to be displayed</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Smaller descriptive text to be displayed.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`graphic`') %></td>
-  <td>Graphic to be displayed</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Graphic to be displayed') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`reversed`') %></td>
-  <td>Allows content and graphic ordering to be reversed</td>
-  <td><%= md('`Boolean`') %></td>
+   <td><%= md('Allows content and graphic ordering to be reversed') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`center-vertical`') %></td>
-  <td>Centers the null view vertically on page</td>
-  <td><%= md('`Boolean`') %></td>
+  <td><%= md('Centers the null view vertically on page') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/page_heading/_props.html.erb
+++ b/docs/app/views/examples/objects/page_heading/_props.html.erb
@@ -1,0 +1,30 @@
+<tr>
+  <td><%= md('`title`') %></td>
+  <td><%= md('Title text for page heading.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`secondary_text`') %></td>
+  <td><%= md('Secondary text for page heading.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`help_title`') %></td>
+  <td><%= md('Text for help link.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`help_link`') %></td>
+  <td><%= md('Array containing help link `name` and `href`') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`help_html`') %></td>
+  <td><%= md('HTML that is passed to help link popover') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/objects/pagination/_props.html.erb
+++ b/docs/app/views/examples/objects/pagination/_props.html.erb
@@ -1,36 +1,36 @@
 <tr>
-  <td><%= md("`items`") %></td>
-  <td><%= md("Maps records to create page link items") %></td>
-  <td><%= md("Object") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`items`') %></td>
+  <td><%= md('Maps records to create page link items') %></td>
+  <td><%= md('Object') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`hide_pages`") %></td>
-  <td><%= md("When set to `true`, links to individual pages will not be rendered, leaving only the 'Back' and 'Next' links visible.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`hide_pages`') %></td>
+  <td><%= md('When set to `true`, links to individual pages will not be rendered, leaving only the "Back" and "Next links visible.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`hide_counter`") %></td>
-  <td><%= md("When set to `true`, the record count will not be displayed.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`hide_counter`') %></td>
+  <td><%= md('When set to `true`, the record count will not be displayed.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("current") %></td>
-  <td><%= md("Pagination uses a `--current` modifier to visually indicate which page is currently being viewed.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('current') %></td>
+  <td><%= md('Pagination uses a `--current` modifier to visually indicate which page is currently being viewed.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("disabled") %></td>
-  <td><%= md("Pagination uses a `--disabled` modifier to disable a link to prevent navigation. For example, when a user has reached the last page, the Next link should be disabled since there are no other pages/results to navigate to.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('disabled') %></td>
+  <td><%= md('Pagination uses a `--disabled` modifier to disable a link to prevent navigation. For example, when a user has reached the last page, the Next link should be disabled since there are no other pages/results to navigate to.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("gap") %></td>
-  <td><%= md("When there are many pages, a `--gap` modifier along with an ellipsis (&hellip;) can be used to truncate the pagination list items. Should be used in conjunction with `sage-pagination__page`") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`null`") %></td>
+  <td><%= md('gap') %></td>
+  <td><%= md('When there are many pages, a `--gap` modifier along with an ellipsis (&hellip;) can be used to truncate the pagination list items. Should be used in conjunction with `sage-pagination__page`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/panel/_props.html.erb
+++ b/docs/app/views/examples/objects/panel/_props.html.erb
@@ -1,21 +1,21 @@
 <tr>
   <td><%= md('`clear_bottom_padding`') %></td>
-  <td>Erases padding on bottom of the Panel for tighter alignment of child items.</td>
-  <td>Boolean</td>
+  <td><%= md('Erases padding on bottom of the Panel for tighter alignment of child items.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`clear_top_padding`') %></td>
-  <td>Erases padding on top of the Panel for tighter alignment of child items.</td>
-  <td>Boolean</td>
+  <td><%= md('Erases padding on top of the Panel for tighter alignment of child items.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></code></td>
 </tr>
 <tr>
-  <td colspan="4"><strong>Panel List</strong></td>
+  <td colspan="4"><%= md('**Panel List**') %></td>
 </tr>
 <tr>
   <td><%= md('`block_spacing`') %></td>
-  <td>Adjusts the default spacing settings on top and bottom of items inside the list</td>
-  <td><%= md('Optionally: `"md"`') %></td>
-  <td><%= md('--') %></td>
+  <td><%= md('Adjusts the default spacing settings on top and bottom of items inside the list.') %></td>
+  <td><%= md('Optionally: `md`') %></td>
+  <td><%= md('`--`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_props.html.erb
@@ -1,78 +1,53 @@
 <tr>
-  <td>
-    <code>target</code>
-  </td>
-  <td>
-    <%= md("The HTML ID for the list this panel controls will target with any events.") %>
-  </td>
-  <td>String</td>
-  <td>null</td>
+  <td><%= md('`target`') %></td>
+  <td><%= md("The HTML ID for the list this panel controls will target with any events.") %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td>
-    <code>item_count_label</code>
-  </td>
-  <td>
-    <%= md("A caption for the bulk actions checkbox.") %>
-  </td>
-  <td>String</td>
-  <td>"Select all"</td>
+  <td><%= md('`item_count_label`') %></td>
+  <td><%= md("A caption for the bulk actions checkbox.") %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('Select all') %></td>
 </tr>
-
 <tr>
-  <td>
-    <code>bulk_action_items</code>
-  </td>
-  <td>
-    <%= md("The list of items to populate in the bulk actions dropdown.") %>
-  </td>
-  <td>Array: See structure for Dropdown items</td>
-  <td>null</td>
+  <td><%= md('`bulk_action_items`') %></td>
+  <td><%= md("The list of items to populate in the bulk actions dropdown.") %></td>
+  <td><%= md('Array: See structure for Dropdown items') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
-
 <tr>
-  <td>
-    <code>sort_items</code>
-  </td>
-  <td>
-    <%= md("The list of items to populate in the sort dropdown.") %>
-  </td>
-  <td>Array: See structure for Dropdown items</td>
-  <td>null</td>
+  <td><%= md('`sort_items`') %></td>
+  <td><%= md("The list of items to populate in the sort dropdown.") %></td>
+  <td><%= md('Array: See structure for Dropdown items') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
-
 <tr>
+  <td><%= md('`start_expanded`') %></td>
   <td>
-    <code>start_expanded</code>
-  </td>
-  <td>
-    <%= md("
+    <%= md('
       Whether or not the controls should start as expanded or collapsed.
       This merely affects which of the two buttons appears by default
       and should be syncronized with the actual target list.
-    ") %>
+    ') %>
   </td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`show_bulk_actions`') %></td>
   <td>
-    <code>show_bulk_actions</code>
-  </td>
-  <td>
-    <%= md("
+    <%= md('
       Whether or not to render the bulk actions checkmark and dropdown.
       If set to `true`, the `bulk_action_items`
       should also be provided to populate the dropdown.
-    ") %>
+    ') %>
   </td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>
-    <code>show_expand_collapse</code>
-  </td>
+  <td><%= md('`show_expand_collapse`') %></td>
   <td>
     <%= md('
       Whether or not to show the "expand"/"collapse" button toggle.
@@ -80,30 +55,25 @@
       unless `start_expanded` is set to `true` as well.
     ') %>
   </td>
-  <td>Boolean</td>
-  <td>false</td>
-</tr>
-
-<tr>
-  <td>
-    <code>show_pagination</code>
-  </td>
-  <td><%= md("TBD") %>
-  </td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td>
-    <code>show_sort</code>
+  <td><%= md('`show_pagination`') %></td>
+  <td><%= md('TBD') %>
   </td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`show_sort`') %></td>
   <td>
-    <%= md("
+    <%= md('
       Whether or not to render the sorting dropdown.
       If set to `true`, the `sort_items`
       should also be provided to populate the dropdown.
-    ") %>
+    ') %>
   </td>
-  <td>Boolean</td>
-  <td>false</td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/popover/_props.html.erb
+++ b/docs/app/views/examples/objects/popover/_props.html.erb
@@ -1,58 +1,60 @@
 <tr>
-  <td><code>body</code></td>
-  <td>The content to display inside the popover panel</td>
-  <td>String</td>
-  <td><code></code></td>
+  <td><%= md('`body`') %></td>
+  <td><%= md('The content to display inside the popover panel.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>custom_content_class</code></td>
+  <td><%= md('`custom_content_class`') %></td>
   <td>
-    A class to add to the panel's content contianer for cusotm styling.
-    When present, <code>sage-popover__content--custom</code> is also added,
-    and default styling on the content panel is disabled.
+    <%= md('
+      A class to add to the panel\'s content contianer for custom styling.
+      When present, `sage-popover__content--custom` is also added,
+      and default styling on the content panel is disabled.
+    ') %>
   </td>
-  <td>String</td>
-  <td><code></code></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>icon</code></td>
-  <td>Which icon to display in the panel trigger button.</td>
-  <td>String</td>
-  <td><code></code></td>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Which icon to display in the panel trigger button.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>id</code></td>
-  <td>Id attribute for the panel.</td>
-  <td>String</td>
-  <td><code></code></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('`id` attribute for the panel.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>link</code></td>
-  <td>If provided, this turns on the actions area with a link that points to the provided URL.</td>
-  <td>String</td>
-  <td><code>nil</code></td>
+  <td><%= md('`link`') %></td>
+  <td><%= md('If provided, this turns on the actions area with a link that points to the provided URL.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>popover_position</code></td>
-  <td>Where to position the popover panel in relation to the trigger button.</td>
-  <td>String</td>
-  <td><code>right</code></td>
+  <td><%= md('`popover_position`') %></td>
+  <td><%= md('Where to position the popover panel in relation to the trigger button.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`right`') %></td>
 </tr>
 <tr>
-  <td><code>title</code></td>
-  <td>The heading to show at the top of the popover.</td>
-  <td>String</td>
-  <td><code>nil</code></td>
+  <td><%= md('`title`') %></td>
+  <td><%= md('The heading to show at the top of the popover.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><code>trigger_icon_only</code></td>
-  <td>Whether or not the trigger button should only show an icon and not a label</td>
-  <td>Boolean</td>
-  <td><code>true</code></td>
+  <td><%= md('`trigger_icon_only`') %></td>
+  <td><%= md('Whether or not the trigger button should only show an icon and not a label') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`true`') %></td>
 </tr>
 <tr>
-  <td><code>trigger_value</code></td>
-  <td>The text label to show on the trigger</td>
-  <td>String</td>
-  <td><code>nil</code></td>
+  <td><%= md('`trigger_value`') %></td>
+  <td><%= md('The text label to show on the trigger') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/sidebar/_props.html.erb
+++ b/docs/app/views/examples/objects/sidebar/_props.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td><%= md("`id`") %></td>
-  <td><%= md("Unique identifier to use with associated button") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier to use with associated button') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`size`") %></td>
-  <td><%= md("Additional sizing variations available for sidebar") %></td>
-  <td><%= md("`md` or `lg`") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`size`') %></td>
+  <td><%= md('Additional sizing variations available for sidebar') %></td>
+  <td><%= md('`md` or `lg`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/sortable/_props.html.erb
+++ b/docs/app/views/examples/objects/sortable/_props.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td><%= md('`resource_name`') %></td>
+  <td><%= md('Sets the value for the `data-js-sortable` attribute.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/objects/tabs/_props.html.erb
+++ b/docs/app/views/examples/objects/tabs/_props.html.erb
@@ -1,47 +1,47 @@
 <tr>
-  <td><%= md("`style`") %></td>
-  <td><%= md("What kind of tab style to use. A simple style is default, but the `choice` setting enables a more complex Choice style (See Tab versus Choice components)") %></td>
-  <td><%= md("`nil` or `choice`") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`style`') %></td>
+  <td><%= md('What kind of tab style to use. A simple style is default, but the `choice` setting enables a more complex Choice style (See Tab versus Choice components)') %></td>
+  <td><%= md('`nil` or `choice`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`stacked`") %></td>
-  <td><%= md("Whether or not the tab set should be laid out in a stack versus inline (default) fashion.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`stacked`') %></td>
+  <td><%= md('Whether or not the tab set should be laid out in a stack versus inline (default) fashion.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`id`") %></td>
-  <td><%= md("Unique identifier for this tab set.") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this tab set.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`items`") %></td>
-  <td><%= md("
+  <td><%= md('`items`') %></td>
+  <td><%= md('
     A set of items that render as tabs.
     Values for each item must conform to the properties available
     for either Tab or Choice components,
     depending on the `style` setting used here.
-  ") %></td>
-  <td><%= md("`Array<{See Choice or Tab component properties}>`") %></td>
-  <td><%= md("") %></td>
+  ') %></td>
+  <td><%= md('`Array<{See Choice or Tab component properties}>`') %></td>
+  <td><%= md('') %></td>
 </tr>
 <tr>
-  <td><%= md("`progressbar`") %></td>
-  <td><%= md("Whether or not to display tabs in a Progress bar layoutu with carets separating each.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`progressbar`') %></td>
+  <td><%= md('Whether or not to display tabs in a Progress bar layoutu with carets separating each.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`align_items_center`") %></td>
-  <td><%= md("Whether or not to center the content in each tab.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`align_items_center`') %></td>
+  <td><%= md('Whether or not to center the content in each tab.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md("`navigational`") %></td>
-  <td><%= md("Whether or not the tab set acts functionally as a navigation set for pages such as in a progressbar fashion.") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`false`") %></td>
+  <td><%= md('`navigational`') %></td>
+  <td><%= md('Whether or not the tab set acts functionally as a navigation set for pages such as in a progressbar fashion.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/transaction_card/_props.html.erb
+++ b/docs/app/views/examples/objects/transaction_card/_props.html.erb
@@ -1,42 +1,56 @@
 <tr>
   <td><%= md('`label_color`') %></td>
-  <td>Color of transaction label</td>
-  <td><%= md("String: [\"published\", \"draft\", \"danger\", \"info\", \"warning\", \"locked\"]") %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Color of transaction label.') %></td>
+  <td><%= md('String: ["published", "draft", "danger", "info", "warning", "locked"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`label_text`') %></td>
-  <td>Text displayed in label</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Text displayed in label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`name`') %></td>
-  <td>Name of contact that initiated transaction</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Name of contact that initiated transaction.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`amount`') %></td>
-  <td>Amount of the transaction</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Amount of the transaction.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`amount_color`') %></td>
-  <td>Color that can be applied to the transaction amount</td>
-  <td><%= md("String: [\"red\", \"sage\"]") %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Color that can be applied to the transaction amount.') %></td>
+  <td><%= md('String: ["red", "sage"]') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`product_name`') %></td>
-  <td>Name of product related to transaction</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Name of product related to transaction.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`transacton_time`') %></td>
-  <td>Time that transaction occured</td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('`null`') %></td>
+  <td><%= md('Time that transaction occured.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`dropdown_options`') %></td>
+  <td><%= md('Array for dropdown options') %></td>
+  <td>
+    <%= md('```
+      Array<{
+        value: String,
+        icon: String,
+        attributes: Hash,
+      }>
+    ') %>
+  </td>
+  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/upload_card/_props.html.erb
+++ b/docs/app/views/examples/objects/upload_card/_props.html.erb
@@ -1,45 +1,49 @@
 <tr>
-  <td><%= md("`selection_subtext`") %></td>
-  <td><%= md("Small text to provide additional information") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`selection_subtext`') %></td>
+  <td><%= md('Small text to provide additional information') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`selection_label`") %></td>
-  <td><%= md("Text for upload button") %></td>
-  <td><%= md("String") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`selection_label`') %></td>
+  <td><%= md('Text for upload button') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`file_selected`") %></td>
-  <td><%= md("Adjusts UI to selected state when file is selected") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`file_selected`') %></td>
+  <td><%= md('Adjusts UI to selected state when file is selected') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`has_error`") %></td>
-  <td><%= md("Adjusts UI to error state") %></td>
-  <td><%= md("Boolean") %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`has_error`') %></td>
+  <td><%= md('Adjusts UI to error state') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`accepted_files`") %></td>
-  <td><%= md("Array containing file information") %></td>
-  <td><%= md('```
-Array<{
-  name: String,
-  size: String,
-}>
-') %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`accepted_files`') %></td>
+  <td><%= md('Array containing file information') %></td>
+  <td>
+    <%= md('```
+      Array<{
+        name: String,
+        size: String,
+      }>
+    ') %>
+  </td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md("`errors`") %></td>
-  <td><%= md("Array containing error messages") %></td>
-  <td><%= md('```
-Array<{
-  text: String,
-}>
-') %></td>
-  <td><%= md("`nil`") %></td>
+  <td><%= md('`errors`') %></td>
+  <td><%= md('Array containing error messages') %></td>
+  <td>
+    <%= md('```
+      Array<{
+        text: String,
+      }>
+    ') %>
+  </td>
+  <td><%= md('`nil`') %></td>
 </tr>


### PR DESCRIPTION
## Description
This PR updates all the `_props.html.erb` files with the following changes to better standardize these files:

- Adds props documentation to elements/objects where missing.
- Converts all outstanding objects and elements to use markdown.
- Updates all files to use `nil` instead of `null` where applicable.
- Updates all files to use `'` for wrapping `md` content unless inner contents need `"` or `%(...)` as a last resort.

### Screenshots
No visual changes with these updates.

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit any object or element breakout page.
2. Verify properties display and `nil` is used instead of `null`


## Related
<!-- OPTIONAL section: link related/fixed issues and any PRs for context -->
- N/A
