### PR TITLE
Modal transition & animation settings

### DIFF
--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -11,14 +11,6 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
-      value: "Modal with Animation",
-      attributes: {
-        "data-js-modaltrigger": "cool-modal-animate",
-      }
-    } %>
-    <%= sage_component SageButton, {
-      style: "primary",
-      icon: { name: "launch", style: "right" },
       value: "Large Modal",
       attributes: {
         "data-js-modaltrigger": "cool-modal-large",
@@ -36,42 +28,6 @@
 
   <%# Standard Modal %>
   <%= sage_component SageModal, { id: "cool-modal" } do %>
-    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
-      <% content_for :sage_header_aside do %>
-        <%= sage_component SageButton, {
-          style: "secondary",
-          subtle: true,
-          value: "Close Modal",
-          icon: { name: "remove", style: "only" },
-          attributes: { "data-js-modal": true }
-        } %>
-      <% end %>
-
-      <p class="t-sage-body">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      </p>
-
-      <% content_for :sage_footer do %>
-        <% content_for :sage_footer_aside do %>
-          <%= sage_component SageButton, {
-            style: "secondary",
-            subtle: true,
-            value: "Close Modal",
-            attributes: { "data-js-modal": true }
-          } %>
-        <% end %>
-        <%= sage_component SageButton, {
-          style: "primary",
-          icon: { name: "check", style: "left" },
-          value: "Take An Action",
-        } %>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%# Standard Modal %>
-  <%= sage_component SageModal, { id: "cool-modal-animate", animate: true } do %>
     <%= sage_component SageModalContent, { title: "Example Modal" } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
@@ -202,4 +158,185 @@
       <% end %>
     <% end %>
   <% end %>
+
+<% end %>
+
+<%= sage_component SagePanelBlock, {} do %>
+  <h3 class="t-sage-heading-6">Animated</h3>
+  <div class="sage-btn-group">
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Default (to bottom)",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-animate-default",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Animate to top",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-animate-top",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Animate left",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-animate-left",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Animate right",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-animate-right",
+      }
+    } %>
+  </div>
+
+  <%# Animated Modals %>
+  <%= sage_component SageModal, { id: "cool-modal-animate-default", animate: true } do %>
+    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= sage_component SageModal, { id: "cool-modal-animate-top", animate: true, animate_direction: "top" } do %>
+    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= sage_component SageModal, { id: "cool-modal-animate-left", animate: true, animate_direction: "left" } do %>
+    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= sage_component SageModal, { id: "cool-modal-animate-right", animate: true, animate_direction: "right" } do %>
+    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
 <% end %>

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -11,6 +11,14 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
+      value: "Modal with Animation",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-animate",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
       value: "Large Modal",
       attributes: {
         "data-js-modaltrigger": "cool-modal-large",
@@ -62,8 +70,44 @@
     <% end %>
   <% end %>
 
+  <%# Standard Modal %>
+  <%= sage_component SageModal, { id: "cool-modal-animate", animate: true } do %>
+    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <%# Large Modal %>
-  <%= sage_component SageModal, { 
+  <%= sage_component SageModal, {
     id: "cool-modal-large",
     large: true,
     remove_content_on_close: true
@@ -103,7 +147,7 @@
   <% end %>
 
   <%# Spaced Modal %>
-  <%= sage_component SageModal, { 
+  <%= sage_component SageModal, {
     id: "cool-modal-spaced",
     large: true
   } do %>

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -11,7 +11,7 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
-      value: "Large Modal",
+      value: "Large Modal (removed)",
       attributes: {
         "data-js-modaltrigger": "cool-modal-large",
       }
@@ -167,7 +167,7 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
-      value: "Default (to bottom)",
+      value: "Default",
       attributes: {
         "data-js-modaltrigger": "cool-modal-animate-default",
       }
@@ -175,7 +175,7 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
-      value: "Animate to top",
+      value: "To top",
       attributes: {
         "data-js-modaltrigger": "cool-modal-animate-top",
       }
@@ -183,7 +183,7 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
-      value: "Animate left",
+      value: "To left (blur off)",
       attributes: {
         "data-js-modaltrigger": "cool-modal-animate-left",
       }
@@ -191,7 +191,7 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
-      value: "Animate right",
+      value: "To right (blur off)",
       attributes: {
         "data-js-modaltrigger": "cool-modal-animate-right",
       }
@@ -234,7 +234,7 @@
     <% end %>
   <% end %>
 
-  <%= sage_component SageModal, { id: "cool-modal-animate-top", animate: true, animate_direction: "top" } do %>
+  <%= sage_component SageModal, { id: "cool-modal-animate-top", animate: { direction: "top" } } do %>
     <%= sage_component SageModalContent, { title: "Example Modal" } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
@@ -269,7 +269,7 @@
     <% end %>
   <% end %>
 
-  <%= sage_component SageModal, { id: "cool-modal-animate-left", animate: true, animate_direction: "left" } do %>
+  <%= sage_component SageModal, { id: "cool-modal-animate-left", disable_background_blur: true, animate: { direction: "left" } } do %>
     <%= sage_component SageModalContent, { title: "Example Modal" } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
@@ -304,7 +304,7 @@
     <% end %>
   <% end %>
 
-  <%= sage_component SageModal, { id: "cool-modal-animate-right", animate: true, animate_direction: "right" } do %>
+  <%= sage_component SageModal, { id: "cool-modal-animate-right", disable_background_blur: true, animate: { direction: "right" } } do %>
     <%= sage_component SageModalContent, { title: "Example Modal" } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -1,5 +1,5 @@
 <%= sage_component SagePanelBlock, {} do %>
-  <div class="sage-btn-group">
+  <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
@@ -24,7 +24,7 @@
         "data-js-modaltrigger": "cool-modal-spaced",
       }
     } %>
-  </div>
+  <% end %>
 
   <%# Standard Modal %>
   <%= sage_component SageModal, { id: "cool-modal" } do %>
@@ -163,7 +163,7 @@
 
 <%= sage_component SagePanelBlock, {} do %>
   <h3 class="t-sage-heading-6">Animated</h3>
-  <div class="sage-btn-group">
+  <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
@@ -196,7 +196,7 @@
         "data-js-modaltrigger": "cool-modal-animate-right",
       }
     } %>
