### PR TITLE
feat(catalog-item): gives the Catalog Item Optional Image and Icon

### DIFF
--- a/docs/app/views/examples/objects/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/objects/catalog_item/_preview.html.erb
@@ -1,4 +1,4 @@
-<% 3.times do %>
+<% 2.times do %>
   <%= sage_component SageCatalogItem, {
     title: "Fun For All – The Children Call: Their Favorite Time Of Year",
     image: "/assets/card-placeholder-sm.png",
@@ -17,13 +17,6 @@
       small: true,
       icon: { name: "users", style: "left" },
       value: "3 Geese A-Laying",
-    } %>
-    <%= sage_component SageButton, {
-      style: "secondary",
-      subtle: true,
-      small: true,
-      icon: { name: "coupon", style: "left" },
-      value: "1 Partridge In A Pear Tree",
     } %>
     <%= content_for :sage_aside do %>
       <%= sage_component SageDropdown, {
@@ -71,7 +64,7 @@
     <% end %>
   <% end %>
 <% end %>
-<% 3.times do %>
+<% 2.times do %>
   <%= sage_component SageCatalogItem, {
     title: "Fun For All – The Children Call: Their Favorite Time Of Year",
     icon: "sage-icon-mail-xl",

--- a/docs/app/views/examples/objects/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/objects/catalog_item/_preview.html.erb
@@ -71,3 +71,76 @@
     <% end %>
   <% end %>
 <% end %>
+<% 3.times do %>
+  <%= sage_component SageCatalogItem, {
+    title: "Fun For All – The Children Call: Their Favorite Time Of Year",
+    icon: "sage-icon-mail-xl",
+    href: "#"
+  } do %>
+    <%= sage_component SageButton, {
+      style: "secondary",
+      subtle: true,
+      small: true,
+      icon: { name: "comment", style: "left" },
+      value: "5 Golden Eggs",
+    } %>
+    <%= sage_component SageButton, {
+      style: "secondary",
+      subtle: true,
+      small: true,
+      icon: { name: "users", style: "left" },
+      value: "3 Geese A-Laying",
+    } %>
+    <%= sage_component SageButton, {
+      style: "secondary",
+      subtle: true,
+      small: true,
+      icon: { name: "coupon", style: "left" },
+      value: "1 Partridge In A Pear Tree",
+    } %>
+    <%= content_for :sage_aside do %>
+      <%= sage_component SageDropdown, {
+        align: "right",
+        items: [{
+          value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+          attributes: { "href": "#" },
+        }, {
+          value: sage_component(SageLabel, { color: "info", value: "Drip" }),
+          attributes: { "href": "#" },
+        }, {
+          value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
+          attributes: { "href": "#" },
+        }, {
+          value: "Delete Category",
+          icon: "trash",
+          style: "danger",
+          attributes: { "href": "#" },
+        }]
+      } do %>
+        <%= sage_component SageLabel, {
+          color: "info",
+          interactive_type: :dropdown,
+          value: "Drip",
+        } %>
+      <% end %>
+      <%= sage_component SageDropdown, {
+        align: "right",
+        items: [{
+          value: "Edit Item",
+          icon: "pen",
+          attributes: {
+            "href": "#",
+          },
+        }]
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          icon: { name: "dot-menu-horizontal", style: "only" },
+          value: "Edit",
+          align: "end",
+          subtle: true,
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/app/views/examples/objects/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/objects/catalog_item/_preview.html.erb
@@ -1,138 +1,212 @@
-<% 2.times do %>
-  <%= sage_component SageCatalogItem, {
-    title: "Fun For All – The Children Call: Their Favorite Time Of Year",
-    image: "/assets/card-placeholder-sm.png",
-    href: "#"
-  } do %>
-    <%= sage_component SageButton, {
-      style: "secondary",
-      subtle: true,
-      small: true,
-      icon: { name: "comment", style: "left" },
-      value: "5 Golden Eggs",
-    } %>
-    <%= sage_component SageButton, {
-      style: "secondary",
-      subtle: true,
-      small: true,
-      icon: { name: "users", style: "left" },
-      value: "3 Geese A-Laying",
-    } %>
-    <%= content_for :sage_aside do %>
-      <%= sage_component SageDropdown, {
-        align: "right",
-        items: [{
-          value: sage_component(SageLabel, { color: "success", value: "Publish" }),
-          attributes: { "href": "#" },
-        }, {
-          value: sage_component(SageLabel, { color: "info", value: "Drip" }),
-          attributes: { "href": "#" },
-        }, {
-          value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
-          attributes: { "href": "#" },
-        }, {
-          value: "Delete Category",
-          icon: "trash",
-          style: "danger",
-          attributes: { "href": "#" },
-        }]
-      } do %>
-        <%= sage_component SageLabel, {
-          color: "info",
-          interactive_type: :dropdown,
-          value: "Drip",
-        } %>
-      <% end %>
-      <%= sage_component SageDropdown, {
-        align: "right",
-        items: [{
-          value: "Edit Item",
-          icon: "pen",
-          attributes: {
-            "href": "#",
-          },
-        }]
-      } do %>
-        <%= sage_component SageButton, {
-          style: "secondary",
-          icon: { name: "dot-menu-horizontal", style: "only" },
-          value: "Edit",
-          align: "end",
-          subtle: true,
-        } %>
+<%= sage_component SagePanelList, {} do %>
+  <% 2.times do %>
+    <%= sage_component SageCatalogItem, {
+      title: "Fun For All – The Children Call: Their Favorite Time Of Year",
+      image: "/assets/card-placeholder-sm.png",
+      href: "#"
+    } do %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "comment", style: "left" },
+        value: "5 Golden Eggs",
+      } %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "users", style: "left" },
+        value: "3 Geese A-Laying",
+      } %>
+      <%= content_for :sage_aside do %>
+        <%= sage_component SageDropdown, {
+          align: "right",
+          items: [{
+            value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+            attributes: { "href": "#" },
+          }, {
+            value: sage_component(SageLabel, { color: "info", value: "Drip" }),
+            attributes: { "href": "#" },
+          }, {
+            value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
+            attributes: { "href": "#" },
+          }, {
+            value: "Delete Category",
+            icon: "trash",
+            style: "danger",
+            attributes: { "href": "#" },
+          }]
+        } do %>
+          <%= sage_component SageLabel, {
+            color: "info",
+            interactive_type: :dropdown,
+            value: "Drip",
+          } %>
+        <% end %>
+        <%= sage_component SageDropdown, {
+          align: "right",
+          items: [{
+            value: "Edit Item",
+            icon: "pen",
+            attributes: {
+              "href": "#",
+            },
+          }]
+        } do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            icon: { name: "dot-menu-horizontal", style: "only" },
+            value: "Edit",
+            align: "end",
+            subtle: true,
+          } %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>
-<% end %>
-<% 2.times do %>
-  <%= sage_component SageCatalogItem, {
-    title: "Fun For All – The Children Call: Their Favorite Time Of Year",
-    icon: "sage-icon-mail-xl",
-    href: "#"
-  } do %>
-    <%= sage_component SageButton, {
-      style: "secondary",
-      subtle: true,
-      small: true,
-      icon: { name: "comment", style: "left" },
-      value: "5 Golden Eggs",
-    } %>
-    <%= sage_component SageButton, {
-      style: "secondary",
-      subtle: true,
-      small: true,
-      icon: { name: "users", style: "left" },
-      value: "3 Geese A-Laying",
-    } %>
-    <%= sage_component SageButton, {
-      style: "secondary",
-      subtle: true,
-      small: true,
-      icon: { name: "coupon", style: "left" },
-      value: "1 Partridge In A Pear Tree",
-    } %>
-    <%= content_for :sage_aside do %>
-      <%= sage_component SageDropdown, {
-        align: "right",
-        items: [{
-          value: sage_component(SageLabel, { color: "success", value: "Publish" }),
-          attributes: { "href": "#" },
-        }, {
-          value: sage_component(SageLabel, { color: "info", value: "Drip" }),
-          attributes: { "href": "#" },
-        }, {
-          value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
-          attributes: { "href": "#" },
-        }, {
-          value: "Delete Category",
-          icon: "trash",
-          style: "danger",
-          attributes: { "href": "#" },
-        }]
-      } do %>
-        <%= sage_component SageLabel, {
-          color: "info",
-          interactive_type: :dropdown,
-          value: "Drip",
-        } %>
+  <% 2.times do %>
+    <%= sage_component SageCatalogItem, {
+      title: "Fun For All – The Children Call: Their Favorite Time Of Year",
+      icon: "sage-icon-mail-xl",
+      href: "#"
+    } do %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "comment", style: "left" },
+        value: "5 Golden Eggs",
+      } %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "users", style: "left" },
+        value: "3 Geese A-Laying",
+      } %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "coupon", style: "left" },
+        value: "1 Partridge In A Pear Tree",
+      } %>
+      <%= content_for :sage_aside do %>
+        <%= sage_component SageDropdown, {
+          align: "right",
+          items: [{
+            value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+            attributes: { "href": "#" },
+          }, {
+            value: sage_component(SageLabel, { color: "info", value: "Drip" }),
+            attributes: { "href": "#" },
+          }, {
+            value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
+            attributes: { "href": "#" },
+          }, {
+            value: "Delete Category",
+            icon: "trash",
+            style: "danger",
+            attributes: { "href": "#" },
+          }]
+        } do %>
+          <%= sage_component SageLabel, {
+            color: "info",
+            interactive_type: :dropdown,
+            value: "Drip",
+          } %>
+        <% end %>
+        <%= sage_component SageDropdown, {
+          align: "right",
+          items: [{
+            value: "Edit Item",
+            icon: "pen",
+            attributes: {
+              "href": "#",
+            },
+          }]
+        } do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            icon: { name: "dot-menu-horizontal", style: "only" },
+            value: "Edit",
+            align: "end",
+            subtle: true,
+          } %>
+        <% end %>
       <% end %>
