### PR TITLE
Panel Controls(Rails) - update pagination and bulk actions selection

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -11,6 +11,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '~> 4.x'
 
 gem 'sage_rails', path: 'lib/sage_rails'
+gem "kaminari", "~> 1.2.1"
 
 group :production do
   gem 'rails_12factor'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -61,6 +61,18 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     lockup (1.5.1)
       rails (>= 3, < 6.1)
     loofah (2.7.0)
@@ -176,6 +188,7 @@ PLATFORMS
 DEPENDENCIES
   bump (~> 0.9.0)
   byebug
+  kaminari (~> 1.2.1)
   lockup (~> 1.5)
   pry
   rails (= 4.2.11.1)

--- a/docs/app/views/examples/objects/pagination/_props.html.erb
+++ b/docs/app/views/examples/objects/pagination/_props.html.erb
@@ -1,22 +1,4 @@
 <tr>
-  <td><%= md('`items`') %></td>
-  <td><%= md('Maps records to create page link items') %></td>
-  <td><%= md('Object') %></td>
-  <td><%= md('`false`') %></td>
-</tr>
-<tr>
-  <td><%= md('`hide_pages`') %></td>
-  <td><%= md('When set to `true`, links to individual pages will not be rendered, leaving only the "Back" and "Next links visible.') %></td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`false`') %></td>
-</tr>
-<tr>
-  <td><%= md('`hide_counter`') %></td>
-  <td><%= md('When set to `true`, the record count will not be displayed.') %></td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('current') %></td>
   <td><%= md('Pagination uses a `--current` modifier to visually indicate which page is currently being viewed.') %></td>
   <td><%= md('String') %></td>
@@ -33,4 +15,28 @@
   <td><%= md('When there are many pages, a `--gap` modifier along with an ellipsis (&hellip;) can be used to truncate the pagination list items. Should be used in conjunction with `sage-pagination__page`') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`hide_counter`') %></td>
