### PR TITLE
Select - icon cursor hover styles

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
@@ -40,6 +40,7 @@ $-select-padding-label: map-get($sage-field-configs, padding-label);
 
 .sage-select__label {
   @extend %t-sage-body;
+  z-index: sage-z-index(default, 1);
   position: absolute;
   transform: translateY(-50%);
   padding: 0 $-select-padding-label;

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
@@ -79,6 +79,8 @@ $-select-padding-label: map-get($sage-field-configs, padding-label);
 }
 
 .sage-select__field {
+  z-index: sage-z-index(default, 1);
+  position: relative;
   height: $-select-height;
   width: 100%;
   padding: $-select-filled-top-padding $-select-padding-x 0;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
 - [x] - updated select icon styles

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![selectIconBefore](https://user-images.githubusercontent.com/1241836/109530662-92103080-7a7c-11eb-9dd7-6bf3115ff782.gif)|![selectIconAfter](https://user-images.githubusercontent.com/1241836/109530685-96d4e480-7a7c-11eb-85c2-5e36e971b8f0.gif)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the select rails and react page. Hover the icon within the `<select>` and verify that the `cursor` style display
    - select react page: http://localhost:4100/?path=/docs/sage-select--default
    - select rails page: http://localhost:4000/pages/element/form_select
    
### QA Steps
#347 (MEDIUM) Updates select icon and label styles
    - [ ] - Podcast Edit Form
    - [ ] - New Post Form