### PR TITLE
[TME-959] Fix data-kjb-disable-search placement

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_search.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_search.rb
@@ -5,6 +5,5 @@ class SageSearch < SageComponent
     label_text: [:optional, String],
     placeholder: [:optional, String],
     value: [:optional, String, NilClass],
-    disable_search_on_clear: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -5,8 +5,6 @@
   "
   data-js-search
 
-  <%# Prevents the default Kajabi-Products Search.js from binding to this input %>
-  data-kjb-disable-search
   <%= component.generated_html_attributes.html_safe %>
 >
   <label for="<%= component.id %>" class="sage-search__label">
@@ -15,6 +13,8 @@
   <input
     id="<%= component.id %>"
     class="sage-search__input"
+    <%# Prevents the default Kajabi-Products Search.js from binding to this input %>
+    data-kjb-disable-search
     type="search"
     placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
     value="<%= component.value %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -15,7 +15,6 @@
   <input
     id="<%= component.id %>"
     class="sage-search__input"
-    <%= "data-js-disable-search-on-clear=true" if component.disable_search_on_clear %>
     type="search"
     placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
     value="<%= component.value %>"

--- a/packages/sage-system/lib/search.js
+++ b/packages/sage-system/lib/search.js
@@ -5,7 +5,6 @@ Sage.search = (function() {
 
   const SELECTOR_CLEAR_BUTTON = 'data-js-search-clear';
   const CLASS_HAS_TEXT = 'sage-search--has-text';
-  const DISABLE_SEARCH_ON_CLEAR = 'data-js-disable-search-on-clear';
 
 
   // ==================================================
@@ -38,10 +37,9 @@ Sage.search = (function() {
   function onClearButtonClick(evt) {
     let el = evt.target.parentNode,
         elInput = getInput(el);
+
     elInput.value = '';
-    if (!elInput.getAttribute(DISABLE_SEARCH_ON_CLEAR)){
-      search(elInput.value);
-    }
+    search(elInput.value);
     hasTextCssClassController(el);
   }
 


### PR DESCRIPTION
## Description
JIRA: [TME-959](https://kajabi.atlassian.net/browse/TME-959)
In SageSearch, we added the attribute of `data-kjb-disable-search` to  `<form>` to "Prevent the default Kajabi-Products Search.js from binding to this input"; however, in [products' search](https://github.com/Kajabi/kajabi-products/blob/master/app/assets/javascripts/search.js#L1), we are checking for `data-kjb-disable-search` on an `input` instead. 


### Screenshots
n/a


## Test notes
This should be tested against products
1.) Go to https://www.kajabi.test/admin/sites/1/landing_pages?website_page=all, and type `Home`
2.) Click outside of the text input and it should no longer auto submit
3.) Go back to the search input and press enter, and it should now submit.

### Estimated impact
Fixes bug where in products, any page that was using the `SageSearch` component was autosubmitting when it should not have been (users will now have to press enter to submit the form)
- [ ] Go to `https://www.kajabi.test/admin/sites/1/products` and search for a product.  It should not execute query until you press enter

