### PR TITLE
Property Element Icon Alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_property.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_property.scss
@@ -27,7 +27,7 @@
   margin-right: sage-spacing(xs);
 
   &::before {
-    vertical-align: text-top;
+    vertical-align: top;
   }
 }
 


### PR DESCRIPTION
## Description
Adjusts the alignment of the Property element icons.
Noticed these are out of alignment while watching the London Facebook recap.

### Screenshots

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-03-15 at 10 50 43 AM](https://user-images.githubusercontent.com/1175111/111199262-aaed0b80-857d-11eb-8179-0110514fffca.png)|![Screen Shot 2021-03-15 at 10 51 05 AM](https://user-images.githubusercontent.com/1175111/111199321-b9d3be00-857d-11eb-8e80-dc3052b7fb7e.png)|

## Test notes

- Visit http://localhost:4000/pages/breakout/element/property
- Verify property icons align as expected and are no longer out of alignment.

### Estimated impact
- [ ] (LOW) Style only updates to address Property icon alignment.

## Related
-N/A