### PR TITLE
Adds remote_url option for modals

### DIFF
--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -53,6 +53,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`remote_url`') %></td>
+  <td><%= md('Specify a url which from which to load the modal content on open. This will be requested & content replaced every time the modal is opened.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td colspan="4">
     <strong>Modal Content</strong>
   </td>

--- a/docs/app/views/examples/objects/modal/_props.html.erb
+++ b/docs/app/views/examples/objects/modal/_props.html.erb
@@ -55,7 +55,7 @@
 <tr>
   <td><%= md('`remote_url`') %></td>
   <td><%= md('Specify a url which from which to load the modal content on open. This will be requested & content replaced every time the modal is opened.') %></td>
-  <td><%= md('Boolean') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -9,6 +9,7 @@ class SageModal < SageComponent
     disable_background_blur: [:optional, TrueClass],
     animate: [:optional, String, TrueClass, {
       direction: [:optional, String, Set.new(["bottom", "top", "left", "right"])]
-    }]
+    }],
+    remote_url: [:optional, String]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -6,6 +6,7 @@
     <%= component.css_classes.html_safe if component.css_classes.present? %>
   "
   <%= "data-sage-animate" if component.animate.present? %>
+  <%= "data-js-remote-url='#{component.remote_url}'" if component.remote_url.present? %>
   <%- if component.animate.is_a?(Hash) -%>
     <%- component.animate.each do |key, value| -%>
       <%= "data-sage-animate-#{ key }=#{ value }" %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -6,7 +6,7 @@
     <%= component.css_classes.html_safe if component.css_classes.present? %>
   "
   <%= "data-sage-animate" if component.animate.present? %>
-  <%= "data-js-remote-url='#{component.remote_url}'" if component.remote_url.present? %>
+  <%= "data-js-remote-url=#{component.remote_url}" if component.remote_url.present? %>
   <%- if component.animate.is_a?(Hash) -%>
     <%- component.animate.each do |key, value| -%>
       <%= "data-sage-animate-#{ key }=#{ value }" %>

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -104,11 +104,12 @@ Sage.modal = (function() {
   }
 
   function fetchModalContent(el) {
+    let elContainer = el.querySelector(`[${SELECTOR_MODAL_CONTAINER}]`);
     let url = el.getAttribute(SELECTOR_MODAL_REMOTE_URL);
     const xhr = new XMLHttpRequest();
 
     xhr.addEventListener('load', (evt) => {
-      el.innerHTML = evt.currentTarget.response;
+      elContainer.innerHTML = evt.currentTarget.response;
     }, { once: true });
 
     xhr.open('GET', url, true);

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -5,7 +5,7 @@ Sage.modal = (function() {
   // ==================================================
 
   const SELECTOR_MODAL = 'data-js-modal';
-  const SELECTOR_MODAL_CONTAINER = '.sage-modal__container';
+  const SELECTOR_MODAL_CONTAINER = 'data-js-modal-container';
   const SELECTOR_MODAL_DISABLE_CLOSE = 'data-js-modal-disable-close';
   const SELECTOR_MODAL_REMOTE_URL = 'data-js-remote-url';
   const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = 'data-js-modal-remove-content-on-close';
@@ -117,7 +117,7 @@ Sage.modal = (function() {
 
   function removeModalContents(el) {
     if ( el.hasAttribute(SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE) ) {
-      let elContainer = el.querySelector(`${SELECTOR_MODAL_CONTAINER}`);
+      let elContainer = el.querySelector(`[${SELECTOR_MODAL_CONTAINER}]`);
       elContainer.innerHTML = "";
     }
   }

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -7,6 +7,7 @@ Sage.modal = (function() {
   const SELECTOR_MODAL = 'data-js-modal';
   const SELECTOR_MODAL_CONTAINER = '.sage-modal__container';
   const SELECTOR_MODAL_DISABLE_CLOSE = 'data-js-modal-disable-close';
+  const SELECTOR_MODAL_REMOTE_URL = 'data-js-remote-url';
   const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = 'data-js-modal-remove-content-on-close';
   const SELECTOR_MODAL_CLOSE = 'data-js-modal-close';
   const SELECTOR_MODALTRIGGER = 'data-js-modaltrigger';
@@ -55,6 +56,9 @@ Sage.modal = (function() {
   function openModal(modalId) {
     let modal = document.querySelector(`[${SELECTOR_MODAL}="${modalId}"]`);
     let focusableEls = modal.querySelectorAll(SELECTOR_FOCUSABLE_ELEMENTS);
+    if(modal.hasAttribute(SELECTOR_MODAL_REMOTE_URL)) {
+      fetchModalContent(modal);
+    }
 
     SELECTOR_LAST_FOCUSED = document.activeElement;
     modal.classList.add('sage-modal--active');
@@ -97,6 +101,18 @@ Sage.modal = (function() {
     el.removeEventListener('keydown', focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
     removeModalContents(el);
+  }
+
+  function fetchModalContent(el) {
+    let url = el.getAttribute(SELECTOR_MODAL_REMOTE_URL);
+    const xhr = new XMLHttpRequest();
+
+    xhr.addEventListener('load', (evt) => {
+      el.innerHTML = evt.currentTarget.response;
+    }, { once: true });
+
+    xhr.open('GET', url, true);
+    xhr.send();
   }
 
   function removeModalContents(el) {


### PR DESCRIPTION
## Description
There are plenty of places in the app where it would be useful to load modal content via ajax. This has been done in the past in an (imo) unnecessarily complicated way. For example, see [this open pr](https://github.com/Kajabi/kajabi-products/pull/18437), which took this basic idea from elsewhere in the app.

One related problem is that there is no `open` event for the modal (this would be my next PR, regardless). With an `open` event, devs could do the footwork. But why should we make them re-invent the wheel over and over again?

Making "modals with remote content" should be easy & ergonomic. I can think of at least two other modals our team worked on recently that would benefit from this.


This PR makes it drop-dead simple to make a modal with content that loads via ajax. Simply pass `remote_url` as an option to the modal and hook up the endpoint to render (without layout of course) and BOOM! Remote modal.

### Screenshots
N/A no visual changes

## Test notes
Make sure your controller endpoint does not render layout :grimacing:

### Estimated impact
Adds ability to load content asynchronously in Modals easily. No impact on existing implementations; Verify the following modals continue to behave as expected:
- [x] Website > Navigation > + Add New Navigation Menu
- [x] Website > Navigation > + Add (Button on a navigation panel) > Add Product