### PR TITLE
Add hidden radio option in choice and tabs

### DIFF
--- a/docs/app/views/examples/elements/choice/_preview.html.erb
+++ b/docs/app/views/examples/elements/choice/_preview.html.erb
@@ -11,6 +11,20 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
+<h3 class="t-sage-heading-6">With Radio</h3>
+<%= sage_component SageChoice, {
+    target: "example",
+    text: "Option 1a",
+    type: "radio",
+    active: false,
+    radio_configs: {
+      id: 'cr-1a',
+      name: 'cr-1',
+      value: 'option-a',
+    }
+  }
+%>
+
 <h3 class="t-sage-heading-6">Multi-Line  (radio type)</h3>
 <%= sage_component SageChoice, {
     target: "example",

--- a/docs/app/views/examples/elements/choice/_props.html.erb
+++ b/docs/app/views/examples/elements/choice/_props.html.erb
@@ -47,6 +47,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`radio_configs`') %></td>
+  <td><%= md('If provided, this adjusts a choice to include a radio `input` that is visually hidden and toggles on when the choice is selected.') %></td>
+  <td><%= md('{ name: String, id: String, value: String }') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`subtext`') %></td>
   <td><%= md('Sets the content of the secondary text line') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/objects/tabs/_preview.html.erb
+++ b/docs/app/views/examples/objects/tabs/_preview.html.erb
@@ -85,17 +85,32 @@
           text: "Sub Page 1",
           target: "choice-test1",
           active: true,
-          type: "radio"
+          type: "radio",
+          radio_configs: {
+            id: "page-1",
+            name: "pages",
+            value: "page-1",
+          }
         },
         {
           text: "Sub Page 2",
           target: "choice-test2",
-          type: "radio"
+          type: "radio",
+          radio_configs: {
+            id: "page-2",
+            name: "pages",
+            value: "page-2",
+          }
         },
         {
           text: "Sub Page 3",
           target: "choice-test3",
           type: "radio",
+          radio_configs: {
+            id: "page-3",
+            name: "pages",
+            value: "page-3",
+          }
         },
       ],
       style: "choice"

--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -11,6 +11,11 @@ class SageChoice < SageComponent
     target: [:optional, NilClass, String],
     text: [:optional, NilClass, String],
     type: [:optional, NilClass, Set.new(["arrow", "graphic", "icon", "radio"])],
-    vertical_align_icon: [:optional, NilClass, Set.new(["start"])]
+    vertical_align_icon: [:optional, NilClass, Set.new(["start"])],
+    radio_configs: [:optional, NilClass, {
+      value: String,
+      name: String,
+      id: String,
+    }]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -16,7 +16,12 @@ class SageTabs < SageComponent
       target: [:optional, NilClass, String],
       text: [:optional, NilClass, String],
       type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
-      vertical_align_icon: [:optional, NilClass, Set.new(["start"])]
+      vertical_align_icon: [:optional, NilClass, Set.new(["start"])],
+      radio_configs: [:optional, NilClass, {
+        value: String,
+        name: String,
+        id: String,
+      }]
     ]]],
     navigational: [:optional, TrueClass],
     progressbar: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -1,7 +1,14 @@
 <%
-css_active_class = "sage-choice--active" 
-is_button = !component.attributes&.has_key?(:href)
-html_tag = is_button ? (component.content.present? ? "div" : "button") : "a"
+css_active_class = "sage-choice--active"
+is_label = component.radio_configs.present?
+is_link = component.attributes&.has_key?(:href)
+is_button = !is_link and !is_label
+html_tag = component.content.present? ? "div" : "button"
+if is_link
+  html_tag = "a"
+elsif is_label
+  html_tag = "label"
+end
 %>
 
 <<%= html_tag %>
@@ -29,7 +36,20 @@ html_tag = is_button ? (component.content.present? ? "div" : "button") : "a"
   data-sage-active-class="<%= css_active_class %>"
   role="tab"
   aria-controls="<%= component.target %>"
+  <% if component.radio_configs.present? %>
+    for="<%= component.radio_configs[:id] %>"
+  <% end %>
 >
+   <% if component.radio_configs.present? %>
+    <div class="sage-choice__radio visually-hidden">
+      <input
+        type="radio"
+        name="<%= component.radio_configs[:name] %>"
+        id="<%= component.radio_configs[:id] %>"
+        value="<%= component.radio_configs[:value] %>"
+      />
+    </div>
+  <% end %>
   <% if component.graphic.present? %>
     <div class="sage-choice__graphic">
       <%= component.graphic.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -47,6 +47,7 @@ end
         name="<%= component.radio_configs[:name] %>"
         id="<%= component.radio_configs[:id] %>"
         value="<%= component.radio_configs[:value] %>"
+        <%= "checked=checked" if component.active %>
       />
     </div>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -22,6 +22,7 @@
         icon: item[:icon],
         attributes: item[:attributes],
         disabled: item[:disabled],
+        radio_configs: item[:radio_configs],
         vertical_align_icon: item[:vertical_align_icon],
       } do %>
         <%= item[:content].html_safe if defined?(item[:content]) and item[:content] %>


### PR DESCRIPTION
## Description

Adds an optional visually hidden radio input behind Choice components. Useful when Choice is used for tabs within a form and the selected tab needs to be recognized in the form submission.

### Screenshots

No visual changes


## Test notes

See Choice and Tabs

### Estimated impact
1. (LOW) Added optional radio buttons behind "choice" tab components for use in form contexts. Confirm no effect on existing uses of choice tabs in:
   - [ ] Website > Navigation > Add new item and in modal, choice tabs function as planned.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