-      <%= sage_component SageDropdown, {
-        align: "right",
-        items: [{
-          value: "Edit Item",
-          icon: "pen",
-          attributes: {
-            "href": "#",
-          },
-        }]
-      } do %>
-        <%= sage_component SageButton, {
-          style: "secondary",
-          icon: { name: "dot-menu-horizontal", style: "only" },
-          value: "Edit",
-          align: "end",
-          subtle: true,
-        } %>
+    <% end %>
+  <% end %>
+  <% 2.times do %>
+    <%= sage_component SageCatalogItem, {
+      title: "Fun For All – The Children Call: Their Favorite Time Of Year",
+      href: "#"
+    } do %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "comment", style: "left" },
+        value: "5 Golden Eggs",
+      } %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "users", style: "left" },
+        value: "3 Geese A-Laying",
+      } %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        small: true,
+        icon: { name: "coupon", style: "left" },
+        value: "1 Partridge In A Pear Tree",
+      } %>
+      <%= content_for :sage_aside do %>
+        <%= sage_component SageDropdown, {
+          align: "right",
+          items: [{
+            value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+            attributes: { "href": "#" },
+          }, {
+            value: sage_component(SageLabel, { color: "info", value: "Drip" }),
+            attributes: { "href": "#" },
+          }, {
+            value: sage_component(SageLabel, { color: "draft", value: "Draft" }),
+            attributes: { "href": "#" },
+          }, {
+            value: "Delete Category",
+            icon: "trash",
+            style: "danger",
+            attributes: { "href": "#" },
+          }]
+        } do %>
+          <%= sage_component SageLabel, {
+            color: "info",
+            interactive_type: :dropdown,
+            value: "Drip",
+          } %>
+        <% end %>
+        <%= sage_component SageDropdown, {
+          align: "right",
+          items: [{
+            value: "Edit Item",
+            icon: "pen",
+            attributes: {
+              "href": "#",
+            },
+          }]
+        } do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            icon: { name: "dot-menu-horizontal", style: "only" },
+            value: "Edit",
+            align: "end",
+            subtle: true,
+          } %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/docs/app/views/examples/objects/catalog_item/_props.html.erb
+++ b/docs/app/views/examples/objects/catalog_item/_props.html.erb
@@ -16,3 +16,9 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Icon for the catalog item') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_catalog_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_catalog_item.rb
@@ -3,6 +3,7 @@ class SageCatalogItem < SageComponent
     href: [:optional, String],
     image: [:optional, String],
     title: [:optional, String],
