### PR TITLE
Icon button space tweak

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -80,7 +80,8 @@
         @include sage-icon-base($icon-name, md);
 
         align-self: center;
-        margin: 0 0 0 sage-spacing(xs);
+        margin-left: sage-spacing(xs);
+        padding: var(--icon-block-padding) 0;
       }
     }
   }
@@ -94,7 +95,8 @@
         @include sage-icon-base($icon-name);
 
         align-self: center;
-        margin: 0 sage-spacing(xs) 0 0;
+        margin-right: sage-spacing(xs);
+        padding: var(--icon-block-padding) 0;
       }
     }
   }
@@ -107,7 +109,9 @@
 
       &::before {
         @include sage-icon-base($icon-name);
+
         align-self: center;
+        padding: var(--icon-block-padding) 0;
       }
     }
   }

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
@@ -101,6 +101,7 @@ $-btn-interactive-label-icon-size: rem(24px);
 // stylelint-disable max-nesting-depth
 
 .sage-btn {
+  --icon-block-padding: #{rem(6px)}; // actually applied in the icon building loop in core/_icon.scss
   @extend %t-sage-body-med;
   @include sage-button-style-reset();
   @include sage-focus-outline;
@@ -111,7 +112,6 @@ $-btn-interactive-label-icon-size: rem(24px);
   align-self: inherit;
   align-items: center;
   position: relative;
-  min-height: ($-padding-block * 2 + sage-line-height(md));
   padding: $-padding-block sage-spacing(sm);
   text-align: left; // Prevents text alignment issue when inner text is truncated
   border: 0;
@@ -163,7 +163,6 @@ $-btn-interactive-label-icon-size: rem(24px);
     position: absolute;
     right: 0;
     width: $-btn-interactive-label-icon-size;
-    min-height: $-btn-interactive-label-icon-size;
     margin: auto 0;
     border-radius: 0 sage-border(radius) sage-border(radius) 0;
 
@@ -221,7 +220,6 @@ $-btn-interactive-label-icon-size: rem(24px);
     transform: translateY(-50%);
     top: 50%;
     right: calc(#{rem(2px)} / 2);
-    min-height: 0;
     height: calc(100% - #{rem(2px)});
     background-color: sage-color(white);
     box-shadow: rem(-1px) 0 0 0 sage-color(grey, 300);
@@ -359,7 +357,6 @@ $-btn-interactive-label-icon-size: rem(24px);
 
 // Subtle buttons are smaller with no padding or background color but still use a focus ring
 .sage-btn--subtle {
-  min-height: sage-line-height(md);
   padding: 0;
   box-shadow: none;
 
@@ -410,6 +407,8 @@ $-btn-interactive-label-icon-size: rem(24px);
 
 .sage-btn--small {
   @extend %t-sage-body-small;
+
+  --icon-block-padding: #{rem(4px)};
 }
 
 // TODO: Investigate deprecating the float setting here


### PR DESCRIPTION
This PR adjusts setup for icons within buttons. No visual changes result but the outcome is that buttons adjust a little better when used for vertical alignment with various type specs.

### Testing and Impact

See Buttons to ensure all behave as before.

(MEDIUM) Updates made to button internal styling that should not lead to any visual changes but impacts all sage buttons. A general exploration of any features using Sage should not render any unexpected button styling.