### PR TITLE
fix(rails empty state): collapse Rails EmptyState title when no title provided, matches React

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
   <%= "<i class='sage-empty-state__icon sage-icon-#{component.icon}-3xl'></i>".html_safe if component.icon %>
-  <h1 class="sage-empty-state__title"><%= component.title %></h1>
-  <p class="sage-empty-state__text"><%= component.text %></p>
+  <%= "<h2 class='sage-empty-state__title'>#{component.title}</h2>".html_safe if component.title %>
+  <%= "<p class='sage-empty-state__text'>#{component.text}</p>".html_safe if component.text %>
   <%= component.content %>
 </section>


### PR DESCRIPTION
BUILD-619

## Description
Matches react implementation:
- Removes empty SageEmptyState title tag when no title defined
- Removes empty SageEmptyState text tag when no text defined
- Updates title tag to be an `h2` (matching React component)

### Screenshots

|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/108756086-119a7e80-7516-11eb-88d1-1c1903c7fb50.png)|![image](https://user-images.githubusercontent.com/565743/108756015-fb8cbe00-7515-11eb-9a9b-cc8ee5d70d3e.png)|


## Test notes
Ensure title & text are collapsing

## Related
BUILD-619