### PR TITLE
Table Overflow Gradient Adjustment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_table.scss
@@ -284,6 +284,9 @@ $-table-sort-indicator-direction: rem(7px);
     height: 100%;
     width: $-table-overflow-indicator-width;
     background: $-table-overflow-indicator-gradient;
+    @media screen and (min-width: sage-breakpoint(sm-max)) {
+      display: none;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_table.scss
@@ -285,7 +285,7 @@ $-table-sort-indicator-direction: rem(7px);
     width: $-table-overflow-indicator-width;
     background: $-table-overflow-indicator-gradient;
     @media screen and (min-width: sage-breakpoint(sm-max)) {
-      display: none;
+      background: none;
     }
   }
 }


### PR DESCRIPTION
## Description
Adjustments to display the table overflow gradient on smaller screen sizes only.
On larger screen sizes this causes the table alignment to look like it does not expand full width when using the striped-table variant.

This came as a request from design after a recent design review where a striped table is being implemented.

### Screenshots

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-03-15 at 11 21 10 AM](https://user-images.githubusercontent.com/1175111/111203353-22bd3500-8582-11eb-9122-7c83f059f749.png)|![Screen Shot 2021-03-15 at 11 21 59 AM](https://user-images.githubusercontent.com/1175111/111203432-3e284000-8582-11eb-9072-213d3de8e5da.png)|

## Test notes

- Visit http://localhost:4000/pages/breakout/element/table
- Verify the overflow gradient is applied to small screens, but does not appear on larger screens.

### Estimated impact
- [ ] (LOW) Style only updates to address when the table overflow gradient is displayed.

## Related
-N/A