### PR TITLE
Switch - add border and focus styles to parent of switch element

### DIFF
--- a/docs/app/views/examples/elements/choice/_rules_dont.html.erb
+++ b/docs/app/views/examples/elements/choice/_rules_dont.html.erb
@@ -1,3 +1,3 @@
-<%= md("
+<%= md('
 - The `radio` type should only be used to conditionally render content. This component should not be used as a form field. In that case use the <a href=\"/pages/element/radio\"> Radio</a> component
-", use_sage_type: true) %>
+', use_sage_type: true) %>

--- a/docs/app/views/examples/elements/choice/_rules_dont.html.erb
+++ b/docs/app/views/examples/elements/choice/_rules_dont.html.erb
@@ -1,0 +1,3 @@
+<%= md("
+- The `radio` type should only be used to conditionally render content. This component should not be used as a form field. In that case use the <a href=\"/pages/element/radio\"> Radio</a> component
+", use_sage_type: true) %>

--- a/docs/app/views/examples/elements/radio/_preview.html.erb
+++ b/docs/app/views/examples/elements/radio/_preview.html.erb
@@ -52,7 +52,7 @@
   name: "radio5",
   value: "6",
   has_border: true,
-  label_text: "Error",
+  label_text: "Bordered Option",
   required: true,
 } %>
 
@@ -61,7 +61,7 @@
   id: "r7",
   name: "radio6",
   value: "7",
-  label_text: "Error",
+  label_text: "Bordered Option with Error",
   required: true,
   has_border: true,
   has_error: true

--- a/docs/app/views/examples/elements/radio/_preview.html.erb
+++ b/docs/app/views/examples/elements/radio/_preview.html.erb
@@ -44,3 +44,25 @@
     has_error: true
   } %>
 <% end %>
+
+<h3 class="t-sage-heading-6">Bordered Radio</h3>
+<%= sage_component SageRadio, {
+  caption: "caption text",
+  id: "r6",
+  name: "radio5",
+  value: "6",
+  has_border: true,
+  label_text: "Error",
+  required: true,
+} %>
+
+<%= sage_component SageRadio, {
+  caption: "caption text",
+  id: "r7",
+  name: "radio6",
+  value: "7",
+  label_text: "Error",
+  required: true,
+  has_border: true,
+  has_error: true
+} %>

--- a/docs/app/views/examples/elements/radio/_props.html.erb
+++ b/docs/app/views/examples/elements/radio/_props.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td><%= md('`id`') %></td>
-  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md('`attributes`') %></td>
+  <td><%= md('For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes') %></td>
+  <td><%= md('Hash') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`name`') %></td>
-  <td><%= md('Using a singular name groups radio buttons together, allowing the user to toggle between them (see Option 1 and Option 2 examples above)') %></td>
+  <td><%= md('`caption`') %></td>
+  <td><%= md('Sets the caption text for the component.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -17,21 +17,56 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`required`') %></td>
-  <td><%= md('Adding this attribute allows basic HTML form validation on this field') %></td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`disabled`') %></td>
   <td><%= md('Prevents all user interaction with the control. Be aware that when combining a disabled radio button with a default `checked` state, the value of the radio button <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions" target="_blank" rel="noopener">will not be included when its parent form is submitted</a>. Likewise, setting Required will not have any effect.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`attributes`') %></td>
-  <td><%= md('For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes') %></td>
-  <td><%= md('Hash') %></td>
+  <td><%= md('`has_border`') %></td>
+  <td><%= md('When set, the focus styles affect the parent container, not the form element.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
-
+<tr>
+  <td><%= md('`has_error`') %></td>
+  <td><%= md('This will display error styles on the component.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`id`') %></td>
+  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`label_text`') %></td>
+  <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`name`') %></td>
+  <td><%= md('Using a singular name groups radio buttons together, allowing the user to toggle between them (see Option 1 and Option 2 examples above)') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`required`') %></td>
+  <td><%= md('Adding this attribute allows basic HTML form validation on this field') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`standalone`') %></td>
+  <td><%= md('When set, this component is expected to be used in isolation.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`value`') %></td>
+  <td><%= md('Sets the value of the form component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/elements/switch/_preview.html.erb
+++ b/docs/app/views/examples/elements/switch/_preview.html.erb
@@ -123,15 +123,50 @@
       label_text: "Switch - visually hidden text",
       message: ""
     } %>
-    
-    <%= sage_component SageSwitch, { 
-      type: "checkbox",
-      id: "sage-switch-20",
-      name: "sage-switch-20",
-      value: "switch-20-value",
-      label_text: "Switch (checkbox) with info",
-      message: "Additional Info",
-      toggle_position: "right"
-    } %>
   <% end %>
 <% end %>
+
+<h3 class="t-sage-heading-6">Bordered Switch</h3>
+<%= sage_component SageSwitch, { 
+  type: "checkbox",
+  id: "sage-switch-20",
+  name: "sage-switch-20",
+  value: "switch-20-value",
+  has_border: true,
+  label_text: "Switch (checkbox) with info",
+  message: "Additional Info",
+  toggle_position: "right"
+} %>
+<%= sage_component SageSwitch, { 
+  type: "checkbox",
+  id: "sage-switch-21",
+  name: "sage-switch-21",
+  value: "switch-21-value",
+  has_border: true,
+  has_error: true,
+  label_text: "Switch (checkbox) with info",
+  message: "Additional Info",
+  toggle_position: "right"
+} %>
+
+<h3 class="t-sage-heading-6">Bordered Switch (Radio)</h3>
+<%= sage_component SageSwitch, { 
+  type: "radio",
+  id: "sage-switch-22",
+  name: "sage-switch-22",
+  value: "switch-22-value",
+  has_border: true,
+  label_text: "Switch (radio) with info",
+  message: "Additional Info",
+  toggle_position: "right"
+} %>
+<%= sage_component SageSwitch, { 
+  type: "radio",
+  id: "sage-switch-23",
+  name: "sage-switch-22",
+  value: "switch-23-value",
+  has_border: true,
+  label_text: "Switch (radio) with info",
+  message: "Additional Info",
+  toggle_position: "right"
+} %>

--- a/docs/app/views/examples/elements/switch/_preview.html.erb
+++ b/docs/app/views/examples/elements/switch/_preview.html.erb
@@ -123,5 +123,15 @@
       label_text: "Switch - visually hidden text",
       message: ""
     } %>
+    
+    <%= sage_component SageSwitch, { 
+      type: "checkbox",
+      id: "sage-switch-20",
+      name: "sage-switch-20",
+      value: "switch-20-value",
+      label_text: "Switch (checkbox) with info",
+      message: "Additional Info",
+      toggle_position: "right"
+    } %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/elements/switch/_preview.html.erb
+++ b/docs/app/views/examples/elements/switch/_preview.html.erb
@@ -48,7 +48,7 @@
       name: "sage-switch-5",
       value: "switch-5-value",
       label_text: "Switch (checkbox) with info",
-      message: "Additional Info"
+      message: "Additional Info 1"
     } %>
     <%= sage_component SageSwitch, { 
       type: "checkbox",
@@ -58,7 +58,7 @@
       label_text: "Switch (checkbox) error with info",
       has_error: true,
       required: true,
-      message: "Additional Info"
+      message: "Additional Info 2"
     } %>
   <% end %>
   <%= sage_component SagePanelStack, {} do %>

