### PR TITLE
Ensure expandable card content is truly hidden by default

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -7,6 +7,7 @@
     css_classes: "sage-expandable-card__trigger",
     attributes: {
       "data-js-accordion": "header",
+      "aria-expanded": "false",
     },
     full_width: true,
   } %>

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -41,9 +41,11 @@ export const ExpandableCard = ({ bodyBordered, children, className, sageType, tr
       >
         {triggerLabel}
       </Button>
-      <div id={id} className={bodyClassnames}>
-        {children}
-      </div>
+      {selfActive && (
+        <div id={id} className={bodyClassnames}>
+          {children}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

Current implementations of this component were exhibiting a temporary flash of the panel content. This PR ensures the content is set to hide by default. JS or React will then enable it to be toggled on as appropriate. 

No visual difference.

## Test notes

See Expandable Card in Rails and React to see no visual or functional difference other than absence of possible flash of content.

### Estimated impact
(LOW) Removes undesired flash of content in expandable card component. No adverse effects expected. Verify the following behave as expected but without the initial flash of content:
   - [ ] New custom domain flow "Need help" toggles
   - [ ] (if relevant) Old custom domain flow step "5. Setup Page Rules & Orange Cloud" toggles
