### PR TITLE
Form Select - select label z-index adjustment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_form_select.scss
@@ -40,7 +40,7 @@ $-select-padding-label: map-get($sage-field-configs, padding-label);
 
 .sage-select__label {
   @extend %t-sage-body;
-  z-index: sage-z-index(default, 1);
+  z-index: sage-z-index(default, 2);
   position: absolute;
   transform: translateY(-50%);
   padding: 0 $-select-padding-label;


### PR DESCRIPTION
## Description
Minor fix bumping the `z-index` value on `.sage-select__label` to account for the generated markup used with a simpleform association.

Simpleform association outputs the label before the `select`, unlike our expected markup order. As a result, the matching `z-index` values display the `.sage-select__field` border on top of `.sage-select__label` due to the source order.

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![simpleform-sage-select-before](https://user-images.githubusercontent.com/816579/109741750-8c9d0e00-7b82-11eb-9146-4ff70937f1d0.png)|![simpleform-sage-select-after](https://user-images.githubusercontent.com/816579/109741759-90309500-7b82-11eb-859f-c0f61e8f0bef.png)|


## Test notes
<!-- General notes here surrounding this change -->

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- [ ] (LOW) `z-index` increased for `.sage-select_label`. Functionality should not be impacted by this change. A few examples for testing:
   - Offer checkout testimonials (view any offer checkout)
   - Offer price modal for multiple payment or subscription payments (Sales -> Offers -> select an offer -> "Edit Price")