+  <td><%= md('When set to `true`, the record count will not be displayed.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`hide_pages`') %></td>
+  <td><%= md('When set to `true`, links to individual pages will not be rendered, leaving only the "Back" and "Next links visible.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`items`') %></td>
+  <td><%= md('Maps records to create page link items') %></td>
+  <td><%= md('Object') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`show_arrows`') %></td>
+  <td><%= md('When enabled, replaces the "Back" and "Next" text with arrows.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -129,7 +129,8 @@ actions_items = [
 <h3 class="t-sage-heading-6">Bulk actions</h3>
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
-    show_bulk_actions: true,
+    item_count_label: "testing",
+    show_bulk_actions: false,
     show_expand_collapse: true,
     show_pagination: true,
     show_sort: true,

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -135,6 +135,7 @@ actions_items = [
     show_sort: true,
     bulk_action_items: actions_items,
     sort_items: sort_items,
+    items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10)
   } %>
 <% end %>
 

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -129,9 +129,8 @@ actions_items = [
 <h3 class="t-sage-heading-6">Bulk actions</h3>
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
-    item_count_label: "testing",
     show_bulk_actions: false,
-    show_expand_collapse: true,
+    show_expand_collapse: false,
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -135,8 +135,17 @@ actions_items = [
     show_sort: true,
     bulk_action_items: actions_items,
     sort_items: sort_items,
-    items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10)
-  } %>
+  } do %>
+    <% content_for :sage_panel_controls_pagination do %>
+      <%= sage_component SagePagination, {
+        items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
+        collection_name: "Some name here",
+        window: 2,
+        hide_pages: true,
+        show_arrows: true
+      } %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <h3 class="t-sage-heading-6">Sample Custom Toolbar</h3>
@@ -166,6 +175,15 @@ actions_items = [
     <% content_for :sage_panel_controls_toolbar do %>
       <%= search_filter_toolbar %>
       <%= dropdown %>
+    <% end %>
+    <% content_for :sage_panel_controls_pagination do %>
+      <%= sage_component SagePagination, {
+        items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
+        collection_name: "Some name here",
+        window: 2,
+        hide_pages: true,
+        show_arrows: true
+      } %>
     <% end %>
   <% end %>
 

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -126,7 +126,42 @@ actions_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Bulk actions</h3>
+<h3 class="t-sage-heading-6">No Pagination</h3>
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SagePanelControls, {
+    item_count_label: "Text here",
+    show_bulk_actions: false,
+    show_expand_collapse: true,
+    show_pagination: false,
+    show_sort: true,
+    bulk_action_items: actions_items,
+    sort_items: sort_items,
+  } %>
+<% end %>
+
+<h3 class="t-sage-heading-6">Pagination</h3>
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SagePanelControls, {
+    show_bulk_actions: false,
+    show_expand_collapse: true,
+    show_pagination: true,
+    show_sort: true,
+    bulk_action_items: actions_items,
+    sort_items: sort_items,
+  } do %>
+    <% content_for :sage_panel_controls_pagination do %>
+      <%= sage_component SagePagination, {
+        items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
+        collection_name: "Some name here",
+        window: 2,
+        hide_pages: true,
+        show_arrows: true
+      } %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h3 class="t-sage-heading-6">Pagination with Bulk actions</h3>
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
     show_bulk_actions: true,

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -129,8 +129,8 @@ actions_items = [
 <h3 class="t-sage-heading-6">Bulk actions</h3>
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
-    show_bulk_actions: false,
-    show_expand_collapse: false,
+    show_bulk_actions: true,
+    show_expand_collapse: true,
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,

--- a/docs/app/views/examples/objects/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_props.html.erb
@@ -18,10 +18,22 @@ Array<{
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`items`') %></td>
+  <td><%= md('Maps records to create page link items') %></td>
+  <td><%= md('Object') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`item_count_label`') %></td>
   <td><%= md("A caption for the bulk actions checkbox.") %></td>
   <td><%= md('String') %></td>
   <td><%= md('Select all') %></td>
+</tr>
+<tr>
+  <td><%= md('`pagination_additional_params`') %></td>
+  <td><%= md('This allows for params to be passed to the pagination component') %></td>
+  <td><%= md('Object') %></td>
+  <td><%= md('`{}`') %></td>
 </tr>
 <tr>
   <td><%= md('`show_bulk_actions`') %></td>
@@ -34,6 +46,12 @@ Array<{
   </td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`show_checkboxes`') %></td>
+  <td><%= md('When enabled, shows the checkbox and allows for selection of the adjacent list.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`true`') %></td>
 </tr>
 <tr>
   <td><%= md('`show_expand_collapse`') %></td>

--- a/docs/app/views/examples/objects/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_props.html.erb
@@ -30,12 +30,6 @@ Array<{
   <td><%= md('Select all') %></td>
 </tr>
 <tr>
-  <td><%= md('`pagination_additional_params`') %></td>
-  <td><%= md('This allows for params to be passed to the pagination component') %></td>
-  <td><%= md('Object') %></td>
-  <td><%= md('`{}`') %></td>
-</tr>
-<tr>
   <td><%= md('`show_bulk_actions`') %></td>
   <td>
     <%= md('

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -4,6 +4,7 @@ class SagePagination < SageComponent
     window: [:optional, Integer],
     hide_pages: [:optional, TrueClass],
     hide_counter: [:optional, TrueClass],
+    show_arrows: [:optional, TrueClass],
     additional_params: [:optional, Hash],
     collection_name: [:optional, String]
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -5,6 +5,9 @@ class SagePanelControls < SageComponent
       value: String,
     }]]],
     item_count_label: [:optional, String],
+    # pagination: [:optional, SagePagination]
+    items: [:optional, -> (v) { SageSchemaHelper.can_paginate?(v) }],
+    pagination_additional_params: [:optional, Hash],
     show_bulk_actions: [:optional, TrueClass],
     show_checkboxes: [:optional, TrueClass],
     show_expand_collapse: [:optional, TrueClass],
@@ -21,6 +24,20 @@ class SagePanelControls < SageComponent
   def sections
     %w(panel_controls_toolbar panel_controls_tabs)
   end
+
+  # def page_count(collection)
+    
+  #   name = "Record"
+  #   entry_name = name.titleize.pluralize(collection.total_count)
+
+  #   if collection.total_pages < 2
+  #     "<strong>#{collection.total_count}</strong> #{entry_name}"
+  #   else
+  #     first = collection.offset_value + 1
+  #     last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
+  #     "<strong>#{first}</strong> - <strong>#{last}</strong> of <strong>#{collection.total_count}</strong> #{entry_name}"
+  #   end.html_safe
+  # end
 end
 
 
@@ -29,6 +46,7 @@ end
  :show_expand_collapse=>true,
  :show_pagination=>true,
  :show_sort=>true,
+ :pagination_additional_params=>{},
  :bulk_action_items=>
   [{:value=>"Delete",
     :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -4,8 +4,9 @@ class SagePanelControls < SageComponent
       attributes: [:optional, Hash],
       value: String,
     }]]],
