### PR TITLE
Pagination - updates styles when arrows present

### DIFF
--- a/docs/app/views/examples/objects/pagination/_preview.html.erb
+++ b/docs/app/views/examples/objects/pagination/_preview.html.erb
@@ -1,3 +1,12 @@
+<h3 class="t-sage-heading-6">Default with arrows</h3>
+<%= sage_component SagePagination, {
+  items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
+  collection_name: "Record",
+  window: 2,
+  hide_pages: true,
+  show_arrows: true
+} %>
+
 <h3 class="t-sage-heading-6">Default</h3>
 <%= render "examples/objects/pagination/markup",
   total_count: "32",

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -39,7 +39,8 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   border: $-pagination-border;
   border-radius: $-pagination-radius;
 
-  .sage-panel-controls--show-pagination & {
+  
+  &.sage-pagination__pages--show-arrows {
     border: 0;
   }
 }
@@ -53,13 +54,18 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
     border: 0;
   }
 
-  .sage-panel-controls--show-pagination & {
+  .sage-panel-controls--show-pagination &,
+  .sage-pagination__pages--show-arrows & {
     margin-right: rem(12px);
     border: 0;
 
     &:last-of-type {
       margin-right: 0;
     }
+  }
+
+  .sage-pagination__pages--show-arrows &:first-child {
+    margin-right: 12px;
   }
 }
 
@@ -79,7 +85,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
     box-shadow: none;
   }
 
-  .sage-panel-controls--show-pagination & {
+  .sage-pagination__pages--show-arrows & {
     min-height: rem(40px);
     font-size: sage-font-size(lg);
     border: 0;
@@ -87,13 +93,17 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
     box-shadow: map-get($sage-toolbar-button-borders, default);
   }
 
-  .sage-panel-controls--show-pagination &:hover {
+  .sage-pagination__pages--show-arrows &:hover {
     box-shadow: map-get($sage-toolbar-button-borders, hover);
   }
 
-  .sage-panel-controls--show-pagination &:focus {
+  .sage-pagination__pages--show-arrows &:focus {
     box-shadow: 0 0 0 rem(2px) sage-color(primary);
     background-color: sage-color(white);
+  }
+
+  .sage-pagination__pages--show-arrows & {
+    min-height: rem(40px);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_pagination.scss
@@ -65,7 +65,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   }
 
   .sage-pagination__pages--show-arrows &:first-child {
-    margin-right: 12px;
+    margin-right: rem(12px);
   }
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - resolve arrow styling issue when pagination exist in a `SagePanel` but not `SagePanelControls`

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2021-03-30_at_8_45_26_AM](https://user-images.githubusercontent.com/1241836/113000126-27aee680-9135-11eb-9e3c-419166db323d.png)|![Screen_Shot_2021-03-30_at_8_44_46_AM](https://user-images.githubusercontent.com/1241836/113000153-2bdb0400-9135-11eb-9dea-f4483545a9b7.png)|


## Test notes
<!-- General notes here surrounding this change -->
Visit the sage rails pagination page: http://localhost:4000/pages/object/pagination

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- [ ] (**MEDIUM**) This style update affects all instances of `SagePagination` that exists within `SagePanel` instead of `SagePanelControls`.
    - [ ] - Product Index page
    - [ ] - Podcast Index page


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
