### PR TITLE
Add Icon Card option to FeatureToggle

### DIFF
--- a/docs/app/views/examples/elements/icon_card/_preview.html.erb
+++ b/docs/app/views/examples/elements/icon_card/_preview.html.erb
@@ -1,3 +1,4 @@
+<h3 class="t-sage-heading-6">Icon Card</h3>
 <div class="sage-row">
   <% [
   "draft",
@@ -7,10 +8,29 @@
   "danger"
 ].each do | color | %>
     <div class="sage-col-2">
-      <%= sage_component SageIconCard, { 
+      <%= sage_component SageIconCard, {
         color: color,
         icon: "file",
         label: "File graphic"
+      } %>
+    </div>
+  <% end %>
+</div>
+<h3 class="t-sage-heading-6">Icon Card with custom <code>background_color</code> and <code>foreground_color</code></h3>
+<div class="sage-row">
+  <% [
+  { background_color: "#A463F2", foreground_color: "#9EEBCF" },
+  { background_color: "#9EEBCF", foreground_color: "#FF41B4" },
+  { background_color: "#FF41B4", foreground_color: "#FBF1A9" },
+  { background_color: "#FBF1A9", foreground_color: "#001B44" },
+  { background_color: "#001B44", foreground_color: "#A463F2" },
+].each do | color | %>
+    <div class="sage-col-2">
+      <%= sage_component SageIconCard, {
+        background_color: color[:background_color],
+        foreground_color: color[:foreground_color],
+        icon: "customize",
+        label: "Custom color"
       } %>
     </div>
   <% end %>

--- a/docs/app/views/examples/elements/icon_card/_props.html.erb
+++ b/docs/app/views/examples/elements/icon_card/_props.html.erb
@@ -5,10 +5,22 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`background_color`') %></td>
+  <td><%= md('The color set to use for the background color of the card.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`color`') %></td>
   <td><%= md('The color set to use for the foreground and background colors of the card.') %></td>
   <td><%= md('`"draft"`, `"info"`, `"success"`, `"warning"`, and `"danger"`') %></td>
   <td><%= md('`"draft"`') %></td>
+</tr>
+<tr>
+  <td><%= md('`foreground_color`') %></td>
+  <td><%= md('The color set to use for the foreground color of the card.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`icon`') %></td>

--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -1,4 +1,4 @@
-<h3 class="t-sage-heading-6">Feature Toggle
+<h3 class="t-sage-heading-6">Feature Toggle</h3>
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {
     alt_text: "Text alt text",

--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -33,6 +33,39 @@
     <% end %>
   <% end %>
 <% end %>
+<h3 class="t-sage-heading-6">Feature Toggle with <code><a href="/pages/element/icon_card">Icon Card</a></code></h3>
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SageFeatureToggle, {
+    description: "New navigation bar layout that places Offers, Coupons, and Affiliates under a brand new “Sales” tab.",
+    icon: {
+      color: "published",
+      icon: "tag",
+      label: "New Sales Tab",
+    },
+    links: [
+      {
+        icon: "comment",
+        location: "#",
+        target: "_blank",
+        text: "Feedback",
+      },
+    ],
+    title: "New Sales Tab",
+  } do %>
+    <%= sage_component_section :feature_toggle_input do %>
+      <%= sage_component SageSwitch, {
+        type: "checkbox",
+        id: "feature-toggle-id-2",
+        hide_text: true,
+        label_text: "Label Title",
+        message: "",
+        name: "feature-toggle-id",
+        value: "feature-toggle-value",
+        css_classes: "sage-feature-toggle__switch"
+      } %>
+    <% end %>
+  <% end %>
+<% end %>
 <h3 class="t-sage-heading-6">Feature Toggle with <code>image</code></h3>
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {

--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -40,7 +40,7 @@
     icon: {
       color: "published",
       icon: "tag",
-      label: "New Sales Tab",
+      label: "New Sales Tab"
     },
     links: [
       {

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -13,7 +13,15 @@
 <tr>
   <td><%= md('`icon`') %></td>
   <td><%= md('Sets an optional [Icon Card](/pages/element/icon_card) component.') %></td>
-  <td><%= md('Hash') %></td>
+  <td>
+      <%= md('```
+Hash<{
+  color: String,
+  icon: String,
+  label: String,
+  size: String
+}>
+    ') %>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -36,7 +36,6 @@ Hash<{
   <td>
     <%= md('```
 Array<{
-  attributes: Hash,
   icon: String,
   location: String,
   target: String,

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -36,6 +36,7 @@ Hash<{
   <td>
     <%= md('```
 Array<{
+  attributes: Hash,
   icon: String,
   location: String,
   target: String,

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -11,9 +11,14 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Sets an optional [Icon Card](/pages/element/icon_card) component.') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`image`') %></td>
   <td><%= md('Sets the `src` for the component\'s image.') %></td>
-  <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/objects/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_props.html.erb
@@ -16,6 +16,7 @@
   <td>
       <%= md('```
 Hash<{
+  attributes: Hash,
   color: String,
   icon: String,
   label: String,

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -2,6 +2,7 @@ class SageFeatureToggle < SageComponent
   set_attribute_schema({
     alt_text: [:optional, String],
     description: [:optional, String],
+    icon: [:optional, SageIconCard::ATTRIBUTE_SCHEMA],
     image: [:optional, String],
     links: [:optional, [[{
       icon: [:optional, NilClass, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
@@ -1,8 +1,10 @@
 class SageIconCard < SageComponent
   set_attribute_schema({
     attributes: [:optional, NilClass, Hash],
-    color: Set.new(["draft", "published", "info", "warning", "danger"]),
+    background_color: [:optional, String],
+    color: [:optional, Set.new(["draft", "published", "info", "warning", "danger"])],
     css_classes: [:optional, String],
+    foreground_color: [:optional, String],
     icon: String,
     label: [:optional, String],
     size: [:optional, SageSchemaHelper::ICON_SIZE],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -1,8 +1,6 @@
-<%
-feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3"
-%>
+<% feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3" %>
 
-<li class="sage-feature-toggle <%= "sage-feature-toggle--no-media" if component.image.blank? && component.icon.blank? %>">
+<li class="sage-feature-toggle <%= "sage-feature-toggle--no-image" if component.image.blank? && component.icon.blank? %>">
   <<%= feature_toggle_title_tag %> class="sage-feature-toggle__title"><%= component.title %></<%= feature_toggle_title_tag %>>
   <div class="sage-feature-toggle__content">
     <p><%= component.description %></p>
@@ -33,7 +31,7 @@ feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3"
     </div>
   <% end %>
   <% if component.icon.present? or component.image.present? %>
-    <div class="sage-feature-toggle__media">
+    <div class="sage-feature-toggle__image-link">
       <% if component.icon.present? %>
         <%= sage_component SageIconCard, {
           attributes: (component.icon[:attributes] if component.icon[:attributes].present?),

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -35,7 +35,9 @@
       <% if component.icon.present? %>
         <%= sage_component SageIconCard, {
           attributes: (component.icon[:attributes] if component.icon[:attributes].present?),
+          background_color: (component.icon[:background_color] if component.icon[:background_color].present?),
           color: (component.icon[:color] if component.icon[:color].present?),
+          foreground_color: (component.icon[:foreground_color] if component.icon[:foreground_color].present?),
           icon: (component.icon[:icon] if component.icon[:icon].present?),
           label: (component.icon[:label] if component.icon[:label].present?),
           size: (component.icon[:size] if component.icon[:size].present?),

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -1,6 +1,5 @@
 <%
 feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3"
-feature_toggle_icon_default_size = "3xl"
 %>
 
 <li class="sage-feature-toggle <%= "sage-feature-toggle--no-media" if component.image.blank? && component.icon.blank? %>">
@@ -33,22 +32,19 @@ feature_toggle_icon_default_size = "3xl"
       <%= content_for :sage_feature_toggle_input %>
     </div>
   <% end %>
-  <% if component.icon.present? %>
-    <div class="sage-feature-toggle__media-link">
-      <%= sage_component SageIconCard, {
-        attributes: {
-          class: "sage-feature-toggle__media",
-        },
-        color: component.icon[:color],
-        icon: component.icon[:icon],
-        label: component.icon[:label] || component.alt_text || "",
-        size: component.icon[:size] || feature_toggle_icon_default_size,
-      } %>
-    </div>
-  <% end %>
-  <% if component.image.present? %>
-    <div class="sage-feature-toggle__media-link">
-      <img class="sage-feature-toggle__media" src=<%= component.image %> alt="<%= component.alt_text %>" <%= "aria-hidden=true" if component.alt_text.blank? %> />
+  <% if component.icon.present? or component.image.present? %>
+    <div class="sage-feature-toggle__media">
+      <% if component.icon.present? %>
+        <%= sage_component SageIconCard, {
+          attributes: (component.icon[:attributes] if component.icon[:attributes].present?),
+          color: (component.icon[:color] if component.icon[:color].present?),
+          icon: (component.icon[:icon] if component.icon[:icon].present?),
+          label: (component.icon[:label] if component.icon[:label].present?),
+          size: (component.icon[:size] if component.icon[:size].present?),
+        }.compact %>
+      <% elsif component.image.present? %>
+        <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>" <%= "aria-hidden=true" if component.alt_text.blank? %> />
+      <% end %>
     </div>
   <% end %>
 </li>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -1,6 +1,9 @@
-<% feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3" %>
+<%
+feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3"
+feature_toggle_icon_default_size = "3xl"
+%>
 
-<li class="sage-feature-toggle <%= "sage-feature-toggle--no-image" if component.image.blank? %>">
+<li class="sage-feature-toggle <%= "sage-feature-toggle--no-media" if component.image.blank? && component.icon.blank? %>">
   <<%= feature_toggle_title_tag %> class="sage-feature-toggle__title"><%= component.title %></<%= feature_toggle_title_tag %>>
   <div class="sage-feature-toggle__content">
     <p><%= component.description %></p>
@@ -30,9 +33,22 @@
       <%= content_for :sage_feature_toggle_input %>
     </div>
   <% end %>
+  <% if component.icon.present? %>
+    <div class="sage-feature-toggle__media-link">
+      <%= sage_component SageIconCard, {
+        attributes: {
+          class: "sage-feature-toggle__media",
+        },
+        color: component.icon[:color],
+        icon: component.icon[:icon],
+        label: component.icon[:label] || component.alt_text || "",
+        size: component.icon[:size] || feature_toggle_icon_default_size,
+      } %>
+    </div>
+  <% end %>
   <% if component.image.present? %>
-    <div class="sage-feature-toggle__image-link" >
-      <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>" <%= "aria-hidden=true" if component.alt_text.blank? %> />
+    <div class="sage-feature-toggle__media-link">
+      <img class="sage-feature-toggle__media" src=<%= component.image %> alt="<%= component.alt_text %>" <%= "aria-hidden=true" if component.alt_text.blank? %> />
     </div>
   <% end %>
 </li>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
@@ -1,9 +1,6 @@
 <%
-color = "draft"
-if component.color.present?
-  color = component.color
-end
-size = component.size.present? ? component.size : "3xl"
+color = component.color.present? ? component.color : "draft"
+size = component.size.present? ? component.size == "md" ? "" : "-#{component.size}" : "-3xl"
 style = {
   "--background-color": (component.background_color if component.background_color.present?),
   "--color": (component.foreground_color if component.foreground_color.present?),
@@ -23,7 +20,7 @@ style = {
   <% end %>
 >
   <i
-    class="sage-icon-<%= component.icon %>-<%= size %>"
+    class="sage-icon-<%= component.icon %><%= size %>"
     <% if component.label.present? %>
     aria-label="<%= component.label %>"
     <% else %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
@@ -1,16 +1,26 @@
 <%
-size = component.size.present? ? component.size : '3xl'
-color = component.color.present? ? component.color : 'draft'
+size = component.size.present? ? component.size : "3xl"
+color = "draft"
+if component.color.present?
+  color = component.color
+elsif component.background_color.present? and component.foreground_color.present?
+  color = false
+end
 %>
 <div
   class="
     sage-icon-card
-    <%= "sage-icon-card--#{color}" %>
+    <% if component.color.present? %>
+      <%= "sage-icon-card--#{color}" %>
+    <% end %>
     <%= component.css_classes if component.css_classes.present? %>
   "
   <% component.attributes.each do |key, value| %>
     <%= "#{key}=\"#{value}\"".html_safe %>
   <% end if component.attributes&.is_a?(Hash) %>
+  <% if component.background_color.present? and component.foreground_color.present? %>
+    style="--background-color: <%= component.background_color %>; --color: <%= component.foreground_color %>"
+  <% end %>
 >
   <i
     class="sage-icon-<%= component.icon %>-<%= size %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
@@ -1,25 +1,25 @@
 <%
-size = component.size.present? ? component.size : "3xl"
 color = "draft"
 if component.color.present?
   color = component.color
-elsif component.background_color.present? and component.foreground_color.present?
-  color = false
 end
+size = component.size.present? ? component.size : "3xl"
+style = {
+  "--background-color": (component.background_color if component.background_color.present?),
+  "--color": (component.foreground_color if component.foreground_color.present?),
+}.compact.map{|k,v| "#{k}:#{v}"}.join(";")
 %>
 <div
   class="
     sage-icon-card
-    <% if component.color.present? %>
-      <%= "sage-icon-card--#{color}" %>
-    <% end %>
+    <%= "sage-icon-card--#{color}" if color.present? %>
     <%= component.css_classes if component.css_classes.present? %>
   "
   <% component.attributes.each do |key, value| %>
     <%= "#{key}=\"#{value}\"".html_safe %>
   <% end if component.attributes&.is_a?(Hash) %>
-  <% if component.background_color.present? and component.foreground_color.present? %>
-    style="--background-color: <%= component.background_color %>; --color: <%= component.foreground_color %>"
+  <% if component.background_color.present? or component.foreground_color.present? %>
+    style="<%= style %>"
   <% end %>
 >
   <i

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_icon_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_icon_card.scss
@@ -12,10 +12,11 @@
   align-self: stretch;
   padding: sage-spacing(lg);
   border-radius: sage-border(radius);
+  background-color: var(--background-color, inherit);
 
   [class*="sage-icon-"] {
     display: block;
-    color: currentColor;
+    color: var(--color, currentColor);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_icon_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_icon_card.scss
@@ -15,7 +15,7 @@
   background-color: var(--background-color, inherit);
 
   [class*="sage-icon-"] {
-    display: block;
+    display: flex;
     color: var(--color, currentColor);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_icon_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_icon_card.scss
@@ -25,7 +25,7 @@
   $-bold-values: map-get($-values, bold);
 
   .sage-icon-card--#{$-color} {
-    color: sage-color-combo($-color, default, foreground);
-    background-color: sage-color-combo($-color, default, background);
+    --color: #{sage-color-combo($-color, default, foreground)};
+    --background-color: #{sage-color-combo($-color, default, background)};
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -5,9 +5,9 @@
 ////
 
 
-$-feature-toggle-image-width: rem(120px);
-$-feature-toggle-image-height-min: rem(64px);
-$-feature-toggle-image-height-mobile: rem(120px);
+$-feature-toggle-media-width: rem(120px);
+$-feature-toggle-media-height-min: rem(64px);
+$-feature-toggle-media-height-mobile: rem(120px);
 
 
 .sage-feature-toggle {
@@ -16,8 +16,8 @@ $-feature-toggle-image-height-mobile: rem(120px);
   grid-row-gap: sage-spacing(sm);
 
   @media (max-width: sage-breakpoint(md-min)) {
-    grid-template-columns: 1fr min-content;
-    grid-template-rows: $-feature-toggle-image-height-mobile auto auto;
+    grid-template-columns: min-content min-content;
+    grid-template-rows: $-feature-toggle-media-height-mobile auto auto;
     grid-template-areas:
       "img      aside"
       "title    title"
@@ -25,14 +25,14 @@ $-feature-toggle-image-height-mobile: rem(120px);
   }
 
   @media (min-width: sage-breakpoint(md-min)) {
-    grid-template-columns: $-feature-toggle-image-width 1fr min-content;
+    grid-template-columns: min-content 1fr min-content;
     grid-template-rows: sage-spacing(md) auto;
     grid-template-areas:
       "img  title    aside"
       "img  content  content";
   }
 
-  &.sage-feature-toggle--no-image {
+  &.sage-feature-toggle--no-media {
     grid-template-columns: 1fr min-content;
     grid-template-rows: auto auto;
     grid-template-areas:
@@ -96,7 +96,7 @@ $-feature-toggle-image-height-mobile: rem(120px);
   grid-area: aside;
   padding-right: sage-spacing(xs);
 
-  .sage-feature-toggle--no-image & {
+  .sage-feature-toggle--no-media & {
     align-self: center;
   }
 }
@@ -111,7 +111,7 @@ $-feature-toggle-image-height-mobile: rem(120px);
   padding-right: sage-spacing(xs);
 }
 
-.sage-feature-toggle__image-link {
+.sage-feature-toggle__media-link {
   display: flex;
   position: relative;
   grid-area: img;
@@ -121,11 +121,11 @@ $-feature-toggle-image-height-mobile: rem(120px);
   }
 }
 
-.sage-feature-toggle__image {
+.sage-feature-toggle__media {
   align-self: flex-start;
   max-width: rem(140px);
-  width: $-feature-toggle-image-width;
-  height: $-feature-toggle-image-width;
+  width: $-feature-toggle-media-width;
+  height: $-feature-toggle-media-width;
   border-radius: sage-border(radius);
   object-fit: cover;
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -5,9 +5,9 @@
 ////
 
 
-$-feature-toggle-media-width: rem(120px);
-$-feature-toggle-media-height-min: rem(64px);
-$-feature-toggle-media-height-mobile: rem(120px);
+$-feature-toggle-image-width: rem(120px);
+$-feature-toggle-image-height-min: rem(64px);
+$-feature-toggle-image-height-mobile: rem(120px);
 
 
 .sage-feature-toggle {
@@ -17,7 +17,7 @@ $-feature-toggle-media-height-mobile: rem(120px);
 
   @media (max-width: sage-breakpoint(md-min)) {
     grid-template-columns: min-content min-content;
-    grid-template-rows: $-feature-toggle-media-height-mobile auto auto;
+    grid-template-rows: $-feature-toggle-image-height-mobile auto auto;
     grid-template-areas:
       "img      aside"
       "title    title"
@@ -32,7 +32,7 @@ $-feature-toggle-media-height-mobile: rem(120px);
       "img  content  content";
   }
 
-  &.sage-feature-toggle--no-media {
+  &.sage-feature-toggle--no-image {
     grid-template-columns: 1fr min-content;
     grid-template-rows: auto auto;
     grid-template-areas:
@@ -96,7 +96,7 @@ $-feature-toggle-media-height-mobile: rem(120px);
   grid-area: aside;
   padding-right: sage-spacing(xs);
 
-  .sage-feature-toggle--no-media & {
+  .sage-feature-toggle--no-image & {
     align-self: center;
   }
 }
@@ -111,7 +111,7 @@ $-feature-toggle-media-height-mobile: rem(120px);
   padding-right: sage-spacing(xs);
 }
 
-.sage-feature-toggle__media {
+.sage-feature-toggle__image-link {
   display: flex;
   position: relative;
   grid-area: img;
@@ -124,8 +124,8 @@ $-feature-toggle-media-height-mobile: rem(120px);
 .sage-feature-toggle__image {
   align-self: flex-start;
   max-width: rem(140px);
-  width: $-feature-toggle-media-width;
-  height: $-feature-toggle-media-width;
+  width: $-feature-toggle-image-width;
+  height: $-feature-toggle-image-width;
   border-radius: sage-border(radius);
   object-fit: cover;
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -111,7 +111,7 @@ $-feature-toggle-media-height-mobile: rem(120px);
   padding-right: sage-spacing(xs);
 }
 
-.sage-feature-toggle__media-link {
+.sage-feature-toggle__media {
   display: flex;
   position: relative;
   grid-area: img;
@@ -121,7 +121,7 @@ $-feature-toggle-media-height-mobile: rem(120px);
   }
 }
 
-.sage-feature-toggle__media {
+.sage-feature-toggle__image {
   align-self: flex-start;
   max-width: rem(140px);
   width: $-feature-toggle-media-width;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_feature_toggle.scss
@@ -16,7 +16,7 @@ $-feature-toggle-image-height-mobile: rem(120px);
   grid-row-gap: sage-spacing(sm);
 
   @media (max-width: sage-breakpoint(md-min)) {
-    grid-template-columns: min-content min-content;
+    grid-template-columns: min-content;
     grid-template-rows: $-feature-toggle-image-height-mobile auto auto;
     grid-template-areas:
       "img      aside"


### PR DESCRIPTION
## Description
Adds the ability to assign an `IconCard` component to an `icon` property of the `FeatureToggle` component.

This feature enables you to specify an `IconCard` in place of an image like so:

```
<%= sage_component SageFeatureToggle, {
    description: "New navigation bar layout that places Offers, Coupons, and Affiliates under a brand new “Sales” tab.",
    icon: {
      color: "published",
      icon: "tag",
      label: "New Sales Tab",
      size: "lg"
    }
...
```

### Notes
- The component should only render an `image` or an `icon`, not both.
- The complete schema for an `IconCard` can be used to configure the icon
- The icon or image container shrinks to fit the content, so smaller/larger icon sizes WILL adjust the container width; this is by design
- Added `background_color` and `foreground_color` to `IconCard` which can be used in `FeatureToggle`

## Screenshots
| |Image|Icon|
|-|------|----|
|FeatureToggle|<img width="721" alt="Image" src="https://user-images.githubusercontent.com/7331038/110148199-88533980-7daa-11eb-84e7-86682e4f7afa.png">|<img width="721" alt="Icon" src="https://user-images.githubusercontent.com/7331038/110148216-8c7f5700-7daa-11eb-89f9-3517753d2f51.png">|

### Color states

The following states can be achieved based on setting `color`, `foreground_color` and/or `background_color`:

| `color` | `foreground` | `background` | output |
|---|---|---|---|
| not | not | not | <img width="839" alt="0-0-0" src="https://user-images.githubusercontent.com/7331038/110548859-376f7800-80ff-11eb-9cd7-d9728b09393d.png"> |
| not | not | provided | <img width="839" alt="0-0-1" src="https://user-images.githubusercontent.com/7331038/110548877-3fc7b300-80ff-11eb-8b51-bad90c18ec1c.png"> |
| not | provided | not | <img width="839" alt="0-1-0" src="https://user-images.githubusercontent.com/7331038/110548902-45bd9400-80ff-11eb-9ca9-8e204542b046.png"> |
| not | provided | provided | <img width="839" alt="0-1-1" src="https://user-images.githubusercontent.com/7331038/110548912-4b1ade80-80ff-11eb-9195-8732f269c0b9.png"> |
| provided | not | not | <img width="839" alt="1-0-0" src="https://user-images.githubusercontent.com/7331038/110548925-50782900-80ff-11eb-95dc-6afd8ca4d76e.png"> |
| provided | not | provided | <img width="839" alt="1-0-1" src="https://user-images.githubusercontent.com/7331038/110548940-55d57380-80ff-11eb-82c5-7588530f2704.png"> |
| provided | provided | not | <img width="839" alt="1-1-0" src="https://user-images.githubusercontent.com/7331038/110548951-5a9a2780-80ff-11eb-9611-04c53fdbff6d.png"> |
| provided | provided | provided | <img width="839" alt="1-1-1" src="https://user-images.githubusercontent.com/7331038/110548972-5ff77200-80ff-11eb-9c44-fa66f961896c.png"> |

## Testing
1. Visit http://0.0.0.0:4000/pages/object/feature_toggle
2. Visit http://0.0.0.0:4000/pages/element/icon_card

## Affected Product Areas
1. (High) **Admin -> Labs** - Local: http://www.kajabi.test:3000/admin/sites/1/labs
2. (High) **Admin -> Products -> Edit Product** - Local: http://www.kajabi.test:3000/admin/products/12/edit