### PR TITLE
Replace placehold.it images

### DIFF
--- a/docs/app/views/examples/elements/description/_preview.html.erb
+++ b/docs/app/views/examples/elements/description/_preview.html.erb
@@ -50,7 +50,7 @@
     },
     {
       title: "Name",
-      data: %(<img src="//placehold.it/24x18?text=VISA" /> John Doe).html_safe,
+      data: %(<img src="/assets/card-placeholder-sm.png" width="24" height="16" /> John Doe).html_safe,
     }
   ],
   inline_spread: true,

--- a/docs/app/views/examples/objects/sortable/_preview.html.erb
+++ b/docs/app/views/examples/objects/sortable/_preview.html.erb
@@ -91,7 +91,7 @@
     <%= sage_component SageSortableItem, {
       title: "Fringilla Ullamcorper Dolor Adipiscing Ultricies",
       url_update: "update/endpoint",
-      image: "http://placehold.it/150",
+      image: "/assets/card-placeholder-sm.png",
       id: "id",
       card: true
     } do %>
@@ -171,7 +171,7 @@
 <% end %>
 
 <h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "me"</code></h3>
-<%= sage_component SageSortable, { 
+<%= sage_component SageSortable, {
   resource_name: "link" } do %>
   <% 3.times do %>
     <%= sage_component SageSortableItemCustom, {


### PR DESCRIPTION
## Description
In a couple of components, we're using `placehold.it` for including images. Their SSL certificate is expired and is causing network/console errors and images not to render.

Examples:
- Sortable Object
- Description Element

To address, the image paths were updated to use our local placeholder images.

### Screenshots
![Screen Shot 2021-04-09 at 10 42 11 AM](https://user-images.githubusercontent.com/1175111/114220748-3b223480-9921-11eb-88a0-abe51cc60556.png)

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-04-09 at 10 53 49 AM](https://user-images.githubusercontent.com/1175111/114221316-0793da00-9922-11eb-95ff-258c3092bc42.png)|![Screen Shot 2021-04-09 at 10 54 11 AM](https://user-images.githubusercontent.com/1175111/114221341-1084ab80-9922-11eb-801d-7bf1e48dc8fb.png)|

## Test notes
Visit Sortable and Description pages and verify error no longer appears in Network/Console and that local placeholder images appear.

### Estimated impact
- [ ] (LOW) Docs only image adjustments. Should not affect any objects or elements being used elsewhere.

## Related
- N/A
