### PR TITLE
Jcm example cleanup

### DIFF
--- a/docs/app/views/examples/elements/breadcrumbs/_preview.html.erb
+++ b/docs/app/views/examples/elements/breadcrumbs/_preview.html.erb
@@ -1,9 +1,7 @@
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Default"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBreadcrumbs, {
   items: [
     {
@@ -21,12 +19,10 @@
   ]
 } %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Back Link Variation"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Back Link"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBreadcrumbs, {
   items: [
     {
@@ -36,12 +32,10 @@
   ]
 } %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Progress Bar Variation"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Progress Bar"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBreadcrumbs, {
   is_progressbar: true,
   items: [

--- a/docs/app/views/examples/elements/button/_preview.html.erb
+++ b/docs/app/views/examples/elements/button/_preview.html.erb
@@ -18,12 +18,10 @@ demo_configs = [
 ]
 %>
 <% demo_configs.each do | config | %>
-  <%= sage_component SageCardBlock, {} do %>
-    <%= sage_component SageLabel, {
-      color: "draft",
-      value: config[:heading],
-    } %>
-  <% end %>
+
+  <!-- Docs Only Label -->
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: config[:heading]} %><% end %>
+  <!-- Docs Only Label End -->
 
   <% [false, true].each do | disabled | %>
     <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
@@ -81,12 +79,10 @@ demo_configs = [
 <% end %>
 
 <% demo_configs.each do | config | %>
-  <%= sage_component SageCardBlock, {} do %>
-    <%= sage_component SageLabel, {
-      color: "draft",
-      value: "Subtle #{config[:heading]}",
-    } %>
-  <% end %>
+
+  <!-- Docs Only Label -->
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Subtle #{config[:heading]}"} %><% end %>
+  <!-- Docs Only Label End -->
 
   <% [false, true].each do | size | %>
     <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
@@ -148,12 +144,10 @@ demo_configs = [
   <% end %>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Button group: Align End",
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Button group: Align End"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageButtonGroup, { gap: :md, align: "end" } do %>
   <%= sage_component SageButton, {
     value: "Cancel",
@@ -165,12 +159,10 @@ demo_configs = [
   } %>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Button group: Align Space-Between",
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Button group: Align Space-Between"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageButtonGroup, { gap: :md, align: "space-between" } do %>
   <%= sage_component SageButton, {
     value: "Cancel",
@@ -182,12 +174,10 @@ demo_configs = [
   } %>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Button group: Align Space-Between with top border",
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Button group: Align Space-Between with top border"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageButtonGroup, { gap: :md, align: "space-between", borderTop: true } do %>
   <%= sage_component SageButton, {
     value: "Cancel",
@@ -199,18 +189,10 @@ demo_configs = [
   } %>
 <% end %>
 
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Shadow Treatment"} %><% end %>
+<!-- Docs Only Label End -->
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Shadow Treatment",
-  } %>
-<% end %>
-<p>
-  Regular buttons allow for a "raised" shadow treatement to be toggled on or off.
-  This is on by default for "Primary" button styles and can be toggled off with "no_shadow".
-  For the other styles it is off by default but can be toggled on with "raised".  
-</p>
 <%= sage_component SageButtonGroup, { gap: :md, spacer: { bottom: :md } } do %>
   <%= sage_component SageButton, {
     value: "Raised (default)",
@@ -244,3 +226,14 @@ demo_configs = [
     raised: true,
   } %>
 <% end %>
+
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Regular buttons allow for a 'raised' shadow treatement to be toggled on or off.
+  This is on by default for 'rimary' button styles and can be toggled off with 'no_shadow'.
+  For the other styles it is off by default but can be toggled on with 'raised'.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->

--- a/docs/app/views/examples/elements/card_highlight/_preview.html.erb
+++ b/docs/app/views/examples/elements/card_highlight/_preview.html.erb
@@ -1,11 +1,17 @@
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <!-- Default -->
-<h4>Default</h4>
 <%= sage_component SageCard, {} do %>
   <p>This card has a default settings.</p>
   <%= sage_component SageCardHighlight, {} %>
 <% end %>
 
-<h4>Placement</h4>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Placement"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelTiles, { tiles_in_row: 3 } do %>
   <%= sage_component SageCard, {} do %>
     <p>Highlight on top.</p>
@@ -21,7 +27,10 @@
   <% end %>
 <% end %>
 
-<h4>Colors</h4>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Colors"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelTiles, { tiles_in_row: 3 } do %>
   <% ["charcoal", "grey", "purple", "sage", "yellow", "orange", "red"].each do | color | %>
     <%= sage_component SageCard, {} do %>
@@ -37,16 +46,21 @@
   <% end %>
 <% end %>
 
-<%= md("
-**Note:** While highlights may often be just decorative,
-the `value` property can be provided to provided semantic
-and accessible labels for this highlight.
-Internal content can also be provided compositionally
-but will be wrapped with `visually-hidden`.
-") %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "semantic and accessible labels"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageCard, {} do %>
   <%= sage_component SageCardHeader, { title: "1-on-1 Meeting w/ Julie" } %>
   <p class="t-sage-body-small t-sage--grey">Tue, Jan 12, 2021, 3:00pm</p>
   <%= sage_component SageCardHighlight, { value: "1-on-1 Meeting type" } %>
 <% end %>
+
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "While highlights may often be just decorative, the value property can be provided to provided semantic and accessible labels for this highlight. Internal content can also be provided compositionally but will be wrapped with visually-hidden",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->

--- a/docs/app/views/examples/elements/choice/_preview.html.erb
+++ b/docs/app/views/examples/elements/choice/_preview.html.erb
@@ -1,7 +1,9 @@
 <%
 long_description = "Description with longer text to cause wrapping and make the top alignment appear more necessary."
 %>
-<h3 class="t-sage-heading-6">Single Line (radio type)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Single Line (radio type)"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageChoice, {
     target: "example",
@@ -11,7 +13,10 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
-<h3 class="t-sage-heading-6">With Radio</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With Radio"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
     target: "example",
     text: "Option 1a",
@@ -25,7 +30,10 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
-<h3 class="t-sage-heading-6">Multi-Line  (radio type)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Multi-Line  (radio type)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
     target: "example",
     text: "Option 1",
@@ -34,7 +42,10 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
-<h3 class="t-sage-heading-6">Arrow Variation</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Arrow Variation"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
     attributes: {
       href: "//example.com"
@@ -44,8 +55,10 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
-<h3 class="t-sage-heading-6">Icon Variation</h3>
-<p>Select any icon to appear to the left of the text.</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Icon Variation"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
     target: "example",
     text: "Option 1",
@@ -54,8 +67,10 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
-<h3 class="t-sage-heading-6">Graphic Variation (with link text)</h3>
-<p>Provide a graphic to the left of the text.</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Graphic Variation (with link text)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
     target: "example",
     text: "Calendly",
@@ -68,8 +83,10 @@ long_description = "Description with longer text to cause wrapping and make the 
   }
 %>
 
-<h3 class="t-sage-heading-6">Rich text/Customized</h3>
-<p>Choice cards can also be opened up for custom content to be composed within.</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Rich text/Customized"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
   target: "example",
   attributes: {
@@ -83,9 +100,19 @@ long_description = "Description with longer text to cause wrapping and make the 
   <% end %>
 <% end %>
 
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Choice cards can also be opened up for custom content to be composed within.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
 
-<h3 class="t-sage-heading-6">Icon alignment</h3>
-<p>While by default all icon types will align in the center of the choice card, they can be adjusted to align at the "start" or top of the card.</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Icon alignment"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageChoice, {
     target: "example",
     text: "Option 1",
@@ -103,3 +130,12 @@ long_description = "Description with longer text to cause wrapping and make the 
     vertical_align_icon: "start",
   }
 %>
+
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "While by default all icon types will align in the center of the choice card, they can be adjusted to align at the 'start' or top of the card.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->

--- a/docs/app/views/examples/elements/copy_text/_preview.html.erb
+++ b/docs/app/views/examples/elements/copy_text/_preview.html.erb
@@ -1,12 +1,21 @@
-<h3 class="t-sage-heading-6">Copy Text (inline)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Copy Text (inline)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageCopyText, { value: "me.ns.cloudflare.com", semibold: true } %>
 
-<h3 class="t-sage-heading-6">Copy Text (block)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Copy Text (block)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageCopyTextCard, {} do %>
   <p><b>Reply:</b> me.ns.cloudflare.com</p>
   <p>me.ns.cloudflare.com</p>
   <p>me.ns.cloudflare.com</p>
 <% end %>
 
-<h3 class="t-sage-heading-6">Copy Button</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Copy Button"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageCopyButton, { value: "me.ns.cloudflare.com", semibold: true } %>

--- a/docs/app/views/examples/elements/description/_preview.html.erb
+++ b/docs/app/views/examples/elements/description/_preview.html.erb
@@ -1,17 +1,26 @@
-<h2>Single item</h2>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Single item"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDescription, {
   title: "Name",
   data: "John Doe",
 } %>
 
-<h2>Single item (title normal case)</h2>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Single item (title normal case)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDescription, {
   title: "Name",
   data: "John Doe",
   allcaps_titles: false,
 } %>
 
-<h2>Multiple items</h2>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Multiple items"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDescription, {
   items: [
     {
@@ -33,7 +42,10 @@
   ],
 } %>
 
-<h2>Mulitple items (inline layout)</h2>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Mulitple items (inline layout)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDescription, {
   items: [
     {

--- a/docs/app/views/examples/elements/form_input/_preview.html.erb
+++ b/docs/app/views/examples/elements/form_input/_preview.html.erb
@@ -1,175 +1,207 @@
-<fieldset class="sage-type">
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Text (default)"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Text (default)</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__fname1",
-    input_type: "text",
-    label_text: "First name",
-    placeholder: "First name",
-    required: true,
-    disabled: false,
-    has_error: false,
-    name: "custom_input_name",
-    message_text: "This is a message",
-    has_placeholder: false
-  } %>
+<%= sage_component SageFormInput, {
+  id: "form__fname1",
+  input_type: "text",
+  label_text: "First name",
+  placeholder: "First name",
+  required: true,
+  disabled: false,
+  has_error: false,
+  name: "custom_input_name",
+  message_text: "This is a message",
+  has_placeholder: false
+} %>
 
-  <h3 class="t-sage-heading-6">Text (with error)</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__fname2",
-    input_type: "text",
-    label_text: "First name",
-    placeholder: "First name",
-    required: true,
-    disabled: false,
-    has_error: true,
-    message_text: "This is a message",
-    has_placeholder: false
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Text (with error)"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Text (prefilled)</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__country",
-    input_type: "text",
-    label_text: "Country",
-    placeholder: "Country",
-    value: "USA",
-    required: true,
-    disabled: false,
-    has_error: false,
-    has_placeholder: false
-  } %>
+<%= sage_component SageFormInput, {
+  id: "form__fname2",
+  input_type: "text",
+  label_text: "First name",
+  placeholder: "First name",
+  required: true,
+  disabled: false,
+  has_error: true,
+  message_text: "This is a message",
+  has_placeholder: false
+} %>
 
-  <h3 class="t-sage-heading-6">Text (disabled)</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__apt",
-    input_type: "text",
-    label_text: "PO Box",
-    placeholder: "PO Box",
-    required: true,
-    disabled: true,
-    has_error: false,
-    message_text: "This is a message",
-    has_placeholder: false
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Text (prefilled)"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Text (readonly)</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__readonly",
-    value: "This text can't be modified by the user",
-    input_type: "text",
-    label_text: "Can't touch this",
-    placeholder: "Can't touch this",
-    required: false,
-    disabled: false,
-    readonly: true,
-    has_error: false,
-    message_text: "This is a message",
-    has_placeholder: false
-  } %>
+<%= sage_component SageFormInput, {
+  id: "form__country",
+  input_type: "text",
+  label_text: "Country",
+  placeholder: "Country",
+  value: "USA",
+  required: true,
+  disabled: false,
+  has_error: false,
+  has_placeholder: false
+} %>
 
-  <h3 class="t-sage-heading-6">Email</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__email",
-    input_type: "email",
-    label_text: "Email address",
-    placeholder: "Email address",
-    required: true,
-    disabled: false,
-    has_error: false,
-    message_text: "This is a message",
-    has_placeholder: false
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Text (disabled)"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Password</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__pw",
-    input_type: "password",
-    label_text: "Create a password",
-    placeholder: "Create a password",
-    required: true,
-    disabled: false,
-    minlength: "8",
-    maxlength: "128",
-    has_error: false,
-    has_placeholder: false
-  } %>
+<%= sage_component SageFormInput, {
+  id: "form__apt",
+  input_type: "text",
+  label_text: "PO Box",
+  placeholder: "PO Box",
+  required: true,
+  disabled: true,
+  has_error: false,
+  message_text: "This is a message",
+  has_placeholder: false
+} %>
 
-  <h3 class="t-sage-heading-6">Numbers</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__num",
-    input_type: "number",
-    label_text: "Enter quantity (max 48)",
-    placeholder: "Enter quantity (max 48)",
-    required: true,
-    disabled: false,
-    input_mode: "numeric",
-    pattern: "[0-9]{2}",
-    max: "48",
-    maxlength: "2",
-    has_error: false,
-    has_placeholder: false
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Text (readonly)"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Numbers (incremented)</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__num",
-    input_type: "number",
-    label_text: "Enter percentage (max 5%)",
-    placeholder: "Enter percentage (max 5%)",
-    required: true,
-    disabled: false,
-    input_mode: "numeric",
-    max: "5",
-    maxlength: "2",
-    min: "0",
-    step: "0.5",
-    has_error: false,
-    has_placeholder: false
-  } %>
+<%= sage_component SageFormInput, {
+  id: "form__readonly",
+  value: "This text can't be modified by the user",
+  input_type: "text",
+  label_text: "Can't touch this",
+  placeholder: "Can't touch this",
+  required: false,
+  disabled: false,
+  readonly: true,
+  has_error: false,
+  message_text: "This is a message",
+  has_placeholder: false
+} %>
 
-  <h3 class="t-sage-heading-6">Prefixed</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__pre",
-    input_type: "text",
-    label_text: "Custom domain",
-    placeholder: "Custom domain",
-    required: true,
-    disabled: false,
-    input_mode: "text",
-    pattern: "[a-z]+\.[a-zA-Z0-9\/\-]+",
-    has_error: false,
-    prefix: "https://",
-    has_placeholder: false
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Email"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Suffixed</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__suf",
-    input_type: "number",
-    label_text: "Price per month",
-    placeholder: "Price per month",
-    required: true,
-    disabled: false,
-    input_mode: "numeric",
-    pattern: "[0-9]{6}",
-    max: "100000",
-    maxlength: "6",
-    has_error: false,
-    suffix: ".00",
-    has_placeholder: false
-  } %>
+<%= sage_component SageFormInput, {
+  id: "form__email",
+  input_type: "email",
+  label_text: "Email address",
+  placeholder: "Email address",
+  required: true,
+  disabled: false,
+  has_error: false,
+  message_text: "This is a message",
+  has_placeholder: false
+} %>
 
-  <h3 class="t-sage-heading-6">Custom placeholder & label visible</h3>
-  <%= sage_component SageFormInput, {
-    id: "form__reply1",
-    input_type: "text",
-    label_text: "Reply-to email",
-    placeholder: "Custom placeholder text",
-    required: true,
-    disabled: false,
-    has_error: false,
-    has_placeholder: true
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Password"} %><% end %>
+<!-- Docs Only Label End -->
 
-</fieldset>
+<%= sage_component SageFormInput, {
+  id: "form__pw",
+  input_type: "password",
+  label_text: "Create a password",
+  placeholder: "Create a password",
+  required: true,
+  disabled: false,
+  minlength: "8",
+  maxlength: "128",
+  has_error: false,
+  has_placeholder: false
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Numbers"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageFormInput, {
+  id: "form__num",
+  input_type: "number",
+  label_text: "Enter quantity (max 48)",
+  placeholder: "Enter quantity (max 48)",
+  required: true,
+  disabled: false,
+  input_mode: "numeric",
+  pattern: "[0-9]{2}",
+  max: "48",
+  maxlength: "2",
+  has_error: false,
+  has_placeholder: false
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Numbers (incremented)"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageFormInput, {
+  id: "form__num",
+  input_type: "number",
+  label_text: "Enter percentage (max 5%)",
+  placeholder: "Enter percentage (max 5%)",
+  required: true,
+  disabled: false,
+  input_mode: "numeric",
+  max: "5",
+  maxlength: "2",
+  min: "0",
+  step: "0.5",
+  has_error: false,
+  has_placeholder: false
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Prefixed"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageFormInput, {
+  id: "form__pre",
+  input_type: "text",
+  label_text: "Custom domain",
+  placeholder: "Custom domain",
+  required: true,
+  disabled: false,
+  input_mode: "text",
+  pattern: "[a-z]+\.[a-zA-Z0-9\/\-]+",
+  has_error: false,
+  prefix: "https://",
+  has_placeholder: false
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Suffixed"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageFormInput, {
+  id: "form__suf",
+  input_type: "number",
+  label_text: "Price per month",
+  placeholder: "Price per month",
+  required: true,
+  disabled: false,
+  input_mode: "numeric",
+  pattern: "[0-9]{6}",
+  max: "100000",
+  maxlength: "6",
+  has_error: false,
+  suffix: ".00",
+  has_placeholder: false
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Custom placeholder & label visible"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageFormInput, {
+  id: "form__reply1",
+  input_type: "text",
+  label_text: "Reply-to email",
+  placeholder: "Custom placeholder text",
+  required: true,
+  disabled: false,
+  has_error: false,
+  has_placeholder: true
+} %>

--- a/docs/app/views/examples/elements/form_select/_preview.html.erb
+++ b/docs/app/views/examples/elements/form_select/_preview.html.erb
@@ -1,3 +1,7 @@
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageFormSelect, {
   name: "Characters",
   has_error: false,
@@ -33,6 +37,10 @@
   ],
   message: "This is a message"
 } %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With Errors"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageFormSelect, {
   name: "Pets",
@@ -74,4 +82,11 @@
   message: "This is a message"
 } %>
 
-<p><strong>Note:</strong> For a fully styled dropdown selector, see the Dropdown object.</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "For a fully styled dropdown selector, see the Dropdown object.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->

--- a/docs/app/views/examples/elements/form_textarea/_preview.html.erb
+++ b/docs/app/views/examples/elements/form_textarea/_preview.html.erb
@@ -1,41 +1,49 @@
-<fieldset class="sage-type">
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">Default</h3>
-  <%= sage_component SageFormTextarea, {
-    id: "txtarea-example",
-    name: "txtarea-custom-name",
-    placeholder: "Your message",
-    label_text: "Your message",
-    disabled: false,
-    has_error: false,
-  } %>
+<%= sage_component SageFormTextarea, {
+  id: "txtarea-example",
+  name: "txtarea-custom-name",
+  placeholder: "Your message",
+  label_text: "Your message",
+  disabled: false,
+  has_error: false,
+} %>
 
-  <h3 class="t-sage-heading-6">Error</h3>
-  <%= sage_component SageFormTextarea, {
-    id: "txtarea-example-error",
-    placeholder: "Your message",
-    label_text: "Your message",
-    disabled: false,
-    has_error: true,
-    message_text: "Error message"
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Error"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <h3 class="t-sage-heading-6">No label (placeholder only)</h3>
-  <%= sage_component SageFormTextarea, {
-    id: "txtarea-example-nolabel",
-    placeholder: "Your message",
-    disabled: false,
-    has_error: false,
-  } %>
+<%= sage_component SageFormTextarea, {
+  id: "txtarea-example-error",
+  placeholder: "Your message",
+  label_text: "Your message",
+  disabled: false,
+  has_error: true,
+  message_text: "Error message"
+} %>
 
-  <h3 class="t-sage-heading-6">Disabled</h3>
-  <%= sage_component SageFormTextarea, {
-    id: "txtarea-example-disabled",
-    placeholder: "Your message",
-    label_text: "Your message",
-    disabled: true,
-    has_error: false,
-    content: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.",
-  } %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "No label (placeholder only)"} %><% end %>
+<!-- Docs Only Label End -->
 
-</fieldset>
+<%= sage_component SageFormTextarea, {
+  id: "txtarea-example-nolabel",
+  placeholder: "Your message",
+  disabled: false,
+  has_error: false,
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Disabled"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageFormTextarea, {
+  id: "txtarea-example-disabled",
+  placeholder: "Your message",
+  label_text: "Your message",
+  disabled: true,
+  has_error: false,
+  content: "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.",
+} %>

--- a/docs/app/views/examples/elements/icon_card/_preview.html.erb
+++ b/docs/app/views/examples/elements/icon_card/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Icon Card</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Icon Card"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-row">
   <% [
   "draft",
@@ -16,7 +19,11 @@
     </div>
   <% end %>
 </div>
-<h3 class="t-sage-heading-6">Icon Card with custom <code>background_color</code> and <code>foreground_color</code></h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Icon Card with custom colors"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-row">
   <% [
   { background_color: "#A463F2", foreground_color: "#9EEBCF" },
@@ -35,3 +42,5 @@
     </div>
   <% end %>
 </div>
+
+<p><code>background_color</code> and <code>foreground_color</code></p>

--- a/docs/app/views/examples/elements/indicator/_preview.html.erb
+++ b/docs/app/views/examples/elements/indicator/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Default</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageIndicator, {
   current_item: 2,
   label: "Page",

--- a/docs/app/views/examples/elements/label/_preview.html.erb
+++ b/docs/app/views/examples/elements/label/_preview.html.erb
@@ -26,9 +26,12 @@ configs = [
   }
 ]
 %>
-<%= md("**Note:** Examples on this page all use the `SageLabelGroup` to wrap them but this is not required. It simply makes a set of `Label`s display neatly :)") %>
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Default</h3>
+
+  <!-- Docs Only Label -->
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>
       <%= sage_component SageLabel, {
@@ -41,7 +44,12 @@ configs = [
 
 
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Subtle</h3>
+
+  <!-- Docs Only Label -->
+  <br>
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Subtle"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>
       <%= sage_component SageLabel, {
@@ -54,7 +62,12 @@ configs = [
 <% end %>
 
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Bold</h3>
+  
+  <!-- Docs Only Label -->
+  <br>
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Bold"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>
       <%= sage_component SageLabel, {
@@ -67,7 +80,12 @@ configs = [
 <% end %>
 
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">With Icons</h3>
+
+  <!-- Docs Only Label -->
+  <br>
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With Icons"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <%= sage_component SageLabel, {
       color: "draft",
@@ -83,7 +101,12 @@ configs = [
 <% end %>
 
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Interactive Default</h3>
+
+  <!-- Docs Only Label -->
+  <br>
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Interactive Default"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>
       <%= sage_component SageLabel, {
@@ -97,7 +120,12 @@ configs = [
 <% end %>
 
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Interactive With Secondary Button</h3>
+
+  <!-- Docs Only Label -->
+  <br>
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Interactive With Secondary Button"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>
       <%= sage_component SageLabel, {
@@ -112,7 +140,12 @@ configs = [
 <% end %>
 
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Interactive With Dropdown Treatment</h3>
+
+  <!-- Docs Only Label -->
+  <br>
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Interactive With Dropdown Treatment"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>
       <%= sage_component SageLabel, {
@@ -124,3 +157,12 @@ configs = [
     <% end %>
   <% end %>
 <% end %>
+
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Examples on this page all use the `SageLabelGroup` to wrap them but this is not required. It simply makes a set of `Label`s display neatly :)",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->

--- a/docs/app/views/examples/elements/link/_preview.html.erb
+++ b/docs/app/views/examples/elements/link/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Standard link</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Standard link"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelStack, {} do %>
   <%= sage_component SageLink, {
     url: "#",
@@ -29,7 +32,10 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">External links</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "External links"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelStack, {} do %>
   <%= sage_component SageLink, {
     url: "https://example.com",
@@ -61,7 +67,10 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Help/Info links</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Help/Info links"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelStack, {} do %>
   <%= sage_component SageLink, {
     url: "#",
@@ -93,6 +102,8 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Subtext links</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Subtext links"} %><% end %>
+<!-- Docs Only Label End -->
 
 <a href="//example.com" class="sage-link--subtext">Link for placement in subtext</a>

--- a/docs/app/views/examples/elements/lists/_preview.html.erb
+++ b/docs/app/views/examples/elements/lists/_preview.html.erb
@@ -1,5 +1,6 @@
-<h3 class="t-sage-heading-6">Default Lists</h3>
-<p>Lists in Sage get simple default styling.</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default Lists"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageLists, {
 } do %>
@@ -40,8 +41,18 @@
   </ol>
 <% end %>
 
-<h3 class="t-sage-heading-6">Unstyled List</h3>
-<p>Add <code>sage-list</code> to create an unstyled list such as for complex elements:</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Lists in Sage get simple default styling.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Unstyled List"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageLists, {
 } do %>
@@ -89,8 +100,18 @@
   </ol>
 <% end %>
 
-<h3 class="t-sage-heading-6">Inline List</h3>
-<p>Inline lists will wrap by default so this works best with items that have an intrinsically limited smaller width that affords space for other elements to a point.</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Add 'sage-list' to create an unstyled list such as for complex elements:",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Inline List"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageLists, {
 } do %>
@@ -138,8 +159,18 @@
   </ul>
 <% end %>
 
-<h3 class="t-sage-heading-6">Non-wrapping Inline List</h3>
-<p>Non-wrapping list will stay packed on one line until 768px at which point it will wrap. This may be most relevant for inline lists for which wrapping is undesirable but has clear limitations inside restricted containers.</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Inline lists will wrap by default so this works best with items that have an intrinsically limited smaller width that affords space for other elements to a point.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Non-wrapping Inline List"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageLists, {
 } do %>
@@ -158,3 +189,12 @@
     </li>
   </ul>
 <% end %>
+
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Non-wrapping list will stay packed on one line until 768px at which point it will wrap. This may be most relevant for inline lists for which wrapping is undesirable but has clear limitations inside restricted containers.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->

--- a/docs/app/views/examples/elements/loader/_preview.html.erb
+++ b/docs/app/views/examples/elements/loader/_preview.html.erb
@@ -1,12 +1,16 @@
-<div class="sage-row">
-  <div class="sage-col--md-6 example__block--lg">
-    <%= sage_component SageLoader, {
-      type: "bar"
-    } %>
-  </div>
-  <div class="sage-col--md-6 example__block--lg">
-    <%= sage_component SageLoader, {
-      type: "spinner"
-    } %>
-  </div>
-</div>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Loading Bar"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageLoader, {
+  type: "bar"
+} %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Loading Spinner"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageLoader, {
+  type: "spinner"
+} %>
+

--- a/docs/app/views/examples/elements/meter/_preview.html.erb
+++ b/docs/app/views/examples/elements/meter/_preview.html.erb
@@ -1,4 +1,6 @@
-<!-- Default -->
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Meter Input"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageFormInput, {
   id: "pw-meter-example",
@@ -19,6 +21,10 @@
   suffix: "",
   has_placeholder: false
 } %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Password Meter"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageMeter, {
   id: "pw-hint-meter",

--- a/docs/app/views/examples/elements/nav_link/_preview.html.erb
+++ b/docs/app/views/examples/elements/nav_link/_preview.html.erb
@@ -1,15 +1,26 @@
-<h3>Standard Nav Link<h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Standard Nav Link"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageNavLink, {
   link: "#",
   text: "Nav Link 1", 
 } %>
-<h3>Nav Link with Icon<h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Nav Link with Icon"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageNavLink, {
   icon: "launch",
   link: "#",
   text: "Nav Link 2 with icon",
 } %>
-<h3>Nav Link with Child Nav Links<h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Nav Link with Child Nav Links"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageNavLink, {
   link: "#",
   text: "Nav Link 3",

--- a/docs/app/views/examples/elements/property/_preview.html.erb
+++ b/docs/app/views/examples/elements/property/_preview.html.erb
@@ -1,7 +1,13 @@
-<h4>Single Property</h4>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Single Property"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageProperty, { icon: "calendar-date", value: "Created on April 20th, 2020" } %>
 
-<h4>Property group</h4>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Property group"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePropertyGroup, {} do %>
   <%= sage_component SageProperty, { icon: "calendar-date", value: "April 20th, 2020" } %>
   <%= sage_component SageProperty, { icon: "users", value: "14 Users" } %>

--- a/docs/app/views/examples/elements/radio/_preview.html.erb
+++ b/docs/app/views/examples/elements/radio/_preview.html.erb
@@ -53,7 +53,10 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Bordered Radio</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Bordered Radio"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageRadio, {
   caption: "caption text",
   id: "r6",

--- a/docs/app/views/examples/elements/search/_preview.html.erb
+++ b/docs/app/views/examples/elements/search/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Default</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSearch, {
   id: "search-1",
   placeholder: "Search Products",
@@ -6,7 +9,10 @@
   label_text: "Search"
 } %>
 
-<h3 class="t-sage-heading-6">Contained</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Contained"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSearch, {
   id: "search-2",
   placeholder: "Search Products",

--- a/docs/app/views/examples/elements/switch/_preview.html.erb
+++ b/docs/app/views/examples/elements/switch/_preview.html.erb
@@ -126,7 +126,10 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Bordered Switch</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Bordered Switch"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSwitch, { 
   type: "checkbox",
   id: "sage-switch-20",
@@ -149,7 +152,10 @@
   toggle_position: "right"
 } %>
 
-<h3 class="t-sage-heading-6">Bordered Switch (Radio)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Bordered Switch (Radio)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSwitch, { 
   type: "radio",
   id: "sage-switch-22",

--- a/docs/app/views/examples/elements/tab/_preview.html.erb
+++ b/docs/app/views/examples/elements/tab/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">As a button with a target pane in mind</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "As a button with a target pane in mind"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTab, {
       target: "example-tab1",
@@ -7,7 +10,10 @@
   %>
 <% end %>
 
-<h3 class="t-sage-heading-6">As a link with a route or site in mind</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "As a link with a route or site in mind"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTab, {
       attributes: {

--- a/docs/app/views/examples/elements/table/_preview.html.erb
+++ b/docs/app/views/examples/elements/table/_preview.html.erb
@@ -40,14 +40,20 @@ sample_table = {
 }
 %>
 
-<h3 class="t-sage-heading-6">Responsive table</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Responsive table"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageTable, {
   headers: sample_table[:headers],
   rows: sample_table[:rows],
   caption: "Responsive tables require the use of two parent containers",
 } %>
 
-<h3 class="t-sage-heading-6">Striped table</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Striped table"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageTable, {
   headers: sample_table[:headers],
   rows: sample_table[:rows],
@@ -55,7 +61,10 @@ sample_table = {
   striped: true
 } %>
 
-<h3 class="t-sage-heading-6">Sortable table</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Sortable table"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageTable, {
   headers: sample_table[:headers],
   rows: sample_table[:rows],
@@ -64,7 +73,10 @@ sample_table = {
   striped: true
 } %>
 
-<h3 class="t-sage-heading-6">Table with highlighted rows and block cells</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Table with highlighted rows and block cells"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageTable, {
   caption: %(
     Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
@@ -108,8 +120,10 @@ sample_table = {
   ]
 } %>
 
-<h3 class="t-sage-heading-6">Striped table with selectively truncated cells</h3>
-<p>Individual cells should be assigned the <code>.sage-table-cell--truncate</code> class. Not suggested for use with long strings of <em>important</em> text: use the responsive (scrolling) table instead.</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Striped table with selectively truncated cells"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageTable, {
   headers: [
     "Malesuada",
@@ -141,9 +155,19 @@ sample_table = {
   ]
 } %>
 
-<h3 class="t-sage-heading-6">Hiding and showing cell content</h3>
-<p>Individual cells can make use of the <a href="<%= pages_design_path(:grid) %>">Sage Grid</a> classes for responsive display of content. Refer to the <a href="<%= pages_design_path(:icon) %>#grid-responsive-show-hide">Grid documentation</a> for more details.</p>
-<p>Remember to apply the same classes equally to <strong>all related vertical columns</strong>, or the structure of the table will be misaligned.</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "Individual cells should be assigned the '.sage-table-cell--truncate' class. Not suggested for use with long strings of important text: use the responsive (scrolling) table instead.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+  
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Hiding and showing cell content"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageTable, {
   headers: [
     "Malesuada",
@@ -167,3 +191,16 @@ sample_table = {
     ]
   ]
 } %>
+
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Our privacy policy has changed",
+  desc: "Individual cells can make use of the Sage Grid classes for responsive display of content.
+  Remember to apply the same classes equally to all related vertical columns, or the structure of the table will be misaligned.
+  Refer to the Grid documentation for more details.",
+  icon_name: "sage-icon-info-circle",
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= link_to "Sage Grid", pages_design_path(:grid) %>
+  <% end %>
+<% end %>

--- a/docs/app/views/examples/elements/tooltip/_preview.html.erb
+++ b/docs/app/views/examples/elements/tooltip/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Dark Tooltips</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Dark Tooltips"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTooltip, {
     position: "top",
@@ -19,7 +22,10 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Light Tooltips</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Light Tooltips"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTooltip, {
     position: "top",

--- a/docs/app/views/examples/objects/alert/_preview.html.erb
+++ b/docs/app/views/examples/objects/alert/_preview.html.erb
@@ -53,8 +53,9 @@
   <% end %>
 <% end %>
 
-
-<h3 class="t-sage-heading-6">Raised Variant</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Raised Variant"} %><% end %>
+<!-- Docs Only Label End -->
 
 <!-- Info -->
 <%= sage_component SageAlert, {

--- a/docs/app/views/examples/objects/assistant/_preview.html.erb
+++ b/docs/app/views/examples/objects/assistant/_preview.html.erb
@@ -1,10 +1,16 @@
-<h3 class="t-sage-heading-6">With menu button (visible below medium breakpoint)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With menu button (visible below medium breakpoint)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageAssistant, {
   menu_button: true,
   logo: { path: "sage.svg" }
 } %>
 
-<h3 class="t-sage-heading-6">Without menu button</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Without menu button"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageAssistant, {
   menu_button: false,
   logo: { path: "sage.svg" }

--- a/docs/app/views/examples/objects/avatar/_preview.html.erb
+++ b/docs/app/views/examples/objects/avatar/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3>Sample Avatars</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Sample Avatars"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-avatar-wrapper">
   <!-- Showing default -->
   <%= sage_component SageAvatar, { color: nil, initials: "JC" } %>
@@ -13,10 +16,16 @@
   <%= sage_component SageAvatar, { color: "orange", initials: "KJ", css_classes: "my-custom-class" } %>
 </div>
 
-<h3>Avatar centered + custom size</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Avatar centered + custom size"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageAvatar, { color: nil, centered: true, initials: "JC", size: "128px" } %>
 
-<h3>Avatar Groups</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Avatar Groups"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-avatar-wrapper">
   <%= sage_component SageAvatarGroup, {
     items: [

--- a/docs/app/views/examples/objects/banner/_preview.html.erb
+++ b/docs/app/views/examples/objects/banner/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Announcement (with link)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Announcement (with link)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBanner, {
   banner_context: "sage-demo",
   active: true,
@@ -13,7 +16,10 @@
   }
 } %>
 
-<h3 class="t-sage-heading-6">Secondary (with link)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Secondary (with link)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBanner, {
   banner_context: "sage-demo",
   active: true,
@@ -29,7 +35,10 @@
   }
 } %>
 
-<h3 class="t-sage-heading-6">Warning (with button)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Warning (with button)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBanner, {
   banner_context: "sage-demo",
   active: true,
@@ -46,7 +55,10 @@
   }
 } %>
 
-<h3 class="t-sage-heading-6">Danger (dismiss disabled)</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Danger (dismiss disabled)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageBanner, {
   banner_context: "sage-demo",
   active: true,
@@ -55,8 +67,10 @@
   text: "It's over, Anakin. I have the high ground.",
 } %>
 
-<h3 class="t-sage-heading-6">Primary fixed (Ladera top context)</h3>
-<p>See active example at top of page</p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Primary fixed (Ladera top context)"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageButton, {
   style: "primary",
   value: "Toggle banner",

--- a/docs/app/views/examples/objects/card/_preview.html.erb
+++ b/docs/app/views/examples/objects/card/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Basic Card</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Basic Card"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageCard, {} do %>
   <%= sage_component SageCardHeader, { title: "Card heading" } do %>
     <%= sage_component SageButton, {
@@ -86,7 +89,10 @@ Cards have three core areas:
   It employs the Sage Row layout base with `16px` gutters.
 ", use_sage_type: true) %>
 
-<h3 class="t-sage-heading-6">Card with stack and row blocks</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Card with stack and row blocks"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageCard, {} do %>
   <%= sage_component SageCardHeader, { title: "Block:" } %>
   <%= sage_component SageCardBlock, {} do %>

--- a/docs/app/views/examples/objects/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/objects/catalog_item/_preview.html.erb
@@ -1,3 +1,7 @@
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With Image"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelList, {} do %>
   <% 2.times do %>
     <%= sage_component SageCatalogItem, {
@@ -65,6 +69,13 @@
       <% end %>
     <% end %>
   <% end %>
+<% end %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With Icon"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SagePanelList, {} do %>
   <% 2.times do %>
     <%= sage_component SageCatalogItem, {
       title: "Fun For All – The Children Call: Their Favorite Time Of Year",
@@ -138,6 +149,13 @@
       <% end %>
     <% end %>
   <% end %>
+<% end %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With Nothing"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SagePanelList, {} do %>
   <% 2.times do %>
     <%= sage_component SageCatalogItem, {
       title: "Fun For All – The Children Call: Their Favorite Time Of Year",

--- a/docs/app/views/examples/objects/data_card/_preview.html.erb
+++ b/docs/app/views/examples/objects/data_card/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Default</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDataCard, {
   body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
   header_aside: sage_component(SageButton, { value: "Options", subtle: true, style: "secondary", icon: { name: "mapped", style: "only" }}),
@@ -6,7 +9,10 @@
   title_tag: "h2",
 } %>
 
-<h3 class="t-sage-heading-6">Colors</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Colors"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-data-card-group">
   <%= sage_component SageDataCard, {
     body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
@@ -27,7 +33,10 @@
   } %>
 </div>
 
-<h3 class="t-sage-heading-6">Inline/Scrolling Layout</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Inline/Scrolling Layout"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-data-card-scroll-container">
   <div class="sage-data-card-scroll">
     <div class="sage-data-card-group sage-data-card-group--danger">

--- a/docs/app/views/examples/objects/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/objects/dropdown/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Menu Button</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Menu Button"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDropdown, {
   items: [{
     value: "Edit",
@@ -47,7 +50,10 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Dropdown menu with Headings</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Dropdown menu with Headings"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDropdown, {
   contained: true,
   items: [{
@@ -98,8 +104,10 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">SageLabel Button, with SageLabel Values, and aligned right</h3>
-<p>Note: The wrapping div with inline styles is for <i>preview-purposes only</i>. </p>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "SageLabel Button, with SageLabel Values, and aligned right"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div style="display: flex; flex-direction: row-reverse;">
   <%= sage_component SageDropdown, {
     align: "right",
@@ -132,8 +140,19 @@
   <% end %>
 </div>
 
-<h3 class="t-sage-heading-6">Select</h3>
-<p>Note: This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "The wrapping div with inline styles is for preview-purposes only.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Select"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDropdown, {
   search: true,
   trigger_type: "select",
@@ -172,8 +191,19 @@
   <label class="sage-dropdown__trigger-label">Add an Element</label>
 <% end %>
 
-<h3 class="t-sage-heading-6">Form Field</h3>
-<p>Note: This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.</p>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Form Field"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDropdown, {
   search: true,
   trigger_type: "select-labeled",
@@ -201,7 +231,19 @@
   <label class="sage-dropdown__trigger-label">Add an Element</label>
 <% end %>
 
-<h3 class="t-sage-heading-6">Dropdown Field with full-width Custom Content and Footer</h3>
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.",
+  icon_name: "sage-icon-info-circle",
+} %>
+<!-- Docs Only Note End -->
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Dropdown Field with full-width Custom Content and Footer"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDropdown, {
   search: true,
   trigger_type: "select",
@@ -252,7 +294,10 @@
   <label class="sage-dropdown__trigger-label">Select Product(s)</label>
 <% end %>
 
-<h3 class="t-sage-heading-6">Dropdown Menu Button with Custom Content</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Dropdown Menu Button with Custom Content"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageDropdown, {
 } do %>
   <%= sage_component SageButton, {

--- a/docs/app/views/examples/objects/expandable_card/_preview.html.erb
+++ b/docs/app/views/examples/objects/expandable_card/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Bordered</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Bordered"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageExpandableCard, {
   trigger_label: "Expand",
   body_bordered: true,
@@ -25,7 +28,11 @@
     has_error: false
   } %>
 <% end %>
-<h3 class="t-sage-heading-6">No Border</h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "No Border"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageExpandableCard, {
   trigger_label: "Expand",
 } do %>

--- a/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/objects/feature_toggle/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Feature Toggle</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Feature Toggle"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {
     description: "Quickly see Segments & filter contacts with a consistent People list view.",
@@ -32,7 +35,11 @@
     <% end %>
   <% end %>
 <% end %>
-<h3 class="t-sage-heading-6">Feature Toggle with <code><a href="/pages/element/icon_card">Icon Card</a></code></h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Feature Toggle with Icon Card"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {
     description: "New navigation bar layout that places Offers, Coupons, and Affiliates under a brand new “Sales” tab.",
@@ -65,7 +72,11 @@
     <% end %>
   <% end %>
 <% end %>
-<h3 class="t-sage-heading-6">Feature Toggle with <code>image</code></h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Feature Toggle with image"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {
     description: "Quickly see Segments & filter contacts with a consistent People list view.",

--- a/docs/app/views/examples/objects/form_section/_preview.html.erb
+++ b/docs/app/views/examples/objects/form_section/_preview.html.erb
@@ -1,7 +1,9 @@
 <%= sage_component SagePanelStack, {} do %>
 
-  <!-- Default -->
-  <h3 class="t-sage-heading-6">Default</h3>
+  <!-- Docs Only Label -->
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageFormSection, { 
     id:"c1",
     title: "Form Section Title",
@@ -14,8 +16,10 @@
       } %>
   <% end %>
 
-  <!-- Custom title_tag -->
-  <h3 class="t-sage-heading-6">Form Section with custom header tag</h3>
+  <!-- Docs Only Label -->
+  <%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Form Section with custom header tag"} %><% end %>
+  <!-- Docs Only Label End -->
+
   <%= sage_component SageFormSection, { 
     id:"c2",
     title: "Custom Title Tag",

--- a/docs/app/views/examples/objects/hero/_preview.html.erb
+++ b/docs/app/views/examples/objects/hero/_preview.html.erb
@@ -11,7 +11,10 @@
   } %>
 <% end %>
 
-<h2 class="t-sage-heading-6">Sage Hero with dismiss button</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "With dismiss button"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageCardBlock, {} do %>
   <%= sage_component SageHero, {
     alt_text: "",

--- a/docs/app/views/examples/objects/icon_list/_preview.html.erb
+++ b/docs/app/views/examples/objects/icon_list/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Basic example</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Basic example"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageIconList, {
   items: [
     {
@@ -30,7 +33,11 @@
     }
   ]
 } %>
-<h3 class="t-sage-heading-6">Checkbox list</h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Checkbox list"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageIconList, {
   items: [
     {
@@ -79,7 +86,11 @@
     }
   ]
 } %>
-<h3 class="t-sage-heading-6">Radio list</h3>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Radio list"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageIconList, {
   items: [
     {

--- a/docs/app/views/examples/objects/input_group/_preview.html.erb
+++ b/docs/app/views/examples/objects/input_group/_preview.html.erb
@@ -1,94 +1,99 @@
-<fieldset class="sage-type">
-  <h3 class="t-sage-heading-6">Input group with button disabled</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Input group with button disabled"} %><% end %>
+<!-- Docs Only Label End -->
 
-  <%= sage_component SageInputGroup, {
-    group_id: "input-group-search-example",
-    disabled: true,
-    has_button: true,
-    has_hint: false,
-    group_buttons: [{
-      icon: "sage-btn--icon-left-search",
-      text: "Search",
-      text_hidden: true,
-      tooltip: true,
-      tooltip_position: "top",
-      tooltip_size: "",
-      tooltip_text: "Search",
-    }],
+<%= sage_component SageInputGroup, {
+  group_id: "input-group-search-example",
+  disabled: true,
+  has_button: true,
+  has_hint: false,
+  group_buttons: [{
+    icon: "sage-btn--icon-left-search",
+    text: "Search",
+    text_hidden: true,
+    tooltip: true,
+    tooltip_position: "top",
+    tooltip_size: "",
+    tooltip_text: "Search",
+  }],
+  input_type: "search",
+} do %>
+  <%= sage_component SageFormInput, {
+    id: "input-group-search-field",
     input_type: "search",
-  } do %>
-    <%= sage_component SageFormInput, {
-      id: "input-group-search-field",
-      input_type: "search",
-      label_text: "Search",
-      placeholder: "Search",
-      required: true,
-      disabled: true,
-      has_error: false,
-      message_text: "",
-      has_placeholder: false
-    } %>
-  <% end %>
-  <h3 class="t-sage-heading-6">Input group with number controls</h3>
+    label_text: "Search",
+    placeholder: "Search",
+    required: true,
+    disabled: true,
+    has_error: false,
+    message_text: "",
+    has_placeholder: false
+  } %>
+<% end %>
 
-  <%= sage_component SageInputGroup, {
-    group_id: "input-group-save-example",
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Input group with number controls"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageInputGroup, {
+  group_id: "input-group-save-example",
+  disabled: false,
+  has_button: true,
+  has_hint: false,
+  group_buttons: [{
+    icon: "",
+    text: "Save",
+    tooltip: true,
+    tooltip_position: "top",
+    tooltip_size: "",
+    tooltip_text: "Save",
+  }],
+  input_type: "text"
+} do %>
+  <%= sage_component SageFormInput, {
+    id: "input-group-save-field",
+    max: "100",
+    min: "0",
+    input_type: "number",
+    input_mode: "numeric",
+    label_text: "Percentage",
+    placeholder: "Percentage",
+    required: false,
     disabled: false,
-    has_button: true,
-    has_hint: false,
-    group_buttons: [{
-      icon: "",
-      text: "Save",
-      tooltip: true,
-      tooltip_position: "top",
-      tooltip_size: "",
-      tooltip_text: "Save",
-    }],
-    input_type: "text"
+    has_error: false,
+    message_text: "",
+    has_placeholder: false
+  } %>
+<% end %>
+
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Input group with password reveal toggle and helper"} %><% end %>
+<!-- Docs Only Label End -->
+
+<%= sage_component SageInputGroup, {
+  group_id: "input-group-pw-example",
+  has_button: true,
+  has_hint: true,
+  group_buttons: [{
+    display_on_focus: true,
+    icon: "sage-btn--icon-left-preview-on",
+    text: "Toggle password visibility",
+    tooltip: true,
+    tooltip_position: "top",
+    tooltip_size: "small",
+    tooltip_text: "Toggle password visibility",
+  }],
+  input_type: "password"
   } do %>
-    <%= sage_component SageFormInput, {
-      id: "input-group-save-field",
-      max: "100",
-      min: "0",
-      input_type: "number",
-      input_mode: "numeric",
-      label_text: "Percentage",
-      placeholder: "Percentage",
-      required: false,
-      disabled: false,
-      has_error: false,
-      message_text: "",
-      has_placeholder: false
-    } %>
-  <% end %>
-
-  <h3 class="t-sage-heading-6">Input group with password reveal toggle and helper</h3>
-
-  <%= sage_component SageInputGroup, {
-    group_id: "input-group-pw-example",
-    has_button: true,
-    has_hint: true,
-    group_buttons: [{
-      display_on_focus: true,
-      icon: "sage-btn--icon-left-preview-on",
-      text: "Toggle password visibility",
-      tooltip: true,
-      tooltip_position: "top",
-      tooltip_size: "small",
-      tooltip_text: "Toggle password visibility",
-    }],
-    input_type: "password"
-    } do %>
-    <%= sage_component SageFormInput, {
-      id: "input-group-pw-example",
-      input_type: "password",
-      label_text: "Password",
-      placeholder: "Password",
-      required: true,
-      disabled: false,
-      has_error: false,
-      message_text: "",
-      has_placeholder: false
-    } %>
-  <% end %>
-</fieldset>
+  <%= sage_component SageFormInput, {
+    id: "input-group-pw-example",
+    input_type: "password",
+    label_text: "Password",
+    placeholder: "Password",
+    required: true,
+    disabled: false,
+    has_error: false,
+    message_text: "",
+    has_placeholder: false
+  } %>
+<% end %>

--- a/docs/app/views/examples/objects/input_helper/_preview.html.erb
+++ b/docs/app/views/examples/objects/input_helper/_preview.html.erb
@@ -1,5 +1,4 @@
 <fieldset class="sage-type" data-js-example="input-helper">
-  <h3 class="t-sage-heading-6">Input helper</h3>
   <%= sage_component SageInputHelper, {
     helper_id: "",
     helper_target: "",

--- a/docs/app/views/examples/objects/modal/_preview.html.erb
+++ b/docs/app/views/examples/objects/modal/_preview.html.erb
@@ -210,8 +210,11 @@
 
 <% end %>
 
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Animated"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelBlock, {} do %>
-  <h3 class="t-sage-heading-6">Animated</h3>
   <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
     <%= sage_component SageButton, {
       style: "primary",

--- a/docs/app/views/examples/objects/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/objects/page_heading/_preview.html.erb
@@ -1,11 +1,15 @@
-<h3 class="t-sage-heading-6">Standalone Page Heading</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Standalone Page Heading"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
   spacer: { bottom: :xl },
 } %>
 
-<h3 class="t-sage-heading-6">Page Heading with Back Link</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading with Back Link"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
@@ -23,7 +27,9 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Page Heading with Help Link</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading with Help Link"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
@@ -35,7 +41,9 @@
   },
 } %>
 
-<h3 class="t-sage-heading-6">Page Heading with Help Content</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading with Help Content"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
@@ -48,7 +56,9 @@
   },
 } %>
 
-<h3 class="t-sage-heading-6">Page Heading with Action Buttons</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading with Action Buttons"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
@@ -69,7 +79,9 @@
     <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Page Heading w/ Toolbar + Secondary Text</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading w/ Toolbar + Secondary Text"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
@@ -98,8 +110,9 @@
     <% end %>
 <% end %>
 
-
-<h3 class="t-sage-heading-6">Page Heading w/ Intro</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading w/ Intro"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",
@@ -110,8 +123,9 @@
     <% end %>
 <% end %>
 
-
-<h3 class="t-sage-heading-6">Page Heading w/ All Items</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Page Heading w/ All Items"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePageHeading, {
   title: "Page Title",

--- a/docs/app/views/examples/objects/pagination/_preview.html.erb
+++ b/docs/app/views/examples/objects/pagination/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Default</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePagination, {
   items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(2),
   collection_name: "Record",
@@ -6,7 +9,10 @@
   hide_pages: false,
 } %>
 
-<h3 class="t-sage-heading-6">Default with Prefix and Suffix</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default with Prefix and Suffix"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePagination, {
   items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
   collection_name: "Record",
@@ -17,7 +23,10 @@
   page_count_suffix: "in the last <strong>30 days</strong>".html_safe,
 } %>
 
-<h3 class="t-sage-heading-6">Default - hide counter</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default - hide counter"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePagination, {
   items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
   collection_name: "Record",
@@ -26,7 +35,10 @@
   hide_pages: false,
 } %>
 
-<h3 class="t-sage-heading-6">Default - hide counter / centered</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default - hide counter / centered"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePagination, {
   items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(1),
   collection_name: "Record",
@@ -37,8 +49,10 @@
 } %>
 
 
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default - hide counter"} %><% end %>
+<!-- Docs Only Label End -->
 
-<h3 class="t-sage-heading-6">Default - hide counter</h3>
 <%= sage_component SagePagination, {
   items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
   collection_name: "Record",
@@ -47,7 +61,10 @@
   hide_pages: true,
 } %>
 
-<h3 class="t-sage-heading-6">Default - hide counter / centered</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Default - hide counter / centered"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePagination, {
   items: Kaminari.paginate_array(Array.new(30, 1)).page(1).per(10),
   collection_name: "Record",

--- a/docs/app/views/examples/objects/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/objects/panel_controls/_preview.html.erb
@@ -114,7 +114,10 @@ actions_items = [
 ]
 %>
 
-<h3 class="t-sage-heading-6">Tabs + Search</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Tabs + Search"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {} do %>
     <% content_for :sage_panel_controls_tabs do %>
@@ -129,7 +132,10 @@ actions_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">No Pagination</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "No Pagination"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
     item_count_label: "Text here",
@@ -142,7 +148,10 @@ actions_items = [
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Pagination</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Pagination"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
     show_bulk_actions: false,
@@ -165,7 +174,10 @@ actions_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Pagination with Bulk actions</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Pagination with Bulk actions"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
     show_bulk_actions: true,
@@ -186,7 +198,10 @@ actions_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Sample Custom Toolbar</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Sample Custom Toolbar"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {} do %>
     <% content_for :sage_panel_controls_toolbar do %>
@@ -196,7 +211,10 @@ actions_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Kitchen Sink</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Kitchen Sink"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SagePanelControls, {
     show_bulk_actions: true,

--- a/docs/app/views/examples/objects/popover/_preview.html.erb
+++ b/docs/app/views/examples/objects/popover/_preview.html.erb
@@ -1,9 +1,6 @@
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Standalone Popover"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Standalone Popover"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePopover, {
   title: "Page Title 1",
@@ -21,12 +18,9 @@
   <p>This is a block of content.</p>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Another Standalone Popover"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Another Standalone Popover"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePopover, {
   title: "Page Title 2",
@@ -46,12 +40,9 @@
   </div>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Standalone Popover with Customized Content Panel"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Standalone Popover with Customized Content Panel"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePopover, {
   custom_content_class: "u-popover-customized",
@@ -62,12 +53,9 @@
   <p>I can put whatever content I want in here and use the cusotm class as a hook to style it like a good 'ol BEM mixin!</p>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Popover w/ Full Size Trigger"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Popover w/ Full Size Trigger"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SagePopover, {
   icon: "send-message",
@@ -88,12 +76,9 @@
   </form>
 <% end %>
 
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageLabel, {
-    color: "draft",
-    value: "Popover Positioning"
-  } %>
-<% end %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Popover Positioning"} %><% end %>
+<!-- Docs Only Label End -->
 
 <div class="sage-card__row">
 

--- a/docs/app/views/examples/objects/sortable/_preview.html.erb
+++ b/docs/app/views/examples/objects/sortable/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6"><code>SageSortableItem</code> as a Panel list</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "As a Panel list"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SagePanelList, {} do %>
   <%= sage_component SageSortable, { resource_name: "link" } do %>
 
@@ -43,7 +46,10 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6"><code>SageSortableItem</code> as cards with no subtitles</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "As cards with no subtitles"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSortable, { resource_name: "link" } do %>
   <% 3.times do %>
     <%= sage_component SageSortableItem, {
@@ -85,7 +91,10 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6"><code>SageSortableItem</code> as cards with images and without subtitles</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "As cards with images and without subtitles"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSortable, { resource_name: "link" } do %>
   <% 3.times do %>
     <%= sage_component SageSortableItem, {
@@ -115,12 +124,23 @@
   <% end %>
 <% end %>
 
+<!-- Docs Only Note -->
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "Note:",
+  desc: "`SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the Sage Grid Templates docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.",
+  icon_name: "sage-icon-info-circle",
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= link_to "Sage Grid Templates", "http://sage-design-system.kajabi.com/pages/layout/grid_templates" %>
+  <% end %>
+<% end %>
+<!-- Docs Only Note End -->
 
-<%= md('
-`SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the [Sage Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.
-', use_sage_type: true) %>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Using a custom grid template : 'te'"} %><% end %>
+<!-- Docs Only Label End -->
 
-<h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "te"</code></h3>
 <%= sage_component SageSortable, { resource_name: "link" } do %>
   <% 3.times do %>
     <%= sage_component SageSortableItemCustom, {
@@ -170,7 +190,10 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "me"</code></h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Using a custom grid template : 'me'"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageSortable, {
   resource_name: "link" } do %>
   <% 3.times do %>
@@ -221,4 +244,3 @@
     } %>
   <% end %>
 <% end %>
-

--- a/docs/app/views/examples/objects/tabs/_preview.html.erb
+++ b/docs/app/views/examples/objects/tabs/_preview.html.erb
@@ -1,4 +1,7 @@
-<h3 class="t-sage-heading-6">Regular tabs</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Regular tabs"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs1",
@@ -40,7 +43,10 @@
   <% end %>
 </div>
 
-<h3 class="t-sage-heading-6">Progress styled tabs</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Progress styled tabs"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs2",
@@ -76,7 +82,10 @@
   <% end %>
 </div>
 
-<h3 class="t-sage-heading-6">Choice tabs - radios in default layout</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Choice tabs - radios in default layout"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs3",
@@ -130,7 +139,10 @@
   <% end %>
 </div>
 
-<h3 class="t-sage-heading-6">Choice tabs - arrows as links in stacked layout</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Choice tabs - arrows as links in stacked layout"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs4",
@@ -176,7 +188,10 @@
   <% end %>
 </div>
 
-<h3 class="t-sage-heading-6">Choice tabs with icons and centered</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Choice tabs with icons and centered"} %><% end %>
+<!-- Docs Only Label End -->
+
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
       id: "example-tabs45",

--- a/docs/app/views/examples/objects/typeahead/_preview.html.erb
+++ b/docs/app/views/examples/objects/typeahead/_preview.html.erb
@@ -1,4 +1,6 @@
-<strong>This component is React-only, see storybook for usage.</strong>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "This component is React-only, see storybook for usage."} %><% end %>
+<!-- Docs Only Label End -->
 
 <% itemActions = [
   sage_component(SageButton, {

--- a/docs/app/views/examples/objects/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/objects/upload_card/_preview.html.erb
@@ -1,10 +1,15 @@
-<h3 class="t-sage-heading-6">Initial State</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Initial State"} %><% end %>
+<!-- Docs Only Label End -->
+
 <%= sage_component SageUploadCard, {
   selection_label: "Select a file",
   selection_subtext: "Body small, Charcoal 200",
 } %>
 
-<h3 class="t-sage-heading-6">Selected File State</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Selected File State"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageUploadCard, {
   accepted_files: [
@@ -15,7 +20,9 @@
   selection_subtext: "Body small, Charcoal 200",
 } %>
 
-<h3 class="t-sage-heading-6">Error State</h3>
+<!-- Docs Only Label -->
+<%= sage_component SageCardBlock, {} do %><%= sage_component SageLabel, {color: "draft",value: "Error State"} %><% end %>
+<!-- Docs Only Label End -->
 
 <%= sage_component SageUploadCard, {
   has_error: true,


### PR DESCRIPTION
## Description
Some simple clean-up on the code examples for the elements and objects. This is just a small step toward more clear and consistent code examples and documentation.

<img width="782" alt="Screen Shot 2021-04-22 at 2 47 16 PM" src="https://user-images.githubusercontent.com/14350772/115789233-aa644380-a379-11eb-985c-9eff5414ae46.png">
