### PR TITLE
Add attrs to sortable

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable.html.erb
@@ -1,6 +1,7 @@
 <div
   class="sage-sortable"
   data-js-sortable="<%= component.resource_name %>"
+  <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.content.present? %>
     <%= component.content %>


### PR DESCRIPTION
No visual change... adds `html_attributes` output to `SageSortable`.

### Testing and Impact

Adds html attributes output on Sage Sortable. No impact on existing components. Check the following to confirm they behave as expected:
   - [ ] Website > Navigation ... sortable items retain existing functionality