### PR TITLE
Next version bump

### DIFF
--- a/docs/app/helpers/elements_helper.rb
+++ b/docs/app/helpers/elements_helper.rb
@@ -171,7 +171,7 @@ module ElementsHelper
         scss: "done",
         docs: "done",
         rails: "done",
-        react: "todo",
+        react: "no",
         a11y: "todo"
       },
       {

--- a/docs/app/helpers/objects_helper.rb
+++ b/docs/app/helpers/objects_helper.rb
@@ -180,8 +180,8 @@ module ObjectsHelper
         description: "Nav is a hierarchical, vertical navigation and can include nested menu items.",
         scss: "done",
         docs: "done",
-        rails: "doing",
-        react: "todo",
+        rails: "done",
+        react: "no",
         a11y: "todo"
       },
       {
@@ -242,8 +242,8 @@ module ObjectsHelper
         description: "The sidebar object is a fixed, vertical panel that typica11y displays navigation and/or page hierarchy.",
         scss: "done",
         docs: "done",
-        rails: "doing",
-        react: "todo",
+        rails: "done",
+        react: "no",
         a11y: "todo"
       },
       {

--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -1,227 +1,227 @@
-<%
-foundations_pages = [
-  {
-    name: "Experience Values",
-    path: pages_foundation_path(:ux_values),
-  },
-  {
-    name: "Design Principles",
-    path: pages_foundation_path(:design_principles),
-  },
-  {
-    name: "Accessibility",
-    path: pages_foundation_path(:accessibility),
-  }
-]
-%>
-<%
-content_pages = [
-  {
-    name: "Voice & Tone",
-    path: pages_content_path(:voice_tone),
-  },
-  {
-    name: "Grammar",
-    path: pages_content_path(:grammar),
-  },
-  {
-    name: "Branding",
-    path: pages_content_path(:branding),
-  },
-  {
-    name: "Product Content",
-    path: pages_content_path(:content),
-  },
-  {
-    name: "Vocabulary",
-    path: pages_content_path(:vocabulary),
-  },
-]
-%>
-<%
-experiences_pages = [
-  {
-    name: "Empty States",
-    path: pages_experiences_path(:null),
-  },
-  {
-    name: "Onboarding",
-    path: pages_experiences_path(:onboarding),
-  },
-  {
-    name: "Create & Destroy",
-    path: pages_experiences_path(:crud),
-  },
-  {
-    name: "Loading",
-    path: pages_experiences_path(:loading),
-  },
-  {
-    name: "Navigation",
-    path: pages_experiences_path(:nav),
-  },
-  {
-    name: "Feedback",
-    path: pages_experiences_path(:feedback),
-  },
-  {
-    name: "Help",
-    path: pages_experiences_path(:help),
-  },
-]
-%>
-<%
-design_pages = [
-  {
-    name: "Tokens",
-    path: pages_design_path(:token),
-  },
-  {
-    name: "Colors",
-    path: pages_design_path(:color),
-  },
-  {
-    name: "Typography",
-    path: pages_design_path(:typography),
-  },
-  {
-    name: "Icons",
-    path: pages_design_path(:icon),
-  },
-  {
-    name: "Motion",
-    path: pages_design_path(:motion),
-  }
-]
-%>
-<%
-layout_pages = [
-  {
-    name: "Containers",
-    path: pages_layout_path(:container),
-  },
-  {
-    name: "Panels and Cards",
-    path: pages_layout_path(:panels_cards),
-  },
-  {
-    name: "12 Col Grid",
-    path: pages_layout_path(:grid),
-  },
-  {
-    name: "Grid Templates",
-    path: pages_layout_path(:grid_templates),
-  }
-]
-%>
-<div class="sage-sidebar" data-js-sidebar="sage-sidebar-menu" id="sage-sidebar-menu">
-  <div class="sage-sidebar__body">
-    <nav class="sage-nav" aria-label="Main">
-      <ul class="sage-nav__list">
-        <li><%= link_to "Home", pages_index_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page?(pages_index_path)}" %>
-        <li>
-          <%= link_to "Foundations", pages_foundation_path(:ux_values), class: "sage-nav__link #{"sage-nav__link--active" if current_page_foundations?}" %>
-          <% if current_page_foundations? %>
-            <ul class="sage-nav__list sage-nav__list--sub">
-              <% foundations_pages.each do | page | %>
-                <li>
-                  <%= link_to page[:name], page[:path], class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page?(page[:path])}" %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to "Content", pages_content_path(:voice_tone), class: "sage-nav__link #{"sage-nav__link--active" if current_page_content?}" %>
-          <% if current_page_content? %>
-            <ul class="sage-nav__list sage-nav__list--sub">
-              <% content_pages.each do | page | %>
-                <li>
-                  <%= link_to page[:name], page[:path], class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page?(page[:path])}" %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to "Experiences", pages_experiences_path(:null), class: "sage-nav__link #{"sage-nav__link--active" if current_page_experiences?}" %>
-          <% if current_page_experiences? %>
-            <ul class="sage-nav__list sage-nav__list--sub">
-              <% experiences_pages.each do | page | %>
-                <li>
-                  <%= link_to page[:name], page[:path], class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page?(page[:path])}" %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to "Design", pages_design_path(:token), class: "sage-nav__link #{"sage-nav__link--active" if current_page_design?}" %>
-          <% if current_page_design? %>
-            <ul class="sage-nav__list sage-nav__list--sub">
-              <% design_pages.each do | page | %>
-                <li>
-                  <%= link_to page[:name], page[:path], class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page?(page[:path])}" %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to "Layout", pages_layout_path(:container), class: "sage-nav__link #{"sage-nav__link--active" if current_page_layout?}" %>
-          <% if current_page_layout? %>
-            <ul class="sage-nav__list sage-nav__list--sub">
-              <% layout_pages.each do | page | %>
-                <li>
-                  <%= link_to page[:name], page[:path], class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page?(page[:path])}" %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to "Components", pages_getting_started_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page_elements? || current_page_objects? || current_page?(pages_getting_started_path) }" %>
-          <% if current_page_elements? || current_page_objects? || current_page?(pages_getting_started_path) %>
-            <ul class="sage-nav__list sage-nav__list--sub">
-              <li>
-                <%= link_to "Getting Started", pages_getting_started_path, class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page?(pages_getting_started_path)}" %>
-              </li>
-              <li>
-                <%= link_to "Elements", pages_elements_path, class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page_elements?}" %>
-              </li>
-              <li>
-                <%= link_to "Objects", pages_objects_path, class: "sage-nav__link sage-nav__link--sub #{"sage-nav__link--active" if current_page_objects?}" %>
-              </li>
-            </ul>
-          <% end %>
-        </li>
-      </ul>
-    </nav>
-  </div>
-  <div class="sage-sidebar__footer">
-    <nav class="sage-nav" aria-label="Secondary">
-      <ul class="sage-nav__list">
-        <li><%= link_to "Sandbox", pages_sandbox_path, class: "sage-nav__link #{"sage-nav__link--active" if current_page?(pages_sandbox_path)}" %></li>
-        <li><%= link_to "Code Guidelines", "#{$SAGE_GITHUB_URL}", class: "sage-nav__link", target: "_blank", rel: "noopener noreferrer" %></li>
-        <li>
-          <%= link_to "Release Notes (#{$SAGE_VERSION_GEM})",
-            $SAGE_RELEASE_URL,
-            class: "sage-nav__link",
+<%= sage_component SageSidebar, { id: "sage-sidebar-menu" } do %>
+  <%= sage_component SageNav, {
+    items: [
+      {
+        text: "Home",
+        link: pages_index_path,
+        active: current_page?(pages_index_path),
+      },
+      {
+        text: "Foundations",
+        link: pages_foundation_path(:ux_values),
+        active: current_page_foundations?,
+        items: [
+          {
+            text: "Experience Values",
+            link: pages_foundation_path(:ux_values),
+            active: current_page?(pages_foundation_path(:ux_values)),
+          },
+          {
+            text: "Design Principles",
+            link: pages_foundation_path(:design_principles),
+            active: current_page?(pages_foundation_path(:design_principles)),
+          },
+          {
+            text: "Accessibility",
+            link: pages_foundation_path(:accessibility),
+            active: current_page?(pages_foundation_path(:accessibility)),
+          }
+        ]
+      },
+      {
+        text: "Content",
+        link: pages_content_path(:voice_tone),
+        active: current_page_content?,
+        items: [
+          {
+            text: "Voice & Tone",
+            link: pages_content_path(:voice_tone),
+            active: current_page?(pages_content_path(:voice_tone)),
+          },
+          {
+            text: "Grammar",
+            link: pages_content_path(:grammar),
+            active: current_page?(pages_content_path(:grammar)),
+          },
+          {
+            text: "Branding",
+            link: pages_content_path(:branding),
+            active: current_page?(pages_content_path(:branding)),
+          },
+          {
+            text: "Product Content",
+            link: pages_content_path(:content),
+            active: current_page?(pages_content_path(:content)),
+          },
+          {
+            text: "Vocabulary",
+            link: pages_content_path(:vocabulary),
+            active: current_page?(pages_content_path(:vocabulary)),
+          },
+        ]
+      },
+      {
+        text: "Experiences",
+        link: pages_experiences_path(:null),
+        active: current_page_experiences?,
+        items: [
+          {
+            text: "Empty States",
+            link: pages_experiences_path(:null),
+            active: current_page?(pages_experiences_path(:null)),
+          },
+          {
+            text: "Onboarding",
+            link: pages_experiences_path(:onboarding),
+            active: current_page?(pages_experiences_path(:onboarding)),
+          },
+          {
+            text: "Create & Destroy",
+            link: pages_experiences_path(:crud),
+            active: current_page?(pages_experiences_path(:crud)),
+          },
+          {
+            text: "Loading",
+            link: pages_experiences_path(:loading),
+            active: current_page?(pages_experiences_path(:loading)),
+          },
+          {
+            text: "Navigation",
+            link: pages_experiences_path(:nav),
+            active: current_page?(pages_experiences_path(:nav)),
+          },
+          {
+            text: "Feedback",
+            link: pages_experiences_path(:feedback),
+            active: current_page?(pages_experiences_path(:feedback)),
+          },
+          {
+            text: "Help",
+            link: pages_experiences_path(:help),
+            active: current_page?(pages_experiences_path(:help)),
+          },
+        ]
+      },
+      {
+        text: "Design",
+        link: pages_design_path(:token),
+        active: current_page_design?,
+        items: [
+          {
+            text: "Tokens",
+            link: pages_design_path(:token),
+            active: current_page?(pages_design_path(:token)),
+          },
+          {
+            text: "Colors",
+            link: pages_design_path(:color),
+            active: current_page?(pages_design_path(:color)),
+          },
+          {
+            text: "Typography",
+            link: pages_design_path(:typography),
+            active: current_page?(pages_design_path(:typography)),
+          },
+          {
+            text: "Icons",
+            link: pages_design_path(:icon),
+            active: current_page?(pages_design_path(:icon)),
+          },
+          {
+            text: "Motion",
+            link: pages_design_path(:motion),
+            active: current_page?(pages_design_path(:motion)),
+          }
+        ]
+      },
+      {
+        text: "Layout",
+        link: pages_layout_path(:container),
+        active: current_page_layout?,
+        items: [
+          {
+            text: "Containers",
+            link: pages_layout_path(:container),
+            active: current_page?(pages_layout_path(:container)),
+          },
+          {
+            text: "Panels and Cards",
+            link: pages_layout_path(:panels_cards),
+            active: current_page?(pages_layout_path(:panels_cards)),
+          },
+          {
+            text: "12 Col Grid",
+            link: pages_layout_path(:grid),
+            active: current_page?(pages_layout_path(:grid)),
+          },
+          {
+            text: "Grid Templates",
+            link: pages_layout_path(:grid_templates),
+            active: current_page?(pages_layout_path(:grid_templates)),
+          }
+        ]
+      },
+      {
+        text: "Components",
+        link: pages_getting_started_path,
+        active: current_page_elements? || current_page_objects? || current_page?(pages_getting_started_path),
+        items: [
+          {
+            text: "Getting Started",
+            link: pages_getting_started_path,
+            active: current_page?(pages_getting_started_path)
+          },
+          {
+            text: "Elements",
+            link: pages_elements_path,
+            active: current_page_elements?
+          },
+          {
+            text: "Objects",
+            link: pages_objects_path,
+            active: current_page_objects?,
+          }
+        ]
+      }
+    ]
+  } %>
+
+  <%= content_for :sage_sidebar_footer do %>
+    <%= sage_component SageNav, {
+      aria_label: "Secondary",
+      items: [
+        {
+          text: "Sandbox",
+          link: pages_sandbox_path,
+          active: current_page?(pages_sandbox_path),
+        },
+        {
+          text: "Code Guidelines",
+          link: "#{$SAGE_GITHUB_URL}",
+          attributes: {
+            target: "_blank",
+            rel: "noopener noreferrer"
+          }
+        },
+        {
+          text: "Release Notes (#{$SAGE_VERSION_GEM})",
+          link: $SAGE_RELEASE_URL,
+          attributes: {
             target: "_blank",
             rel: "noopener noreferrer",
             title: "Github release notes"
-          %>
-        </li>
-        <li>
-            <%= link_to "Changelog",
-              "#{$SAGE_GITHUB_URL}/releases",
-              class: "sage-nav__link",
-              target: "_blank",
-              rel: "noopener noreferrer",
-              title: "Github changelog"
-            %>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
+          }
+        },
+        {
+          text: "Changelog",
+          link: "#{$SAGE_GITHUB_URL}/releases",
+          attributes: {
+            target: "_blank",
+            rel: "noopener noreferrer",
+            title: "Github changelog"
+          }
+        }
+      ]
+    } %>
+  <% end %>
+<% end %>

