### PR TITLE
Toggle updates

### DIFF
--- a/docs/app/views/examples/elements/checkbox/_preview.html.erb
+++ b/docs/app/views/examples/elements/checkbox/_preview.html.erb
@@ -19,7 +19,7 @@
   } %>
 
   <%= sage_component SageCheckbox, {
-    id:"c1b",
+    id:"c1c",
     label_text: "Checkbox",
     checked: false,
     disabled: false,

--- a/docs/app/views/examples/elements/checkbox/_preview.html.erb
+++ b/docs/app/views/examples/elements/checkbox/_preview.html.erb
@@ -9,6 +9,24 @@
     partial_selection: true
   } %>
 
+  <%= sage_component SageCheckbox, {
+    id:"c1b",
+    label_text: "Checkbox",
+    checked: false,
+    disabled: false,
+    has_error: false,
+    message: 'This is where a "hint" message would appear.',
+  } %>
+
+  <%= sage_component SageCheckbox, {
+    id:"c1b",
+    label_text: "Checkbox",
+    checked: false,
+    disabled: false,
+    has_error: false,
+    partial_selection: true
+  } %>
+
   <!-- Checked -->
   <%= sage_component SageCheckbox, {
     id: "c2",

--- a/docs/app/views/examples/elements/checkbox/_props.html.erb
+++ b/docs/app/views/examples/elements/checkbox/_props.html.erb
@@ -35,6 +35,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`message`') %></td>
+  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`name`') %></td>
   <td><%= md('Using a singular name groups radio buttons together, allowing the user to toggle between them (see Option 1 and Option 2 examples above)') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/elements/radio/_preview.html.erb
+++ b/docs/app/views/examples/elements/radio/_preview.html.erb
@@ -15,6 +15,14 @@
     label_text: "Option 2"
   } %>
 
