### PR TITLE
Label Optional Attributes

### DIFF
--- a/docs/app/views/examples/elements/label/_props.html.erb
+++ b/docs/app/views/examples/elements/label/_props.html.erb
@@ -7,6 +7,13 @@
   <td><%= md('Required') %></td>
 </tr>
 <tr>
+<tr>
+  <td><%= md('`container_attributes`') %></td>
+  <td><%= md('Additional attributes to provide bindings or actions to the label container.') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`icon`') %></td>
   <td><%= md('
     Specifies an icon to display with the value.
@@ -51,7 +58,7 @@
 </tr>
 <tr>
   <td><%= md('`attributes`') %></td>
-  <td><%= md('Additional attributes such as to provide `data-` bindings or actions.') %></td>
+  <td><%= md('Additional attributes such as to provide `data-` bindings or actions to the button.') %></td>
   <td><%= md('`String`') %></td>
   <td><%= md('`"Remove"`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_label.rb
@@ -1,5 +1,6 @@
 class SageLabel < SageComponent
   set_attribute_schema({
+    attributes: [:optional, Hash],
     color: Set.new(["danger", "draft", "info", "locked", "published", "success", "warning"]),
     icon: [:optional, String],
     interactive_type: [:optional, Set.new([:dropdown, :default, :secondary_button])],

--- a/docs/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_label.rb
@@ -1,6 +1,6 @@
 class SageLabel < SageComponent
   set_attribute_schema({
-    attributes: [:optional, Hash],
+    container_attributes: [:optional, Hash],
     color: Set.new(["danger", "draft", "info", "locked", "published", "success", "warning"]),
     icon: [:optional, String],
     interactive_type: [:optional, Set.new([:dropdown, :default, :secondary_button])],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -10,6 +10,9 @@
     <%= "sage-label--icon-#{component.icon}" if component.icon %>
     <%= component.generated_css_classes %>
   "
+  <% component.attributes.each do |key, value| %>
+    <%= "#{key}='#{value}'".html_safe %>
+  <% end if component.attributes&.is_a?(Hash) %>
 >
   <<%= label_content_tag %>
     class="sage-label__value"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -10,9 +10,9 @@
     <%= "sage-label--icon-#{component.icon}" if component.icon %>
     <%= component.generated_css_classes %>
   "
-  <% component.attributes.each do |key, value| %>
+  <% component.container_attributes.each do |key, value| %>
     <%= "#{key}='#{value}'".html_safe %>
-  <% end if component.attributes&.is_a?(Hash) %>
+  <% end if component.container_attributes&.is_a?(Hash) %>
 >
   <<%= label_content_tag %>
     class="sage-label__value"

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -13,6 +13,7 @@ import { LabelGroup } from './LabelGroup';
 export const Label = React.forwardRef(({
   className,
   color,
+  containerAttributes,
   icon,
   interactiveType,
   isDropdown,
@@ -20,7 +21,6 @@ export const Label = React.forwardRef(({
   secondaryButton,
   style,
   value,
-  labelAttributes,
   ...rest
 }, ref) => {
   const TagName = interactiveType ? 'button' : 'span';
@@ -38,7 +38,7 @@ export const Label = React.forwardRef(({
   );
 
   return (
-    <span className={classNames} ref={ref} {...labelAttributes}>
+    <span className={classNames} ref={ref} {...containerAttributes}>
       <TagName
         className="sage-label__value"
         type={interactiveType ? 'button' : null}
@@ -69,7 +69,7 @@ Label.defaultProps = {
   interactiveType: null,
   isDropdown: false,
   isStatus: false,
-  labelAttributes: null,
+  containerAttributes: null,
   secondaryButton: null,
   style: LABEL_STYLES.DEFAULT,
 };
@@ -81,7 +81,7 @@ Label.propTypes = {
   interactiveType: PropTypes.oneOf(Object.values(LABEL_INTERACTIVE_TYPES)),
   isDropdown: PropTypes.bool,
   isStatus: PropTypes.bool,
-  labelAttributes: PropTypes.shape({}),
+  containerAttributes: PropTypes.shape({}),
   secondaryButton: PropTypes.node,
   style: PropTypes.oneOf(Object.values(LABEL_STYLES)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -81,7 +81,7 @@ Label.propTypes = {
   interactiveType: PropTypes.oneOf(Object.values(LABEL_INTERACTIVE_TYPES)),
   isDropdown: PropTypes.bool,
   isStatus: PropTypes.bool,
-  labelAttributes: PropTypes.node,
+  labelAttributes: PropTypes.shape({}),
   secondaryButton: PropTypes.node,
   style: PropTypes.oneOf(Object.values(LABEL_STYLES)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -20,6 +20,7 @@ export const Label = React.forwardRef(({
   secondaryButton,
   style,
   value,
+  labelAttributes,
   ...rest
 }, ref) => {
   const TagName = interactiveType ? 'button' : 'span';
@@ -37,7 +38,7 @@ export const Label = React.forwardRef(({
   );
 
   return (
-    <span className={classNames} ref={ref}>
+    <span className={classNames} ref={ref} {...labelAttributes}>
       <TagName
         className="sage-label__value"
         type={interactiveType ? 'button' : null}
@@ -68,6 +69,7 @@ Label.defaultProps = {
   interactiveType: null,
   isDropdown: false,
   isStatus: false,
+  labelAttributes: null,
   secondaryButton: null,
   style: LABEL_STYLES.DEFAULT,
 };
@@ -79,6 +81,7 @@ Label.propTypes = {
   interactiveType: PropTypes.oneOf(Object.values(LABEL_INTERACTIVE_TYPES)),
   isDropdown: PropTypes.bool,
   isStatus: PropTypes.bool,
+  labelAttributes: PropTypes.node,
   secondaryButton: PropTypes.node,
   style: PropTypes.oneOf(Object.values(LABEL_STYLES)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,


### PR DESCRIPTION
## Description
Adds `container_attributes` to the label element.
There is a use case for adding a tooltip to a label and this is not currently possible.
Having the `container_attributes` for labels will allow the tooltips (or other attributes) to be added.

### Screenshots
There will be no visual changes to the label, although tooltips and other attributes could be added.

![Screen Shot 2021-04-05 at 1 31 52 PM](https://user-images.githubusercontent.com/1175111/113623566-64864c00-9613-11eb-86c5-99fc3ab194bf.png)

## Test notes

RAILS:

- Try adding `conatiner_attributes` to one of the labels.
- Verify these additional attributes are reflected in the DOM for the label.

STORYBOOK:

- Visit http://localhost:4100/?path=/story/sage-label--default
- Adjust the `containerAttributes` controls.
- Verify attributes are added to DOM as expected.

### Estimated impact
(LOW) Allows for optional `container_attributes` to be passed to labels. This should not affect any current implementations as it is a new addition; verify the following still behave as expected:
   - [ ] Offers > Green labels displayed in Status column
   - [ ] Offer details > Offer Status panel

## Related
- N/A