-    item_count_label: [:optional, TrueClass],
+    item_count_label: [:optional, String],
     show_bulk_actions: [:optional, TrueClass],
+    show_checkboxes: [:optional, TrueClass],
     show_expand_collapse: [:optional, TrueClass],
     show_pagination: [:optional, TrueClass],
     show_sort: [:optional, TrueClass],
@@ -24,6 +25,7 @@ end
 
 
 {:show_bulk_actions=>true,
+ :show_checkboxes=>true,
  :show_expand_collapse=>true,
  :show_pagination=>true,
  :show_sort=>true,

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -6,7 +6,6 @@ class SagePanelControls < SageComponent
     }]]],
     item_count_label: [:optional, String],
     items: [:optional, -> (v) { SageSchemaHelper.can_paginate?(v) }],
-    pagination_additional_params: [:optional, Hash],
     show_bulk_actions: [:optional, TrueClass],
     show_checkboxes: [:optional, TrueClass],
     show_expand_collapse: [:optional, TrueClass],
@@ -31,7 +30,6 @@ end
  :show_expand_collapse=>true,
  :show_pagination=>true,
  :show_sort=>true,
- :pagination_additional_params=>{},
  :bulk_action_items=>
   [{:value=>"Delete",
     :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -5,7 +5,6 @@ class SagePanelControls < SageComponent
       value: String,
     }]]],
     item_count_label: [:optional, String],
-    # pagination: [:optional, SagePagination]
     items: [:optional, -> (v) { SageSchemaHelper.can_paginate?(v) }],
     pagination_additional_params: [:optional, Hash],
     show_bulk_actions: [:optional, TrueClass],
@@ -24,20 +23,6 @@ class SagePanelControls < SageComponent
   def sections
     %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs)
   end
-
-  # def page_count(collection)
-    
-  #   name = "Record"
-  #   entry_name = name.titleize.pluralize(collection.total_count)
-
-  #   if collection.total_pages < 2
-  #     "<strong>#{collection.total_count}</strong> #{entry_name}"
-  #   else
-  #     first = collection.offset_value + 1
-  #     last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
-  #     "<strong>#{first}</strong> - <strong>#{last}</strong> of <strong>#{collection.total_count}</strong> #{entry_name}"
-  #   end.html_safe
-  # end
 end
 
 

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -22,7 +22,7 @@ class SagePanelControls < SageComponent
   })
 
   def sections
-    %w(panel_controls_toolbar panel_controls_tabs)
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs)
   end
 
   # def page_count(collection)

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -14,19 +14,16 @@
 
     <ul class="sage-pagination__pages">
       <% if component.items.first_page? %>
+      <% prev_text = component.show_arrows ? "&larr;".html_safe : component.prev_text %>
+      <% next_text = component.show_arrows ? "&rarr;".html_safe : component.next_text %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
-          &larr;
-          <% if component.show_arrows %>
-            &larr;
-          <% else %>
-            <%= component.prev_text %>
-          <% end %>
+          <%= prev_text %>
         </a>
       </li>
       <% else %>
         <li class="sage-pagination__item">
-          <%= link_to_previous_page component.items, component.prev_text, class: "sage-pagination__page", params: component.additional_params %>
+          <%= link_to_previous_page component.items, prev_text, class: "sage-pagination__page", params: component.additional_params %>
         </li>
       <% end -%>
 
@@ -37,16 +34,12 @@
       <% if component.items.last_page? %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
-          <% if component.show_arrows %>
-            &rarr;
-          <% else %>
-            <%= component.next_text %>
-          <% end %>
+          <%= next_text %>
         </a>
       </li>
       <% else %>
       <li class="sage-pagination__item">
-        <%= link_to_next_page component.items, component.next_text, class: "sage-pagination__page", params: component.additional_params %>
+        <%= link_to_next_page component.items, next_text, class: "sage-pagination__page", params: component.additional_params %>
       </li>
       <% end -%>
     </ul>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -16,7 +16,12 @@
       <% if component.items.first_page? %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