+  <%= sage_component SageRadio, {
+    id: "r2b",
+    name: "radio1",
+    value: "2b",
+    label_text: "Option 2b",
+    message: "Message text goes here.",
+  } %>
+
   <!-- Disabled -->
   <%= sage_component SageRadio, {
     id: "r3",

--- a/docs/app/views/examples/elements/radio/_props.html.erb
+++ b/docs/app/views/examples/elements/radio/_props.html.erb
@@ -6,7 +6,7 @@
 </tr>
 <tr>
   <td><%= md('`caption`') %></td>
-  <td><%= md('Sets the caption text for the component.') %></td>
+  <td><%= md('Sets the caption text for the component in a bordered card.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -43,6 +43,12 @@
 <tr>
   <td><%= md('`label_text`') %></td>
   <td><%= md('Sets the label text for the component.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`message`') %></td>
+  <td><%= md('Sets the message text for the component in the default, unbordered context.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/objects/card/_preview.html.erb
+++ b/docs/app/views/examples/objects/card/_preview.html.erb
@@ -146,3 +146,9 @@ Cards have three core areas:
     <%= image_tag("card-placeholder-sm.png", alt: "") %>
   <% end %>
 <% end %>
+
+<%= sage_component SagePanelHeader, { title: "Card Grid Utility <code>.sage-card-grid</code>".html_safe } %>
+<%= md("
+The `.sage-card-grid` utility class can be added onto containers in order to enforce the Card's internal grid settings.
+This is helpful in cases where a container of some sort is needed around contents but those contents should still recieve the standard Card-scoped gaps.
+", use_sage_type: true) %>

--- a/docs/app/views/examples/objects/panel/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel/_preview.html.erb
@@ -271,3 +271,9 @@ We also have a modifier `.sage-panel__figure--wistia` for when Wistia videos are
     <%= image_tag("card-placeholder-lg.png", alt: "") %>
   <% end %>
 <% end %>
+
+<%= sage_component SagePanelHeader, { title: "Panel Grid Utility <code>.sage-panel-grid</code>".html_safe } %>
+<%= md("
+The `.sage-panel-grid` utility class can be added onto containers in order to enforce the Panel's internal grid settings.
+This is helpful in cases where a container of some sort is needed around contents but those contents should still recieve the standard Panel-scoped gaps.
+", use_sage_type: true) %>

--- a/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
@@ -7,6 +7,7 @@ class SageCheckbox < SageComponent
     has_error:  [:optional, TrueClass],
     id: [:optional, String],
     label_text: [:optional, String],
+    message: [:optional, String],
     name: [:optional, String],
     partial_selection: [:optional, TrueClass],
     required: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_radio.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_radio.rb
@@ -9,6 +9,7 @@ class SageRadio < SageComponent
     has_error: [:optional, TrueClass],
     id: String,
     label_text: String,
+    message: [:optional, String],
     name: String,
     required: [:optional, TrueClass],
     standalone: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
@@ -43,6 +43,9 @@
     <label for="<%= component.id %>" class="sage-checkbox__label">
       <%= component.label_text %>
     </label>
+    <% if component.message.present? %>
+      <div class="sage-checkbox__message"><%= component.message %></div>
+    <% end %>
   </div>
 <% end %>
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -42,6 +42,9 @@
     <label for="<%= component.id %>" class="sage-radio__label">
       <%= component.label_text %>
     </label>
+    <% if component.message.present? %>
+      <div class="sage-radio__message"><%= component.message %></div>
+    <% end %>
     <% if component.caption.present? %>
       <div class="sage-radio__caption"><%= component.caption %></div>
     <% end %>

--- a/packages/sage-assets/lib/stylesheets/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_variables.scss
@@ -63,7 +63,7 @@ $sage-radio-colors: (
   checked: sage-color(primary),
   checked-disabled: sage-color(primary, 200),
   checked-inner: sage-color(white),
-  default: sage-color(grey, 4000),
+  default: sage-color(grey, 400),
   hover: sage-color(grey, 500),
 );
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_checkbox.scss
@@ -13,6 +13,7 @@ $-checkbox-color-disabled: sage-color(grey, 200);
 $-checkbox-color-disabled-checked: sage-color(primary, 200);
 
 $-checkbox-size: rem(20px);
+$-checkbox-label-spacing: rem(12px);
 $-checkbox-border-radius-inner: sage-border(radius-small);
 $-checkbox-border-radius-outer: sage-border(radius);
 $-checkbox-transition: 0.15s ease-in-out;
@@ -104,7 +105,7 @@ $-checkbox-focus-outline-color: sage-color(primary);
 .sage-checkbox__label {
   display: inline-block;
   flex: 1;
-  margin-left: rem(12px);
+  margin-left: $-checkbox-label-spacing;
   vertical-align: top;
   cursor: pointer;
 
@@ -127,6 +128,26 @@ $-checkbox-focus-outline-color: sage-color(primary);
   
   .sage-panel-controls__bulk-actions--checked & {
     display: unset;
+  }
+}
+
+.sage-checkbox__message {
+  position: relative;
+  z-index: sage-z-index(default);
+  width: 100%;
+  margin-left: #{$-checkbox-size + $-checkbox-label-spacing};
+  color: sage-color(charcoal, 200);
+
+  @extend %t-sage-body-xsmall;
+
+  .sage-checkbox--error &,
+  .sage-checkbox__input:invalid + & {
+    color: sage-color(red);
+  }
+
+  .sage-checkbox__input:disabled + & {
+    color: $-checkbox-color-default;
+    cursor: not-allowed;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
@@ -18,6 +18,7 @@ $-radio-color-focus-outline-error: sage-color(red, 300);
 
 // Additional configurations
 $-radio-button-size: $sage-radio-size;
+$-radio-label-spacing: sage-spacing(sm);
 $-radio-transition: 0.15s ease-in-out;
 $-radio-selected-indicator-size: rem(7px);
 
@@ -73,7 +74,7 @@ $-radio-focus-outline-color: currentColor;
 .sage-radio__label {
   display: inline-block;
   flex: 1;
-  margin-left: sage-spacing(sm);
+  margin-left: $-radio-label-spacing;
   vertical-align: top;
   cursor: pointer;
 
@@ -95,7 +96,6 @@ $-radio-focus-outline-color: currentColor;
     font-weight: sage-font-weight(semibold);
   }
 }
-
 
 .sage-radio--standalone,
 .sage-radio__input {
@@ -191,7 +191,8 @@ $-radio-focus-outline-color: currentColor;
       box-shadow: none;
     }
 
-    + .sage-radio__label {
+    + .sage-radio__label,
+    + .sage-radio__message {
       color: $-radio-color-text-disabled;
       cursor: not-allowed;
     }
@@ -218,7 +219,8 @@ $-radio-focus-outline-color: currentColor;
 
 .sage-radio--error {
   .sage-radio__label,
-  .sage-radio__caption {
+  .sage-radio__caption,
+  .sage-radio__message {
     color: sage-color(red);
   }
   .sage-radio__input {
@@ -236,9 +238,12 @@ $-radio-focus-outline-color: currentColor;
   }
 }
 
+.sage-radio__message,
 .sage-radio__caption {
+  position: relative;
+  z-index: sage-z-index(default);
   width: 100%;
-  padding: 0 0 0 2rem;
+  margin-left: #{$-radio-button-size + $-radio-label-spacing};
   color: sage-color(charcoal, 200);
 
   @extend %t-sage-body-xsmall;

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_radio.scss
@@ -134,7 +134,7 @@ $-radio-focus-outline-color: currentColor;
     transform: translate3d(-50%, -50%, 0) scale(0.94);
     width: calc(100% + ((#{$-radio-focus-outline-width} * 1px) + (#{$-radio-focus-outline-size} * 2)));
     height: calc(100% + ((#{$-radio-focus-outline-width} * 1px) + (#{$-radio-focus-outline-size} * 2)));
-    border: calc(#{$-radio-focus-outline-width} * 1px) solid $-radio-focus-outline-color;
+    border: calc(#{$-radio-focus-outline-width} * 1px) solid $-radio-color-default;
     pointer-events: none;
     opacity: 0;
   }
@@ -172,6 +172,7 @@ $-radio-focus-outline-color: currentColor;
     
     &::before {
       transform: translate3d(-50%, -50%, 0) scale(1);
+      border-color: $-radio-color-focus-outline;
       opacity: 1;
     }
 
@@ -231,6 +232,9 @@ $-radio-focus-outline-color: currentColor;
     }
     &::after {
       background-color: sage-color(white);
+    }
+    &:focus::before {
+      border-color: $-radio-color-focus-outline-error;
     }
   }
   :hover:not(:checked):not(:disabled) {

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_switch.scss
@@ -86,8 +86,10 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
 }
 
 .sage-switch__message {
+  position: relative;
+  z-index: sage-z-index(default);
   width: 100%;
-  padding: 0 0 0 ($-switch-width + $-switch-label-left-spacing);
+  margin-left: ($-switch-width + $-switch-label-left-spacing);
   color: sage-color(charcoal, 200);
 
   @extend %t-sage-body-xsmall;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_card.scss
@@ -12,6 +12,10 @@
   width: 100%;
 }
 
+.sage-card-grid {
+  @include sage-grid-card;
+}
+
 .sage-card--clear-padding-top,
 .sage-card--clear-padding-both {
   padding-top: 0;

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_panel.scss
@@ -10,6 +10,10 @@
   @include sage-grid-panel;
 }
 
+.sage-panel-grid {
+  @include sage-grid-panel;
+}
+
 .sage-panel--clear-padding-top,
 .sage-panel--clear-padding-both {
   padding-top: 0;

--- a/packages/sage-react/lib/configs/classnames/index.js
+++ b/packages/sage-react/lib/configs/classnames/index.js
@@ -27,5 +27,7 @@ export const SageClassnames = {
   TRUNCATE_TEXT: CLASSNAME_TRUNCATE_TEXT,
   GRID_TEMPLATES: { ...CLASSNAMES_GRID_TEMPLATES },
   LINK: { ...CLASSNAMES_LINK },
+  CARD_GRID: 'sage-card-grid',
+  PANEL_GRID: 'sage-panel-grid',
   lookupGridTemplate: lookupGridTemplateClassname,
 };


### PR DESCRIPTION
## Description

This PR does a little tidying on toggles such as Switch, Radio, and Checkbox:

- Adds `message` elements to Radio and Checkbox (Rails)
- Fixes border colors for various states of Radio to match specs

Also this PR adds two utilities for adding `card-` and `panel-`-level grid settings on an element, such as when you need to group a set of elements within a panel (such as within a form or for conditional rendering): `.sage-panel-grid` and `sage-card-grid`. Basically everything to build a panel or card container minus the padding and border treatments.

## Test notes

See Radio, Switch, and Toggle for stability.

### Estimated impact

1. (LOW) Updates to Radio, Switch, and Toggle to include a message/hint and correct state coloring. No adverse effects expected. Investigate any Sage-based forms such as the following for continued expected behavior:
   - [ ] Blog post editor form (radio for publishing on the right sidebar)
   - [ ] Navigation editor, edit a link modal (checkbox for whether or not to be only visible to logged in users)

