### PR TITLE
Adds gap for sage choice component group

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
@@ -5,6 +5,8 @@
 
 ================================================== */
 
+/* stylelint-disable max-nesting-depth */
+
 $item-radio: "before";
 $item-icon: "before";
 $item-arrow: "before";

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
@@ -96,8 +96,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     justify-content: center;
   }
 
-  // NOTE: Opportunity to refactors once Safari supports flexbox gap
-
+  // NOTE: This can be simplified once Safari supports flexbox gap
   @each $-key, $-value in $sage-spacings {
     @if ($-key == xs) {
       .sage-btn-group &:not(:last-child) {

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
@@ -93,6 +93,21 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   .sage-tabs--align-items-center & {
     justify-content: center;
   }
+
+  // NOTE: Opportunity to refactors once Safari supports flexbox gap
+
+  @each $-key, $-value in $sage-spacings {
+    @if ($-key == xs) {
+      .sage-btn-group &:not(:last-child) {
+        margin-right: sage-spacing($-key);
+      }
+    }
+    @else if ($-key == sm or $-key == md or $-key == lg) {
+      .sage-btn-group--gap-#{$-key} &:not(:last-child) {
+        margin-right: sage-spacing($-key);
+      }
+    }
+  }
 }
 
 .sage-choice--align-center {


### PR DESCRIPTION
### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

**Before**
![image](https://user-images.githubusercontent.com/21964614/108780689-a5bc1400-751d-11eb-8663-3af6ca0b8016.png)
**After**
![image](https://user-images.githubusercontent.com/21964614/108780748-b79db700-751d-11eb-990f-d5ad2dda0aee.png)

## Test notes
Testing this fix is solely visual, you should be ablle to wrap 2 or more sage choice components inside of a btn-group and there should be a visible gap when adding `--gap` modifiers.

### Steps for testing
1. Add two or more sage choice components inside of a `btn-group` wrapper component
2. Apply a `--gap` modifier to the `btn-group` with a value of `xs`, `sm`, `md` or `lg`
3. Preview the page and you should see a gap with the corresponding size. 