-          <%= component.prev_text %>
+          &larr;
+          <% if component.show_arrows %>
+            &larr;
+          <% else %>
+            <%= component.prev_text %>
+          <% end %>
         </a>
       </li>
       <% else %>
@@ -32,7 +37,11 @@
       <% if component.items.last_page? %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
-          <%= component.next_text %>
+          <% if component.show_arrows %>
+            &rarr;
+          <% else %>
+            <%= component.next_text %>
+          <% end %>
         </a>
       </li>
       <% else %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -12,10 +12,10 @@
       <span class="sage-pagination__count"><%= component.page_count component.items %></span>
     <% end %>
 
-    <ul class="sage-pagination__pages">
+    <ul class="sage-pagination__pages <% if component.show_arrows %>sage-pagination__pages--show-arrows<% end %>">
       <% if component.items.first_page? %>
-      <% prev_text = component.show_arrows ? "&larr;".html_safe : component.prev_text %>
-      <% next_text = component.show_arrows ? "&rarr;".html_safe : component.next_text %>
+      <% prev_text = component.show_arrows ? %(<span class="sage-pagination__page-text">#{component.prev_text}</span>).html_safe : component.prev_text %>
+      <% next_text = component.show_arrows ? %(<span class="sage-pagination__page-text">#{component.next_text}</span>).html_safe : component.next_text %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
           <%= prev_text %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -54,42 +54,19 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
         </p>
       <% end %>
 
-      <% if component.show_pagination && component.items %>
-        <%# sage_component SagePagination, {
-          items: @comments,
-          window: 2,
-          hide_pages: true
-        } %>
-       
-        <%= sage_component SagePagination, {
-          items: component.items,
-          collection_name: "Some name here",
-          window: 2,
-          hide_pages: true,
-          show_arrows: true
-        } %>
-        
+      <% if content_for? :sage_panel_controls_pagination %>
+        <%= content_for :sage_panel_controls_pagination %>
       <% end %>
 
       <% if show_secondary_toolbar %>
         <div class="sage-panel-controls__toolbar">
-          <% if component.show_pagination %>
-            <div class="sage-panel-controls__pagination">
-              <%= sage_component SageButton, {
-                css_classes: "sage-panel-controls__pagination-prev",
-                value: "Previous page",
-                style: "secondary",
-                icon: { name: "arrow-left", style: "only" }
-              } %>
-              <%= sage_component SageButton, {
-                css_classes: "sage-panel-controls__pagination-next",
-                value: "Next page",
-                style: "secondary",
-                icon: { name: "arrow-right", style: "only" }
-              } %>
-            </div>
-          <% end %>
 
+          <%= sage_component SageButton, {
+            css_classes: "sage-panel-controls__pagination-prev",
+            value: "Previous page",
+            style: "secondary",
+            icon: { name: "arrow-left", style: "only" }
+          } %>
           <% if component.show_sort %>
             <%= sage_component SageDropdown, {
               trigger_type: "select",

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -1,9 +1,9 @@
 <%
-show_secondary_toolbar = component.show_pagination or component.show_sort or component.show_expand_collapse
-show_default_controls = component.show_bulk_actions or show_secondary_toolbar
+show_secondary_toolbar = component.show_pagination || component.show_sort || component.show_expand_collapse
+show_default_controls = component.show_bulk_actions || show_secondary_toolbar
 bulk_action_items = component.bulk_action_items.present? ? component.bulk_action_items : []
 sort_items = component.sort_items.present? ? component.sort_items : []
-item_count_text = component.item_count_label.present? ? item_count_label : "Select all"
+item_count_text = component.item_count_label.present? ? component.item_count_label : "Select all"
 %>
 <div class="sage-panel-controls" data-js-panel-controls="<%= component.target %>">
   <% if content_for? :sage_panel_controls_tabs %>
@@ -17,7 +17,7 @@ item_count_text = component.item_count_label.present? ? item_count_label : "Sele
       <%= content_for :sage_panel_controls_toolbar %>
     </div>
   <% end %>
-
+<%= item_count_text %>
   <% if show_default_controls %>
     <div class="sage-panel-controls__default-controls">
       <% if component.show_bulk_actions %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -3,7 +3,7 @@ show_secondary_toolbar = component.show_pagination || component.show_sort || com
 show_default_controls = component.show_bulk_actions || show_secondary_toolbar
 bulk_action_items = component.bulk_action_items.present? ? component.bulk_action_items : []
 sort_items = component.sort_items.present? ? component.sort_items : []
-item_count_text = component.item_count_label.present? ? component.item_count_label : "Select all"
+item_count_text = component.item_count_label.present? ? component.item_count_label : ""
 %>
 <div class="sage-panel-controls" data-js-panel-controls="<%= component.target %>">
   <% if content_for? :sage_panel_controls_tabs %>
@@ -17,7 +17,6 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
       <%= content_for :sage_panel_controls_toolbar %>
     </div>
   <% end %>
-<%= item_count_text %>
   <% if show_default_controls %>
     <div class="sage-panel-controls__default-controls">
       <% if component.show_bulk_actions %>
@@ -53,6 +52,25 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
         <p class="sage-panel-controls__item-count-label">
           <%= item_count_text %>
         </p>
+      <% end %>
+
+      <% if component.show_pagination %>
+        <%# sage_component SagePagination, {
+          items: @comments,
+          window: 2,
+          hide_pages: true
+        } %>
+        <nav class="sage-pagination">
+          <span class="sage-pagination__count"><strong>1</strong> – <strong>50</strong> of <strong>505</strong> Cacti</span>
+          <ul class="sage-pagination__pages">
+            <li class="sage-pagination__item">
+              <a aria-disabled="true" class="sage-pagination__page sage-pagination__page--disabled" href="//example.com/0">&larr;</a>
+            </li>
+            <li class="sage-pagination__item">
+              <a aria-disabled="false" class="sage-pagination__page" href="//example.com/2">&rarr;</a>
+            </li>
+          </ul>
+        </nav>
       <% end %>
 
       <% if show_secondary_toolbar %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -54,23 +54,21 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
         </p>
       <% end %>
 
-      <% if component.show_pagination %>
+      <% if component.show_pagination && component.items %>
         <%# sage_component SagePagination, {
           items: @comments,
           window: 2,
           hide_pages: true
         } %>
