### PR TITLE
Expand card tweaks

### DIFF
--- a/docs/app/views/examples/objects/expandable_card/_props.html.erb
+++ b/docs/app/views/examples/objects/expandable_card/_props.html.erb
@@ -5,6 +5,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`sage_type`') %></td>
+  <td><%= md("Adds the `sage-type` HTML class on the body in order to ease content formatting within it.") %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`trigger_label`') %></td>
   <td><%= md('Sets the text for the trigger button.') %></td>
   <td><%= md('String') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
@@ -1,6 +1,7 @@
 class SageExpandableCard < SageComponent
   set_attribute_schema({
     body_bordered: [:optional, TrueClass],
+    sage_type: [:optional, TrueClass],
     trigger_label: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -18,6 +18,7 @@
     <%= "sage-btn--align-end" if (component.align == "end") %>
     <%= "sage-btn--icon-#{component.icon[:style]}-#{component.icon[:name]}" if component.icon %>
     <%= component.css_classes if component.css_classes %>
+    <%= component.generated_css_classes %>
   "
 >
   <% if component.icon&.dig(:style) == "only" %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_copy_text_card.html.erb
@@ -2,6 +2,7 @@
     sage-copy-text-card
     <%= "sage-copy-text-card--semibold" if component.semibold.present? && component.semibold %>
     <%= "sage-copy-text-card--truncate-contents" if component.truncate_contents.present? && component.truncate_contents %>
+    <%= component.generated_css_classes %>
   "
 >
   <%= component.content.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -7,9 +7,15 @@
     css_classes: "sage-expandable-card__trigger",
     attributes: {
       "data-js-accordion": "header",
-    }
+    },
+    full_width: true,
   } %>
-  <div class="<% if component.body_bordered.present? %>sage-expandable-card__body-bordered<% else %>sage-expandable-card__body<% end %>" data-js-accordion="body">
+  <div class="
+      <% if component.body_bordered.present? %>sage-expandable-card__body-bordered<% else %>sage-expandable-card__body<% end %>
+      <%= "sage-type" if component.sage_type %>
+    "
+    data-js-accordion="body"
+  >
     <%= component.content %>
   </div>
 </div>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_expandable_card.scss
@@ -35,10 +35,6 @@ $-expandable-card-padding-xs: sage-spacing(xs);
   }
 }
 
-.sage-expandable-card__body {
-  padding: $-expandable-card-padding-xs;
-}
-
 .sage-expandable-card__body-bordered {
   padding-left: $-expandable-card-padding;
   padding-right: $-expandable-card-padding;

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import uuid from 'react-uuid';
 import { Button } from '../Button';
-import { SageTokens } from '../configs';
+import { SageClassnames, SageTokens } from '../configs';
 
-export const ExpandableCard = ({ triggerLabel, bodyBordered, children, }) => {
+export const ExpandableCard = ({ bodyBordered, children, className, sageType, triggerLabel, }) => {
   const [selfActive, setSelfActive] = useState(false);
 
   const handleBodyToggle = () => {
@@ -20,20 +21,27 @@ export const ExpandableCard = ({ triggerLabel, bodyBordered, children, }) => {
 
   const id = uuid();
 
+  const bodyClassnames = classnames({
+    'sage-expandable-card__body-bordered': bodyBordered,
+    'sage-expandable-card__body': !bodyBordered,
+    [`${SageClassnames.TYPE_BLOCK}`]: sageType,
+  });
+
   return (
-    <div className="sage-expandable-card">
+    <div className={`sage-expandable-card ${className || ''}`}>
       <Button
         aria-controls={id}
         aria-expanded={selfActive}
-        color="primary"
-        icon={SageTokens.ICONS.CARET_RIGHT}
-        subtle={true}
         className="sage-expandable-card__trigger"
+        color="primary"
+        fullWidth={true}
+        icon={SageTokens.ICONS.CARET_RIGHT}
         onClick={handleTriggerClick}
+        subtle={true}
       >
         {triggerLabel}
       </Button>
-      <div id={id} className={`${bodyBordered ? 'sage-expandable-card__body-bordered' : 'sage-expandable-card__body'}`}>
+      <div id={id} className={bodyClassnames}>
         {children}
       </div>
     </div>
@@ -41,13 +49,17 @@ export const ExpandableCard = ({ triggerLabel, bodyBordered, children, }) => {
 };
 
 ExpandableCard.defaultProps = {
-  triggerLabel: null,
   bodyBordered: false,
   children: null,
+  className: null,
+  sageType: false,
+  triggerLabel: null,
 };
 
 ExpandableCard.propTypes = {
-  triggerLabel: PropTypes.string,
   bodyBordered: PropTypes.bool,
+  className: PropTypes.string,
   children: PropTypes.node,
+  sageType: PropTypes.bool,
+  triggerLabel: PropTypes.string,
 };

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -48,7 +48,16 @@ export const Tabs = ({
   return (
     <div className={`sage-tabs-container ${className || ''}`}>
       <div className={tabsClassNames} {...rest}>
-        {tabs.map(({ disabled, id, label, tabDetails, tabChoiceIcon, tabChoiceIconAlignment, tabChoiceType, subtext }) => (
+        {tabs.map(({
+          disabled,
+          id,
+          label,
+          tabDetails,
+          tabChoiceIcon,
+          tabChoiceIconAlignment,
+          tabChoiceType,
+          subtext
+        }) => (
           <TabsItem
             disabled={disabled}
             icon={tabChoiceIcon}


### PR DESCRIPTION
This PR adds a few tweaks to Expandable Card:

- Full width button
- Option to add sage type on the card body

Plus:
- Fixes breaking linter on `develop`
- Adds generated_css_class onto Button and Copy Button Card components.

No visual changes otherwise

### Testing and Impact

See Expandable Card in Docs site and Storybook.

1. (LOW) Adds additional class settings to Button and Copy Button Card. No impact on implementations
1. (LOW) Adds additional settings on Expandable Card. No impact on current non-production uses.