### PR TITLE
Pagination - updates to button styles conditional to affect all pages, not just the first page - sage bump followup

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -14,9 +14,9 @@
     <% end %>
 
     <ul class="sage-pagination__pages <% if component.show_arrows %>sage-pagination__pages--show-arrows<% end %>">
-      <% if component.items.first_page? %>
       <% prev_text = component.show_arrows ? %(<span class="sage-pagination__page-text">#{component.prev_text}</span>).html_safe : component.prev_text %>
       <% next_text = component.show_arrows ? %(<span class="sage-pagination__page-text">#{component.next_text}</span>).html_safe : component.next_text %>
+      <% if component.items.first_page? %>
       <li class="sage-pagination__item">
         <a href="#" class="sage-pagination__page sage-pagination__page--disabled">
           <%= prev_text %>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - moved `show_arrows` conditional to not only affect the first pagination page, but all pages

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->

##### Pagination
|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-03-25 at 2 22 22 PM](https://user-images.githubusercontent.com/1241836/112545870-b662e280-8d86-11eb-982b-b63cc2ede264.png)|![Screen Shot 2021-03-25 at 2 23 12 PM](https://user-images.githubusercontent.com/1241836/112545892-bd89f080-8d86-11eb-8893-a0324a4a8a80.png)|

##### Pagination within Panel Controls
|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-03-25 at 2 22 16 PM](https://user-images.githubusercontent.com/1241836/112545926-c7135880-8d86-11eb-8393-bd54bda6d9d9.png)|![Screen Shot 2021-03-25 at 2 23 05 PM](https://user-images.githubusercontent.com/1241836/112545945-cbd80c80-8d86-11eb-8252-bd71e49ffe28.png)|



## Test notes
<!-- OPTIONAL section: describe steps to replicate behavior -->

### Steps for testing
With the link on, the only way to test is to implement `SagePanelControls` and click the `Next` button. Once on the second page, you can verify that the button shows only arrows and not the href

### QA Steps
(Medium) This affects all pagination outside of the first page
- [ ] - Products page
- [ ] - Outlines page