-        <nav class="sage-pagination">
-          <span class="sage-pagination__count"><strong>1</strong> – <strong>50</strong> of <strong>505</strong> Cacti</span>
-          <ul class="sage-pagination__pages">
-            <li class="sage-pagination__item">
-              <a aria-disabled="true" class="sage-pagination__page sage-pagination__page--disabled" href="//example.com/0">&larr;</a>
-            </li>
-            <li class="sage-pagination__item">
-              <a aria-disabled="false" class="sage-pagination__page" href="//example.com/2">&rarr;</a>
-            </li>
-          </ul>
-        </nav>
+       
+        <%= sage_component SagePagination, {
+          items: component.items,
+          collection_name: "Some name here",
+          window: 2,
+          hide_pages: true,
+          show_arrows: true
+        } %>
+        
       <% end %>
 
       <% if show_secondary_toolbar %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -5,7 +5,10 @@ bulk_action_items = component.bulk_action_items.present? ? component.bulk_action
 sort_items = component.sort_items.present? ? component.sort_items : []
 item_count_text = component.item_count_label.present? ? component.item_count_label : ""
 %>
-<div class="sage-panel-controls" data-js-panel-controls="<%= component.target %>">
+<div class="
+  sage-panel-controls
+  <% if component.show_pagination %>sage-panel-controls--show-pagination<% end %>" 
+  data-js-panel-controls="<%= component.target %>">
   <% if content_for? :sage_panel_controls_tabs %>
     <div class="sage-panel-controls__tabs">
       <%= content_for :sage_panel_controls_tabs %>
@@ -54,19 +57,13 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
         </p>
       <% end %>
 
-      <% if content_for? :sage_panel_controls_pagination %>
-        <%= content_for :sage_panel_controls_pagination %>
-      <% end %>
-
       <% if show_secondary_toolbar %>
         <div class="sage-panel-controls__toolbar">