+    icon: [:optional, String],
   })
 
   def sections

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -3,6 +3,7 @@
 <li class="
   sage-catalog-item
   <%= "sage-catalog-item--loading" if is_loading %>
+  <%= "sage-catalog-item--img" if component.image.present? %>
   "
   <%= component.generated_html_attributes.html_safe %>
 >
@@ -21,8 +22,10 @@
       <%= content_for :sage_aside %>
     </div>
   <% end %>
-  <%# Uses tabindex="-1" because there are two links to the same location in this component (component.title also links to the href) %>
-  <<%= link_tag %> class="sage-catalog-item__img" href="<%= component.href %>" tabindex="-1" title="Go to: <%= component.title %>">
-    <img src="<%= component.image %>" alt="Cover image for: <%= component.title %>">
-  </<%= link_tag %>>
+  <% if component.image.present? %>
+    <%# Uses tabindex="-1" because there are two links to the same location in this component (component.title also links to the href) %>
+    <<%= link_tag %> class="sage-catalog-item__img" href="<%= component.href %>" tabindex="-1" title="Go to: <%= component.title %>">
+      <img src="<%= component.image %>" alt="Cover image for: <%= component.title %>">
+    </<%= link_tag %>>
+  <% end %>
 </li>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -4,6 +4,7 @@
   sage-catalog-item
   <%= "sage-catalog-item--loading" if is_loading %>
   <%= "sage-catalog-item--img" if component.image.present? %>