-  </div>
+  <% end %>
 
   <%# Animated Modals %>
   <%= sage_component SageModal, { id: "cool-modal-animate-default", animate: true } do %>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -5,6 +5,18 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`animate`') %></td>
+  <td><%= md('When `true`, in addition to the base fade transition assigned to all modals, the modal will animate into view while being displayed. Default direction of this animation runs from the top of the page down, and can be overridden using `animate_direction`. All animations are disabled when the user has <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion" target="_blank" rel="noopener">"reduce motion" enabled in their OS or browser.</a>') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`animate_direction`') %></td>
+  <td><%= md('Sets the direction of the animation. Options include "bottom" (default), "top", "left", and "right". Use caution when setting `animate_direction` in order to maintain consistency within the page or view. This option requires `animate` to be set to `true`.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`disable_close`') %></td>
   <td><%= md('Enabling this property will return the JS early to not initialize any handlers.') %></td>
   <td><%= md('Boolean') %></td>
@@ -25,12 +37,6 @@
 <tr>
   <td><%= md('`remove_content_on_close`') %></td>
   <td><%= md('Toggles whether to delete the `innerHTML` when closing the modal.') %></td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
-  <td><%= md('`animate`') %></td>
-  <td><%= md('When `true`, the modal will animate in from the top of the page when being displayed in addition to the default fade transtion. All animations are disabled when the user has <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion" target="_blank" rel="noopener">"reduce motion" enabled.</a>') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -29,6 +29,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`animate`') %></td>
+  <td><%= md('When `true`, the modal will animate in from the top of the page when being displayed in addition to the default fade transtion. All animations are disabled when the user has <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion" target="_blank" rel="noopener">"reduce motion" enabled.</a>') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td colspan="4">
     <strong>Modal Content</strong>
   </td>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -11,9 +11,15 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`animate_direction`') %></td>
-  <td><%= md('Sets the direction of the animation. Options include "bottom" (default), "top", "left", and "right". Use caution when setting `animate_direction` in order to maintain consistency within the page or view. This option requires `animate` to be set to `true`.') %></td>
+  <td><%= md('`direction`') %></td>
+  <td><%= md('Sets the direction of the animation. Options include "bottom" (default), "top", "left", and "right". Use caution when setting multiple `direction` modals within a page or view to ensure a consistent user experience. This option requires `animate` to be set to `true`.') %></td>
   <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`disable_background_blur`') %></td>