--- a/docs/app/views/examples/elements/link/_preview.html.erb
+++ b/docs/app/views/examples/elements/link/_preview.html.erb
@@ -16,6 +16,17 @@
     help_link: false,
     show_label: true
   } %>
+  <%= sage_component SageLink, {
+    url: "#",
+    label: "Internal link with tooltip",
+    external: false,
+    help_link: false,
+    show_label: true,
+    attributes: {
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "right",
+    },
+  } %>
 <% end %>
 
 <h3 class="t-sage-heading-6">External links</h3>
@@ -36,6 +47,18 @@
     help_link: false,
     show_label: true
   } %>
+  <%= sage_component SageLink, {
+    url: "https://example.com",
+    label: "External link w/ tooltip",
+    external: true,
+    launch: false,
+    help_link: false,
+    show_label: true,
+    attributes: {
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "top"
+    },
+  } %>
 <% end %>
 
 <h3 class="t-sage-heading-6">Help/Info links</h3>
@@ -55,6 +78,18 @@
     launch: false,
     help_link: true,
     show_label: false
+  } %>
+  <%= sage_component SageLink, {
+    url: "#",
+    label: "Help link w/ tooltip",
+    external: false,
+    launch: false,
+    help_link: true,
+    show_label: true,
+    attributes: {
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "bottom"
+    },
   } %>
 <% end %>
 

--- a/docs/app/views/examples/elements/link/_props.html.erb
+++ b/docs/app/views/examples/elements/link/_props.html.erb
@@ -1,4 +1,10 @@
 <tr>
+  <td><%= md('`attributes`') %></td>
+  <td><%= md('For setting additional attributes not defined below. Accepts a Ruby hash of valid key-value properties, such as data-attributes') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`external`') %></td>
   <td><%= md('When set to `true`, `target="_blank"` will be added to the link.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/elements/nav_link/_preview.html.erb
+++ b/docs/app/views/examples/elements/nav_link/_preview.html.erb
@@ -1,25 +1,30 @@
-<%= sage_component SageNav, {} do %>
-  <%= sage_component SageNavLink, {
-    link: "#",
-    text: "Nav Link 1", 
-  } %>
-
-  <%= sage_component SageNavLink, {
-    icon: "launch",
-    link: "#",
-    text: "Nav Link 2 with icon", 
-  } %>
-
-  <div class="sage-nav__list sage-nav__list--sub">
-    <%= sage_component SageNavLink, {
+<h3>Standard Nav Link<h3>
+<%= sage_component SageNavLink, {
+  link: "#",
+  text: "Nav Link 1", 
+} %>
+<h3>Nav Link with Icon<h3>
+<%= sage_component SageNavLink, {
+  icon: "launch",
+  link: "#",
+  text: "Nav Link 2 with icon",
+} %>
+<h3>Nav Link with Child Nav Links<h3>
+<%= sage_component SageNavLink, {
+  link: "#",
+  text: "Nav Link 3",
+  items: [
+    {
       link: "#",
       text: "Nav Sub Link 1", 
-      type: "sub"
-    } %> 
-    <%= sage_component SageNavLink, {
+      type: "sub",
+      active: true,
+    },
+    {
       link: "#",
       text: "Nav Sub Link 2", 
       type: "sub"
-    } %> 
-  </div>
-<% end %>
+    }
+  ]
+} %>
+

--- a/docs/app/views/examples/elements/nav_link/_props.html.erb
+++ b/docs/app/views/examples/elements/nav_link/_props.html.erb
@@ -1,14 +1,26 @@
 <tr>
-  <td><%= md('`icon`') %></td>
-  <td><%= md('Allows for configurations for an and its placement to be provided.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md("`active`") %></td>
+  <td><%= md("Manually set an item to be styled as the selected item.") %></td>
+  <td><%= md("Boolean") %></td>
+  <td><%= md("false") %></td>
 </tr>
 <tr>
-  <td><%= md('`link`') %></td>
-  <td><%= md('This sets the `href` for the link.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md("`icon`") %></td>
+  <td><%= md("Allows for configurations for an and its placement to be provided.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("null") %></td>
+</tr>
+<tr>
+  <td><%= md("`items`") %></td>
+  <td><%= md("Provides a list of sub-items (nested list) to dispaly with this root NavLink.") %></td>
+  <td><%= md("`Array` of items with the same structure as `NavLinks`") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>
+<tr>
+  <td><%= md("`link`") %></td>
+  <td><%= md("This sets the `href` for the link.") %></td>
+  <td><%= md("String") %></td>
+  <td><%= md("null") %></td>
 </tr>
 <tr>
   <td><%= md('`method`') %></td>

--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -23,7 +23,7 @@
     value: "Disabled w/ Tooltip",
     icon: "users",
     attributes: {
-      "data-js-tooltip": "Why is this disabled. Explanation could go here.",
+      "data-js-tooltip": "Tooltip",
       "data-js-tooltip-position": "right"
       },
     modifiers: ["disabled"]
@@ -147,7 +147,7 @@
     value: "Disabled w/ tooltip",
     modifiers: ["disabled"],
     attributes: {
-      "data-js-tooltip": "Why is this disabled. Explanation could go here.",
+      "data-js-tooltip": "Tooltip",
       "data-js-tooltip-position": "left"
     },
   }],

--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -4,7 +4,18 @@
     value: "Edit",
     icon: "pen",
     attributes: { "href": "#" },
-  }, {
+  },
+  {
+    value: "Disabled link w/ tooltip",
+    icon: "pen",
+    modifiers: ["disabled"],
+    attributes: {
+      "href": "https://google.com",
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "right",
+    }
+  },
+  {
     value: "New",
     icon: "add",
     style: "primary",

--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -10,7 +10,7 @@
     icon: "pen",
     modifiers: ["disabled"],
     attributes: {
-      "href": "https://google.com",
+      "href": "https://kajabi.com",
       "data-js-tooltip": "Tooltip",
       "data-js-tooltip-position": "right",
     }

--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -19,7 +19,16 @@
     icon: "remove-circle",
     style: "danger",
     attributes: { "href": "#" },
-  }]
+  }, {
+    value: "Disabled w/ Tooltip",
+    icon: "users",
+    attributes: {
+      "data-js-tooltip": "Why is this disabled. Explanation could go here.",
+      "data-js-tooltip-position": "right"
+      },
+    modifiers: ["disabled"]
+  }
+  ]
 } do %>
   <%= sage_component SageButton, {
     style: "primary",
@@ -97,9 +106,9 @@
       value: "Delete Category",
       icon: "trash",
       style: "danger",
-      attributes: { 
+      attributes: {
         "href": "#",
-        "data-test": "test method" 
+        "data-test": "test method"
       },
     }]
   } do %>
