### PR TITLE
Modal - add header image to modalcontent

### DIFF
--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -11,6 +11,14 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
+      value: "Modal with Header Image",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-header-image",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
       value: "Large Modal (removed)",
       attributes: {
         "data-js-modaltrigger": "cool-modal-large",
@@ -28,7 +36,48 @@
 
   <%# Standard Modal %>
   <%= sage_component SageModal, { id: "cool-modal" } do %>
-    <%= sage_component SageModalContent, { title: "Example Modal" } do %>
+    <%= sage_component SageModalContent, {
+      title: "Example Modal" 
+    } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%# Standard Modal with Header Image %>
+  <%= sage_component SageModal, { id: "cool-modal-header-image" } do %>
+    <%= sage_component SageModalContent, { 
+      header_image: "/assets/card-placeholder-sm.png", 
+      title: "Example Modal" 
+    } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
           style: "secondary",

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -58,6 +58,12 @@
   </td>
 </tr>
 <tr>
+  <td><%= md('`header_image`') %></td>
+  <td><%= md('When present, sets the image in the header of the component') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`title`') %></td>
   <td><%= md('Populates the `sage-modal__header` with a heading containing the provided content') %></td>
   <td><%= md('String') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
@@ -1,5 +1,6 @@
 class SageModalContent < SageComponent
   set_attribute_schema({
+    header_image: [:optional, String],
     spacing: [:optional, NilClass, Set.new(["panel", "card"])],
     title: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -1,5 +1,8 @@
 <% if component.title.present? %>
   <header class="sage-modal__header">
+    <% if component.header_image.present? %>
+      <img class="sage-modal__header-image" src=<%= component.header_image %> alt="" aria-hidden="true"/>
+    <% end %>
     <h1 class="t-sage-heading-4">
       <%= component.title %>
     </h1>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_modal.scss
@@ -7,6 +7,7 @@
 
 $-modal-padding-x: sage-spacing(md);
 $-modal-padding-y: sage-spacing(md);
+$-modal-header-image-size: rem(28px);
 
 
 .sage-modal {
@@ -103,6 +104,13 @@ $-modal-padding-y: sage-spacing(md);
   display: flex;
   align-items: baseline;
   margin: $-modal-padding-y $-modal-padding-x;
+}
+
+.sage-modal__header-image {
+  align-self: center;
+  width: $-modal-header-image-size;
+  height: $-modal-header-image-size;
+  margin-right: sage-spacing(xs);
 }
 
 .sage-modal__header-aside {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - added an optional header image to the modal content
- [x] - updated docs and demo

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before Modal Trigger Click  |  After Modal Trigger Click  |
|--------|--------|
|![Screen Shot 2021-03-29 at 4 58 49 PM](https://user-images.githubusercontent.com/1241836/112906130-45d30300-90b1-11eb-9519-08208a229432.png)|![Screen Shot 2021-03-29 at 4 58 54 PM](https://user-images.githubusercontent.com/1241836/112906141-49ff2080-90b1-11eb-938d-a68a1159ac5e.png)|


## Test notes
<!-- General notes here surrounding this change -->
- Visit the Modal Rails page: http://localhost:4000/pages/object/modal
- Click the Modal with header image and verify the image is present 

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- [ ] (**LOW**) This is a new feature and does not affect any instances of modals



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
