### PR TITLE
Adjust upload card for links in error message

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_upload_card.scss
@@ -101,9 +101,11 @@ $-upload-card-background-hover: sage-color(grey, 100);
     color: inherit;
     text-decoration: underline;
 
+    &:focus,
     &:hover {
-      color: sage-color(red, 400);
+      color: sage-color(red, 500);
       text-decoration: underline;
+      outline: 0;
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_upload_card.scss
@@ -96,6 +96,16 @@ $-upload-card-background-hover: sage-color(grey, 100);
       margin-bottom: sage-spacing(2xs);
     }
   }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+
+    &:hover {
+      color: sage-color(red, 400);
+      text-decoration: underline;
+    }
+  }
 }
 
 .sage-upload-card__icon {

--- a/packages/sage-react/lib/UploadCard/UploadCard.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.jsx
@@ -32,8 +32,8 @@ export const UploadCard = ({
   );
 
   return (
-    <div className={classNames} {...rootProps} {...rest}>
-      <div className="sage-upload-card__dropzone">
+    <div className={classNames} {...rest}>
+      <div className="sage-upload-card__dropzone" {...rootProps}>
         <input className="sage-upload-card__input" {...inputProps} />
         {filesSelected ? (
           <>


### PR DESCRIPTION
## Description

This PR adds styling for links within error messages and moves the handles from `dropzone` in a layer so that clicks on links function as expected.

### Screenshots

No visual changes

## Test notes

See Storybook > Upload Card to see nothing has changed in appearance.

### Steps for testing
1. (Low) Adds handling of links in errors on UploadCard. No impact on current implementations but now allows improved styling and functionality when hyperlinks are included in error messages.
    - [ ] New import contacts main page upload should still function as expected and now allow for links to be added in error messages... and function as links!
