### PR TITLE
Sage form input affix class output fix (Rails)

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -2,7 +2,7 @@
   class="
     sage-input
     <%= "sage-input--error" if component.has_error %>
-    <%= "sage-input--affixed" if component.prefix != "" || component.suffix !="" %>
+    <%= "sage-input--affixed" if component.prefix or component.suffix %>
     <%= "sage-input--showplaceholder" if component.has_placeholder %>"
   <%= "data-js-input-prefix=#{component.prefix}" if component.prefix.present? -%>
   <%= "data-js-input-suffix=#{component.suffix}" if component.suffix.present? -%>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -1,8 +1,7 @@
 <div
-  class="
-    sage-input
+  class="sage-input
     <%= "sage-input--error" if component.has_error %>
-    <%= "sage-input--affixed" if component.prefix or component.suffix %>
+    <%= "sage-input--affixed" if component.prefix.present? or component.suffix.present? %>
     <%= "sage-input--showplaceholder" if component.has_placeholder %>"
   <%= "data-js-input-prefix=#{component.prefix}" if component.prefix.present? -%>
   <%= "data-js-input-suffix=#{component.suffix}" if component.suffix.present? -%>


### PR DESCRIPTION
## Description
Updates conditional display for the `sage-input--affix` class in Rails through presence method on `prefix` and `suffix` attributes rather than empty strings.

Each `sage-input` field is currently being appended with `sage-input-affix` regardless of whether a prefix or suffix is configured. This isn't immediately obvious because the javascript removes the class on document load, but disabling the loop in `inputaffixes.js` shows the actual output (see screen below). This ends up running the affix JS on every page with a Sage input field.

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
<img src="https://user-images.githubusercontent.com/816579/108318191-40aa9c00-7174-11eb-84f8-db311cc55bbc.png" width="360">

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

(MEDIUM) Modifies output of all Sage form input fields. While most form fields should not be affected, any fields using the affix (prefix or suffix) should be verified to be working as expected. Examples include:
- [x] Offer detail view:
  - [x] Affiliate settings (After Purchase panel)
  - [x] Days of Access (Product Access panel)
- [x] New coupon setup view (`app/views/admin/coupons/_form.html.erb`)
- [x] Email sending domains (`/app/views/admin/email_sending_domains/_form.html.erb`)
- [ ] Plan signup pricing form (`app/views/signup/_pricing_form.html.erb`)