+  <td><%= md('Disables the background blur filter, with a darkened background color. Recommended for increased animation performance when `animate` is enabled. This setting is ignored when "reduce motion" is enabled by the user\'s OS.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -5,5 +5,6 @@ class SageModal < SageComponent
     id: [:optional, String],
     large: [:optional, TrueClass],
     remove_content_on_close: [:optional, TrueClass],
+    animate: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -6,5 +6,6 @@ class SageModal < SageComponent
     large: [:optional, TrueClass],
     remove_content_on_close: [:optional, TrueClass],
     animate: [:optional, TrueClass],
+    animate_direction: [:optional, Set.new(["bottom", "top", "left", "right"])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -5,7 +5,9 @@ class SageModal < SageComponent
     id: [:optional, String],
     large: [:optional, TrueClass],
     remove_content_on_close: [:optional, TrueClass],
-    animate: [:optional, TrueClass],
-    animate_direction: [:optional, Set.new(["bottom", "top", "left", "right"])],
+    disable_background_blur: [:optional, TrueClass],
+    animate: [:optional, String, TrueClass, {
+      direction: [:optional, String, Set.new(["bottom", "top", "left", "right"])]
+    }]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -1,13 +1,15 @@
 <dialog
-  class="
-    sage-modal
+  class="sage-modal
     <%= "sage-modal--active" if component.active %>
-    <%= "sage-modal--large" if component.large %>
+    <%= "sage-modal--large" if component.large -%>
+    <%= "sage-modal--no-blur" if component.disable_background_blur -%>
   "
-  <%= "data-sage-animate" if component.animate %>
-  <% if component.animate_direction.present? && component.animate %>
-    <%= "data-sage-animate-dir=#{ component.animate_direction }" %>
-  <% end %>
+  <%= "data-sage-animate" if component.animate.present? %>
+  <%- if component.animate.is_a?(Hash) -%>
+    <%- component.animate.each do |key, value| -%>
+      <%= "data-sage-animate-#{ key }=#{ value }" %>
+    <%- end -%>
+  <%- end -%>
   <%= "data-js-modal-disable-close" if component.disable_close %>
   <%= "data-js-modal-remove-content-on-close" if component.remove_content_on_close %>
   data-js-modal="<%= component.id %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -3,8 +3,12 @@
     sage-modal
     <%= "sage-modal--active" if component.active %>
     <%= "sage-modal--large" if component.large %>
-    <%= "sage-modal--animate" if component.animate %>
   "
+  <%= "data-sage-animate" if component.animate %>
+  <%= "data-sage-animate-prop=translate" if component.animate %>
+  <% if component.animate_direction.present? && component.animate %>
+    <%= "data-sage-animate-dir=#{ component.animate_direction }" %>
+  <% end %>
   <%= "data-js-modal-disable-close" if component.disable_close %>
   <%= "data-js-modal-remove-content-on-close" if component.remove_content_on_close %>
   data-js-modal="<%= component.id %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -5,7 +5,6 @@
     <%= "sage-modal--large" if component.large %>
   "
   <%= "data-sage-animate" if component.animate %>
-  <%= "data-sage-animate-prop=translate" if component.animate %>
   <% if component.animate_direction.present? && component.animate %>
     <%= "data-sage-animate-dir=#{ component.animate_direction }" %>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -3,12 +3,13 @@
     sage-modal
     <%= "sage-modal--active" if component.active %>
     <%= "sage-modal--large" if component.large %>
+    <%= "sage-modal--animate" if component.animate %>
   "
   <%= "data-js-modal-disable-close" if component.disable_close %>
   <%= "data-js-modal-remove-content-on-close" if component.remove_content_on_close %>
   data-js-modal="<%= component.id %>"
 >
-  <section class="sage-modal__container" data-js-modal-container>
+  <section class="sage-modal__container" data-js-modal-container tabindex="-1">
     <% if component.content.present? %>
       <%= component.content %>
     <% else %>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -51,7 +51,7 @@ $-modal-padding-y: sage-spacing(md);
   border-radius: sage-border(radius);
   background-color: sage-color(white);
   box-shadow: sage-shadow(2xl);
-  transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.1s ease-in-out 0.1s;
   pointer-events: none;
   opacity: 0;
 
@@ -65,7 +65,8 @@ $-modal-padding-y: sage-spacing(md);
 
   [data-sage-animate] & {
     transform: translateY(-#{sage-spacing(lg)});
-    transition: opacity 0.1s ease-in-out 0.1s, transform 0.15s ease-out 0.1s;
+    transition: opacity 0.1s ease-in, transform 0.15s ease-out;
+    transition-delay: 0.1s, 0.1s;
   }
 
   [data-sage-animate-dir="top"] & {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -16,7 +16,7 @@ $-modal-padding-y: sage-spacing(md);
   justify-content: center;
   position: fixed;
   overflow-y: scroll;
-  z-index: sage-z-index(modal, -1);
+  z-index: sage-z-index(negative);
   padding: sage-spacing(md);
   background-color: rgba(sage-color(charcoal, 500), 0.4);
   background-image: linear-gradient(
@@ -36,6 +36,7 @@ $-modal-padding-y: sage-spacing(md);
 
   &.sage-modal--active {
     visibility: visible;
+    z-index: sage-z-index(modal, -1);
     pointer-events: auto;
     opacity: 1;
   }
@@ -62,9 +63,19 @@ $-modal-padding-y: sage-spacing(md);
     margin-top: 8vh;
   }
 
-  .sage-modal--animate & {
+  [data-sage-animate] & {
     transform: translateY(-#{sage-spacing(lg)});
     transition: opacity 0.1s ease-in-out 0.1s, transform 0.15s ease-out 0.1s;
+  }
+
+  [data-sage-animate-dir="top"] & {
+    transform: translateY(#{sage-spacing(lg)});
+  }
+  [data-sage-animate-dir="left"] & {
+    transform: translateX(#{sage-spacing(lg)});
+  }
+  [data-sage-animate-dir="right"] & {
+    transform: translateX(-#{sage-spacing(lg)});
   }
 
   .sage-modal--active & {
@@ -136,7 +147,7 @@ $-modal-padding-y: sage-spacing(md);
 
   .sage-modal,
   .sage-modal__container,
-  .sage-modal--animate .sage-modal__container {
+  [data-sage-animate] .sage-modal__container {
     transform: none;
     transition: none;
   }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -23,7 +23,7 @@ $-modal-padding-y: sage-spacing(md);
     rgba(sage-color(charcoal, 200), 0.3) 0%,
     rgba(sage-color(charcoal, 500), 0.3) 100%
   );
-  transition: opacity 0.15s ease-in;
+  transition: opacity 0.1s ease-out;
   pointer-events: none;
   opacity: 0;
   cursor: default;
@@ -50,6 +50,7 @@ $-modal-padding-y: sage-spacing(md);
   border-radius: sage-border(radius);
   background-color: sage-color(white);
   box-shadow: sage-shadow(2xl);
+  transition: opacity 0.15s ease-in-out;
   pointer-events: none;
   opacity: 0;
 
@@ -63,7 +64,7 @@ $-modal-padding-y: sage-spacing(md);
 
   .sage-modal--animate & {
     transform: translateY(-#{sage-spacing(lg)});
-    transition: 0.15s ease-out opacity 0.1s, 0.2s ease-out transform 0.1s;
+    transition: opacity 0.1s ease-in-out 0.1s, transform 0.15s ease-out 0.1s;
   }
 
   .sage-modal--active & {
@@ -128,7 +129,13 @@ $-modal-padding-y: sage-spacing(md);
 }
 
 @media (prefers-reduced-motion) {
+  .sage-modal {
+    background-color: rgba(sage-color(charcoal, 500), 0.9);
+    backdrop-filter: none;
+  }
+
   .sage-modal,
+  .sage-modal__container,
   .sage-modal--animate .sage-modal__container {
     transform: none;
     transition: none;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -20,8 +20,8 @@ $-modal-padding-y: sage-spacing(md);
   padding: sage-spacing(md);
   background-color: rgba(sage-color(charcoal, 500), 0.4);
   background-image: linear-gradient(
-    rgba(sage-color(charcoal, 200), 0.3) 0%,
-    rgba(sage-color(charcoal, 500), 0.3) 100%
+    rgba(sage-color(charcoal, 200), 0.35) 0%,
+    rgba(sage-color(charcoal, 500), 0.4) 100%
   );
   transition: opacity 0.1s ease-out;
   pointer-events: none;
@@ -30,8 +30,16 @@ $-modal-padding-y: sage-spacing(md);
 
   @include position-full;
 
-  @supports (backdrop-filter: blur(2px)) {
-    backdrop-filter: blur(2px);
+  @supports (backdrop-filter: blur(3px)) {
+    backdrop-filter: blur(3px);
+  }
+
+  &.sage-modal--no-blur {
+    backdrop-filter: none;
+    background-image: linear-gradient(
+      rgba(sage-color(charcoal, 300), 0.5) 0%,
+      rgba(sage-color(charcoal, 500), 0.5) 100%
+    );
   }
 
   &.sage-modal--active {
@@ -51,7 +59,7 @@ $-modal-padding-y: sage-spacing(md);
   border-radius: sage-border(radius);
   background-color: sage-color(white);
   box-shadow: sage-shadow(2xl);
-  transition: opacity 0.1s ease-in-out 0.1s;
+  transition: opacity 0.1s ease-in 0.1s;
   pointer-events: none;
   opacity: 0;
 
@@ -64,18 +72,18 @@ $-modal-padding-y: sage-spacing(md);
   }
 
   [data-sage-animate] & {
-    transform: translateY(-#{sage-spacing(lg)});
+    transform: translateY(-#{sage-spacing(md)});
     transition: opacity 0.1s ease-in, transform 0.15s ease-out;
-    transition-delay: 0.1s, 0.1s;
+    transition-delay: 0.1s, 0.15s;
   }
 
-  [data-sage-animate-dir="top"] & {
+  [data-sage-animate-direction="top"] & {
     transform: translateY(#{sage-spacing(lg)});
   }
-  [data-sage-animate-dir="left"] & {
+  [data-sage-animate-direction="left"] & {
     transform: translateX(#{sage-spacing(lg)});
   }
-  [data-sage-animate-dir="right"] & {
+  [data-sage-animate-direction="right"] & {
     transform: translateX(-#{sage-spacing(lg)});
   }
 
@@ -142,7 +150,7 @@ $-modal-padding-y: sage-spacing(md);
 
 @media (prefers-reduced-motion) {
   .sage-modal {
-    background-color: rgba(sage-color(charcoal, 500), 0.9);
+    background-color: rgba(sage-color(charcoal, 500), 0.85);
     backdrop-filter: none;
   }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -11,7 +11,7 @@ $-modal-padding-y: sage-spacing(md);
 
 .sage-modal {
   visibility: hidden;
-  display: none;
+  display: flex;
   align-items: flex-start;
   justify-content: center;
   position: fixed;
@@ -23,6 +23,9 @@ $-modal-padding-y: sage-spacing(md);
     rgba(sage-color(charcoal, 200), 0.3) 0%,
     rgba(sage-color(charcoal, 500), 0.3) 100%
   );
+  transition: opacity 0.15s ease-in;
+  pointer-events: none;
+  opacity: 0;
   cursor: default;
 
   @include position-full;
@@ -33,13 +36,13 @@ $-modal-padding-y: sage-spacing(md);
 
   &.sage-modal--active {
     visibility: visible;
-    display: flex;
+    pointer-events: auto;
+    opacity: 1;
   }
 }
 
 .sage-modal__container {
   visibility: hidden;
-  display: none;
   z-index: sage-z-index(modal);
   width: calc(100vw - #{sage-spacing(md)});
   max-width: sage-container(modal);
@@ -47,6 +50,8 @@ $-modal-padding-y: sage-spacing(md);
   border-radius: sage-border(radius);
   background-color: sage-color(white);
   box-shadow: sage-shadow(2xl);
+  pointer-events: none;
+  opacity: 0;
 
   @media (min-width: sage-breakpoint(lg-min)) {
     margin-top: 6vh;
@@ -56,9 +61,16 @@ $-modal-padding-y: sage-spacing(md);
     margin-top: 8vh;
   }
 
+  .sage-modal--animate & {
+    transform: translateY(-#{sage-spacing(lg)});
+    transition: 0.15s ease-out opacity 0.1s, 0.2s ease-out transform 0.1s;
+  }
+
   .sage-modal--active & {
     visibility: visible;
-    display: block;
+    transform: none;
+    pointer-events: auto;
+    opacity: 1;
   }
 
   .sage-modal--large & {
@@ -113,4 +125,12 @@ $-modal-padding-y: sage-spacing(md);
 
 .sage-modal__footer-aside {
   margin-right: auto;
+}
+
+@media (prefers-reduced-motion) {
+  .sage-modal,
+  .sage-modal--animate .sage-modal__container {
+    transform: none;
+    transition: none;
+  }
 }

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -6,13 +6,15 @@ import { ModalFooter } from './ModalFooter';
 import { ModalFooterAside } from './ModalFooterAside';
 import { ModalHeader } from './ModalHeader';
 import { ModalHeaderAside } from './ModalHeaderAside';
+import { MODAL_ANIMATION_PRESETS, MODAL_ANIMATION_DIRECTIONS } from './configs';
 
 export const Modal = ({
   active,
   children,
   className,
-  large,
   containerClassName,
+  animation,
+  large,
   onExit,
   ...rest
 }) => {
@@ -24,6 +26,16 @@ export const Modal = ({
       'sage-modal--large': large,
     }
   );
+
+  let animationAttributes = {};
+
+  if (animation) {
+    animationAttributes = MODAL_ANIMATION_PRESETS;
+
+    if (animation.direction) {
+      animationAttributes['data-sage-animate-dir'] = animation.direction;
+    }
+  }
 
   const handleBackgroundClick = (evt) => {
     if (evt.target === evt.currentTarget) {
@@ -44,6 +56,7 @@ export const Modal = ({
       onKeyPress={handleBackgroundKeypress}
       role="button"
       tabIndex="0"
+      {...animationAttributes}
     >
       <div
         className={`sage-modal__container ${containerClassName || ''}`}
@@ -61,9 +74,11 @@ Modal.Footer = ModalFooter;
 Modal.FooterAside = ModalFooterAside;
 Modal.Header = ModalHeader;
 Modal.HeaderAside = ModalHeaderAside;
+Modal.ANIMATION_DIRECTIONS = MODAL_ANIMATION_DIRECTIONS;
 
 Modal.defaultProps = {
   active: false,
+  animation: null,
   children: null,
   containerClassName: null,
   className: '',
@@ -73,6 +88,12 @@ Modal.defaultProps = {
 
 Modal.propTypes = {
   active: PropTypes.bool,
+  animation: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      direction: PropTypes.oneOf(Object.values(Modal.ANIMATION_DIRECTIONS))
+    })
+  ]),
   children: PropTypes.node,
   containerClassName: PropTypes.string,
   className: PropTypes.string,

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -10,11 +10,12 @@ import { MODAL_ANIMATION_PRESETS, MODAL_ANIMATION_DIRECTIONS } from './configs';
 
 export const Modal = ({
   active,
+  animation,
   children,
   className,
   containerClassName,
-  animation,
   large,
+  noBlur,
   onExit,
   ...rest
 }) => {
@@ -24,6 +25,7 @@ export const Modal = ({
     {
       'sage-modal--active': active,
       'sage-modal--large': large,
+      'sage-modal--no-blur': noBlur,
     }
   );
 
@@ -33,7 +35,7 @@ export const Modal = ({
     animationAttributes = MODAL_ANIMATION_PRESETS;
 
     if (animation.direction) {
-      animationAttributes['data-sage-animate-dir'] = animation.direction;
+      animationAttributes['data-sage-animate-direction'] = animation.direction;
     }
   }
 
@@ -84,6 +86,7 @@ Modal.defaultProps = {
   containerClassName: null,
   className: '',
   large: false,
+  noBlur: false,
   onExit: (val) => val,
 };
 
@@ -99,5 +102,6 @@ Modal.propTypes = {
   containerClassName: PropTypes.string,
   className: PropTypes.string,
   large: PropTypes.bool,
+  noBlur: PropTypes.bool,
   onExit: PropTypes.func,
 };

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -74,6 +74,7 @@ Modal.Footer = ModalFooter;
 Modal.FooterAside = ModalFooterAside;
 Modal.Header = ModalHeader;
 Modal.HeaderAside = ModalHeaderAside;
+Modal.ANIMATION_PRESETS = MODAL_ANIMATION_PRESETS;
 Modal.ANIMATION_DIRECTIONS = MODAL_ANIMATION_DIRECTIONS;
 
 Modal.defaultProps = {

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Button } from '../Button';
 import { SageTokens, SageClassnames } from '../configs';
-import { disableArgs, selectArgs } from '../story-support/helpers';
+import { disableArgs } from '../story-support/helpers';
 import { Modal } from './Modal';
 
 const DefaultBody = ({ onExit }) => (
@@ -87,7 +87,7 @@ export const Default = Template.bind({});
 Default.decorators = [
   (Story) => (
     <>
-      <p>Note: Use the Controls to toggle the modal's Active property to see it.</p>
+      <p>Note: Use the Controls to toggle the modal&lsquo;s Active property to see it.</p>
       <Story />
     </>
   )
@@ -110,7 +110,7 @@ export const Wired = () => {
       </Button>
       <Modal
         active={active}
-        animation={{direction: Modal.ANIMATION_DIRECTIONS.BOTTOM}}
+        animation={{ direction: Modal.ANIMATION_DIRECTIONS.BOTTOM }}
         onExit={onExit}
       >
         <DefaultBody onExit={onExit} />

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '../Button';
 import { SageTokens, SageClassnames } from '../configs';
+import { disableArgs, selectArgs } from '../story-support/helpers';
 import { Modal } from './Modal';
 
-const defaultBody = (
+const DefaultBody = ({ onExit }) => (
   <>
     <Modal.Header title="Example Sage Modal">
       <Modal.HeaderAside>
@@ -57,18 +58,36 @@ export default {
     'Modal.FooterAside': Modal.FooterAside,
   },
   args: {
-    animation: null
-  }
+    animation: Modal.ANIMATION_PRESETS,
+  },
+  argTypes: {
+    ...disableArgs(['children', 'onExit']),
+  },
 };
 
-const Template = (args) => <Modal {...args} />;
+const Template = (args) => {
+  const [selfActive, setSelfActive] = useState(args.active);
 
+  const handleExit = () => {
+    setSelfActive(false);
+  };
+
+  useEffect(() => {
+    setSelfActive(args.active);
+  }, [args.active]);
+
+  return (
+    <Modal {...args} onExit={handleExit} active={selfActive}>
+      <DefaultBody onExit={handleExit} />
+    </Modal>
+  );
+};
 export const Default = Template.bind({});
 
 Default.decorators = [
   (Story) => (
     <>
-      <p>Note: wired modal demonstrates functionality. See &quot;Docs&quot; tab for properties</p>
+      <p>Note: Use the Controls to toggle the modal's Active property to see it.</p>
       <Story />
     </>
   )
@@ -94,7 +113,7 @@ export const Wired = () => {
         animation={{direction: Modal.ANIMATION_DIRECTIONS.BOTTOM}}
         onExit={onExit}
       >
-        {defaultBody}
+        <DefaultBody onExit={onExit} />
       </Modal>
     </>
   );

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -3,6 +3,49 @@ import { Button } from '../Button';
 import { SageTokens, SageClassnames } from '../configs';
 import { Modal } from './Modal';
 
+const defaultBody = (
+  <>
+    <Modal.Header title="Example Sage Modal">
+      <Modal.HeaderAside>
+        <Button
+          color={Button.COLORS.SECONDARY}
+          iconOnly={true}
+          icon={SageTokens.ICONS.REMOVE}
+          onClick={onExit}
+          subtle={true}
+        >
+          Menu
+        </Button>
+      </Modal.HeaderAside>
+    </Modal.Header>
+    <Modal.Body>
+      <p className={SageClassnames.TYPE.BODY}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+      </p>
+    </Modal.Body>
+    <Modal.Footer>
+      <Modal.FooterAside>
+        <Button
+          color={Button.COLORS.SECONDARY}
+          onClick={onExit}
+        >
+          Close Modal
+        </Button>
+      </Modal.FooterAside>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        icon={SageTokens.ICONS.CHECK}
+        iconPosition={Button.ICON_POSITIONS.LEFT}
+        onClick={onExit}
+      >
+        Take An Action
+      </Button>
+    </Modal.Footer>
+  </>
+);
+
 export default {
   title: 'Sage/Modal',
   component: Modal,
@@ -13,10 +56,16 @@ export default {
     'Modal.Footer': Modal.Footer,
     'Modal.FooterAside': Modal.FooterAside,
   },
+  args: {
+    animation: null
+  }
 };
 
-export const Empty = (args) => <Modal {...args} />;
-Empty.decorators = [
+const Template = (args) => <Modal {...args} />;
+
+export const Default = Template.bind({});
+
+Default.decorators = [
   (Story) => (
     <>
       <p>Note: wired modal demonstrates functionality. See &quot;Docs&quot; tab for properties</p>
@@ -42,46 +91,10 @@ export const Wired = () => {
       </Button>
       <Modal
         active={active}
+        animation={{direction: Modal.ANIMATION_DIRECTIONS.BOTTOM}}
         onExit={onExit}
       >
-        <Modal.Header title="Example Sage Modal">
-          <Modal.HeaderAside>
-            <Button
-              color={Button.COLORS.SECONDARY}
-              iconOnly={true}
-              icon={SageTokens.ICONS.REMOVE}
-              onClick={onExit}
-              subtle={true}
-            >
-              Menu
-            </Button>
-          </Modal.HeaderAside>
-        </Modal.Header>
-        <Modal.Body>
-          <p className={SageClassnames.TYPE.BODY}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-            sed do eiusmod tempor incididunt ut labore et dolore
-            magna aliqua.
-          </p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Modal.FooterAside>
-            <Button
-              color={Button.COLORS.SECONDARY}
-              onClick={onExit}
-            >
-              Close Modal
-            </Button>
-          </Modal.FooterAside>
-          <Button
-            color={Button.COLORS.PRIMARY}
-            icon={SageTokens.ICONS.CHECK}
-            iconPosition={Button.ICON_POSITIONS.LEFT}
-            onClick={onExit}
-          >
-            Take An Action
-          </Button>
-        </Modal.Footer>
+        {defaultBody}
       </Modal>
     </>
   );

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { Button } from '../Button';
 import { SageTokens, SageClassnames } from '../configs';
 import { disableArgs } from '../story-support/helpers';
@@ -46,6 +47,10 @@ const DefaultBody = ({ onExit }) => (
     </Modal.Footer>
   </>
 );
+
+DefaultBody.propTypes = {
+  onExit: PropTypes.func.isRequired
+};
 
 export default {
   title: 'Sage/Modal',

--- a/packages/sage-react/lib/Modal/configs.js
+++ b/packages/sage-react/lib/Modal/configs.js
@@ -3,3 +3,15 @@ export const MODAL_CONTENT_SPACINGS = {
   DEFAULT: null,
   PANEL: 'panel',
 };
+
+export const MODAL_ANIMATION_DIRECTIONS = {
+  TOP: 'top',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+  RIGHT: 'right'
+};
+
+export const MODAL_ANIMATION_PRESETS = {
+  'data-sage-animate': true,
+  'data-sage-animate-dir': MODAL_ANIMATION_DIRECTIONS.TOP
+};

--- a/packages/sage-react/lib/Modal/configs.js
+++ b/packages/sage-react/lib/Modal/configs.js
@@ -13,5 +13,5 @@ export const MODAL_ANIMATION_DIRECTIONS = {
 
 export const MODAL_ANIMATION_PRESETS = {
   'data-sage-animate': true,
-  'data-sage-animate-dir': MODAL_ANIMATION_DIRECTIONS.TOP
+  'data-sage-animate-direction': MODAL_ANIMATION_DIRECTIONS.TOP
 };


### PR DESCRIPTION
## Description
This branch adds a default fade transition to all modals along with options for animated movement. Screens attached below, though the effect should be easier to see on-page.

Transitions are controlled through `data` attributes. Using this implementation as a test case for an extended Sage animation library. 

Notes:
- huge thanks to @philschanely for assistance with the React version 🙇🏼 
- added ability to disable background blur: in testing, the css `filter` tends to increase GPU/CPU usage when animating, resulting in dropped frames


### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![modal-before](https://user-images.githubusercontent.com/816579/110717750-7d3f4580-81be-11eb-808d-20ae74f6262a.gif)|![modal-after](https://user-images.githubusercontent.com/816579/110717712-6dbffc80-81be-11eb-81f3-f56916e48970.gif)|

## Test notes
In order to implement these transitions, the inactive modal CSS was changed from `display: none` to instead use `visibility: hidden` and a negative `z-index`. This should still be sufficient to "hide" the modal from accidental user interaction, but we'll need to ensure the stacking order is working as expected depending on placement of the modal's markup. In Rails, if `SageModal` is nested within a `<% content_for :modal do %>`, there should not be an issue.

All transitions are disabled when "reduce motion" is enabled on a user's OS, or on browsers that support the feature. Modal backdrop opacity is also increased for additional contrast.


### Steps to test
- Navigate to http://localhost:4000/pages/object/modal
- Open some modals
- (optional) Enable "reduce motion" in your MacOS system preferences -> Accessibility (screen below). All transitions should now be disabled

<img width="380" alt="" src="https://user-images.githubusercontent.com/816579/110720496-8383f080-81c3-11eb-80d7-5ceba7d98862.png">


### Estimated impact
- (HIGH) Modal CSS display property has been altered to allow for transitioning effects. Confirm that modal is displayed on page as expected, and cannot be accessed via user interaction or keyboard navigation. Examples of use:
  - [x] Beta features modal 
  - [x] Offer price modal
  - [x] Create site modal
  - [ ] Coupons: delete Coupon modal
  - [ ] Coupons: add Offer modal


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->