### PR TITLE
Icons - updated icon alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_toast.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_toast.scss
@@ -66,6 +66,7 @@ $-toast-viewport-spacing-bottom: sage-spacing();
 }
 
 .sage-toast__icon {
+  display: inline-flex;
   margin-right: sage-spacing(xs);
   color: sage-color(white);
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_alert.scss
@@ -76,7 +76,7 @@ $-alert-icon-colors: (
 }
 
 .sage-alert__icon {
-  transform: translateY(rem(2px));
+  display: inline-flex;
   @each $name, $color in $-alert-icon-colors {
     .sage-alert--#{$name} & {
       color: sage-color($color, 300);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_banner.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_banner.scss
@@ -116,13 +116,8 @@ $-banner-el-icon: "before";
 }
 
 .sage-banner__close {
-  display: none;
   position: absolute;
   right: sage-spacing(card);
-
-  .sage-banner--active & {
-    display: block;
-  }
 }
 
 .sage-banner__close,

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_empty_state.scss
@@ -30,6 +30,7 @@
 }
 
 .sage-empty-state__icon {
+  display: inline-flex;
   color: sage-color(charcoal, 100);
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_nav.scss
@@ -13,6 +13,7 @@ $-nav-icon-size: rem(20px);
 
 
 .sage-nav__icon {
+  display: inline-flex;
   margin-right: rem(12px);
   color: sage-color(charcoal, 200);
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_upload_card.scss
@@ -112,6 +112,7 @@ $-upload-card-background-hover: sage-color(grey, 100);
 }
 
 .sage-upload-card__icon {
+  display: inline-flex;
   color: sage-color(grey, 500);
 
   .sage-upload-card:not(.sage-uploaded-card--selected) & {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
 - [x] - added `display: inline-flex` to icons

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-03-04 at 8 24 20 AM](https://user-images.githubusercontent.com/1241836/109978592-a85bfd80-7cc3-11eb-88dc-a1904e9c1377.png)|![Screen Shot 2021-03-04 at 8 24 03 AM](https://user-images.githubusercontent.com/1241836/109978611-adb94800-7cc3-11eb-8cf0-405c49ebc63a.png)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. In the app, visit the [Product Index](http://www.kajabi.test:3000/admin/sites/1/products) page and observe the property icon: 
    
### QA Steps
(MEDIUM) Updates Property icon alignment
    - [ ] - Product Index
    - [ ] - Podcast index
    - [ ] - Offers index