### PR TITLE
Choice icon alignment

### DIFF
--- a/docs/app/helpers/elements_helper.rb
+++ b/docs/app/helpers/elements_helper.rb
@@ -59,7 +59,8 @@ module ElementsHelper
         docs: "done",
         rails: "done",
         react: "todo",
-        a11y: "todo"
+        a11y: "todo",
+        react_component_slug: "sage-tabs--default"
       },
       {
         title: "copy_text",
@@ -250,7 +251,8 @@ module ElementsHelper
         docs: "done",
         rails: "doing",
         react: "todo",
-        a11y: "todo"
+        a11y: "todo",
+        react_component_slug: "sage-tabs--default"
       },
       {
         title: "table",

--- a/docs/app/views/examples/elements/choice/_preview.html.erb
+++ b/docs/app/views/examples/elements/choice/_preview.html.erb
@@ -1,3 +1,6 @@
+<%
+long_description = "Description with longer text to cause wrapping and make the top alignment appear more necessary."
+%>
 <h3 class="t-sage-heading-6">Single Line (radio type)</h3>
 
 <%= sage_component SageChoice, {
@@ -65,3 +68,24 @@
     <p>Custom content here...</p>
   <% end %>
 <% end %>
+
+
+<h3 class="t-sage-heading-6">Icon alignment</h3>
+<p>While by default all icon types will align in the center of the choice card, they can be adjusted to align at the "start" or top of the card.</p>
+<%= sage_component SageChoice, {
+    target: "example",
+    text: "Option 1",
+    subtext: long_description,
+    type: "radio",
+    vertical_align_icon: "start",
+  }
+%>
+<%= sage_component SageChoice, {
+    target: "example",
+    text: "Option 1",
+    subtext: long_description,
+    type: "icon",
+    icon: "video-on",
+    vertical_align_icon: "start",
+  }
+%>

--- a/docs/app/views/examples/elements/choice/_props.html.erb
+++ b/docs/app/views/examples/elements/choice/_props.html.erb
@@ -10,6 +10,13 @@
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
+<tr>
+  <td><%= md('`vertical_align_icon`') %></td>
+  <td><%= md('Configures how the icons ("radio" and "icon"; not "arrow" or "graphc") should be vertically aligned within the card.') %></td>
+  <td><%= md('`nil` (centered), "start"`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`attributes`') %></td>
   <td><%= md('For setting additional attributes not defined above. Accepts a Ruby hash of valid key-value properties, such as data-attributes') %></td>
   <td><%= md('Hash') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -10,6 +10,7 @@ class SageChoice < SageComponent
     subtext: [:optional, NilClass, String],
     target: [:optional, NilClass, String],
     text: [:optional, NilClass, String],
-    type: [:optional, NilClass, Set.new(["arrow", "graphic", "icon", "radio"])]
+    type: [:optional, NilClass, Set.new(["arrow", "graphic", "icon", "radio"])],
+    vertical_align_icon: [:optional, NilClass, Set.new(["start"])]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -15,7 +15,8 @@ class SageTabs < SageComponent
       subtext: [:optional, NilClass, String],
       target: [:optional, NilClass, String],
       text: [:optional, NilClass, String],
-      type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])]
+      type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
+      vertical_align_icon: [:optional, NilClass, Set.new(["start"])]
     ]]],
     navigational: [:optional, TrueClass],
     progressbar: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -23,6 +23,7 @@ html_tag = is_button ? (component.content.present? ? "div" : "button") : "a"
       <% end %>
     <% end %>
     <%= "sage-choice--align-center" if component.align_center.present? && component.align_center == true %>
+    <%= "sage-choice--vertical-align-icon-#{component.vertical_align_icon}" if component.vertical_align_icon %>
   "
   data-js-tabs-target="<%= component.target %>"
   data-sage-active-class="<%= css_active_class %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -21,7 +21,8 @@
         type: item[:type],
         icon: item[:icon],
         attributes: item[:attributes],
-        disabled: item[:disabled]
+        disabled: item[:disabled],
+        vertical_align_icon: item[:vertical_align_icon],
       } do %>
         <%= item[:content].html_safe if defined?(item[:content]) and item[:content] %>
       <% end %>

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_choice.scss
@@ -16,6 +16,16 @@ $-choice-radio-size: $sage-radio-size;
 $-choice-radio-color-checked: map-get($sage-radio-colors, checked);
 $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
 
+:root {
+  --icon-top-offset: #{rem(7px)};
+}
+
+@media (max-width: sage-breakpoint(md-min)) {
+  :root {
+    --icon-top-offset: #{rem(6px)};
+  }
+}
+
 
 // stylelint-disable max-nesting-depth
 
@@ -28,7 +38,6 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   flex-grow: 1;
   flex-basis: 0;
   padding: sage-spacing(sm);
-  white-space: nowrap;
   color: $-choice-color-default;
   border: sage-border();
   border-radius: sage-border(radius);
