### PR TITLE
Catalog Item - added only-child exception

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -18,6 +18,10 @@ $-image-height-mobile: rem(120px);
   border-top: sage-border(light);
   border-bottom: sage-border(light);
 
+  &:only-child {
+    border: 0;
+  }
+
   &:last-child {
     border-bottom: 0;
   }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen_Shot_2021-02-17_at_2_08_04_PM](https://user-images.githubusercontent.com/1241836/108262066-0fa57980-712a-11eb-9743-a9c256f24552.png)|![Screen Shot 2021-02-17 at 2 07 57 PM](https://user-images.githubusercontent.com/1241836/108261993-f6043200-7129-11eb-83cc-0e21400b09bb.png)|


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Products > Podcasts
2. When only one items is present, no border should exist

