### PR TITLE
Docs Footer Spacing

### DIFF
--- a/docs/lib/sage-frontend/stylesheets/docs/_footer.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_footer.scss
@@ -14,7 +14,7 @@
   }
 
   .sage-stage & {
-    margin-top: sage-spacing(sm);
-    padding: sage-spacing(xl) 0 sage-spacing(2xl) 0;
+    padding: sage-spacing(2xl) 0;
+    background: none;
   }
 }

--- a/docs/lib/sage-frontend/stylesheets/docs/_footer.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_footer.scss
@@ -9,11 +9,12 @@
   background: sage-color(gray, 200);
 
   .devicon {
-    font-size: sage-font-size(2xl);
     align-self: center;
+    font-size: sage-font-size(2xl);
   }
-  
+
   .sage-stage & {
-    padding: sage-spacing(2xl) 0;
+    margin-top: sage-spacing(sm);
+    padding: sage-spacing(xl) 0 sage-spacing(2xl) 0;
   }
 }

--- a/docs/lib/sage-frontend/stylesheets/docs/_home.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_home.scss
@@ -5,13 +5,13 @@
 ================================================== */
 
 .docs-hero {
+  padding: sage-spacing();
+  padding-bottom: rem(100px);
+  color: sage-color(white);
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
   background-color: sage-color(primary, 500);
-  color: #fff;
-  padding: sage-spacing();
-  padding-bottom: rem(100px);
 
   @media (max-width: sage-breakpoint(md-min)) {
     padding-bottom: sage-spacing(xl);
@@ -27,10 +27,10 @@
 }
 
 .docs-hero__title {
-  font-size: 4rem;
-  line-height: 4.5rem;
   margin-bottom: sage-spacing(sm);
   margin-top: sage-spacing();
+  font-size: 4rem;
+  line-height: 4.5rem;
 }
 
 .docs-hero__img {
@@ -43,8 +43,8 @@
 }
 
 .docs-section {
-  background: sage-color(gray, 200);
   padding: sage-spacing(2xl) sage-spacing();
+  background: sage-color(gray, 200);
 
   @media (max-width: sage-breakpoint(md-min)) {
     padding: sage-spacing();
@@ -64,6 +64,6 @@
 }
 
 .docs-section__platform-icon {
-  font-size: rem(48px);
   margin-bottom: sage-spacing();
+  font-size: rem(48px);
 }

--- a/docs/lib/sage-frontend/stylesheets/docs/_home.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_home.scss
@@ -5,8 +5,7 @@
 ================================================== */
 
 .docs-hero {
-  padding: sage-spacing();
-  padding-bottom: rem(100px);
+  padding: sage-spacing() sage-spacing() rem(100px);
   color: sage-color(white);
   background-repeat: no-repeat;
   background-position: center center;
@@ -30,7 +29,7 @@
   margin-bottom: sage-spacing(sm);
   margin-top: sage-spacing();
   font-size: 4rem;
-  line-height: 4.5rem;
+  line-height: sage-baseline(16);
 }
 
 .docs-hero__img {


### PR DESCRIPTION
## Description
Small spacing adjustment to prevent footer from overlapping the panel container within docs internal pages. The footer is cutting off the bottom box shadow of the panel.

In addition, resolves linter warnings for `_home.scss` so it will quit yelling at me.

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-04-08 at 2 10 47 PM](https://user-images.githubusercontent.com/1175111/114208321-3013d800-9912-11eb-9639-22a0d0b95280.png)|![Screen Shot 2021-04-08 at 2 11 51 PM](https://user-images.githubusercontent.com/1175111/114208352-3a35d680-9912-11eb-8046-e263a8c83ead.png)|

## Test notes
Visit any internal page of the docs site and verify panel shadow appears as expected.

### Estimated impact
- [ ] (**LOW**) Docs only styling adjustments. Should not affect any objects or elements.

## Related
-N/A
