### PR TITLE
fix(sagesearch): adds option to not execute search on clear

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_search.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_search.rb
@@ -5,5 +5,6 @@ class SageSearch < SageComponent
     label_text: [:optional, String],
     placeholder: [:optional, String],
     value: [:optional, String, NilClass],
+    disable_search_on_clear: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -14,9 +14,8 @@
   </label>
   <input
     id="<%= component.id %>"
-    class="sage-search__input
-    <%= "sage-search--disable_search_on_clear" if component.disable_search_on_clear %>
-    "
+    class="sage-search__input"
+    <%= "data-js-disable-search-on-clear=true" if component.disable_search_on_clear %>
     type="search"
     placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
     value="<%= component.value %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -14,7 +14,9 @@
   </label>
   <input
     id="<%= component.id %>"
-    class="sage-search__input"
+    class="sage-search__input
+    <%= "sage-search--disable_search_on_clear" if component.disable_search_on_clear %>
+    "
     type="search"
     placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
     value="<%= component.value %>"

--- a/packages/sage-system/lib/search.js
+++ b/packages/sage-system/lib/search.js
@@ -5,6 +5,7 @@ Sage.search = (function() {
 
   const SELECTOR_CLEAR_BUTTON = 'data-js-search-clear';
   const CLASS_HAS_TEXT = 'sage-search--has-text';
+  const DISABLE_SEARCH_ON_CLEAR = 'sage-search--disable_search_on_clear'
 
 
   // ==================================================
@@ -37,9 +38,10 @@ Sage.search = (function() {
   function onClearButtonClick(evt) {
     let el = evt.target.parentNode,
         elInput = getInput(el);
-
     elInput.value = '';
-    search(elInput.value);
+    if (!elInput.classList.contains(DISABLE_SEARCH_ON_CLEAR)){
+      search(elInput.value);
+    }
     hasTextCssClassController(el);
   }
 

--- a/packages/sage-system/lib/search.js
+++ b/packages/sage-system/lib/search.js
@@ -5,7 +5,7 @@ Sage.search = (function() {
 
   const SELECTOR_CLEAR_BUTTON = 'data-js-search-clear';
   const CLASS_HAS_TEXT = 'sage-search--has-text';
-  const DISABLE_SEARCH_ON_CLEAR = 'sage-search--disable_search_on_clear'
+  const DISABLE_SEARCH_ON_CLEAR = 'data-js-disable-search-on-clear';
 
 
   // ==================================================
@@ -39,7 +39,7 @@ Sage.search = (function() {
     let el = evt.target.parentNode,
         elInput = getInput(el);
     elInput.value = '';
-    if (!elInput.classList.contains(DISABLE_SEARCH_ON_CLEAR)){
+    if (!elInput.getAttribute(DISABLE_SEARCH_ON_CLEAR)){
       search(elInput.value);
     }
     hasTextCssClassController(el);


### PR DESCRIPTION
## Description
JIRA: [TME-959](https://kajabi.atlassian.net/browse/TME-959)
This adds the option to add `disable_search_on_clear` attribute on the SageSearch component so that the search does not run when clearing.


### Screenshots
![after](https://user-images.githubusercontent.com/1311769/113327231-b021b880-92e8-11eb-8c7c-cde053e54a4a.gif)


## Test notes
1.) On a rails `SageSearch` component, add `disable_search_on_clear: true` to the attributes
2.) Type in anything in the search field, and press enter (so that search executes)
3.) Click on the `X` to clear the search field, but you should notice that the search does not execute (same results as before should still be appearing)

### Estimated impact
Adds ability to suppress searching again when search terms are cleared. No impact on existing implementations; verify the following search components continue to behave as expected:

- [ ] Go to: `/admin/sites/SITE_ID/email_campaigns` and clearing the search field should execute the search
- [ ] Go to: `/admin/sites/SITE_ID/products` and clearing the search field should execute the search

