### PR TITLE
Dropdown escape hook

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -25,6 +25,7 @@ export const Dropdown = ({
   isLabelVisible,
   isPinned,
   label,
+  onEscapeHook,
   panelModifier,
   panelMaxWidth,
   panelSize,
@@ -104,6 +105,7 @@ export const Dropdown = ({
 
   const onClickScreen = () => {
     setActive(false);
+    onEscapeHook();
   };
 
   const classNames = classnames(
@@ -174,6 +176,7 @@ Dropdown.defaultProps = {
   icon: null,
   isLabelVisible: true,
   isPinned: false,
+  onEscapeHook: () => false,
   panelMaxWidth: null,
   panelModifier: 'default',
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
@@ -199,6 +202,7 @@ Dropdown.propTypes = {
   isLabelVisible: PropTypes.bool,
   isPinned: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  onEscapeHook: PropTypes.func,
   panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
   panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),

--- a/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
@@ -10,6 +10,7 @@ export const OptionsDropdown = ({
   className,
   exitPanelHandler,
   isPinned,
+  onEscapeHook,
   panelMaxWidth,
   panelSize,
   options,
@@ -22,6 +23,7 @@ export const OptionsDropdown = ({
     isLabelVisible={false}
     isPinned={isPinned}
     label="Options"
+    onEscapeHook={onEscapeHook}
     panelMaxWidth={panelMaxWidth}
     panelSize={panelSize}
     triggerModifier="options"
@@ -38,6 +40,7 @@ OptionsDropdown.defaultProps = {
   className: null,
   exitPanelHandler: (evt) => evt,
   isPinned: true,
+  onEscapeHook: () => false,
   panelMaxWidth: null,
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   options: null,
@@ -50,6 +53,7 @@ OptionsDropdown.propTypes = {
   className: PropTypes.string,
   exitPanelHandler: PropTypes.func,
   isPinned: PropTypes.bool,
+  onEscapeHook: PropTypes.func,
   panelMaxWidth: PropTypes.string,
   panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
   options: DropdownItemList.itemsPropTypes,

--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -27,6 +27,7 @@ export const SelectDropdown = ({
   localSelectedItems,
   onChangeHook,
   onDeselect,
+  onEscapeHook,
   onSearch,
   onSelect,
   panelSize,
@@ -194,6 +195,7 @@ export const SelectDropdown = ({
       disabled={disabled}
       exitPanelHandler={changeValue}
       label={emptySelectedValue}
+      onEscapeHook={onEscapeHook}
       panelModifier="select"
       panelSize={panelSize}
       triggerModifier="select"
@@ -250,6 +252,7 @@ SelectDropdown.defaultProps = {
   localSelectedItems: [],
   onChangeHook: null,
   onDeselect: null,
+  onEscapeHook: () => false,
   onSelect: (evt) => evt,
   onSearch: (evt) => evt,
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
@@ -291,6 +294,7 @@ SelectDropdown.propTypes = {
   localSelectedItems: PropTypes.arrayOf(PropTypes.shape({})),
   onChangeHook: PropTypes.func,
   onDeselect: PropTypes.func,
+  onEscapeHook: PropTypes.func,
   onSearch: PropTypes.func,
   onSelect: PropTypes.func,
   panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),


### PR DESCRIPTION
## Description

Adds a new hook for callbacks when exiting dropdown by clicking on the "screen" (and in future on escape keypress)

## Test notes

No changes to Rails dropdown; React only adds a new hook with default fallbacks; ensure existing uses continue as expected.

### Steps for testing
1. Adds new hook for exiting dropdown. Should not affect existing implementations of the Dropdown. Confirm in the following:
    - [ ] Contact table dropdowns (segments, filters, sorts)
    - [ ] Product outline editor dropdowns (publish state, new content, etc.)