@@ -133,6 +142,14 @@
   }, {
     value: "Disabled",
     modifiers: ["disabled"]
+  },
+  {
+    value: "Disabled w/ tooltip",
+    modifiers: ["disabled"],
+    attributes: {
+      "data-js-tooltip": "Why is this disabled. Explanation could go here.",
+      "data-js-tooltip-position": "left"
+    },
   }],
   contained: true
 } do %>

--- a/docs/app/views/examples/objects/nav/_preview.html.erb
+++ b/docs/app/views/examples/objects/nav/_preview.html.erb
@@ -1,44 +1,14 @@
 <%= sage_component SageNav, {
-  aria_label: "My Aria Label",
-} do %>
-  <%= sage_component SageNavLink, { 
-    link: "#",
-    text: "Nav Link 1", 
-  } %>
-  <%= sage_component SageNavLink, { 
-    link: "#",
-    text: "Nav Link 2", 
-  } %>
-  <%= sage_component SageNavLink, { 
-    link: "#",
-    text: "Nav Link 3", 
-  } %>
-  <div class="sage-nav__list sage-nav__list--sub">
-    <%= sage_component SageNavLink, { 
-      link: "#",
-      text: "Nav Sub Link 1", 
-      type: "sub"
-    }
-    %>
-    <%= sage_component SageNavLink, { 
-      link: "#",
-      text: "Nav Sub Link 2", 
-      type: "sub"
-    }
-    %>
-    <%= sage_component SageNavLink, { 
-      link: "#",  
-      text: "Nav Sub Link 3", 
-      type: "sub"
-    }
-    %>
-  </div>
-  <%= sage_component SageNavLink, { 
-    link: "#",
-    text: "Nav Link 4", 
-  } %>
-  <%= sage_component SageNavLink, { 
-    link: "#",
-    text: "Nav Link 5", 
-  } %>
-<% end %>
+  aria_label: "Example Navigation",
+  items: [
+    { link: "#", text: "Nav Link 1", active: true },
+    { link: "#", text: "Nav Link 2" },
+    { link: "#", text: "Nav Link 3", items: [
+      { link: "#", text: "Nav Sub Link 1", type: "sub" },
+      { link: "#", text: "Nav Sub Link 2", type: "sub" },
+      { link: "#", text: "Nav Sub Link 3", type: "sub" }
+    ]},
+    { link: "#", text: "Nav Link 4" },
+    { link: "#", text: "Nav Link 5" }
+  ]
+} %>

--- a/docs/app/views/examples/objects/nav/_props.html.erb
+++ b/docs/app/views/examples/objects/nav/_props.html.erb
@@ -4,3 +4,9 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td><%= md("`items`") %></td>
+  <td><%= md("Provides a list of items to automate displaying inside this `Nav`.") %></td>
+  <td><%= md("`Array` of items with the same structure as `NavLinks`") %></td>
+  <td><%= md("`nil`") %></td>
+</tr>

--- a/docs/app/views/examples/objects/sidebar/_preview.html.erb
+++ b/docs/app/views/examples/objects/sidebar/_preview.html.erb
@@ -1,53 +1,29 @@
-<%= sage_component SageSidebar, {
-  id: "sage-sidebar-menu",
-} do %>
-  <%= sage_component SageNav, {} do %>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Nav Link 1",
-    } %>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Nav Link 2",
-    } %>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Nav Link 3",
-    } %>
-    <div class="sage-nav__list sage-nav__list--sub">
-      <%= sage_component SageNavLink, {
-        link: "#",
-        text: "Nav Sub Link 1",
-        type: "sub"
-      } %>
-      <%= sage_component SageNavLink, {
-        link: "#",
-        text: "Nav Sub Link 2",
-        type: "sub"
-      } %>
-      <%= sage_component SageNavLink, {
-        link: "#",
-        text: "Nav Sub Link 3",
-        type: "sub"
-      } %>
-    </div>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Nav Link 4",
-    } %>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Nav Link 5",
-    } %>
-  <% end %>
-  <% content_for :sidebar_footer do %>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Footer Link 1",
-    } %>
-    <%= sage_component SageNavLink, {
-      link: "#",
-      text: "Footer Link 2",
-    } %>
-  <% end %>
+<%= sage_component SageSidebar, { id: "sample-sidebar" } do %>
+  <%= sage_component SageNav, {
+    aria_label: "Example Navigation",
+    items: [
+      { link: "#", text: "Website", icon: 'monitor', items: [
+        {
+          text: "Design",
+          link: "#",
+          active: true,
+        },
+        {
+          text: "Pages",
+          link: "#",
+        },
+        {
+          text: "Blog",
+          link: "#",
+        },
+        {
+          text: "Analytics",
+          link: "#",
+        }
+      ] },
+      { link: "#", text: "Products", icon: 'product' },
+      { link: "#", text: "Marketing", icon: 'megaphone' },
+      { link: "#", text: "People", icon: 'user-circle' }
+    ]
+  } %>
 <% end %>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -5,3 +5,19 @@
 Use this scratchpad to test out elements and objects in context. Just be sure not to commit your changes. ❤️
 ") %>
 <% end %>
+
+<% empty_state_text = "<span>The maximum file size for audio uploads is \
+  <strong>9</strong></span>\
+  <br/>#{sage_component(SageButton, {
+    style: 'primary',
+    subtle: true,
+    small: true,
+    value: 'Supported Audio Formats'})
+  } \
+".html_safe %>
+
+<%= sage_component SageEmptyState, {
+    icon: "trash",
+    text: empty_state_text,
+    compact: true,
+  }%>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -5,19 +5,3 @@
 Use this scratchpad to test out elements and objects in context. Just be sure not to commit your changes. ❤️
 ") %>
 <% end %>
-
-<% empty_state_text = "<span>The maximum file size for audio uploads is \
-  <strong>9</strong></span>\
-  <br/>#{sage_component(SageButton, {
-    style: 'primary',
-    subtle: true,
-    small: true,
-    value: 'Supported Audio Formats'})
-  } \
-".html_safe %>
-
-<%= sage_component SageEmptyState, {
-    icon: "trash",
-    text: empty_state_text,
-    compact: true,
-  }%>

