### PR TITLE
Fix assistant image path

### DIFF
--- a/docs/app/views/examples/objects/assistant/_preview.html.erb
+++ b/docs/app/views/examples/objects/assistant/_preview.html.erb
@@ -1,9 +1,11 @@
 <h3 class="t-sage-heading-6">With menu button (visible below medium breakpoint)</h3>
 <%= sage_component SageAssistant, {
   menu_button: true,
+  logo: { path: "docs/sage.svg", method: "pack" }
 } %>
 
 <h3 class="t-sage-heading-6">Without menu button</h3>
 <%= sage_component SageAssistant, {
   menu_button: false,
+  logo: { path: "docs/sage.svg", method: "pack" }
 } %>

--- a/docs/app/views/examples/objects/assistant/_props.html.erb
+++ b/docs/app/views/examples/objects/assistant/_props.html.erb
@@ -1,4 +1,15 @@
 <tr>
+  <td><%= md("`logo`") %></td>
+  <td><%= md("Provides settings for the logo to appear in the assistant.") %></td>
+  <td><%= md('```
+{
+  path: String,
+  method: nil | "pack"
+}
+```') %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
   <td><%= md("`menu_button`") %></td>
   <td><%= md("Enables menu button to be displayed. (below medium breakpoint)") %></td>
   <td><%= md("`Boolean`") %></td>

--- a/docs/app/views/layouts/application.html.erb
+++ b/docs/app/views/layouts/application.html.erb
@@ -10,9 +10,7 @@
       link_id: "main-content"
     -%>
     <header class="sage-header">
-      <%= render "application/assistant",
-        menu_button: true
-      -%>
+      <%= sage_component SageAssistant, { logo: { path: "docs/sage.svg", method: "pack" }} %>
     </header>
     <div class="sage-stage">
       <%= render "application/sidebar" %>

--- a/docs/lib/sage_rails/app/sage_components/sage_assistant.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_assistant.rb
@@ -1,6 +1,7 @@
 class SageAssistant < SageComponent
   set_attribute_schema({
     menu_button: [:optional, TrueClass],
+    menu_button_controls: [:optional, String],
     logo: [:optional, {
       path: String,
       method: [:optional, NilClass, Set.new(["pack"])],

--- a/docs/lib/sage_rails/app/sage_components/sage_assistant.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_assistant.rb
@@ -1,6 +1,9 @@
 class SageAssistant < SageComponent
   set_attribute_schema({
     menu_button: [:optional, TrueClass],
+    logo: [:optional, {
+      path: String,
+      logo_method: [:optional, NilClass, Set.new(["pack"])],
+    }]
   })
-
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_assistant.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_assistant.rb
@@ -3,7 +3,7 @@ class SageAssistant < SageComponent
     menu_button: [:optional, TrueClass],
     logo: [:optional, {
       path: String,
-      logo_method: [:optional, NilClass, Set.new(["pack"])],
+      method: [:optional, NilClass, Set.new(["pack"])],
     }]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_assistant.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_assistant.html.erb
@@ -1,3 +1,13 @@
+<%
+# TEMP: provide fallbacks in order to avoid breaking change in `products`
+logo = {
+  path: "nav_logo_white.png",
+  method: nil,
+}
+if component.logo.present?
+  logo = component.logo
+end
+%>
 <div class="sage-assistant">
   <% if component.menu_button.present? %>
     <button class="sage-menubutton" aria-expanded="false" aria-controls="sage-sidebar-menu" data-js-btn-target="sage-sidebar-menu" data-js-target-type="sidebar">
@@ -5,7 +15,11 @@
       <span class="visually-hidden">Toggle main menu</span>
     </button>
   <% end %>
-  <%= image_pack_tag("docs/sage.svg", class: "sage-assistant__branding")%>
+  <% if logo[:method] == "pack" %>
+    <%= image_pack_tag(logo[:path], class: "sage-assistant__branding")%>
+  <% else %>
+    <%= image_tag logo[:path], class: "sage-assistant__branding" %>
+  <% end %>
   <div class="sage-assistant__body"><%= component.content %></div>
   <div class="sage-assistant__actions">
     <% if content_for?(:super_admin_actions) %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_assistant.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_assistant.html.erb
@@ -7,10 +7,20 @@ logo = {
 if component.logo.present?
   logo = component.logo
 end
+
+menu_button = true
+if component.menu_button.present?
+  menu_button = component.menu_button
+end
+
+menu_button_controls = "sage-sidebar-menu"
+if component.menu_button_controls.present?
+  menu_button_controls = component.menu_button_controls
+end
 %>
 <div class="sage-assistant">
-  <% if component.menu_button.present? %>
-    <button class="sage-menubutton" aria-expanded="false" aria-controls="sage-sidebar-menu" data-js-btn-target="sage-sidebar-menu" data-js-target-type="sidebar">
+  <% if menu_button %>
+    <button class="sage-menubutton" aria-expanded="false" aria-controls="<%= menu_button_controls %>" data-js-btn-target="<%= menu_button_controls %>" data-js-target-type="sidebar">
       <span class="sage-menubutton__bar"></span><span class="sage-menubutton__bar"></span><span class="sage-menubutton__bar"></span>
       <span class="visually-hidden">Toggle main menu</span>
     </button>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
@@ -1,4 +1,10 @@
-<div class="sage-sidebar <%= component.size ? "sage-sidebar--#{component.size}" : "" %>" id="<%= component.id %>" data-js-sidebar="<%= component.id %>">
+<%
+id = "sage-sidebar-menu"
+if component.id.present?
+  id = component.id
+end
+%>
+<div class="sage-sidebar <%= component.size ? "sage-sidebar--#{component.size}" : "" %>" id="<%= id %>" data-js-sidebar="<%= id %>">
   <div class="sage-sidebar__body">
     <%= component.content %>
   </div>


### PR DESCRIPTION
## Description

This PR updates the Assistant rails component to fix an issue with the logo image path and calling method. It includes a temporary shim/default value specifically for `kajabi-products` in order to avoid introducing a breaking change that would require a follow up in `kajabi-products`.

### Screenshots

N/A 

## Test notes

See Objects > Assistant and usage at top of Documentation site

### Steps for testing
1. SageAssistant component is updated. It is used exclusively in Super Admin at this time. 
    - [ ] Log in to `super_admin` and confirm the masthead appears as expected.
