### PR TITLE
Tooltip - increase z-index

### DIFF
--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -54,11 +54,6 @@
         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       </p>
 
-      <%= sage_component SageTooltip, {
-        position: "left",
-        text: "Bibendum Condimentum",
-      } %>
-
       <% content_for :sage_footer do %>
         <% content_for :sage_footer_aside do %>
           <%= sage_component SageButton, {

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -54,6 +54,11 @@
         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       </p>
 
+      <%= sage_component SageTooltip, {
+        position: "left",
+        text: "Bibendum Condimentum",
+      } %>
+
       <% content_for :sage_footer do %>
         <% content_for :sage_footer_aside do %>
           <%= sage_component SageButton, {

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_tooltip.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_tooltip.scss
@@ -21,7 +21,7 @@ $-tooltip-shadow: sage-shadow(xl);
 $-tooltip-padding: sage-spacing(2xs) sage-spacing(sm);
 $-tooltip-small-padding: sage-spacing(2xs) sage-spacing(xs);
 $-tooltip-large-padding: sage-spacing(xs) sage-spacing(xs);
-$-tooltip-zindex: sage-z_index(overlay);
+$-tooltip-zindex: sage-z_index(modal, 1);
 $-tooltip-maxwidth: rem(200px);
 $-tooltip-large-maxwidth: rem(320px);
 

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_tooltip.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_tooltip.scss
@@ -21,7 +21,7 @@ $-tooltip-shadow: sage-shadow(xl);
 $-tooltip-padding: sage-spacing(2xs) sage-spacing(sm);
 $-tooltip-small-padding: sage-spacing(2xs) sage-spacing(xs);
 $-tooltip-large-padding: sage-spacing(xs) sage-spacing(xs);
-$-tooltip-zindex: sage-z_index(modal, 1);
+$-tooltip-zindex: sage-z_index(modal, 10);
 $-tooltip-maxwidth: rem(200px);
 $-tooltip-large-maxwidth: rem(320px);
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Increase the z-index to be higher than modals in the case a modal has a tooltip. This will not cause an adverse affect if the tooltip is under the modal since it only shows on hover

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2021-04-14_at_7_26_21_AM](https://user-images.githubusercontent.com/1241836/114721837-ec004900-9cfe-11eb-9ebc-fa3df0b5ba8c.png)|![Screen_Shot_2021-04-14_at_7_26_37_AM](https://user-images.githubusercontent.com/1241836/114721861-eefb3980-9cfe-11eb-9309-540c7e5f091a.png)|


## Test notes
<!-- General notes here surrounding this change -->
To test the existing implementation follow the steps from the video in this ticket, [BUILD-995](https://kajabi.atlassian.net/browse/BUILD-995)
- Visit podcast distribution page
- Expand one of the vendor accordians
- Click on `View Steps`
- Hover the copy button to the right of the `RSS Feed URL` and notice the tooltip
**or **
On the modal's preview page, temporarily include a tooltip within one of the `SageModalContent`s to test


### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- (**MEDIUM** impact level) This change increases the `z-index` for all tooltips to resolve them hiding behind modals.
- [ ] Podcast Distribution page



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[BUILD-995](https://kajabi.atlassian.net/browse/BUILD-995)