+  <%= "sage-catalog-item--icon" if component.icon.present? %>
   "
   <%= component.generated_html_attributes.html_safe %>
 >
@@ -27,5 +28,10 @@
     <<%= link_tag %> class="sage-catalog-item__img" href="<%= component.href %>" tabindex="-1" title="Go to: <%= component.title %>">
       <img src="<%= component.image %>" alt="Cover image for: <%= component.title %>">
     </<%= link_tag %>>
+  <% end %>
+  <% if component.icon.present? %>
+    <div class="sage-catalog-item__icon">
+      <i class="<%= component.icon %>" aria-hidden="true"></i>
+    </div>
   <% end %>
 </li>

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -18,6 +18,11 @@ $-catalogue-item-image-height-mobile: rem(120px);
   margin-bottom: rem(-1px);
   border-top: sage-border(light);
   border-bottom: sage-border(light);
+  grid-template-columns: 1fr min-content;
+  grid-template-rows: auto auto;
+  grid-template-areas:
+    "title aside"
+    "content aside";
 
   &:only-child {
     border: 0;
@@ -32,21 +37,23 @@ $-catalogue-item-image-height-mobile: rem(120px);
     cursor: wait;
   }
 
-  @media (min-width: sage-breakpoint(md-min)) {
-    grid-template-columns: $-catalogue-item-image-width 1fr min-content;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-      "img title aside"
-      "img content aside";
-  }
-
-  @media (max-width: sage-breakpoint(md-min)) {
-    grid-template-columns: 1fr min-content;
-    grid-template-rows: $-catalogue-item-image-height-mobile auto auto;
-    grid-template-areas:
-      "img img"
-      "title aside"
-      "content content";
+  &.sage-catalog-item--img {
+    @media (min-width: sage-breakpoint(md-min)) {
+      grid-template-columns: $-catalogue-item-image-width 1fr min-content;
+      grid-template-rows: auto auto;
+      grid-template-areas:
+        "img title aside"
+        "img content aside";
+    }
+  
+    @media (max-width: sage-breakpoint(md-min)) {
+      grid-template-columns: 1fr min-content;
+      grid-template-rows: $-catalogue-item-image-height-mobile auto auto;
+      grid-template-areas:
+        "img img"
+        "title aside"
+        "content content";
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -55,6 +55,14 @@ $-catalogue-item-image-height-mobile: rem(120px);
         "content content";
     }
   }
+
+  &.sage-catalog-item--icon {
+    grid-template-columns: min-content 1fr min-content;
+    grid-template-rows: auto auto auto;
+    grid-template-areas:
+      "icon title aside"
+      "icon content aside";
+  }
 }
 
 .sage-catalog-item__title {
@@ -90,6 +98,12 @@ $-catalogue-item-image-height-mobile: rem(120px);
     top: 50%;
     width: 100%;
   }
+}
+
+.sage-catalog-item__icon {
+  display: flex;
+  grid-area: icon;
+  align-items: center;
 }
 
 .sage-catalog-item__content {

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_catalog_item.scss
@@ -14,15 +14,15 @@ $-catalogue-item-image-height-mobile: rem(120px);
   display: grid;
   grid-column-gap: sage-spacing(md);
   grid-row-gap: sage-spacing(xs);
-  padding: sage-spacing() sage-spacing();
-  margin-bottom: rem(-1px);
-  border-top: sage-border(light);
-  border-bottom: sage-border(light);
   grid-template-columns: 1fr min-content;
   grid-template-rows: auto auto;
   grid-template-areas:
     "title aside"
     "content aside";
+  padding: sage-spacing() sage-spacing();
+  margin-bottom: rem(-1px);
+  border-top: sage-border(light);
+  border-bottom: sage-border(light);
 
   &:only-child {
     border: 0;


### PR DESCRIPTION
## Description
The Catalog image might not always need to be included in the catalog item so this makes it optional
and adds a formatting class
The Catalog item also might want to have an icon instead of an image. This supports this. 

### Screenshots
<img width="782" alt="Screen Shot 2021-04-13 at 10 48 43 AM" src="https://user-images.githubusercontent.com/14350772/114597667-e5fa6180-9c45-11eb-9b03-fe2abbf7bb51.png">
<img width="777" alt="Screen Shot 2021-04-13 at 10 48 59 AM" src="https://user-images.githubusercontent.com/14350772/114597670-e692f800-9c45-11eb-9150-7d60534cbd13.png">
<img width="763" alt="Screen Shot 2021-04-13 at 11 07 33 AM" src="https://user-images.githubusercontent.com/14350772/114600155-e2b4a500-9c48-11eb-9ef4-43a525cb725c.png">

## Test notes
Create A Catalog Item with an included image URL. The image will show. Do not include a URL and no image will show. 
