### PR TITLE
Pagination Count Prefix & Suffix

### DIFF
--- a/docs/app/views/examples/objects/pagination/_markup.html.erb
+++ b/docs/app/views/examples/objects/pagination/_markup.html.erb
@@ -1,7 +1,11 @@
 <% hide_counter ||= false %>
 <nav class="sage-pagination<% if hide_counter %> sage-pagination--no-counter<% end %>" aria-label="pagination">
   <% unless hide_counter %>
-    <span class="sage-pagination__count"><strong><%= total_count %></strong> Records</span>
+    <span class="sage-pagination__count">
+      <span class="sage-pagination__count-prefix">Displaying</span>
+      <strong><%= total_count %></strong> Records
+      <span class="sage-pagination__count-suffix">in the last <strong>30 days</strong></span>
+    </span>
   <% end %>
   <ul class="sage-pagination__pages">
     <% pagination_items.each do |item| %>

--- a/docs/app/views/examples/objects/pagination/_props.html.erb
+++ b/docs/app/views/examples/objects/pagination/_props.html.erb
@@ -40,3 +40,15 @@
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
+<tr>
+  <td><%= md('`page_count_prefix`') %></td>
+  <td><%= md('Allows string to be added before the page count text.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`page_count_suffix`') %></td>
+  <td><%= md('Allows string to be added after the page count text.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -155,7 +155,9 @@ actions_items = [
     <% content_for :sage_panel_controls_pagination do %>
       <%= sage_component SagePagination, {
         items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
-        collection_name: "Some name here",
+        collection_name: "Items",
+        page_count_prefix: "Displaying",
+        page_count_suffix: "in the last <strong>30 days</strong>".html_safe,
         window: 2,
         hide_pages: true,
         show_arrows: true
@@ -315,7 +317,7 @@ are paired with corresponding responders in context.
 - All these custom events are mapped to the `sage.panelControls.change` event type.</li>
 - The `detail` property of this custom event always contains the following
   along with additional properties outlined in detail below:
-  
+
   - `type`: the more specific type of event in the context of the Panel Controls
   - `targetListId`: the id of the list to be targetted by the action
 
@@ -449,7 +451,7 @@ and accessible on the custom event's `target.dataset` property.
     else document.addEventListener("DOMContentLoaded", callback);
   }
 
-  ready(() => { 
+  ready(() => {
      if (Sage.panelControls) setupPanelControls();
   });
 </script>

--- a/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_pagination.rb
@@ -6,7 +6,9 @@ class SagePagination < SageComponent
     hide_counter: [:optional, TrueClass],
     show_arrows: [:optional, TrueClass],
     additional_params: [:optional, Hash],
-    collection_name: [:optional, String]
+    collection_name: [:optional, String],
+    page_count_prefix: [:optional, String],
+    page_count_suffix: [:optional, String],
   })
 
   def initialize(attributes = {})
@@ -23,7 +25,7 @@ class SagePagination < SageComponent
   end
 
   def page_count(collection)
-    
+
     name = collection_name.presence || collection.entry_name || "Record"
     entry_name = name.titleize.pluralize(collection.total_count)
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -10,7 +10,11 @@
     <%= component.generated_html_attributes.html_safe %>
   >
     <% if !component.hide_counter %>
-      <span class="sage-pagination__count"><%= component.page_count component.items %></span>
+      <span class="sage-pagination__count">
+        <% if component.page_count_prefix %><span class="sage-pagination__count-prefix"><%= component.page_count_prefix %></span><% end %>
+        <%= component.page_count component.items %>
+        <% if component.page_count_prefix %><span class="sage-pagination__count-suffix"><%= component.page_count_suffix %></span><% end %>
+      </span>
     <% end %>
 
     <ul class="sage-pagination__pages <% if component.show_arrows %>sage-pagination__pages--show-arrows<% end %>">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -13,7 +13,7 @@
       <span class="sage-pagination__count">
         <% if component.page_count_prefix %><span class="sage-pagination__count-prefix"><%= component.page_count_prefix %></span><% end %>
         <%= component.page_count component.items %>
-        <% if component.page_count_prefix %><span class="sage-pagination__count-suffix"><%= component.page_count_suffix %></span><% end %>
+        <% if component.page_count_suffix %><span class="sage-pagination__count-suffix"><%= component.page_count_suffix %></span><% end %>
       </span>
     <% end %>
 

--- a/packages/sage-react/lib/Pagination/Pagination.jsx
+++ b/packages/sage-react/lib/Pagination/Pagination.jsx
@@ -22,6 +22,8 @@ export const Pagination = ({
   maxPageButtons,
   onClickPage,
   pageCount,
+  pageCountPrefix,
+  pageCountSuffix,
   pageSize,
   pageURLFn,
 }) => {
@@ -75,8 +77,9 @@ export const Pagination = ({
 
       return (
         <span className={classNames}>
-          <strong>{first}</strong> – <strong>{last}</strong>{' '}
-          of <strong>{itemsTotalCount}</strong> {entryName}
+          {pageCountPrefix && <span className="sage-pagination__count-prefix">{pageCountPrefix}</span>}
+          <strong>{first}</strong> – <strong>{last}</strong>{' '} of <strong>{itemsTotalCount}</strong> {entryName}
+          {pageCountSuffix && <span className="sage-pagination__count-suffix">{pageCountSuffix}</span>}
         </span>
       );
     }
@@ -205,6 +208,8 @@ Pagination.defaultProps = {
   maxPageButtons: 4,
   onClickPage: null,
   pageCount: 1,
+  pageCountPrefix: null,
+  pageCountSuffix: null,
   pageSize: null,
   pageURLFn: null,
 };
@@ -222,6 +227,8 @@ Pagination.propTypes = {
   maxPageButtons: PropTypes.number,
   onClickPage: PropTypes.func,
   pageCount: PropTypes.number,
+  pageCountPrefix: PropTypes.string,
+  pageCountSuffix: PropTypes.string,
   pageSize: PropTypes.number,
   pageURLFn: PropTypes.func,
 };


### PR DESCRIPTION
## Description
Updates pagination in order to allow a custom string to be placed before (prefix) or after (suffix) the page count displayed.
This leaves the functionality of the actual page count as is.

**Note**: While these updates are related to pagination component, their display is for an upcoming design within the panel controls.


### Screenshots
|  Screenshot  |
|--------|
|![Screen Shot 2021-03-30 at 11 33 18 AM](https://user-images.githubusercontent.com/1175111/113046746-46bd7080-9155-11eb-89db-546bb497c58c.png)|

## Test notes
**RAILS**

- Visit http://localhost:4000/pages/breakout/object/panel_controls
- Verify prefix and suffix are being displayed in the panel titled "Pagination"
--
- Visit http://localhost:4000/pages/breakout/object/pagination
- Verify prefix and suffix are being displayed in the example where pagination count is displayed.
- Verify property descriptions are ok in the documentation.

**REACT**

- Visit http://localhost:4100/?path=/story/sage-pagination--default
- Test out `pageCountPrefix` & `pageCountSuffix` in controls
- Verify `<span>` for `pageCountPrefix` does not display within DOM when empty
- Verify `<span>` for `pageCountSuffix` does not display within DOM when empty

### Estimated impact
(LOW) Adjusts pagination to allow for a prefix or suffix string to be added to the page count section. This should not affect any current implementations as it is a new feature; verify the following still behave as expected:
   - [ ] People > pagination below table
   - [ ] Offers > pagination below list of offers

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
