### PR TITLE
Panel Controls - added affordance for tabs dropdown

### DIFF
--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -120,6 +120,9 @@ actions_items = [
     <% content_for :sage_panel_controls_tabs do %>
       <%= tabs %>
     <% end %>
+    <% content_for :sage_panel_controls_tabs_dropdown do %>
+      <%= dropdown %>
+    <% end %>
     <% content_for :sage_panel_controls_toolbar do %>
       <%= search %>
     <% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -20,7 +20,7 @@ class SagePanelControls < SageComponent
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs)
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown )
   end
 end
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -12,6 +12,12 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
   <% if content_for? :sage_panel_controls_tabs %>
     <div class="sage-panel-controls__tabs">
       <%= content_for :sage_panel_controls_tabs %>
+
+      <div class="sage-panel-controls__tabs-dropdown">
+        <% if content_for? :sage_panel_controls_tabs_dropdown %>
+          <%= content_for :sage_panel_controls_tabs_dropdown %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_button.scss
@@ -133,6 +133,7 @@ $-btn-interactive-label-icon-size: rem(24px);
 
   // Contextual modifications
   .sage-dropdown--contained &,
+  .sage-panel-controls__tabs-dropdown .sage-dropdown__trigger &,
   .sage-panel-controls__toolbar .sage-dropdown__trigger &,
   .sage-panel-controls__bulk-actions .sage-dropdown__trigger & {
     @include sage-focus-outline--update-color(transparent);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -33,6 +33,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   // Adds form field styling
   &.sage-dropdown--contained,
   .sage-panel-controls__bulk-actions > &,
+  .sage-panel-controls__tabs-dropdown > &,
   .sage-panel-controls__toolbar > &,
   .sage-panel-controls__toolbar-btn-group > & {
     position: relative;
@@ -73,6 +74,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   &.sage-dropdown--contained,
+  .sage-panel-controls__tabs-dropdown > &,
   .sage-panel-controls__toolbar > & {
     border-radius: sage-border(radius);
   }
@@ -338,6 +340,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown__trigger--select-labeled {
   :not(.sage-dropdown--customized) > & {
     min-width: $-dropdown-width;
+
+    .sage-panel-controls__tabs-dropdown & {
+      min-width: $-dropdown-width-small;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel_controls.scss
@@ -21,6 +21,12 @@
   }
 }
 
+.sage-panel-controls__tabs {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .sage-panel-controls__toolbar,
 .sage-panel-controls__default-controls {
   display: flex;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - added affordance - dropdown to accompany tabs

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-03-24 at 5 16 20 PM](https://user-images.githubusercontent.com/1241836/112390798-d8942c00-8cc4-11eb-8801-798a36e91b72.png)|![Screen Shot 2021-03-24 at 5 11 22 PM](https://user-images.githubusercontent.com/1241836/112390812-dd58e000-8cc4-11eb-81ef-72092ef6da5e.png)|



## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
- Visit rails panel controls page: http://localhost:4000/pages/object/panel_controls
- Notice the tabs variation and the reserved space for the dropdown

### QA Steps
#385  (Low)  This is added to the rails panel controls which is not currently in use within the app
- [ ] - Contacts page panel controls(React)
- [ ] - no existing rails implementation

