### PR TITLE
Button group - add modifier for space-between

### DIFF
--- a/docs/app/views/examples/elements/button/_preview.html.erb
+++ b/docs/app/views/examples/elements/button/_preview.html.erb
@@ -182,6 +182,23 @@ demo_configs = [
   } %>
 <% end %>
 
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Button group: Align Space-Between with top border",
+  } %>
+<% end %>
+<%= sage_component SageButtonGroup, { gap: :md, align: "space-between", borderTop: true } do %>
+  <%= sage_component SageButton, {
+    value: "Cancel",
+    style: "secondary",
+  } %>
+  <%= sage_component SageButton, {
+    value: "Save",
+    style: "primary",
+  } %>
+<% end %>
+
 
 <%= sage_component SageCardBlock, {} do %>
   <%= sage_component SageLabel, {

--- a/docs/app/views/examples/elements/button/_preview.html.erb
+++ b/docs/app/views/examples/elements/button/_preview.html.erb
@@ -165,6 +165,23 @@ demo_configs = [
   } %>
 <% end %>
 
+<%= sage_component SageCardBlock, {} do %>
+  <%= sage_component SageLabel, {
+    color: "draft",
+    value: "Button group: Align Space-Between",
+  } %>
+<% end %>
+<%= sage_component SageButtonGroup, { gap: :md, align: "space-between" } do %>
+  <%= sage_component SageButton, {
+    value: "Cancel",
+    style: "secondary",
+  } %>
+  <%= sage_component SageButton, {
+    value: "Save",
+    style: "primary",
+  } %>
+<% end %>
+
 
 <%= sage_component SageCardBlock, {} do %>
   <%= sage_component SageLabel, {

--- a/docs/app/views/examples/elements/button/_props.html.erb
+++ b/docs/app/views/examples/elements/button/_props.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= md('`align`') %></td>
   <td><%= md('Aligns a button to the "right" rather than its default position.') %></td>
-  <td><%= md('String: [ nil | "end" ]') %></td>
+  <td><%= md('String: [ nil | "space-between" | "end" ]') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/elements/button/_props.html.erb
+++ b/docs/app/views/examples/elements/button/_props.html.erb
@@ -83,3 +83,24 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="4"><%= md('**Button Group**') %></td>
+</tr>
+<tr>
+  <td><%= md('`align`') %></td>
+  <td><%= md('Adjusts the alignment of the buttons within.') %></td>
+  <td><%= md('`"end"`, `"space-between"`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`borderTop`') %></td>
+  <td><%= md('Adds a `border-top` to the component.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between buttons.') %></td>
+  <td><%= md('`:xs`, `:sm`, `:md`, `:lg`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
@@ -1,6 +1,7 @@
 class SageButtonGroup < SageComponent
   set_attribute_schema({
     align: [:optional, Set.new(["space-between", "end"])],
+    borderTop: [:optional, TrueClass],
     gap: [:optional, Set.new([:xs, :sm, :md, :lg])]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button_group.rb
@@ -1,6 +1,6 @@
 class SageButtonGroup < SageComponent
   set_attribute_schema({
-    align: [:optional, Set.new(["end"])],
+    align: [:optional, Set.new(["space-between", "end"])],
     gap: [:optional, Set.new([:xs, :sm, :md, :lg])]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button_group.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button_group.html.erb
@@ -1,6 +1,7 @@
 <div class="
     sage-btn-group
     <%= "sage-btn-group--align-#{component.align}" if component.align.present? %>
+    <%= "sage-btn-group--border-top" if component.borderTop %>
     <%= "sage-btn-group--gap-#{component.gap}" if component.gap.present? %>
     <%= component.generated_css_classes %>
   "

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
@@ -436,3 +436,7 @@ $-btn-interactive-label-icon-size: rem(24px);
 .sage-btn-group--align-end {
   justify-content: flex-end;
 }
+
+.sage-btn-group--align-space-between {
+  justify-content: space-between;
+}

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
@@ -440,3 +440,8 @@ $-btn-interactive-label-icon-size: rem(24px);
 .sage-btn-group--align-space-between {
   justify-content: space-between;
 }
+
+.sage-btn-group--border-top {
+  padding-top: sage-spacing(lg);
+  border-top: 1px solid sage-color(grey, 300);
+}

--- a/packages/sage-react/lib/Button/ButtonGroup.jsx
+++ b/packages/sage-react/lib/Button/ButtonGroup.jsx
@@ -6,6 +6,7 @@ import { BUTTON_GROUP_ALIGN_OPTIONS, BUTTON_GROUP_GAP_OPTIONS } from './configs'
 export const ButtonGroup = ({
   align,
   alignEnd,
+  borderTop,
   children,
   className,
   gap,
@@ -17,6 +18,7 @@ export const ButtonGroup = ({
     {
       'sage-btn-group--align-end': alignEnd,
       [`sage-btn-group--align-${align}`]: align,
+      [`sage-btn-group--border-top`]: borderTop,
       [`sage-btn-group--gap-${gap}`]: gap,
     }
   );
@@ -34,6 +36,7 @@ ButtonGroup.GAP_OPTIONS = BUTTON_GROUP_GAP_OPTIONS;
 ButtonGroup.defaultProps = {
   align: ButtonGroup.ALIGN_OPTIONS.NONE,
   alignEnd: false,
+  borderTop: false,
   className: null,
   children: null,
   gap: ButtonGroup.GAP_OPTIONS.XS,
@@ -42,6 +45,7 @@ ButtonGroup.defaultProps = {
 ButtonGroup.propTypes = {
   align: PropTypes.oneOf(Object.values(ButtonGroup.ALIGN_OPTIONS)),
   alignEnd: PropTypes.bool,
+  borderTop: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
   gap: PropTypes.oneOf(Object.values(ButtonGroup.GAP_OPTIONS)),

--- a/packages/sage-react/lib/Button/ButtonGroup.jsx
+++ b/packages/sage-react/lib/Button/ButtonGroup.jsx
@@ -18,7 +18,7 @@ export const ButtonGroup = ({
     {
       'sage-btn-group--align-end': alignEnd,
       [`sage-btn-group--align-${align}`]: align,
-      [`sage-btn-group--border-top`]: borderTop,
+      'sage-btn-group--border-top': borderTop,
       [`sage-btn-group--gap-${gap}`]: gap,
     }
   );

--- a/packages/sage-react/lib/Button/ButtonGroup.jsx
+++ b/packages/sage-react/lib/Button/ButtonGroup.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { BUTTON_GROUP_GAP_OPTIONS } from './configs';
+import { BUTTON_GROUP_ALIGN_OPTIONS, BUTTON_GROUP_GAP_OPTIONS } from './configs';
 
 export const ButtonGroup = ({
+  align,
   alignEnd,
   children,
   className,
@@ -15,6 +16,7 @@ export const ButtonGroup = ({
     className,
     {
       'sage-btn-group--align-end': alignEnd,
+      [`sage-btn-group--align-${align}`]: align,
       [`sage-btn-group--gap-${gap}`]: gap,
     }
   );
@@ -26,9 +28,11 @@ export const ButtonGroup = ({
   );
 };
 
+ButtonGroup.ALIGN_OPTIONS = BUTTON_GROUP_ALIGN_OPTIONS;
 ButtonGroup.GAP_OPTIONS = BUTTON_GROUP_GAP_OPTIONS;
 
 ButtonGroup.defaultProps = {
+  align: ButtonGroup.ALIGN_OPTIONS.NONE,
   alignEnd: false,
   className: null,
   children: null,
@@ -36,6 +40,7 @@ ButtonGroup.defaultProps = {
 };
 
 ButtonGroup.propTypes = {
+  align: PropTypes.oneOf(Object.values(ButtonGroup.ALIGN_OPTIONS)),
   alignEnd: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,

--- a/packages/sage-react/lib/Button/ButtonGroup.story.jsx
+++ b/packages/sage-react/lib/Button/ButtonGroup.story.jsx
@@ -8,6 +8,7 @@ export default {
   component: ButtonGroup,
   argTypes: {
     ...selectArgs({
+      align: ButtonGroup.ALIGN_OPTIONS,
       gap: ButtonGroup.GAP_OPTIONS,
     }),
   },
@@ -18,6 +19,7 @@ export default {
         <Button color={Button.COLORS.SECONDARY}>Bar</Button>
       </>
     ),
+    align: ButtonGroup.ALIGN_OPTIONS.NONE,
     gap: ButtonGroup.GAP_OPTIONS.SM,
   }
 };

--- a/packages/sage-react/lib/Button/configs.js
+++ b/packages/sage-react/lib/Button/configs.js
@@ -15,3 +15,9 @@ export const BUTTON_GROUP_GAP_OPTIONS = {
   MD: 'md',
   LG: 'lg',
 };
+
+export const BUTTON_GROUP_ALIGN_OPTIONS = {
+  NONE: 'none',
+  END: 'end',
+  SPACEBETWEEN: 'space-between'
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
 - [x] - add modifier for `space-between` alignment - rails
 - [x]  - update `alignEnd` prop to be an array to allow the addition of `space-between` - react

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

#### Align Space-Between
|  before  |  after  |
|--------|--------|
|does not exist|![Screen Shot 2021-03-15 at 9 18 17 AM](https://user-images.githubusercontent.com/1241836/111167754-6ce8eb00-856f-11eb-99ad-69393e2eea43.png)|

##### Align Space-Between with top border

|  before  |  after  |
|--------|--------|
|does not exist|![Screen Shot 2021-03-15 at 9 16 25 AM](https://user-images.githubusercontent.com/1241836/111167490-2f845d80-856f-11eb-8ab6-72e27f682aaa.png)|

## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
1. Visit the button group rails and react page.
    - select react page: http://localhost:4100/?path=/story/sage-button-group--default
    - select rails page: http://localhost:4000/pages/element/button
    
### QA Steps
#369 (Medium) Updates existing instances of `<ButtonGroup>` that have the `alignend` property set
    - [ ] - Product Outlines page, click into an item and hover the row to verify the button group
    - [ ] - Product Outlines page, click into an item, and observe the `Post Thumbnail` panel. Verify that it is unchanged

### PR to apply changes
- https://github.com/Kajabi/kajabi-products/pull/18204

### App checks
- all instances of `alignEnd` pertain to `<Button>` not `<ButtonGroup>` so good here
- all instances of `.sage-bnt-group` have either no modifiers or only modify `.sage-btn-group--gap-*` so no existing button groups are affected