--- a/docs/lib/sage_rails/app/sage_components/sage_link.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_link.rb
@@ -1,5 +1,6 @@
 class SageLink < SageComponent
   set_attribute_schema({
+    attributes: [:optional, NilClass, Hash],
     external: [:optional, TrueClass],
     help_link: [:optional, TrueClass],
     label: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_nav.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_nav.rb
@@ -1,5 +1,25 @@
 class SageNav < SageComponent
   set_attribute_schema({
     aria_label: [:optional, String],
+    items: [:optional, [[
+      active: [:optional, NilClass, TrueClass],
+      attributes: [:optional, Hash],
+      icon: [:optional, String],
+      items: [:optional, [[
+        active: [:optional, NilClass, TrueClass],
+        attributes: [:optional, Hash],
+        icon: [:optional, String],
+        link: [:optional, String],
+        method: [:optional, Symbol],
+        no_active: [:optional, TrueClass],
+        text: [:optional, String],
+        type: [:optional, String],
+      ]]],
+      link: [:optional, String],
+      method: [:optional, Symbol],
+      no_active: [:optional, TrueClass],
+      text: [:optional, String],
+      type: [:optional, String],
+    ]]]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_nav_link.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_nav_link.rb
@@ -1,6 +1,18 @@
 class SageNavLink < SageComponent
   set_attribute_schema({
+    active: [:optional, NilClass, TrueClass],
+    attributes: [:optional, Hash],
     icon: [:optional, String],
+    items: [:optional, [[
+      active: [:optional, NilClass, TrueClass],
+      attributes: [:optional, Hash],
+      icon: [:optional, String],
+      link: [:optional, String],
+      method: [:optional, Symbol],
+      no_active: [:optional, TrueClass],
+      text: [:optional, String],
+      type: [:optional, String],
+    ]]],
     link: [:optional, String],
     method: [:optional, Symbol],
     no_active: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -1,10 +1,11 @@
 class SagePagination < SageComponent
   set_attribute_schema({
-    items: -> (v) { SageSchemaHelper.is_active_record?(v) },
+    items: -> (v) { SageSchemaHelper.can_paginate?(v) },
     window: [:optional, Integer],
     hide_pages: [:optional, TrueClass],
     hide_counter: [:optional, TrueClass],
-    additional_params: [:optional, Hash]
+    additional_params: [:optional, Hash],
+    collection_name: [:optional, String]
   })
 
   def initialize(attributes = {})
@@ -21,7 +22,9 @@ class SagePagination < SageComponent
   end
 
   def page_count(collection)
-    entry_name = (collection.entry_name || "Record").pluralize(collection.total_count)
+    
+    name = collection_name.presence || collection.entry_name || "Record"
+    entry_name = name.titleize.pluralize(collection.total_count)
 
     if collection.total_pages < 2
       "<strong>#{collection.total_count}</strong> #{entry_name}"

--- a/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schema_helper.rb
@@ -19,8 +19,8 @@ module SageSchemaHelper
     left: [:optional, Set.new([:xs, :sm, :md, :lg, :xl, "xs", "sm", "md", "lg", "xl"])],
   }
 
-  # Accepts ActiveRecord descendants
-  def self.is_active_record?(value)
-    value.superclass == ActiveRecord::Base
+  # Accepts any Collection that can be paginated
+  def self.can_paginate?(value)
+    value.respond_to?(:total_pages)
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_sidebar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sidebar.rb
@@ -1,6 +1,6 @@
 class SageSidebar < SageComponent
   set_attribute_schema({
-    id: [:optional, String],
+    id: String,
     size: [:optional, Set.new(["md", "lg"])],
   })
   def sections

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -1,15 +1,17 @@
 <% if component.help_link && component.show_label %>
-  <a href="<%= component.url %>" class="sage-link--help"><%= component.label %></a>
+  <a href="<%= component.url %>" class="sage-link--help" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
 <% elsif component.help_link && !component.show_label %>
-  <a href="<%= component.url %>" class="sage-link--help-icon-only">
+  <a href="<%= component.url %>" class="sage-link--help-icon-only" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %>
+  <% end if component.attributes&.is_a?(Hash) %>>
     <span class="visually-hidden"><%= component.label %></span>
   </a>
 <% elsif !component.external && !component.launch %>
-  <a href="<%= component.url %>"><%= component.label %></a>
+  <a href="<%= component.url %>" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>
+  ><%= component.label %></a>
 <% elsif !component.external && component.launch %>
-  <a href="<%= component.url %>" class="sage-link--launch"><%= component.label %></a>
+  <a href="<%= component.url %>" class="sage-link--launch" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
 <% elsif component.external && component.launch %>
-  <a href="<%= component.url %>" target="_blank" rel="noopener noreferrer"><%= component.label %></a>
+  <a href="<%= component.url %>" target="_blank" rel="noopener noreferrer" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
 <% elsif component.external && !component.launch %>
-  <a href="<%= component.url %>" target="_blank" class="sage-link--no-launch" rel="noopener noreferrer"><%= component.label %></a>
+  <a href="<%= component.url %>" target="_blank" class="sage-link--no-launch" rel="noopener noreferrer" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_nav.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_nav.html.erb
@@ -1,3 +1,17 @@
-<div class="sage-nav" <% if component.aria_label.present? %> aria-label="<%= component.aria_label %>"<% end %>>
+<nav
+  class="sage-nav"
+  <% if component.aria_label.present? %>
+    aria-label="<%= component.aria_label %>"
+  <% end %>
+>
+  <% if component.items.present? and component.items.length() > 0 %>
+    <ul class="sage-nav__list">
+      <% component.items.each do | item | %>
+        <li>
+          <%= sage_component(SageNavLink, item) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
   <%= component.content %>
-</div>
+</nav>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_nav_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_nav_link.html.erb
@@ -1,9 +1,39 @@
-<% active_class = (component.no_active.blank? && current_page?(component.link)) ? "sage-nav__link--active" : "" %>
-<% component_class = component.type ? "sage-nav__link--#{component.type}" : "" %>
-<%= link_to component.link, method: component.method, class: "sage-nav__link #{active_class} #{component_class}" do %>
+<%
+
+# Search items to see if any items are active or not.
+subitems_active = false
+component.items.each do | item |
+  if (item[:active] == true) or current_page?(item[:link]) 
+    subitems_active = true
+  end
+end if component.items.present?
+
+# Determing whether root element is active or not.
+active_class = (subitems_active or component.active or (component.no_active.blank? && current_page?(component.link))) ? "sage-nav__link--active" : ""
+
+# Determine nav type class
+component_class = component.type ? "sage-nav__link--#{component.type}" : ""
+
+# Ensure attributes are a Hash
+attributes = component.attributes.present? ? component.attributes : {}
+
+%>
+<%= link_to component.link, method: component.method, class: "sage-nav__link #{active_class} #{component_class}", **attributes do %>
   <% if component.icon %>
-    <i class="sage-icon-<%= component.icon %> sage-nav__icon"></i>
+    <i class="sage-icon-<%= component.icon %>-lg sage-nav__icon"></i>
   <% end %>
-  <%= component.text %>
+  <span class="sage-nav__label">
+    <%= component.text %>
+  </span>
+<% end %>
+<% if subitems_active %>
+  <ul class="sage-nav__list <%= component.icon ? "sage-nav__list--sub-with-icon" : "sage-nav__list--sub" %>">
+    <% component.items.each do | item | %>
+    <% item[:type] = item[:type].present? ? item[:type] : "sub" %>
+      <li>
+        <%= sage_component(SageNavLink, item) %>
+      </li>
+    <% end %>
+  </ul>
 <% end %>
 <%= component.content %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
@@ -8,9 +8,9 @@ end
   <div class="sage-sidebar__body">
     <%= component.content %>
   </div>
-  <% if content_for? :sidebar_footer %>
+  <% if content_for? :sage_sidebar_footer %>
     <div class="sage-sidebar__footer">
-      <%= content_for :sidebar_footer %>
+      <%= yield :sage_sidebar_footer %>
     </div>
   <% end %>
 </div>

--- a/packages/sage-assets/lib/stylesheets/core/_icons.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_icons.scss
@@ -30,6 +30,9 @@ $-icon-font-path: "../fonts/sage";
     }
 
     .sage-icon-#{$icon-name}#{$suffix} {
+      width: $size;
+      height: $size;
+
       &::before {
         @include sage-icon-base($icon-name, $size-name);
       }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
@@ -5,6 +5,8 @@
 
 ================================================== */
 
+/* stylelint-disable max-nesting-depth */
+
 $item-radio: "before";
 $item-icon: "before";
 $item-arrow: "before";
@@ -92,6 +94,20 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
 
   .sage-tabs--align-items-center & {
     justify-content: center;
+  }
+
+  // NOTE: This can be simplified once Safari supports flexbox gap
+  @each $-key, $-value in $sage-spacings {
+    @if ($-key == xs) {
+      .sage-btn-group &:not(:last-child) {
+        margin-right: sage-spacing($-key);
+      }
+    }
+    @else if ($-key == sm or $-key == md or $-key == lg) {
+      .sage-btn-group--gap-#{$-key} &:not(:last-child) {
+        margin-right: sage-spacing($-key);
+      }
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
@@ -40,6 +40,7 @@ $-select-padding-label: map-get($sage-field-configs, padding-label);
 
 .sage-select__label {
   @extend %t-sage-body;
+  z-index: sage-z-index(default, 1);
   position: absolute;
   transform: translateY(-50%);
   padding: 0 $-select-padding-label;
@@ -79,6 +80,8 @@ $-select-padding-label: map-get($sage-field-configs, padding-label);
 }
 
 .sage-select__field {
+  z-index: sage-z-index(default, 1);
+  position: relative;
   height: $-select-height;
   width: 100%;
   padding: $-select-filled-top-padding $-select-padding-x 0;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -193,8 +193,7 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
     cursor: not-allowed;
   }
 
-  &[data-js-tooltip],
-  &:disabled {
+  &[data-js-tooltip] {
     pointer-events: visible;
   }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -189,6 +189,7 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   .sage-dropdown__item--disabled &,
   &:disabled {
     color: sage-color(grey, 400);
+    pointer-events: none;
     cursor: not-allowed;
   }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -194,7 +194,7 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   &[data-js-tooltip] {
-    pointer-events: visible;
+    pointer-events: auto;
   }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -59,7 +59,7 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
       margin-right: sage-spacing(panel);
     }
   }
-  
+
   .sage-panel-controls__bulk-actions > &,
   .sage-panel-controls__toolbar-btn-group > & {
     border-radius: 0;
@@ -189,8 +189,12 @@ $-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   .sage-dropdown__item--disabled &,
   &:disabled {
     color: sage-color(grey, 400);
-    pointer-events: none;
     cursor: not-allowed;
+  }
+
+  &[data-js-tooltip],
+  &:disabled {
+    pointer-events: visible;
   }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_nav.scss
@@ -5,60 +5,65 @@
 ================================================== */
 $-sage-nav-color-text: sage-color(charcoal, 400);
 $-sage-nav-color-focus: sage-color(primary);
-$-sage-nav-color-background: sage-color(primary, 400);
+$-sage-nav-color-background: sage-color(grey, 200);
+$-sage-nav-color-background-hover: sage-color(grey, 100);
 $-sage-nav-icon-size: rem(20px);
 
-.sage-nav__list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
+
+.sage-nav__icon {
+  margin-right: rem(12px);
+  color: sage-color(charcoal, 200);
+
+  .sage-nav__link--active & {
+    color: sage-color(primary);
+  }
 }
 
-.sage-nav__list--sub {
-  margin-left: rem(36px);
+.sage-nav__label {
+  @extend %t-sage-nav;
 
-  .sage-nav__link--active {
+  color: sage-color(charcoal, 200);
+
+  .sage-nav__list--sub & {
+    @extend %t-sage-nav-sub;
+  }
+
+  .sage-nav__link--active & {
+    color: sage-color(charcoal, 500);
+  }
+
+  .sage-nav__link--sub.sage-nav__link--active & {
     color: sage-color(primary);
-    background: rgba($-sage-nav-color-background, 0.06);
   }
 }
 
 .sage-nav__link {
   display: flex;
   align-items: center;
-  height: rem(32px);
-  margin-bottom: sage-spacer(2xs);
-  padding: sage-spacing(2xs) sage-spacing(xs);
+  padding: rem(10px) rem(12px);
   color: $-sage-nav-color-text;
   border-radius: sage-border(radius);
   transition: map-get($sage-transitions, default);
   transition-property: background, box-shadow;
 
-  &:not(.sage-nav__link--sub) {
-    @extend %t-sage-body-med;
-  }
-
+  &:active,
   &:hover,
   &:focus {
-    background: rgba($-sage-nav-color-background, 0.03);
+    background-color: $-sage-nav-color-background-hover;
   }
 
   &:focus {
     box-shadow: inset 0 0 0 1px $-sage-nav-color-focus;
     outline: none;
   }
-
-  &:active {
-    background: rgba($-sage-nav-color-background, 0.12);
-  }
 }
 
 .sage-nav__link--sub {
-  @extend %t-sage-body-small-med;
-}
+  padding: sage-spacing(2xs) sage-spacing(xs);
 
-.sage-nav__link--active .sage-nav__icon {
-  color: sage-color(primary);
+  &.sage-nav__link--active {
+    background: $-sage-nav-color-background;
+  }
 }
 
 .sage-nav__link-decorator {
@@ -73,10 +78,23 @@ $-sage-nav-icon-size: rem(20px);
   }
 }
 
-.sage-nav__icon {
-  margin-right: sage-spacing(xs);
+.sage-nav__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 
-  &::before {
-    @include sage-icon-base(null, xl);
+.sage-nav__list--sub-with-icon,
+.sage-nav__list--sub {
+  > li:not(:last-child) {
+    margin-bottom: sage-spacing(2xs);
   }
+}
+
+.sage-nav__list--sub {
+  margin-left: rem(12px);
+}
+
+.sage-nav__list--sub-with-icon {
+  margin-left: rem(44px);
 }

--- a/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
@@ -64,6 +64,18 @@ $sage-type-specs: (
     leading: sage-line-height(xs),
     kerning: sage-letter-spacing(sm)
   ),
+  "nav": (
+    weight: sage-font-weight(medium),
+    size: sage-font-size(lg),
+    leading: sage-line-height(xs),
+    kerning: sage-letter-spacing(sm)
+  ),
+  "nav-sub": (
+    weight: sage-font-weight(meidum),
+    size: sage-font-size(),
+    leading: sage-line-height(sm),
+    kerning: sage-letter-spacing(sm)
+  ),
 
   // Body
   "body": $-t-base-spec,

--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -84,6 +84,15 @@ export const DropdownItem = ({
 
   const fieldId = `${groupId}-checkbox-${id}`;
 
+  const renderOptions = () => (
+    <OptionsDropdown
+      className="sage-dropdown__item-options"
+      id={`${groupId}-${id}-options`}
+      exitPanelHandler={onExitSubmenu}
+      options={options}
+    />
+  );
+
   const renderItem = () => {
     if (isHeading) {
       return <>{label}</>;
@@ -158,12 +167,7 @@ export const DropdownItem = ({
           <li className={classNames} role="none">
             {renderItem()}
             {options && (
-              <OptionsDropdown
-                className="sage-dropdown__item-options"
-                id={`${groupId}-${id}-options`}
-                exitPanelHandler={onExitSubmenu}
-                options={options}
-              />
+              renderOptions()
             )}
           </li>
         </Tooltip>
@@ -171,12 +175,7 @@ export const DropdownItem = ({
         <li className={classNames} role="none">
           {renderItem()}
           {options && (
-            <OptionsDropdown
-              className="sage-dropdown__item-options"
-              id={`${groupId}-${id}-options`}
-              exitPanelHandler={onExitSubmenu}
-              options={options}
-            />
+            renderOptions()
           )}
         </li>
       )}
@@ -235,7 +234,10 @@ DropdownItem.propTypes = {
     PropTypes.func,
   ]),
   to: PropTypes.string,
-  tooltip: PropTypes.arrayOf(PropTypes.shape({
+  tooltip: PropTypes.shape({
+    position: PropTypes.oneOf(Object.values(Tooltip.POSITIONS)),
+    size: PropTypes.oneOf(Object.values(Tooltip.SIZES)),
+    theme: PropTypes.oneOf(Object.values(Tooltip.THEMES)),
+  }),
 
-  }))
 };

--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Checkbox } from '../Toggle';
 import { Link } from '../Link';
+import { Tooltip } from '../Tooltip';
 import { SageTokens } from '../configs';
 import { OptionsDropdown } from './OptionsDropdown';
 import { DROPDOWN_ITEM_COLORS } from './configs';
@@ -27,6 +28,7 @@ export const DropdownItem = ({
   options,
   payload,
   to,
+  tooltip,
   ...rest
 }) => {
   const classNames = classnames(
@@ -150,17 +152,35 @@ export const DropdownItem = ({
   };
 
   return (
-    <li className={classNames} role="none">
-      {renderItem()}
-      {options && (
-        <OptionsDropdown
-          className="sage-dropdown__item-options"
-          id={`${groupId}-${id}-options`}
-          exitPanelHandler={onExitSubmenu}
-          options={options}
-        />
+    <>
+      {tooltip ? (
+        <Tooltip {...tooltip}>
+          <li className={classNames} role="none">
+            {renderItem()}
+            {options && (
+              <OptionsDropdown
+                className="sage-dropdown__item-options"
+                id={`${groupId}-${id}-options`}
+                exitPanelHandler={onExitSubmenu}
+                options={options}
+              />
+            )}
+          </li>
+        </Tooltip>
+      ) : (
+        <li className={classNames} role="none">
+          {renderItem()}
+          {options && (
+            <OptionsDropdown
+              className="sage-dropdown__item-options"
+              id={`${groupId}-${id}-options`}
+              exitPanelHandler={onExitSubmenu}
+              options={options}
+            />
+          )}
+        </li>
       )}
-    </li>
+    </>
   );
 };
 
@@ -184,6 +204,7 @@ DropdownItem.defaultProps = {
   options: null,
   payload: null,
   to: null,
+  tooltip: null,
 };
 
 DropdownItem.propTypes = {
@@ -214,4 +235,7 @@ DropdownItem.propTypes = {
     PropTypes.func,
   ]),
   to: PropTypes.string,
+  tooltip: PropTypes.arrayOf(({
+
+  }))
 };

--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -235,7 +235,7 @@ DropdownItem.propTypes = {
     PropTypes.func,
   ]),
   to: PropTypes.string,
-  tooltip: PropTypes.arrayOf(({
+  tooltip: PropTypes.arrayOf(PropTypes.shape({
 
   }))
 };

--- a/packages/sage-react/lib/Dropdown/stories/story-helper.jsx
+++ b/packages/sage-react/lib/Dropdown/stories/story-helper.jsx
@@ -64,12 +64,10 @@ export const sampleMenuItems = [
   },
   {
     id: 5,
-    isActive: true,
-    color: 'muted',
     label: 'Disabled w/ tooltip',
     tooltip: {
       content: 'Tooltip',
-      position: 'right'
+      position: 'left'
     },
     disabled: true
   },

--- a/packages/sage-react/lib/Dropdown/stories/story-helper.jsx
+++ b/packages/sage-react/lib/Dropdown/stories/story-helper.jsx
@@ -63,7 +63,18 @@ export const sampleMenuItems = [
     label: 'View none',
   },
   {
-    id: 4,
+    id: 5,
+    isActive: true,
+    color: 'muted',
+    label: 'Disabled w/ tooltip',
+    tooltip: {
+      content: 'Tooltip',
+      position: 'right'
+    },
+    disabled: true
+  },
+  {
+    id: 6,
     label: 'Option 1',
     icon: SageTokens.ICONS.USERS,
     payload: {
@@ -74,7 +85,7 @@ export const sampleMenuItems = [
     options: sampleOptions,
   },
   {
-    id: 5,
+    id: 7,
     label: 'Option 2',
     icon: SageTokens.ICONS.MEGAPHONE,
     payload: {
@@ -84,7 +95,7 @@ export const sampleMenuItems = [
     options: sampleOptions,
   },
   {
-    id: 6,
+    id: 8,
     label: 'Option 3',
     icon: SageTokens.ICONS.CUSTOMIZE,
     payload: {
@@ -98,7 +109,7 @@ export const sampleMenuItems = [
     options: sampleOptions,
   },
   {
-    id: 7,
+    id: 9,
     color: 'primary',
     label: 'Add something',
     icon: SageTokens.ICONS.ADD,

--- a/packages/sage-react/lib/EmptyState/EmptyState.jsx
+++ b/packages/sage-react/lib/EmptyState/EmptyState.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { SageTokens } from '../configs';
 import { Icon } from '../Icon';
 
 export const EmptyState = ({
@@ -58,7 +59,7 @@ EmptyState.propTypes = {
   children: PropTypes.node,
   compact: PropTypes.bool,
   graphic: PropTypes.node,
-  icon: PropTypes.string,
+  icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };

--- a/packages/sage-react/lib/EmptyState/EmptyState.story.jsx
+++ b/packages/sage-react/lib/EmptyState/EmptyState.story.jsx
@@ -1,24 +1,30 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
+import { selectArgs } from '../story-support/helpers';
 import { Button } from '../Button';
-import { Grid } from '../Grid';
 import { SageTokens } from '../configs';
 import { EmptyState } from './EmptyState';
 
-storiesOf('Sage/EmptyState', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <Grid container={Grid.CONTAINER_SIZES.XS}>
-      <EmptyState
-        title={text('Title', 'Title Here')}
-        text={text('Text', 'Text Here')}
-        icon={select('Icon', { ...SageTokens.ICONS, NONE: null }, SageTokens.ICONS.GEAR)}
-        compact={boolean('Compact', false)}
-      >
+export default {
+  title: 'Sage/EmptyState',
+  component: EmptyState,
+  argTypes: {
+    ...selectArgs({
+      icon: SageTokens.ICONS
+    })
+  },
+  args: {
+    children: (
+      <>
         <Button>Lorem ipsum</Button>
-      </EmptyState>
-    </Grid>
-  ));
+      </>
+    ),
+    compact: false,
+    icon: SageTokens.ICONS.GEAR,
+    text: 'Text Here',
+    title: 'Title Here'
+  }
+};
+
+const Template = (args) => <EmptyState {...args} />;
+
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx
@@ -1,39 +1,43 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import { Checkbox } from '../Toggle';
 import { ExpandableCard } from './ExpandableCard';
 
-storiesOf('Sage/ExpandableCard', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => (
-    <ExpandableCard
-      triggerLabel={text('Trigger Label', 'Expand')}
-      bodyBordered={boolean('Body Border', false)}
-    >
-      <Checkbox
-        checked={false}
-        disabled={false}
-        hasError={false}
-        id="checkbox1-demo"
-        label="Grant offers"
-        name="checkbox1-demo"
-      />
-      <Checkbox
-        checked={false}
-        disabled={false}
-        hasError={false}
-        id="checkbox2-demo"
-        label="Add tags"
-        name="checkbox2-demo"
-      />
-      <Checkbox
-        checked={false}
-        disabled={false}
-        hasError={false}
-        id="checkbox3-demo"
-        label="Subscribe to emails"
-        name="checkbox3-demo"
-      />
-    </ExpandableCard>
-  ));
+export default {
+  title: 'Sage/ExpandableCard',
+  component: ExpandableCard,
+  args: {
+    bodyBordered: false,
+    children: (
+      <>
+        <Checkbox
+          checked={false}
+          disabled={false}
+          hasError={false}
+          id="checkbox1-demo"
+          label="Grant offers"
+          name="checkbox1-demo"
+        />
+        <Checkbox
+          checked={false}
+          disabled={false}
+          hasError={false}
+          id="checkbox2-demo"
+          label="Add tags"
+          name="checkbox2-demo"
+        />
+        <Checkbox
+          checked={false}
+          disabled={false}
+          hasError={false}
+          id="checkbox3-demo"
+          label="Subscribe to emails"
+          name="checkbox3-demo"
+        />
+      </>
+    ),
+    triggerLabel: 'Expand'
+  }
+};
+const Template = (args) => <ExpandableCard {...args} />;
+
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/FormSection/FormSection.story.jsx
+++ b/packages/sage-react/lib/FormSection/FormSection.story.jsx
@@ -1,25 +1,26 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { FormSection } from './FormSection';
 
-storiesOf('Sage/Form Section', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <div style={{ width: '75%' }}>
-      <FormSection
-        title={text('Title', 'Sign in')}
-        subtitle={text('Subtitle', 'Log in to access our applicaiton and all its great features!')}
-      >
+export default {
+  title: 'Sage/FormSection',
+  component: FormSection,
+  decorators: [(Story) => <div style={{ width: '75%' }}><Story /></div>],
+  args: {
+    children: (
+      <>
         <Input id="fs-email" label="Email/username" />
         <Input id="fs-password" label="Password" type="password" />
         <Button color="primary">
           Log in
         </Button>
-      </FormSection>
-    </div>
-  ));
+      </>
+    ),
+    subtitle: 'Log in to access our application and all its great features!',
+    title: 'Sign in'
+  }
+};
+const Template = (args) => <FormSection {...args} />;
+
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/HelpLink/HelpLink.story.jsx
+++ b/packages/sage-react/lib/HelpLink/HelpLink.story.jsx
@@ -1,14 +1,24 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
 import { HelpLink } from './HelpLink';
 
-storiesOf('Sage/HelpLink', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <HelpLink href="http://example.com" target="_blank" referrer="no-referrer" labelIsVisible={boolean('Show label', false)}>
-      {text('Text', 'Learn something!')}
-    </HelpLink>
-  ));
+export default {
+  title: 'Sage/HelpLink',
+  component: HelpLink,
+};
+const Template = (args) => <HelpLink target="_blank" referrer="no-referrer" {...args} />;
+
+// Each story then reuses that template
+export const Default = Template.bind({});
+Default.args = {
+  labelIsVisible: false,
+  text: 'Learn something'
+};
+
+// storiesOf('Sage/HelpLink', module)
+//   .addDecorator(withKnobs)
+//   .addDecorator(centerXY)
+//   .add('Default', () => (
+//     <HelpLink href="http://example.com" target="_blank" referrer="no-referrer" labelIsVisible={boolean('Show label', false)}>
+//       {text('Text', 'Learn something!')}
+//     </HelpLink>
+//   ));

--- a/packages/sage-react/lib/HelpLink/HelpLink.story.jsx
+++ b/packages/sage-react/lib/HelpLink/HelpLink.story.jsx
@@ -4,21 +4,11 @@ import { HelpLink } from './HelpLink';
 export default {
   title: 'Sage/HelpLink',
   component: HelpLink,
+  args: {
+    labelIsVisible: false,
+    text: 'Learn something'
+  }
 };
-const Template = (args) => <HelpLink target="_blank" referrer="no-referrer" {...args} />;
+const Template = (args) => <HelpLink href="http://example.com" target="_blank" referrer="no-referrer" {...args} />;
 
-// Each story then reuses that template
 export const Default = Template.bind({});
-Default.args = {
-  labelIsVisible: false,
-  text: 'Learn something'
-};
-
-// storiesOf('Sage/HelpLink', module)
-//   .addDecorator(withKnobs)
-//   .addDecorator(centerXY)
-//   .add('Default', () => (
-//     <HelpLink href="http://example.com" target="_blank" referrer="no-referrer" labelIsVisible={boolean('Show label', false)}>
-//       {text('Text', 'Learn something!')}
-//     </HelpLink>
-//   ));

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -46,8 +46,8 @@ Icon.defaultProps = {
 
 Icon.propTypes = {
   className: PropTypes.string,
-  color: PropTypes.oneOf(Object.values(SageTokens.COLOR_SLIDERS)),
-  icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)).isRequired,
+  color: PropTypes.oneOf(Object.values(Icon.COLORS)),
+  icon: PropTypes.oneOf(Object.values(Icon.ICONS)).isRequired,
   label: PropTypes.string,
-  size: PropTypes.oneOf(Object.values(ICON_SIZES)),
+  size: PropTypes.oneOf(Object.values(Icon.SIZES)),
 };

--- a/packages/sage-react/lib/Icon/Icon.story.jsx
+++ b/packages/sage-react/lib/Icon/Icon.story.jsx
@@ -1,17 +1,25 @@
 import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { SageTokens } from '../configs';
 import { Icon } from './Icon';
 
 export default {
   title: 'Sage/Icon',
   component: Icon,
+  argTypes: {
+    ...selectArgs({
+      color: Icon.COLORS,
+      icon: SageTokens.ICONS,
+      size: Icon.SIZES
+    }),
+  },
+  args: {
+    color: Icon.COLORS.CHARCOAL,
+    icon: Icon.ICONS.CHECK_CIRCLE,
+    label: 'Click me',
+    size: Icon.SIZES.MD
+  }
 };
 const Template = (args) => <Icon {...args} />;
 
-// Each story then reuses that template
 export const Default = Template.bind({});
-Default.args = {
-  color: Icon.COLORS.CHARCOAL,
-  icon: Icon.ICONS.CHECK_CIRCLE,
-  label: 'Click me',
-  size: Icon.SIZES.MD
-};

--- a/packages/sage-react/lib/Icon/Icon.story.jsx
+++ b/packages/sage-react/lib/Icon/Icon.story.jsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, select, text } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
 import { Icon } from './Icon';
 
-storiesOf('Sage/Icon', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <div style={{ marginTop: 50 }}>
-      <Icon
-        color={select('Color', Icon.COLORS, Icon.COLORS.CHARCOAL)}
-        icon={select('Icon', Icon.ICONS, Icon.ICONS.CHECK_CIRCLE)}
-        label={text('Label (not visible)', '')}
-        size={select('Size', Icon.SIZES, Icon.SIZES.MD)}
-      />
-    </div>
-  ));
+export default {
+  title: 'Sage/Icon',
+  component: Icon,
+};
+const Template = (args) => <Icon {...args} />;
+
+// Each story then reuses that template
+export const Default = Template.bind({});
+Default.args = {
+  color: Icon.COLORS.CHARCOAL,
+  icon: Icon.ICONS.CHECK_CIRCLE,
+  label: 'Click me',
+  size: Icon.SIZES.MD
+};

--- a/packages/sage-react/lib/IconCard/IconCard.story.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.story.jsx
@@ -1,18 +1,33 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, select } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
+// import { storiesOf } from '@storybook/react';
+// import { withKnobs, select } from '@storybook/addon-knobs';
+// import { centerXY } from '../story-support/decorators';
 import { IconCard } from './IconCard';
 
-storiesOf('Sage/Icon Card', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <div style={{ marginTop: 50 }}>
-      <IconCard
-        color={select('Color', IconCard.COLORS, IconCard.COLORS.DRAFT)}
-        icon={select('Icon', IconCard.ICONS, IconCard.ICONS.CHECK_CIRCLE)}
-        size={select('Size', IconCard.SIZES)}
-      />
-    </div>
-  ));
+export default {
+  title: 'Sage/IconCard',
+  component: IconCard,
+  decorators: [(Story) => <div style={{ marginTop: 50 }}><Story/></div>]
+};
+const Template = (args) => <IconCard {...args} />;
+
+// Each story then reuses that template
+export const Default = Template.bind({});
+Default.args = {
+  color: IconCard.COLORS.DRAFT,
+  icon: IconCard.ICONS.CHECK_CIRCLE,
+  size: IconCard.SIZES
+};
+
+// storiesOf('Sage/Icon Card', module)
+//   .addDecorator(withKnobs)
+//   .addDecorator(centerXY)
+//   .add('Default', () => (
+//     <div style={{ marginTop: 50 }}>
+//       <IconCard
+//         color={select('Color', IconCard.COLORS, IconCard.COLORS.DRAFT)}
+//         icon={select('Icon', IconCard.ICONS, IconCard.ICONS.CHECK_CIRCLE)}
+//         size={select('Size', IconCard.SIZES)}
+//       />
+//     </div>
+//   ));

--- a/packages/sage-react/lib/IconCard/IconCard.story.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.story.jsx
@@ -6,7 +6,7 @@ import { IconCard } from './IconCard';
 export default {
   title: 'Sage/IconCard',
   component: IconCard,
-  decorators:  [(Story) => <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Story/></div>],
+  decorators: [(Story) => <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Story /></div>],
   argTypes: {
     ...selectArgs({
       color: IconCard.COLORS,

--- a/packages/sage-react/lib/IconCard/IconCard.story.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.story.jsx
@@ -1,33 +1,25 @@
 import React from 'react';
-// import { storiesOf } from '@storybook/react';
-// import { withKnobs, select } from '@storybook/addon-knobs';
-// import { centerXY } from '../story-support/decorators';
+import { selectArgs } from '../story-support/helpers';
+import { SageTokens } from '../configs';
 import { IconCard } from './IconCard';
 
 export default {
   title: 'Sage/IconCard',
   component: IconCard,
-  decorators: [(Story) => <div style={{ marginTop: 50 }}><Story/></div>]
+  decorators:  [(Story) => <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Story/></div>],
+  argTypes: {
+    ...selectArgs({
+      color: IconCard.COLORS,
+      icon: SageTokens.ICONS,
+      size: IconCard.SIZES
+    }),
+  },
+  args: {
+    color: IconCard.COLORS.DRAFT,
+    icon: IconCard.ICONS.CHECK_CIRCLE,
+    size: IconCard.SIZES.MD
+  }
 };
 const Template = (args) => <IconCard {...args} />;
 
-// Each story then reuses that template
 export const Default = Template.bind({});
-Default.args = {
-  color: IconCard.COLORS.DRAFT,
-  icon: IconCard.ICONS.CHECK_CIRCLE,
-  size: IconCard.SIZES
-};
-
-// storiesOf('Sage/Icon Card', module)
-//   .addDecorator(withKnobs)
-//   .addDecorator(centerXY)
-//   .add('Default', () => (
-//     <div style={{ marginTop: 50 }}>
-//       <IconCard
-//         color={select('Color', IconCard.COLORS, IconCard.COLORS.DRAFT)}
-//         icon={select('Icon', IconCard.ICONS, IconCard.ICONS.CHECK_CIRCLE)}
-//         size={select('Size', IconCard.SIZES)}
-//       />
-//     </div>
-//   ));

--- a/packages/sage-react/lib/Label/Label.story.jsx
+++ b/packages/sage-react/lib/Label/Label.story.jsx
@@ -1,52 +1,52 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, text, select } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
+import { selectArgs } from '../story-support/helpers';
 import { Button } from '../Button';
 import { SageTokens } from '../configs';
 import { Label } from './Label';
-import LabelNotes from './LabelNotes.md';
 
-const LabelWithDefaultProps = ({ ...rest }) => (
-  <Label
-    color={select('Color', Label.COLORS, Label.COLORS.DRAFT)}
-    icon={select('Icon', { ...SageTokens.ICONS, NONE: null }, null)}
-    style={select('Style', Label.STYLES, Label.STYLES.DEFAULT)}
-    value={text('Text', 'Hello world')}
-    {...rest}
-  />
-);
+export default {
+  title: 'Sage/Label',
+  component: Label,
+  argTypes: {
+    ...selectArgs({
+      color: Label.COLORS,
+      icon: SageTokens.ICONS,
+      interactiveType: Label.INTERACTIVE_TYPES,
+      style: Label.STYLES,
+    }),
+  },
+  args: {
+    color: Label.COLORS.DRAFT,
+    icon: SageTokens.ICONS.NONE,
+    style: Label.STYLES.DEFAULT,
+    value: 'Hello world'
+  }
+};
+const Template = (args) => <Label {...args} />;
 
-storiesOf('Sage/Label', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <LabelWithDefaultProps />
-  ), {
-    notes: { markdown: LabelNotes }
-  })
-  .add('Interactive: default', () => (
-    <LabelWithDefaultProps
-      interactiveType={Label.INTERACTIVE_TYPES.DEFAULT}
-    />
-  ))
-  .add('Interactive: dropdown treatment', () => (
-    <LabelWithDefaultProps
-      interactiveType={Label.INTERACTIVE_TYPES.DROPDOWN}
-    />
-  ))
-  .add('Interactive: with secondary_button', () => (
-    <LabelWithDefaultProps
-      interactiveType={Label.INTERACTIVE_TYPES.SECONDARY_BUTTON}
-      secondaryButton={(
-        <Button
-          color={Button.COLORS.SECONDARY}
-          subtle={true}
-          icon={SageTokens.ICONS.REMOVE}
-          iconOnly={true}
-        >
-          Cancel
-        </Button>
-      )}
-    />
-  ));
+export const Default = Template.bind({});
+
+export const InteractiveDefault = Template.bind({});
+InteractiveDefault.args = {
+  interactiveType: Label.INTERACTIVE_TYPES.DEFAULT
+};
+
+export const InteractiveDropdownTreatment = Template.bind({});
+InteractiveDropdownTreatment.args = {
+  interactiveType: Label.INTERACTIVE_TYPES.DROPDOWN
+};
+
+export const InteractiveWithSecondaryButton = Template.bind({});
+InteractiveWithSecondaryButton.args = {
+  interactiveType: Label.INTERACTIVE_TYPES.SECONDARY_BUTTON,
+  secondaryButton: (
+    <Button
+      color={Button.COLORS.SECONDARY}
+      subtle={true}
+      icon={SageTokens.ICONS.REMOVE}
+      iconOnly={true}
+    >
+      Cancel
+    </Button>
+  )
+};

--- a/packages/sage-react/lib/Link/Link.jsx
+++ b/packages/sage-react/lib/Link/Link.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { SageClassnames } from '../configs';
+import { Tooltip } from '../Tooltip';
 
 const tagPropTypes = PropTypes.oneOfType([
   PropTypes.string,
@@ -10,20 +11,32 @@ const tagPropTypes = PropTypes.oneOfType([
 export const Link = ({
   children,
   tag,
+  tooltip,
   ...rest
 }) => {
   const SelfTag = tag || 'a';
 
   return (
-    <SelfTag {...rest}>
-      {children}
-    </SelfTag>
+    <>
+      {tooltip ? (
+        <Tooltip {...tooltip}>
+          <SelfTag {...rest}>
+            {children}
+          </SelfTag>
+        </Tooltip>
+      ) : (
+        <SelfTag {...rest}>
+          {children}
+        </SelfTag>
+      )}
+    </>
   );
 };
 
 Link.defaultProps = {
   children: null,
   tag: null,
+  tooltip: null,
 };
 
 Link.CLASSNAMES = { ...SageClassnames.LINK };
@@ -33,4 +46,9 @@ Link.tagPropTypes = tagPropTypes;
 Link.propTypes = {
   children: PropTypes.node,
   tag: tagPropTypes,
+  tooltip: PropTypes.shape({
+    position: PropTypes.oneOf(Object.values(Tooltip.POSITIONS)),
+    size: PropTypes.oneOf(Object.values(Tooltip.SIZES)),
+    theme: PropTypes.oneOf(Object.values(Tooltip.THEMES)),
+  }),
 };

--- a/packages/sage-react/lib/Link/Link.story.jsx
+++ b/packages/sage-react/lib/Link/Link.story.jsx
@@ -29,3 +29,13 @@ Subtext.args = {
   className: Link.CLASSNAMES.SUBTEXT,
   href: '#',
 };
+
+export const Tooltip = Template.bind({});
+Tooltip.args = {
+  children: 'Link with Tooltip',
+  href: '#',
+  tooltip: {
+    content: 'Tooltip',
+    position: 'right'
+  },
+};

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -1,21 +1,33 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
-import { SageTokens } from '../configs';
 import { Popover } from './Popover';
 
-storiesOf('Sage/Popover', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Default', () => (
-    <Popover
-      label={text('Trigger Label', 'Learn more')}
-      icon={select('Trigger icon', SageTokens.ICONS, SageTokens.ICONS.QUESTION_CIRCLE)}
-      iconOnly={boolean('Icon only trigger', true)}
-      moreLinkURL="//example.com"
-      title="Amazing popover"
-    >
-      <p>Testing...</p>
-    </Popover>
-  ));
+export default {
+  title: 'Sage/Popover',
+  component: Popover,
+};
+const Template = (args) => <Popover {...args} />;
+
+// Each story then reuses that template
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Learn more',
+  icon: 'add',
+  iconOnly: true,
+  moreLinkURL: '//example.com',
+  title: 'Amazing popover'
+};
+
+// storiesOf('Sage/Popover', module)
+//   .addDecorator(withKnobs)
+//   .addDecorator(centerXY)
+//   .add('Default', () => (
+//     <Popover
+//       label={text('Trigger Label', 'Learn more')}
+//       icon={select('Trigger icon', SageTokens.ICONS, SageTokens.ICONS.QUESTION_CIRCLE)}
+//       iconOnly={boolean('Icon only trigger', true)}
+//       moreLinkURL="//example.com"
+//       title="Amazing popover"
+//     >
+//       <p>Testing...</p>
+//     </Popover>
+//   ));

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -6,7 +6,7 @@ import { Popover } from './Popover';
 export default {
   title: 'Sage/Popover',
   component: Popover,
-  decorators:  [(Story) => <div style={{ minHeight: 150 }}><Story/></div>],
+  decorators: [(Story) => <div style={{ minHeight: 150 }}><Story /></div>],
   argTypes: {
     ...selectArgs({
       icon: SageTokens.ICONS,

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -1,33 +1,25 @@
 import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { SageTokens } from '../configs';
 import { Popover } from './Popover';
 
 export default {
   title: 'Sage/Popover',
   component: Popover,
+  decorators:  [(Story) => <div style={{ minHeight: 150 }}><Story/></div>],
+  argTypes: {
+    ...selectArgs({
+      icon: SageTokens.ICONS,
+    }),
+  },
+  args: {
+    label: 'Learn more',
+    icon: SageTokens.ICONS.QUESTION_CIRCLE,
+    iconOnly: true,
+    moreLinkURL: '//example.com',
+    title: 'Amazing popover'
+  }
 };
 const Template = (args) => <Popover {...args} />;
 
-// Each story then reuses that template
 export const Default = Template.bind({});
-Default.args = {
-  label: 'Learn more',
-  icon: 'add',
-  iconOnly: true,
-  moreLinkURL: '//example.com',
-  title: 'Amazing popover'
-};
-
-// storiesOf('Sage/Popover', module)
-//   .addDecorator(withKnobs)
-//   .addDecorator(centerXY)
-//   .add('Default', () => (
-//     <Popover
-//       label={text('Trigger Label', 'Learn more')}
-//       icon={select('Trigger icon', SageTokens.ICONS, SageTokens.ICONS.QUESTION_CIRCLE)}
-//       iconOnly={boolean('Icon only trigger', true)}
-//       moreLinkURL="//example.com"
-//       title="Amazing popover"
-//     >
-//       <p>Testing...</p>
-//     </Popover>
-//   ));

--- a/packages/sage-react/lib/Search/Search.story.jsx
+++ b/packages/sage-react/lib/Search/Search.story.jsx
@@ -1,25 +1,30 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
-import { centerXY } from '../story-support/decorators';
 import { Search } from './Search';
 
-const InputWithState = (rest) => {
+export default {
+  title: 'Sage/Search',
+  component: Search,
+};
+
+const Template = (args) => <Search {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  placeholder: 'find',
+  value: ''
+};
+
+export const Contained = () => {
   const [value, setValue] = useState('');
 
   return (
-    <Search
-      placeholder={text('Placeholder', 'Find')}
-      onChange={(evt) => setValue(evt.target.value)}
-      onClear={() => setValue('')}
-      value={value}
-      {...rest}
-    />
+    <>
+      <Search
+        placeholder="Find"
+        onChange={(evt) => setValue(evt.target.value)}
+        onClear={() => setValue('')}
+        value={value}
+      />
+    </>
   );
 };
-
-storiesOf('Sage/Search', module)
-  .addDecorator(withKnobs)
-  .addDecorator(centerXY)
-  .add('Controlled: Uncontained', () => <InputWithState contained={boolean('Contained', false)} />)
-  .add('Controlled: Contained', () => <InputWithState contained={boolean('Contained', true)} />);

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -76,11 +76,8 @@ Sage.dropdown = (function () {
 
     // Stop if the dropdown item clicked and parent is disabled
     if (el.parentNode.classList.contains(dropdownDisabledItemClass)) {
-      if (el.tagName.toLowerCase() == "a") {
-        evt.preventDefault();
-      } else {
-        return;
-      }
+      evt.preventDefault();
+      return;
     }
 
     // If the dropdown is in select mode, display the selected content

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -1,42 +1,43 @@
-Sage.dropdown = (function() {
+Sage.dropdown = (function () {
   // ==================================================
   // Variables
   // ==================================================
 
   // The class to toggle on the menu when values are selected in selection mode
-  const dropdownValueSelectedClass = 'sage-dropdown--value-selected';
+  const dropdownValueSelectedClass = "sage-dropdown--value-selected";
 
   // The class to toggle on the menu when the menu is disabled
-  const dropdownDisabledClass = 'sage-dropdown--disabled';
+  const dropdownDisabledClass = "sage-dropdown--disabled";
 
   // Selector for a menu item
-  const dropdownItemClass = 'sage-dropdown__item-control';
+  const dropdownItemClass = "sage-dropdown__item-control";
 
   // The class to toggle on the menu when the menu is disabled
-  const dropdownDisabledItemClass = 'sage-dropdown__item--disabled';
+  const dropdownDisabledItemClass = "sage-dropdown__item--disabled";
 
   // Selector for seach item in menu
-  const dropdownSearchItemClass = 'sage-search__input';
+  const dropdownSearchItemClass = "sage-search__input";
 
   // The selected value needs some content in order to have height
-  const defaultSelectedValue = '&nbsp;';
+  const defaultSelectedValue = "&nbsp;";
 
   // In order to reset the label in seleciton mode, provide a standard prefix for the reset trigger item
-  const triggerRestPrefix = '--';
+  const triggerRestPrefix = "--";
 
   // Several variations exist for triggers in selection mode; this is a grouped selector to grab any of them
-  const triggerSelectClasses = '.sage-dropdown__trigger--select-labeled, .sage-dropdown__trigger--select';
+  const triggerSelectClasses =
+    ".sage-dropdown__trigger--select-labeled, .sage-dropdown__trigger--select";
 
   // The element in which to show the selected value when dropdown is in selection mode
-  const triggerSelectedValueClass = '.sage-dropdown__trigger-selected-value .sage-btn__truncate-text';
+  const triggerSelectedValueClass = ".sage-dropdown__trigger-selected-value .sage-btn__truncate-text";
 
   const SELECTOR_FOCUSABLE_ELEMENTS = '.sage-dropdown__panel a, .sage-dropdown__panel button, .sage-dropdown__panel textarea, .sage-dropdown__panel input[type="text"], .sage-dropdown__panel input[type="radio"], .sage-dropdown__panel input[type="checkbox"], .sage-dropdown__panel input[type="search"], .sage-dropdown__panel select';
   let SELECTOR_LAST_FOCUSED;
 
   const dropdownItemAriaSelectedClass = '.sage-dropdown__panel .sage-dropdown__item[aria-selected="true"]';
-  const dropdownItemControlClass = '.sage-dropdown__item-control';
-  const dropdownClass = '.sage-dropdown';
-  const dropdownTriggerLabelClass = '.sage-dropdown__trigger-label';
+  const dropdownItemControlClass = ".sage-dropdown__item-control";
+  const dropdownClass = ".sage-dropdown";
+  const dropdownTriggerLabelClass = ".sage-dropdown__trigger-label";
 
   // ==================================================
   // Functions
@@ -45,13 +46,13 @@ Sage.dropdown = (function() {
   function init(el) {
     buildA11y(el);
     checkSelected(el);
-    el.addEventListener('click', handleClick);
-    el.addEventListener('keyup', handleKeyAction);
+    el.addEventListener("click", handleClick);
+    el.addEventListener("keyup", handleKeyAction);
   }
 
   function unbind(el) {
-    el.removeEventListener('click', handleClick);
-    el.removeEventListener('keyup', handleKeyAction);
+    el.removeEventListener("click", handleClick);
+    el.removeEventListener("keyup", handleKeyAction);
   }
 
   function handleClick(evt) {
@@ -73,6 +74,15 @@ Sage.dropdown = (function() {
       return;
     }
 
+    // Stop if the dropdown item clicked and parent is disabled
+    if (el.parentNode.classList.contains(dropdownDisabledItemClass)) {
+      if (el.tagName.toLowerCase() == "a") {
+        evt.preventDefault();
+      } else {
+        return;
+      }
+    }
+
     // If the dropdown is in select mode, display the selected content
     const elTrigger = elDropdown.querySelector(triggerSelectClasses);
     const eventIsOnDropdownItem = el.classList.contains(dropdownItemClass);
@@ -86,27 +96,31 @@ Sage.dropdown = (function() {
   }
 
   function updateStateClass(val, elDropdown) {
-    const hasSelectValueClass = elDropdown.classList.contains(dropdownValueSelectedClass);
+    const hasSelectValueClass = elDropdown.classList.contains(
+      dropdownValueSelectedClass
+    );
     if (val.startsWith(triggerRestPrefix)) {
       if (hasSelectValueClass) {
-        elDropdown.classList.remove(dropdownValueSelectedClass)
+        elDropdown.classList.remove(dropdownValueSelectedClass);
       }
     } else {
       if (!hasSelectValueClass) {
-        elDropdown.classList.add(dropdownValueSelectedClass)
+        elDropdown.classList.add(dropdownValueSelectedClass);
       }
     }
   }
 
   function updateTriggerLabel(val, elTrigger) {
-    const triggerSelectedValue = elTrigger.querySelector(triggerSelectedValueClass);
-    
+    const triggerSelectedValue = elTrigger.querySelector(
+      triggerSelectedValueClass
+    );
+
     if (!triggerSelectedValue) {
       return;
     }
 
     if (val.startsWith(triggerRestPrefix)) {
-      triggerSelectedValue.innerHTML = defaultSelectedValue;  
+      triggerSelectedValue.innerHTML = defaultSelectedValue;
     } else {
       triggerSelectedValue.innerHTML = val;
     }
@@ -123,34 +137,38 @@ Sage.dropdown = (function() {
   }
 
   function open(el) {
-    el.setAttribute('aria-expanded', 'true');
+    el.setAttribute("aria-expanded", "true");
     let focusableEls = el.querySelectorAll(SELECTOR_FOCUSABLE_ELEMENTS);
     SELECTOR_LAST_FOCUSED = document.activeElement;
-    el.addEventListener('keydown', focusTrap.bind(focusableEls));
+    el.addEventListener("keydown", focusTrap.bind(focusableEls));
   }
 
   function close(el) {
-    el.setAttribute('aria-expanded', 'false');
-    el.removeEventListener('keydown', focusTrap);
+    el.setAttribute("aria-expanded", "false");
+    el.removeEventListener("keydown", focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
   }
 
   function isExpanded(el) {
-    return el.getAttribute('aria-expanded') === 'true';
+    return el.getAttribute("aria-expanded") === "true";
   }
 
   function buildA11y(el) {
-    el.setAttribute('aria-haspopup', true);
-    el.setAttribute('aria-expanded', false);
+    el.setAttribute("aria-haspopup", true);
+    el.setAttribute("aria-expanded", false);
   }
 
   function checkSelected(el) {
-    let selectedItem = el.querySelector(dropdownItemAriaSelectedClass); 
-    
+    let selectedItem = el.querySelector(dropdownItemAriaSelectedClass);
+
     if (selectedItem != null) {
-      let selectedItemValue = selectedItem.querySelector(dropdownItemControlClass).innerHTML;
+      let selectedItemValue = selectedItem.querySelector(
+        dropdownItemControlClass
+      ).innerHTML;
       let selectedParent = selectedItem.closest(dropdownClass);
-      selectedParent.querySelector(dropdownTriggerLabelClass).innerHTML = selectedItemValue;
+      selectedParent.querySelector(
+        dropdownTriggerLabelClass
+      ).innerHTML = selectedItemValue;
     }
   }
 
@@ -158,18 +176,18 @@ Sage.dropdown = (function() {
     let firstFocusableEl = this[0];
     let lastFocusableEl = this[this.length - 1];
     let KEYCODE_TAB = 9;
-    var isTabPressed = (evt.key === 'Tab' || evt.keyCode === KEYCODE_TAB);
+    var isTabPressed = evt.key === "Tab" || evt.keyCode === KEYCODE_TAB;
 
-    if (!isTabPressed) { 
-      return; 
+    if (!isTabPressed) {
+      return;
     }
 
-    if ( evt.shiftKey ) /* shift + tab */ {
-      if (document.activeElement === firstFocusableEl) {
+    if (evt.shiftKey) {
+      /* shift + tab */ if (document.activeElement === firstFocusableEl) {
         lastFocusableEl.focus();
         evt.preventDefault();
       }
-    } else /* tab */ {
+    } /* tab */ else {
       if (document.activeElement === lastFocusableEl) {
         firstFocusableEl.focus();
         evt.preventDefault();
@@ -180,6 +198,5 @@ Sage.dropdown = (function() {
   return {
     init: init,
     unbind: unbind,
-  }
-
+  };
 })();


### PR DESCRIPTION
## Testing and estimated impact
<!-- REQUIRED: link to the merged branch, its impact level (LOW/MEDIUM/HIGH/BREAKING), and list examples of affected areas to test.
For example,
1. #101 (**MEDIUM**): Decrease padding in breadcrumbs
    - [ ] Product index
    - [ ] Settings > Domains
-->
1. #315 (BREAKING) Updates Sidebar, Nav and NavLink in Rails. These are currently only used in `super_admin` and an [this PR](https://github.com/Kajabi/kajabi-products/pull/17832) will introduce the fixes along with QA test steps at the time of the version bump PR.
   - [ ] Ensure side navbar in super admin works as expected.
1. #347 (MED) Updates select icon and label styles. Ensure the following continue to behave as expected:
    - [ ] Podcast Edit Form
    - [ ] New Post Form
1. #339 (MED) Updates pagination component to be more agnostic. [This PR](https://github.com/Kajabi/sage-lib/pull/339) allows the pagination component to accept any type of collection as opposed to only descendants of active directory. All existing implementations of pagination should work as normal and paginate at 25 items. 
For example:
    - [ ] Products > All Products
    - [ ] Sales > Offers
    - [ ] Offers > Coupons
1. #334 (LOW) Adds support for tooltips in disabled dropdown items and in the link elements. No impact on current implementations as this is a new enhancement, but a quick regression check of existing dropdowns should be performed.
For example:
    - [ ] Products > All Products
    - [ ] Sales > Offers
    - [ ] People > Sort Dropdown
1. #332 (LOW) Allows support for adding a gap between sage choice components by using the `sage-btn-group--gap` modifier. There is no implementation of this currently in the app but moving forward developers will be able to use the gap modifier class. 
1. #345, #342 (LOW) - Documentation updates to standardize, clean up, and add missing props for React elements and objects.