### PR TITLE
SageFormInput autocomplete prop fix

### DIFF
--- a/docs/app/views/examples/elements/form_input/_props.html.erb
+++ b/docs/app/views/examples/elements/form_input/_props.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td><%= md('`autocomplete`') %></td>
   <td><%= md('Enables the browser to autofill values from saved fields or password managers. Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete" target="_blank" rel="nofollow">the allowed values for acceptable properties</a>.') %></td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`false`') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`disabled`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
@@ -1,6 +1,6 @@
 class SageFormInput < SageComponent
   set_attribute_schema({
-    autocomplete: [:optional, TrueClass],
+    autocomplete: [:optional, String],
     css_classes: [:optional, String],
     disabled: [:optional, TrueClass],
     has_error: [:optional, TrueClass],


### PR DESCRIPTION
## Description
This PR updates the `autocomplete` prop on the SageFormInput component to have a value of `String` instead of `TrueClass` in order to allow for non-Boolean values.

## Test notes
1. Visit http://0.0.0.0:4000/pages/element/form_input
2. Ensure that the **Properties** tab shows the `autocomplete` type as `String` with a default value of `nil`

### Estimated impact
- [ ] (**LOW**) There are no instances of `SageFormInput` with an `autocomplete` property currently being used