-
-          <%= sage_component SageButton, {
-            css_classes: "sage-panel-controls__pagination-prev",
-            value: "Previous page",
-            style: "secondary",
-            icon: { name: "arrow-left", style: "only" }
-          } %>
+          <% if content_for? :sage_panel_controls_pagination %>
+            <div class="sage-panel-controls__pagination">
+              <%= content_for :sage_panel_controls_pagination %>
+            </div>
+          <% end %>
           <% if component.show_sort %>
             <%= sage_component SageDropdown, {
               trigger_type: "select",

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
@@ -58,6 +58,10 @@ $-checkbox-focus-outline-color: sage-color(primary);
     z-index: sage-z-index(default);
     padding: rem(6px) sage-spacing(xs);
     border: 0;
+
+    .sage-panel-controls & {
+      flex-flow: row;
+    }
   }
 
   .sage-panel-controls__bulk-actions--checked & {
@@ -114,6 +118,10 @@ $-checkbox-focus-outline-color: sage-color(primary);
   .sage-checkbox--error &,
   .sage-checkbox__input:invalid + & {
     color: sage-color(red);
+  }
+
+  .sage-panel-controls & {
+    white-space: nowrap;
   }
 }
 
@@ -247,7 +255,7 @@ $-checkbox-focus-outline-color: sage-color(primary);
     margin-top: 4px;
 
     .sage-panel-controls & {
-      margin-top: 0;
+      // margin-top: 0;
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
@@ -121,7 +121,12 @@ $-checkbox-focus-outline-color: sage-color(primary);
   }
 
   .sage-panel-controls & {
+    display: none;
     white-space: nowrap;
+  }
+  
+  .sage-panel-controls__bulk-actions--checked & {
+    display: unset;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
@@ -245,5 +245,9 @@ $-checkbox-focus-outline-color: sage-color(primary);
 
   &:not(.sage-checkbox--standalone) {
     margin-top: 4px;
+
+    .sage-panel-controls & {
+      margin-top: 0;
+    }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
@@ -258,9 +258,5 @@ $-checkbox-focus-outline-color: sage-color(primary);
 
   &:not(.sage-checkbox--standalone) {
     margin-top: 4px;
-
-    .sage-panel-controls & {
-      // margin-top: 0;
-    }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
@@ -120,7 +120,7 @@ $-checkbox-focus-outline-color: sage-color(primary);
     color: sage-color(red);
   }
 
-  .sage-panel-controls & {
+  .sage-panel-controls--show-pagination & {
     display: none;
     white-space: nowrap;
   }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -97,6 +97,19 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   }
 }
 
+.sage-pagination__pages--show-arrows {
+  .sage-pagination__item:first-of-type .sage-pagination__page::before {
+    @include sage-icon-base(arrow-left);
+  }
+  .sage-pagination__item:last-of-type .sage-pagination__page::before {
+    @include sage-icon-base(arrow-right);
+  }
+}
+
+.sage-pagination__page-text {
+  @include visually-hidden();
+}
+
 .sage-pagination__page--current {
   background: $-pagination-bg-color-dark;
 }

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -20,6 +20,11 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   justify-content: space-between;
   flex-flow: row wrap;
   align-items: center;
+  flex-grow: 1;
+
+  .sage-panel-controls__default-controls & {
+    margin-right: 1.5rem;
+  }
 }
 
 .sage-pagination--no-counter {
@@ -33,6 +38,10 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   list-style-type: none;
   border: $-pagination-border;
   border-radius: $-pagination-radius;
+
+  .sage-panel-controls & {
+    border: none;
+  }
 }
 
 .sage-pagination__item {
@@ -42,6 +51,15 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 
   &:last-of-type {
     border: 0;
+  }
+
+  .sage-panel-controls & {
+    border: 0;
+    margin-right: 12px;
+
+    &:last-of-type {
+       margin-right: 0;
+    }
   }
 }
 
@@ -59,6 +77,12 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   &:focus {
     background: $-pagination-bg-color;
     box-shadow: none;
+  }
+
+  .sage-panel-controls & {
+    min-height: rem(40px);
+    border: $-pagination-border;
+    border-radius: $-pagination-radius;
   }
 }
 
@@ -79,6 +103,10 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 .sage-pagination__count {
   @extend %t-sage-body;
   padding-right: sage-spacing();
+
+  .sage-panel-controls__bulk-actions--checked + .sage-pagination & {
+    visibility: hidden;
+  }
 }
 
 .sage-pagination__count--solo {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -39,7 +39,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   border: $-pagination-border;
   border-radius: $-pagination-radius;
 
-  .sage-panel-controls & {
+  .sage-panel-controls--show-pagination & {
     border: 0;
   }
 }
@@ -53,7 +53,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
     border: 0;
   }
 
