### PR TITLE
Makes pagination less subjective and adds parameter for collection name

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -1,10 +1,11 @@
 class SagePagination < SageComponent
   set_attribute_schema({
-    items: -> (v) { SageSchemaHelper.is_active_record?(v) },
+    items: -> (v) { SageSchemaHelper.will_paginate?(v) },
     window: [:optional, Integer],
     hide_pages: [:optional, TrueClass],
     hide_counter: [:optional, TrueClass],
-    additional_params: [:optional, Hash]
+    additional_params: [:optional, Hash],
+    collection_name: [:optional, String]
   })
 
   def initialize(attributes = {})
@@ -21,7 +22,11 @@ class SagePagination < SageComponent
   end
 
   def page_count(collection)
-    entry_name = (collection.entry_name || "Record").pluralize(collection.total_count)
+    unless collection_name.blank?
+      entry_name = collection_name
+    else
+      entry_name = (collection.entry_name || "Record").pluralize(collection.total_count)
+    end
 
     if collection.total_pages < 2
       "<strong>#{collection.total_count}</strong> #{entry_name}"

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -22,11 +22,9 @@ class SagePagination < SageComponent
   end
 
   def page_count(collection)
-    unless collection_name.blank?
-      entry_name = collection_name.titleize.pluralize(collection.total_count)
-    else
-      entry_name = (collection.entry_name || "Record").titleize.pluralize(collection.total_count)
-    end
+    
+    name = collection_name.presence || collection.entry_name || "Record"
+    entry_name = name.titleize.pluralize(collection.total_count)
 
     if collection.total_pages < 2
       "<strong>#{collection.total_count}</strong> #{entry_name}"

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -23,9 +23,9 @@ class SagePagination < SageComponent
 
   def page_count(collection)
     unless collection_name.blank?
-      entry_name = collection_name.pluralize(collection.total_count)
+      entry_name = collection_name.titleize.pluralize(collection.total_count)
     else
-      entry_name = (collection.entry_name || "Record").pluralize(collection.total_count)
+      entry_name = (collection.entry_name || "Record").titleize.pluralize(collection.total_count)
     end
 
     if collection.total_pages < 2

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -23,7 +23,7 @@ class SagePagination < SageComponent
 
   def page_count(collection)
     unless collection_name.blank?
-      entry_name = collection_name
+      entry_name = collection_name.pluralize(collection.total_count)
     else
       entry_name = (collection.entry_name || "Record").pluralize(collection.total_count)
     end

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -1,6 +1,6 @@
 class SagePagination < SageComponent
   set_attribute_schema({
-    items: -> (v) { SageSchemaHelper.will_paginate?(v) },
+    items: -> (v) { SageSchemaHelper.can_paginate?(v) },
     window: [:optional, Integer],
     hide_pages: [:optional, TrueClass],
     hide_counter: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
@@ -19,7 +19,7 @@ module SageSchemaHelper
     left: [:optional, Set.new([:xs, :sm, :md, :lg, :xl, "xs", "sm", "md", "lg", "xl"])],
   }
 
-  # Accepts ActiveRecord descendants
+  # Accepts any Collection that can be paginated
   def self.will_paginate?(value)
     value.respond_to?(:total_pages)
   end

--- a/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
@@ -20,7 +20,7 @@ module SageSchemaHelper
   }
 
   # Accepts ActiveRecord descendants
-  def self.is_active_record?(value)
-    value.superclass == ActiveRecord::Base
+  def self.will_paginate?(value)
+    value.respond_to?(:total_pages)
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
@@ -20,7 +20,7 @@ module SageSchemaHelper
   }
 
   # Accepts any Collection that can be paginated
-  def self.will_paginate?(value)
+  def self.can_paginate?(value)
     value.respond_to?(:total_pages)
   end
 end


### PR DESCRIPTION
## Description 

The pagination component works great under the correct conditions. However, in an effort to make it more generalized, I made the following two adjustments.

**1. It currently only accepts a collection that's a descendant of an `Active Record` class.**
This requirement makes it impossible to feed collections items that are non-descendant of Active Record classes. For example, We tried feeding the pagination a Website Pages collection list that is a descendant from `Themefile`. Even though the collection is enumerable, the check explicitly tries for Active Record descendants, and it, therefore, raised an error. 

**2. It creates a name based on the collection `entry_name` without the option for an override.**
The `entry_name` for our collection was "Template Theme File", this is less than ideal from a UX perspective. To get around this I added a new parameter to override the collection name. 

### Example use case:
```
<%= sage_component SagePagination, {
  items: presenter.website_pages,
  window: 1,
  hide_pages: hide_pages,
  collection_name: "Collection Name"
} %>
```
**Collection name is pluralized and titleized

### Screenshots
|  before  |  after  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/21964614/109066676-43d8e700-76a2-11eb-99af-5c60d222c1ed.png)|![image](https://user-images.githubusercontent.com/21964614/109066523-07a58680-76a2-11eb-8b54-0bfb3b365a7d.png)|


## Test notes

### Steps for testing
1. The first fix should allow pagination for work with any enumerable object in rails. 
2. Pass the component a `colection_name` attribute as a string. 
3. Preview the page to reveal the pagination elements.
4. The name should be pluralized and display the name as a string. 