### PR TITLE
Modal: Enable custom CSS classes

### DIFF
--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -199,7 +199,7 @@
   <% end %>
 
   <%# Animated Modals %>
-  <%= sage_component SageModal, { id: "cool-modal-animate-default", animate: true } do %>
+  <%= sage_component SageModal, { id: "cool-modal-animate-default", animate: true, css_classes: "custom-class-name-here" } do %>
     <%= sage_component SageModalContent, { title: "Example Modal" } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -11,8 +11,14 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`css_classes`') %></td>
+  <td><%= md('Outputs additional CSS classes as specified.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`direction`') %></td>
-  <td><%= md('Sets the direction of the animation. Options include "bottom" (default), "top", "left", and "right". Use caution when setting multiple `direction` modals within a page or view to ensure a consistent user experience. This option requires `animate` to be set to `true`.') %></td>
+  <td><%= md('Sets the direction of the animation when `animate` has been enabled. Options include "bottom" (default), "top", "left", and "right". Use caution when setting multiple `direction` modals within a page or view to ensure a consistent user experience. This option requires `animate` to be set to `true`.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/shared/_props.html.erb
+++ b/docs/app/views/examples/shared/_props.html.erb
@@ -5,7 +5,7 @@
   <%= sage_component SageCard, {} do %>
     <div class="sage-table-wrapper sage-table-wrapper--scroll">
       <div class="sage-table-wrapper__overflow">
-        <table class="sage-table sage-table--properties">
+        <table class="sage-table sage-table--properties sage-table--striped">
           <thead>
             <tr>
               <th>Property</th>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -1,6 +1,7 @@
 class SageModal < SageComponent
   set_attribute_schema({
     active: [:optional, TrueClass],
+    css_classes: [:optional, String],
     disable_close: [:optional, TrueClass],
     id: [:optional, String],
     large: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -3,6 +3,7 @@
     <%= "sage-modal--active" if component.active %>
     <%= "sage-modal--large" if component.large -%>
     <%= "sage-modal--no-blur" if component.disable_background_blur -%>
+    <%= component.css_classes.html_safe if component.css_classes.present? %>
   "
   <%= "data-sage-animate" if component.animate.present? %>
   <%- if component.animate.is_a?(Hash) -%>


### PR DESCRIPTION
## Description
This update allows for optional custom CSS classes on the Sage modal `dialog`. No visual changes apply.

Also includes an update for the documentation site's object/element Properties tables, adding striping on rows to help with readability:

|  Before   |  After  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/112911381-284e6b00-90aa-11eb-8ff7-3084f80f5ef9.png)|![after](https://user-images.githubusercontent.com/816579/112911395-2dabb580-90aa-11eb-9c24-4423ea6a9563.png)|


## Test notes
<!-- General notes here surrounding this change -->

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- (**LOW**) No expected impact from adding this optional param. Check the following implementations to verify expected functionality:
  - [x] Sites -> New Site modal
  - [x] Product blueprint -> New Product modal



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
- COMM-845