-  .sage-panel-controls & {
+  .sage-panel-controls--show-pagination & {
     margin-right: 12px;
     border: 0;
 
@@ -79,7 +79,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
     box-shadow: none;
   }
 
-  .sage-panel-controls & {
+  .sage-panel-controls--show-pagination & {
     min-height: rem(40px);
     font-size: 18px;
     border: 0;
@@ -87,11 +87,11 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
     box-shadow: map-get($sage-toolbar-button-borders, default);
   }
 
-  .sage-panel-controls &:hover {
+  .sage-panel-controls--show-pagination &:hover {
     box-shadow: map-get($sage-toolbar-button-borders, hover);
   }
 
-  .sage-panel-controls &:focus {
+  .sage-panel-controls--show-pagination &:focus {
     box-shadow: 0 0 0 rem(2px) sage-color(primary);
     background-color: sage-color(white);
   }
@@ -99,7 +99,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 
 .sage-pagination__pages--show-arrows {
   margin-left: auto;
-  
+
   .sage-pagination__item:first-of-type .sage-pagination__page::before {
     @include sage-icon-base(arrow-left);
   }
@@ -130,9 +130,11 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   @extend %t-sage-body;
   padding-right: sage-spacing();
 
+  /* stylelint-disable selector-max-compound-selectors */
   .sage-panel-controls--show-pagination .sage-panel-controls__bulk-actions--checked + .sage-panel-controls__toolbar .sage-pagination & {
     @include visually-hidden();
   }
+  /* stylelint-enable selector-max-compound-selectors */
 }
 
 .sage-pagination__count--solo {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -98,6 +98,8 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 }
 
 .sage-pagination__pages--show-arrows {
+  margin-left: auto;
+  
   .sage-pagination__item:first-of-type .sage-pagination__page::before {
     @include sage-icon-base(arrow-left);
   }
@@ -128,8 +130,8 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   @extend %t-sage-body;
   padding-right: sage-spacing();
 
-  .sage-panel-controls__bulk-actions--checked + .sage-pagination & {
-    visibility: hidden;
+  .sage-panel-controls--show-pagination .sage-panel-controls__bulk-actions--checked + .sage-panel-controls__toolbar .sage-pagination & {
+    @include visually-hidden();
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -23,7 +23,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   flex-grow: 1;
 
   .sage-panel-controls__default-controls & {
-    margin-right: 1.5rem;
+    margin-right: sage-spacing(sm);
   }
 }
 
@@ -54,7 +54,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   }
 
   .sage-panel-controls--show-pagination & {
-    margin-right: 12px;
+    margin-right: rem(12px);
     border: 0;
 
     &:last-of-type {
@@ -81,7 +81,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 
   .sage-panel-controls--show-pagination & {
     min-height: rem(40px);
-    font-size: 18px;
+    font-size: sage-font-size(lg);
     border: 0;
     border-radius: $-pagination-radius;
     box-shadow: map-get($sage-toolbar-button-borders, default);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -40,7 +40,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   border-radius: $-pagination-radius;
 
   .sage-panel-controls & {
-    border: none;
+    border: 0;
   }
 }
 
@@ -54,11 +54,11 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   }
 
   .sage-panel-controls & {
-    border: 0;
     margin-right: 12px;
+    border: 0;
 
     &:last-of-type {
-       margin-right: 0;
+      margin-right: 0;
     }
   }
 }
@@ -81,8 +81,19 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 
   .sage-panel-controls & {
     min-height: rem(40px);
-    border: $-pagination-border;
+    font-size: 18px;
+    border: 0;
     border-radius: $-pagination-radius;
+    box-shadow: map-get($sage-toolbar-button-borders, default);
+  }
+
+  .sage-panel-controls &:hover {
+    box-shadow: map-get($sage-toolbar-button-borders, hover);
+  }
+
+  .sage-panel-controls &:focus {
+    box-shadow: 0 0 0 rem(2px) sage-color(primary);
+    background-color: sage-color(white);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -58,6 +58,10 @@
   }
 }
 
+.sage-panel-controls__bulk-actions-checkbox {
+  min-height: rem(40px);
+}
+
 .sage-panel-controls__bulk-actions-dropdown {
   display: none;
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -35,6 +35,10 @@
   /* stylelint-enable selector-max-compound-selectors */
 }
 
+.sage-panel-controls__default-controls .sage-panel-controls__toolbar:only-child {
+  flex-grow: 1;
+}
+
 .sage-panel-controls__toolbar-btn-group {
   display: flex;
   align-items: center;
@@ -94,7 +98,7 @@
 }
 
 .sage-panel-controls__item-count-label {
-  margin-left: sage-spacing(xs);
+  font-weight: sage-font-weight(semibold);
 }
 
 // Expand/collapse button setup

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -28,9 +28,11 @@
   align-items: center;
   justify-content: space-between;
 
+  /* stylelint-disable selector-max-compound-selectors */
   .sage-panel-controls--show-pagination .sage-panel-controls__bulk-actions + & {
-    flex-grow: 1
+    flex-grow: 1;
   }
+  /* stylelint-enable selector-max-compound-selectors */
 }
 
 .sage-panel-controls__toolbar-btn-group {
@@ -48,7 +50,6 @@
 }
 
 .sage-panel-controls__pagination {
-  display: none;
   display: flex;
   align-items: center;
   flex-grow: 1;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -40,6 +40,7 @@
 }
 
 .sage-panel-controls__pagination {
+  display: none;
   display: flex;
   align-items: center;
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -50,11 +50,11 @@
 
 .sage-panel-controls__bulk-actions {
   display: flex;
-  flex: 1;
+  flex: 0 1;
   align-items: center;
 
   &:not(:last-child) {
-    margin-right: sage-spacing(panel);
+    // margin-right: sage-spacing(panel);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -27,6 +27,10 @@
   flex-flow: row wrap;
   align-items: center;
   justify-content: space-between;
+
+  .sage-panel-controls--show-pagination .sage-panel-controls__bulk-actions + & {
+    flex-grow: 1
+  }
 }
 
 .sage-panel-controls__toolbar-btn-group {
@@ -37,12 +41,17 @@
   &:not(:last-child) {
     margin-right: sage-spacing(panel);
   }
+
+  .sage-panel-controls__toolbar &:last-child {
+    flex: 0 1;
+  }
 }
 
 .sage-panel-controls__pagination {
   display: none;
   display: flex;
   align-items: center;
+  flex-grow: 1;
 
   &:not(:last-child) {
     margin-right: sage-spacing(panel);
@@ -51,11 +60,19 @@
 
 .sage-panel-controls__bulk-actions {
   display: flex;
-  flex: 0 1;
+  flex: 1;
   align-items: center;
 
   &:not(:last-child) {
-    // margin-right: sage-spacing(panel);
+    margin-right: sage-spacing(panel);
+
+    .sage-panel-controls--show-pagination & {
+      margin-right: 0;
+    }
+  }
+
+  .sage-panel-controls--show-pagination & {
+    flex: 0 1;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -56,6 +56,10 @@
   &:not(:last-child) {
     margin-right: sage-spacing(panel);
   }
+
+  .sage-panel-controls--show-pagination .sage-panel-controls__default-controls & {
+    margin-right: 0;
+  }
 }
 
 .sage-panel-controls__bulk-actions {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -48,7 +48,7 @@
     margin-right: sage-spacing(panel);
   }
 
-  .sage-panel-controls__toolbar &:last-child {
+  .sage-panel-controls--show-pagination .sage-panel-controls__toolbar &:last-child {
     flex: 0 1;
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - add `kaminari` gem so that we can use backend `ActiveRecord` functionality to product demos with `SagePagination` in isolation or within `SagePanelControls`
- [x] - add `SagePagination` to panel controls
- [x] - updated `bulkactions` conditional to not include pagination because pagination can exist without `bulkactions`
- [x] - updated `SagePagination` docs due to new props
- [x] - updated `SagePanelControls` docs to account for `SagePagination` use enabled

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
No visual changes but added demo variations
![Screen Shot 2021-03-24 at 1 18 53 PM](https://user-images.githubusercontent.com/1241836/112363553-a3c3ad00-8ca3-11eb-9d27-1a4d347be5e9.png)


## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
pending
- Visit rails panel controls page: http://localhost:4000/pages/object/panel_controls
- Notice the updated variations of the panel controls

### QA Steps
#380 (Low)  There should be no change as all work is rails based and any styles are behind classes that only exist on the rails variation
- [ ] - Contacts page panel controls(React)
- [ ] - no existing rails implementation

