### PR TITLE
Page size updates in React Panel Controls

### DIFF
--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -51,11 +51,23 @@ export const SelectDropdown = ({
     }
   );
 
+  const displaySelectedValue = () => {
+    if (!initialSelectedValue) {
+      return emptySelectedValue;
+    }
+
+    if (initialSelectedValue.label) {
+      return initialSelectedValue.label;
+    }
+
+    return initialSelectedValue;
+  };
+
   const [configs, setConfigs] = useState({
     classNames: setClassNames(!!initialSelectedValue),
     hasSelectedValue: !!initialSelectedValue,
     icon: defaultIcon,
-    selectedValue: initialSelectedValue || emptySelectedValue,
+    selectedValue: displaySelectedValue(),
   });
 
   const deselectValue = () => {

--- a/packages/sage-react/lib/PanelControls/PanelControls.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.jsx
@@ -103,6 +103,45 @@ export const PanelControls = ({
   // Render
   //
 
+  const renderPageSizeDropdown = () => {
+    const pageSizeItems = selfConfigs.pageSizeOptions.map((size) => {
+      const suffix = selfConfigs.pageSizeOptionSuffix || '';
+      const label = `${size}${suffix}`;
+      return {
+        id: `page-size-${size}`,
+        label,
+        payload: {
+          id: `page-size-${size}`,
+          label,
+          size,
+        }
+      };
+    });
+
+    let initialPageSizeItem = pageSizeItems.filter(
+      (item) => item.payload.size === selfConfigs.pageSize
+    );
+
+    if (initialPageSizeItem && initialPageSizeItem.length >= 1) {
+      [initialPageSizeItem] = initialPageSizeItem;
+    } else {
+      initialPageSizeItem = pageSizeItems.length >= 1 ? pageSizeItems[0] : null;
+    }
+
+    return (
+      <SelectDropdown
+        align="right"
+        className="sage-dropdown--page-size sage-panel-controls__page-size"
+        customized={true}
+        initialSelectedValue={initialPageSizeItem}
+        items={pageSizeItems}
+        label="Page size"
+        onSelect={handlePageSizeSelection}
+        selectionBecomesLabel={true}
+      />
+    );
+  };
+
   // Primary render
   const classNames = classnames(
     'sage-panel-controls',
@@ -131,29 +170,7 @@ export const PanelControls = ({
             onClickPagination={onClickPagination}
             totalPages={selfConfigs.totalPages}
           />
-          {selfConfigs.pageSizeOptions && (
-            <SelectDropdown
-              align="right"
-              className="sage-dropdown--page-size sage-panel-controls__page-size"
-              customized={true}
-              items={selfConfigs.pageSizeOptions.map((size) => {
-                const suffix = selfConfigs.pageSizeOptionSuffix || '';
-                const label = `${size}${suffix}`;
-                return {
-                  id: `page-size-${size}`,
-                  label,
-                  payload: {
-                    id: `page-size-${size}`,
-                    label,
-                    size,
-                  }
-                };
-              })}
-              label="Page size"
-              onSelect={handlePageSizeSelection}
-              selectionBecomesLabel={false}
-            />
-          )}
+          {selfConfigs.pageSizeOptions && renderPageSizeDropdown()}
           {selfConfigs.sortOptions && (
             <SelectDropdown
               align="right"
@@ -194,7 +211,7 @@ PanelControls.propTypes = {
     numSelectedRows: PropTypes.number,
     pageSize: PropTypes.number,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
-    pageSizeOptionSuffix: PropTypes.stirng,
+    pageSizeOptionSuffix: PropTypes.string,
     rowNoun: PropTypes.shape({
       singular: PropTypes.string,
       plural: PropTypes.string,

--- a/packages/sage-react/lib/PanelControls/PanelControls.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.jsx
@@ -30,6 +30,7 @@ export const PanelControls = ({
     numSelectedRows: 0,
     pageSize: 1,
     pageSizeOptions: null,
+    pageSizeOptionSuffix: null,
     rowNoun: { ...DEFAULT_NOUN },
     selectionType: SELECTION_TYPES.NONE,
     totalItems: 0,
@@ -125,30 +126,34 @@ export const PanelControls = ({
           totalItems={selfConfigs.totalItems}
         />
         <div className="sage-panel-controls__toolbar">
-          {selfConfigs.pageSizeOptions && (
-            <SelectDropdown
-              align="right"
-              className="sage-dropdown--page-size sage-panel-controls__page-size"
-              customized={true}
-              items={selfConfigs.pageSizeOptions.map((size) => ({
-                id: `page-size-${size}`,
-                label: size,
-                payload: {
-                  id: `page-size-${size}`,
-                  label: size,
-                  size,
-                }
-              }))}
-              label="Page size"
-              onSelect={handlePageSizeSelection}
-              selectionBecomesLabel={false}
-            />
-          )}
           <PanelControlsPagination
             currentPage={selfConfigs.currentPage}
             onClickPagination={onClickPagination}
             totalPages={selfConfigs.totalPages}
           />
+          {selfConfigs.pageSizeOptions && (
+            <SelectDropdown
+              align="right"
+              className="sage-dropdown--page-size sage-panel-controls__page-size"
+              customized={true}
+              items={selfConfigs.pageSizeOptions.map((size) => {
+                const suffix = selfConfigs.pageSizeOptionSuffix || '';
+                const label = `${size}${suffix}`;
+                return {
+                  id: `page-size-${size}`,
+                  label,
+                  payload: {
+                    id: `page-size-${size}`,
+                    label,
+                    size,
+                  }
+                };
+              })}
+              label="Page size"
+              onSelect={handlePageSizeSelection}
+              selectionBecomesLabel={false}
+            />
+          )}
           {selfConfigs.sortOptions && (
             <SelectDropdown
               align="right"
@@ -189,6 +194,7 @@ PanelControls.propTypes = {
     numSelectedRows: PropTypes.number,
     pageSize: PropTypes.number,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+    pageSizeOptionSuffix: PropTypes.stirng,
     rowNoun: PropTypes.shape({
       singular: PropTypes.string,
       plural: PropTypes.string,

--- a/packages/sage-react/lib/PanelControls/PanelControls.story.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.story.jsx
@@ -41,6 +41,7 @@ export const Default = (args) => {
       numSelectedRows: 0,
       pageSize: 1,
       pageSizeOptions: [25, 50, 100],
+      pageSizeOptionSuffix: ' / pg',
       rowNoun: {
         singular: 'article',
         plural: 'articles',

--- a/packages/sage-react/lib/PanelControls/PanelControls.story.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.story.jsx
@@ -39,7 +39,7 @@ export const Default = (args) => {
       currentPage: 1,
       itemsOnThisPage: 0,
       numSelectedRows: 0,
-      pageSize: 1,
+      pageSize: 50,
       pageSizeOptions: [25, 50, 100],
       pageSizeOptionSuffix: ' / pg',
       rowNoun: {


### PR DESCRIPTION
## Description

Updates page size dropdown in React Panel Controls to allow selected value to appear in dropdown and to allow a "suffix" string to be added to values.

### Screenshots

![Screen Shot 2021-04-08 at 10 12 50 AM](https://user-images.githubusercontent.com/17955295/114042163-2f683c80-9853-11eb-97f7-5efb83d2f6c9.png)


## Test notes

See Panel controls in Storybook.

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- [ ] (LOW) Adjustments to page size controls in Panel Controls; not currently in use in production.
- [ ] (MEDIUM): Adjustments to logic behind Select Dropdown labels are displayed. Ensure the following React select dropdowns still behave as expected:
   - [ ] People > Filters dropdown > dropdowns contained within (these cover a variety of use cases exhibited elsewhere in the app)