@@ -142,6 +151,11 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     color: currentColor;
     transition: color map-get($sage-transitions, default);
   }
+
+  &.sage-choice--vertical-align-icon-start::#{$-choice-el-icon} {
+    align-self: start;
+    margin-top: var(--icon-top-offset);
+  }
 }
 
 .sage-choice--radio {
@@ -172,6 +186,11 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
       border-color: $-choice-radio-color-checked;
     }
   }
+
+  &.sage-choice--vertical-align-icon-start::#{$-choice-el-radio} {
+    align-self: start;
+    margin-top: var(--icon-top-offset);
+  }
 }
 
 .sage-choice__content {
@@ -194,7 +213,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
 .sage-choice__graphic {
   overflow: hidden;
   width: rem(48px);
-  height: remb(48px);
+  height: rem(48px);
   margin-right: sage-spacing(sm);
   border-radius: sage-border(radius-small);
 

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -48,7 +48,7 @@ export const Tabs = ({
   return (
     <div className={`sage-tabs-container ${className || ''}`}>
       <div className={tabsClassNames} {...rest}>
-        {tabs.map(({ disabled, id, label, tabDetails, tabChoiceIcon, tabChoiceType, subtext }) => (
+        {tabs.map(({ disabled, id, label, tabDetails, tabChoiceIcon, tabChoiceIconAlignment, tabChoiceType, subtext }) => (
           <TabsItem
             disabled={disabled}
             icon={tabChoiceIcon}
@@ -60,6 +60,7 @@ export const Tabs = ({
             label={label}
             subtext={subtext}
             type={tabChoiceType}
+            verticalAlignIcon={tabChoiceIconAlignment}
           >
             {tabDetails}
           </TabsItem>

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -28,8 +28,10 @@ export const Default = (args) => {
     iconPosition: 'right'
   };
 
-  const choiceIcon = null;
-  const choiceType = Tabs.Item.CHOICE_TYPES.RADIO;
+  const tabChoiceSettings = {
+    tabChoiceType: Tabs.Item.CHOICE_TYPES.RADIO,
+    tabChoiceIcon: null,
+  };
 
   return (
     <Tabs
@@ -41,8 +43,6 @@ export const Default = (args) => {
           id: 'tab-1',
           label: 'Tab 1',
           subtext: 'Subtext content...',
-          tabChoiceType: choiceType,
-          tabChoiceIcon: choiceIcon,
           content: (
             <>
               <p>Tab 1 content. Lorem ipsum dolor sit amut consectitor.</p>
@@ -52,13 +52,12 @@ export const Default = (args) => {
             </>
           ),
           panelSpacing: true,
+          ...tabChoiceSettings,
         },
         {
           id: 'tab-2',
           label: 'Tab 2',
           subtext: 'Subtext content...',
-          tabChoiceType: choiceType,
-          tabChoiceIcon: choiceIcon,
           content: (
             <>
               <p>Tab 2 content. Lorem ipsum dolor sit amut consectitor.</p>
@@ -68,14 +67,13 @@ export const Default = (args) => {
             </>
           ),
           panelSpacing: true,
+          ...tabChoiceSettings,
         },
         {
           id: 'tab-3',
           disabled: true,
           label: 'Tab 3',
           subtext: 'Subtext content...',
-          tabChoiceType: choiceType,
-          tabChoiceIcon: choiceIcon,
           content: (
             <>
               <p>Tab 3 content. Lorem ipsum dolor sit amut consectitor.</p>
@@ -85,6 +83,7 @@ export const Default = (args) => {
             </>
           ),
           panelSpacing: true,
+          ...tabChoiceSettings,
         },
       ]}
     />
@@ -125,4 +124,45 @@ RichContent.args = {
     },
   ],
   tabStyle: Tabs.STYLES.CHOICE
+};
+
+export const IconAlignment = () => {
+  const tabChoiceSettings = {
+    tabChoiceType: Tabs.Item.CHOICE_TYPES.RADIO,
+    tabChoiceIcon: null,
+    tabChoiceIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,
+  };
+
+  return (
+    <Tabs
+      useSeparator={true}
+      tabs={[
+        {
+          id: 'tab-1',
+          label: 'Tab 1',
+          subtext: 'Subtext content...',
+          content: 'Content 1',
+          panelSpacing: true,
+          ...tabChoiceSettings,
+        },
+        {
+          id: 'tab-2',
+          label: 'Tab 2',
+          subtext: 'Subtext content...',
+          content: 'Content 2',
+          panelSpacing: true,
+          ...tabChoiceSettings,
+        },
+        {
+          id: 'tab-3',
+          label: 'Tab 3',
+          subtext: 'Subtext content...',
+          content: 'Content 3',
+          panelSpacing: true,
+          ...tabChoiceSettings,
+        },
+      ]}
+      tabStyle={Tabs.STYLES.CHOICE}
+    />
+  );
 };

--- a/packages/sage-react/lib/Tabs/TabsItem.jsx
+++ b/packages/sage-react/lib/Tabs/TabsItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from '../Link';
 import { SageTokens } from '../configs';
-import { TAB_STYLES, CHOICE_TYPES } from './configs';
+import { TAB_STYLES, CHOICE_TYPES, CHOICE_ICON_ALIGNMENTS } from './configs';
 
 export const TabsItem = ({
   alignCenter,
@@ -20,6 +20,7 @@ export const TabsItem = ({
   panelId,
   subtext,
   type,
+  verticalAlignIcon,
   ...rest
 }) => {
   const { to, href } = rest;
@@ -33,7 +34,11 @@ export const TabsItem = ({
   const itemStyleProtected = itemStyle === TAB_STYLES.PROGRESSBAR ? TAB_STYLES.TAB : itemStyle;
   const isChoice = itemStyle === TAB_STYLES.CHOICE;
   const isIconType = type && type === CHOICE_TYPES.ICON;
+  const isRadioType = type && type === CHOICE_TYPES.RADIO;
   const baseClass = `sage-${itemStyleProtected}`;
+
+  console.log(isChoice, verticalAlignIcon, (isIconType || isRadioType));
+
   const classNames = classnames(
     className,
     {
@@ -42,6 +47,7 @@ export const TabsItem = ({
       [`${baseClass}--align-center`]: isIconType && alignCenter,
       [`${baseClass}--${type}`]: type && !isIconType,
       [`${baseClass}--icon-${icon}`]: isIconType && icon,
+      [`${baseClass}--vertical-align-icon-${verticalAlignIcon}`]: isChoice && verticalAlignIcon && (isIconType || isRadioType),
     }
   );
 
@@ -103,7 +109,9 @@ export const TabsItem = ({
   );
 };
 
+TabsItem.STYLES = TAB_STYLES;
 TabsItem.CHOICE_TYPES = CHOICE_TYPES;
+TabsItem.ICON_ALIGNMENTS = CHOICE_ICON_ALIGNMENTS;
 
 TabsItem.defaultProps = {
   alignCenter: false,
@@ -118,6 +126,7 @@ TabsItem.defaultProps = {
   onClick: (id) => id,
   subtext: null,
   type: null,
+  verticalAlignIcon: CHOICE_ICON_ALIGNMENTS.DEFAULT,
 };
 
 TabsItem.propTypes = {
@@ -128,11 +137,12 @@ TabsItem.propTypes = {
   graphic: PropTypes.node,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   isActive: PropTypes.bool,
-  itemStyle: PropTypes.oneOf(Object.values(TAB_STYLES)),
+  itemStyle: PropTypes.oneOf(Object.values(TabsItem.STYLES)),
   label: PropTypes.string.isRequired,
   linkText: PropTypes.string,
   onClick: PropTypes.func,
   panelId: PropTypes.string.isRequired,
   subtext: PropTypes.string,
-  type: PropTypes.oneOf(Object.values(CHOICE_TYPES)),
+  type: PropTypes.oneOf(Object.values(TabsItem.CHOICE_TYPES)),
+  verticalAlignIcon: PropTypes.oneOf(Object.values(TabsItem.ICON_ALIGNMENTS))
 };

--- a/packages/sage-react/lib/Tabs/configs.js
+++ b/packages/sage-react/lib/Tabs/configs.js
@@ -8,6 +8,11 @@ export const CHOICE_TYPES = {
   RADIO: 'radio',
 };
 
+export const CHOICE_ICON_ALIGNMENTS = {
+  DEFAULT: null,
+  START: 'start',
+};
+
 export const TAB_LAYOUTS = {
   DEFAULT: 'default',
   STACKED: 'stacked',
@@ -26,5 +31,6 @@ export const tabsItemsPropTypes = PropTypes.shape({
   label: PropTypes.string.isRequired,
   subtext: PropTypes.string,
   tabChoiceIcon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
+  tabChoicIconAlignment: PropTypes.oneOf(Object.values(CHOICE_ICON_ALIGNMENTS)),
   tabChoiceType: PropTypes.oneOf(Object.values(CHOICE_TYPES)),
 });


### PR DESCRIPTION
Adds a new setting for Choice (modifies Tabs as well as a result) that allows for radio and icon to be aligned to the top of the choice when desired.

![Screen Shot 2021-03-17 at 11 27 58 AM](https://user-images.githubusercontent.com/17955295/111493515-0224e480-8714-11eb-810c-736e883cfdc1.png)

Also removes the `nowrap` setting that was present on Choice

### Testing and Impact

See new section on documentation page for Choice in docs site and new setting in React.

1. Adds new setting for aligning icons in Choice elements. No impact on current uses. Validate the following work as before:
   - [ ] Website > Navigation > + New in a menu > See Choice card in the Modal that appears
   - [ ] People > Import Contacts (new) > first page has Choice cards for selecting import modes