--- a/docs/app/views/examples/elements/switch/_props.html.erb
+++ b/docs/app/views/examples/elements/switch/_props.html.erb
@@ -41,6 +41,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`message`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`name`') %></td>
   <td><%= md('Sets the \"label\" attribute for the component. This is usedful for grouping form elements') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/elements/switch/_props.html.erb
+++ b/docs/app/views/examples/elements/switch/_props.html.erb
@@ -1,12 +1,48 @@
 <tr>
+  <td><%= md('`checked`') %></td>
+  <td><%= md('Sets the state to \"checked\" by default.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Sets the state to \"disabled\" by default.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`has_border`') %></td>
+  <td><%= md('When set, the focus styles affect the parent container, not the form element.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`has_error`') %></td>
+  <td><%= md('This will display error styles on the component.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`hide_text`') %></td>
+  <td><%= md('This will visually hide the text but will remain accessible for assistive technologies.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
-  <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
+  <td><%= md('ID.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`checked`') %></td>
-  <td><%= md('Sets the state to "checked" by default.') %></td>
+  <td><%= md('`label_text`') %></td>
+  <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`name`') %></td>
+  <td><%= md('Sets the \"label\" attribute for the component. This is usedful for grouping form elements') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -17,8 +53,26 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`hide_text`') %></td>
-  <td><%= md('This will visually hide the text but will remain accessible for assistive technologies.') %></td>
+  <td><%= md('`standalone`') %></td>
+  <td><%= md('When set, this component is expected to be used in isolation.') %></td>
   <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`toggle_position`') %></td>
+  <td><%= md('Sets the position of the toggle.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`type`') %></td>
+  <td><%= md('Sets the \"type\" attribute of the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`value`') %></td>
+  <td><%= md('Sets the value of the form component.') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/elements/switch/_props.html.erb
+++ b/docs/app/views/examples/elements/switch/_props.html.erb
@@ -67,7 +67,7 @@
 <tr>
   <td><%= md('`toggle_position`') %></td>
   <td><%= md('Sets the position of the toggle.') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md('`"right"`') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_radio.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_radio.rb
@@ -12,7 +12,6 @@ class SageRadio < SageComponent
     name: String,
     required: [:optional, TrueClass],
     standalone: [:optional, TrueClass],
-    toggle_position: [:optional, String],
     value: String,
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_radio.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_radio.rb
@@ -1,15 +1,18 @@
 class SageRadio < SageComponent
   set_attribute_schema({
     attributes: [:optional, Hash],
+    caption: [:optional, String],
     checked: [:optional, TrueClass],
     css_classes: [:optional, String],
     disabled: [:optional, TrueClass],
+    has_border: [:optional, TrueClass],
     has_error: [:optional, TrueClass],
     id: String,
     label_text: String,
     name: String,
     required: [:optional, TrueClass],
     standalone: [:optional, TrueClass],
+    toggle_position: [:optional, String],
     value: String,
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_switch.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_switch.rb
@@ -3,6 +3,7 @@ class SageSwitch < SageComponent
     css_classes: [:optional, String],
     checked: [:optional, TrueClass],
     disabled: [:optional, TrueClass],
+    has_border: [:optional, TrueClass],
     has_error: [:optional, TrueClass],
     hide_text: [:optional, TrueClass],
     id: String,

--- a/docs/lib/sage_rails/app/sage_components/sage_switch.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_switch.rb
@@ -10,6 +10,8 @@ class SageSwitch < SageComponent
     name: String,
     message: [:optional, String],
     required: [:optional, TrueClass],
+    standalone: [:optional, TrueClass],
+    toggle_position: [:optional, String],
     type: String,
     value: String,
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_switch.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_switch.rb
@@ -12,7 +12,7 @@ class SageSwitch < SageComponent
     message: [:optional, String],
     required: [:optional, TrueClass],
     standalone: [:optional, TrueClass],
-    toggle_position: [:optional, String],
+    toggle_position: [:optional, Set.new(["right"])],
     type: String,
     value: String,
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -43,7 +43,7 @@
       <%= component.label_text %>
     </label>
     <% if component.caption.present? %>
-      <div class="sage-radio__message"><%= component.caption %></div>
+      <div class="sage-radio__caption"><%= component.caption %></div>
     <% end %>
   </div>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -22,7 +22,6 @@
   <div class="
       sage-radio
       <%= component.has_border ? "sage-radio--has-border" : "" %>
-      <%= component.toggle_position ? "sage-radio--toggle-#{component.toggle_position}" : "" %>
       <%= component.has_error ? "sage-radio--error" : "" %>
       <%= component.css_classes if component.css_classes.present? %>
     "

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -21,6 +21,8 @@
 <% else %>
   <div class="
       sage-radio
+      <%= component.has_border ? "sage-radio--has-border" : "" %>
+      <%= component.toggle_position ? "sage-radio--toggle-#{component.toggle_position}" : "" %>
       <%= component.has_error ? "sage-radio--error" : "" %>
       <%= component.css_classes if component.css_classes.present? %>
     "
@@ -41,5 +43,8 @@
     <label for="<%= component.id %>" class="sage-radio__label">
       <%= component.label_text %>
     </label>
+    <% if component.caption.present? %>
+      <div class="sage-radio__message"><%= component.caption %></div>
+    <% end %>
   </div>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
@@ -34,8 +34,8 @@
       <%= "required" if component.required %>
     >
     <label for="<%= component.id %>" class="sage-switch__label <%= "sage-switch__label--hide-text" if component.hide_text %>"><%= component.label_text %></label>
-    <% if component.message != "" %>
-      <div class="sage-switch__message">Additional Info</div>
+    <% if component.message.present? %>
+      <div class="sage-switch__message"><%= component.message %></div>
     <% end %>
   </div>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
@@ -17,6 +17,7 @@
 <% else %>
   <div class="
       sage-switch
+      <%= component.has_border ? "sage-switch--has-border" : "" %>
       <%= component.toggle_position ? "sage-switch--toggle-#{component.toggle_position}" : "" %>
       <%= component.has_error ? "sage-switch--error" : "" %>
       <%= component.css_classes if component.css_classes.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
@@ -1,21 +1,40 @@
-<div class="
-    sage-switch
-    <%= component.has_error ? "sage-switch--error" : "" %>
-    <%= component.css_classes if component.css_classes.present? %>
-  "
->
+<% if component.standalone %>
   <input 
-    type="<%= component.type %>" 
-    id="<%= component.id %>" 
-    class="sage-switch__input" 
-    name="<%= component.name %>" 
-    value="<%= component.id %>"
-    <%= "checked" if component.checked %>
-    <%= "disabled" if component.disabled %>
-    <%= "required" if component.required %>
+      type="<%= component.type %>" 
+      id="<%= component.id %>" 
+      class="
+        sage-switch
+        sage-switch--standalone
+        <%= component.has_error ? "sage-switch--error" : "" %>
+        <%= component.css_classes if component.css_classes.present? %>
+      " 
+      name="<%= component.name %>" 
+      value="<%= component.id %>"
+      <%= "checked" if component.checked %>
+      <%= "disabled" if component.disabled %>
+      <%= "required" if component.required %>
+    >
+<% else %>
+  <div class="
+      sage-switch
+      <%= component.toggle_position ? "sage-switch--toggle-#{component.toggle_position}" : "" %>
+      <%= component.has_error ? "sage-switch--error" : "" %>
+      <%= component.css_classes if component.css_classes.present? %>
+    "
   >
-  <label for="<%= component.id %>" class="sage-switch__label <%= "sage-switch__label--hide-text" if component.hide_text %>"><%= component.label_text %></label>
-  <% if component.message != "" %>
-    <div class="sage-switch__message">Additional Info</div>
-  <% end %>
-</div>
+    <input 
+      type="<%= component.type %>" 
+      id="<%= component.id %>" 
+      class="sage-switch__input" 
+      name="<%= component.name %>" 
+      value="<%= component.id %>"
+      <%= "checked" if component.checked %>
+      <%= "disabled" if component.disabled %>
+      <%= "required" if component.required %>
+    >
+    <label for="<%= component.id %>" class="sage-switch__label <%= "sage-switch__label--hide-text" if component.hide_text %>"><%= component.label_text %></label>
+    <% if component.message != "" %>
+      <div class="sage-switch__message">Additional Info</div>
+    <% end %>
+  </div>
+<% end %>

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
@@ -13,6 +13,8 @@ $-radio-color-default: map-get($sage-radio-colors, default);
 $-radio-color-disabled: map-get($sage-radio-colors, disabled);
 $-radio-color-hover: map-get($sage-radio-colors, hover);
 $-radio-color-text-disabled: sage-color(charcoal, 100);
+$-radio-color-focus-outline: sage-color(primary, 200);
+$-radio-color-focus-outline-error: sage-color(red, 300);
 
 // Additional configurations
 $-radio-button-size: $sage-radio-size;
@@ -25,6 +27,8 @@ $-radio-focus-outline-width: 2;
 $-radio-focus-outline-color: currentColor;
 
 .sage-radio {
+  position: relative;
+
   &:not(.sage-radio--standalone) {
     display: flex;
     flex-flow: row wrap;
@@ -50,6 +54,21 @@ $-radio-focus-outline-color: currentColor;
   display: inline-block;
 }
 
+.sage-radio--has-border {
+  align-items: center;
+  padding: sage-spacing(card);
+  border: sage-border();
+  border-radius: sage-border(radius);
+
+  &:focus-within {
+    box-shadow: 0 0 0 ($-radio-focus-outline-width * 1px) $-radio-color-focus-outline;
+  }
+
+  &.sage-radio--error:focus-within {
+    box-shadow: 0 0 0 ($-radio-focus-outline-width * 1px) $-radio-color-focus-outline-error;
+  }
+}
+
 .sage-radio__label {
   display: inline-block;
   flex: 1;
@@ -58,6 +77,15 @@ $-radio-focus-outline-color: currentColor;
   cursor: pointer;
 
   @extend %t-sage-body;
+
+  &::after {
+    content: "" ;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 
@@ -170,7 +198,8 @@ $-radio-focus-outline-color: currentColor;
 }
 
 .sage-radio--error {
-  .sage-radio__label {
+  .sage-radio__label,
+  .sage-radio__message {
     color: sage-color(red);
   }
   .sage-radio__input {
@@ -186,4 +215,11 @@ $-radio-focus-outline-color: currentColor;
   :hover:not(:checked):not(:disabled) {
     border-color: sage-color(red);
   }
+}
+
+.sage-radio__message {
+  width: 100%;
+  padding: 0 0 0 2rem;
+
+  @extend %t-sage-body-xsmall;
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
@@ -89,6 +89,8 @@ $-radio-focus-outline-color: currentColor;
 
   .sage-radio--has-border & {
     margin-left: sage-spacing(lg);
+    color: sage-color(charcoal, 400);
+    font-weight: sage-font-weight(semibold);
   }
 }
 
@@ -203,6 +205,11 @@ $-radio-focus-outline-color: currentColor;
       position: absolute;
       margin-top: 0;
     }
+
+    .sage-radio--has-border &::after,
+    .sage-radio--has-border &::before {
+      border-color: transparent;
+    }
   }
 }
 
@@ -229,6 +236,7 @@ $-radio-focus-outline-color: currentColor;
 .sage-radio__message {
   width: 100%;
   padding: 0 0 0 2rem;
+  color: sage-color(charcoal, 200);
 
   @extend %t-sage-body-xsmall;
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
@@ -13,7 +13,7 @@ $-radio-color-default: map-get($sage-radio-colors, default);
 $-radio-color-disabled: map-get($sage-radio-colors, disabled);
 $-radio-color-hover: map-get($sage-radio-colors, hover);
 $-radio-color-text-disabled: sage-color(charcoal, 100);
-$-radio-color-focus-outline: sage-color(primary, 200);
+$-radio-color-focus-outline: sage-color(primary, 300);
 $-radio-color-focus-outline-error: sage-color(red, 300);
 
 // Additional configurations
@@ -54,7 +54,7 @@ $-radio-focus-outline-color: currentColor;
   display: inline-block;
 }
 
-.sage-radio--has-border {
+.sage-radio--has-border:not(.sage-radio--standalone) {
   align-items: center;
   padding: sage-spacing(card);
   border: sage-border();
@@ -85,6 +85,10 @@ $-radio-focus-outline-color: currentColor;
     left: 0;
     width: 100%;
     height: 100%;
+  }
+
+  .sage-radio--has-border & {
+    margin-left: sage-spacing(lg);
   }
 }
 
@@ -194,6 +198,11 @@ $-radio-focus-outline-color: currentColor;
 
   &:not(.sage-radio--standalone) {
     margin-top: 5px;
+
+    .sage-radio--has-border & {
+      position: absolute;
+      margin-top: 0;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
@@ -215,7 +215,7 @@ $-radio-focus-outline-color: currentColor;
 
 .sage-radio--error {
   .sage-radio__label,
-  .sage-radio__message {
+  .sage-radio__caption {
     color: sage-color(red);
   }
   .sage-radio__input {
@@ -233,7 +233,7 @@ $-radio-focus-outline-color: currentColor;
   }
 }
 
-.sage-radio__message {
+.sage-radio__caption {
   width: 100%;
   padding: 0 0 0 2rem;
   color: sage-color(charcoal, 200);

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
@@ -27,11 +27,14 @@ $-switch-toggle-size: rem(20px);
 $-switch-focus-outline-spacing: sage-spacing(2xs);
 $-switch-focus-outline-width: 2;
 $-switch-focus-outline-color: sage-color(primary);
+$-switch-focus-outline-error-color: sage-color(red, 300);
 
 .sage-switch {
   display: flex;
   flex-flow: row wrap;
   align-items: flex-start;
+  width: 100%;
+  position: relative;
   margin-bottom: sage-spacing(card);
   color: $-switch-color-default-text;
 
@@ -39,7 +42,22 @@ $-switch-focus-outline-color: sage-color(primary);
     margin-top: -(sage-spacing(card) / 2);
   }
 
-  .sage-switch--toggle-right {
+  &.sage-switch--has-border {
+    align-items: center;
+    padding: sage-spacing(card);
+    border: sage-border();
+    border-radius: sage-border(radius);
+
+    &:focus-within {
+      box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-color;
+    }
+
+    &.sage-switch--error:focus-within {
+      box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-error-color;
+    }
+  }
+
+  &.sage-switch--toggle-right {
     flex-direction: row-reverse;
   }
 
@@ -71,6 +89,10 @@ $-switch-focus-outline-color: sage-color(primary);
   padding: 0 0 0 ($-switch-width + $-switch-label-left-spacing);
 
   @extend %t-sage-body-xsmall;
+
+  .sage-switch--toggle-right & {
+    padding-left: 0;
+  }
 }
 
 .sage-switch__input {
@@ -89,6 +111,15 @@ $-switch-focus-outline-color: sage-color(primary);
   transition: background 0.3s ease-out;
   cursor: pointer;
 
+  .sage-switch--has-border & {
+    position: absolute;
+
+    &::after,
+    &::before {
+      border-color: transparent;
+    }
+  }
+
   + .sage-switch__label {
     display: inline-block;
     flex: 1;
@@ -98,8 +129,17 @@ $-switch-focus-outline-color: sage-color(primary);
 
     @extend %t-sage-body;
 
+    &::after {
+      content: "" ;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+
     .sage-switch--toggle-right & {
-      margin-left: -($-switch-label-left-spacing);
+      margin-left: 0;
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
@@ -33,8 +33,8 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
   display: flex;
   flex-flow: row wrap;
   align-items: flex-start;
-  width: 100%;
   position: relative;
+  width: 100%;
   margin-bottom: sage-spacing(card);
   color: $-switch-color-default-text;
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
@@ -87,6 +87,7 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
 .sage-switch__message {
   width: 100%;
   padding: 0 0 0 ($-switch-width + $-switch-label-left-spacing);
+  color: sage-color(charcoal, 200);
 
   @extend %t-sage-body-xsmall;
 
@@ -138,6 +139,11 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
       height: 100%;
     }
 
+    .sage-switch--has-border & {
+      color: sage-color(charcoal, 400);
+      font-weight: sage-font-weight(semibold);
+    }
+
     .sage-switch--toggle-right & {
       margin-left: 0;
     }
@@ -186,6 +192,11 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     &::before {
       border-color: sage-color(red);
     }
+  }
+
+  .sage-switch--has-border:not(.sage-switch--standalone) &::after,
+  .sage-switch--has-border:not(.sage-switch--standalone) &::before {
+    border-color: transparent;
   }
 
   // checked

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
@@ -39,6 +39,10 @@ $-switch-focus-outline-color: sage-color(primary);
     margin-top: -(sage-spacing(card) / 2);
   }
 
+  .sage-switch--toggle-right {
+    flex-direction: row-reverse;
+  }
+
   .sage-list & {
     margin-top: 0;
     margin-bottom: sage-spacing(card) / 2;
@@ -93,6 +97,10 @@ $-switch-focus-outline-color: sage-color(primary);
     cursor: pointer;
 
     @extend %t-sage-body;
+
+    .sage-switch--toggle-right & {
+      margin-left: -($-switch-label-left-spacing);
+    }
   }
 
   &::before,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - Switch - added border variation with updated focus styles
- [x] - Switch - updated docs and props
- [x] - Switch - fixed issue regarding hardcoded `message`
- [x] - Radio - added border variation with updated focus styles
- [x] - Radio - updated docs and props

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

##### Switch
|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-02-19 at 9 38 24 AM](https://user-images.githubusercontent.com/1241836/108525986-400a2680-7296-11eb-9d6a-414ccc855d5b.png)|![Screen Shot 2021-02-19 at 9 38 16 AM](https://user-images.githubusercontent.com/1241836/108525997-44364400-7296-11eb-8faf-c4a8c9a02588.png)|

##### Radio
|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-02-19 at 9 39 26 AM](https://user-images.githubusercontent.com/1241836/108526178-70ea5b80-7296-11eb-8135-ac76a42d10ca.png)|![Screen Shot 2021-02-19 at 9 39 16 AM](https://user-images.githubusercontent.com/1241836/108526112-629c3f80-7296-11eb-98da-3c3ddeda7710.png)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
* Switch
1. Visit the Sage Rails Switch page: http://localhost:4000/pages/element/switch
2. Verify that the Bordered variation's focus state affects the parent wrapper and verify colors and docs
* Radio
1. Visit the Sage Rails Radio page: http://localhost:4000/pages/element/radio
2. Verify that the Bordered variation's focus state affects the parent wrapper and verify colors and docs

### QA Steps
(Low) - This adds new properties to the Rails Switch and Rails Radio. 
- [x] - /admin/sites/1/coupons/new
- [x] - /admin/sites/1/offers -> Export Modal
- [x] - /admin/sites/1/beta_features