### PR TITLE
Tiny-mce -  add toolbar button wrapping

### DIFF
--- a/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
@@ -11,7 +11,6 @@
   border-radius: sage-border(radius);
 
   .mce-panel {
-    overflow-x: scroll;
     border: unset !important; /* stylelint-disable-line declaration-no-important */
 
     &.mce-toolbar-grp {
@@ -19,12 +18,8 @@
     }
   }
 
-  .mce-container-body {
-    white-space: nowrap;
-  }
-
   .mce-btn button {
-    padding: rem(8px) rem(12px) rem(12px) !important; /* stylelint-disable-line declaration-no-important */
+    padding: rem(8px) rem(10px) rem(10px) !important; /* stylelint-disable-line declaration-no-important */
   }
 
   .mce-btn.mce-colorbutton button[role="presentation"] {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
This PR wraps the buttons in the tiny-mce toolbar row. The interaction currently requires scrolling along the x-axis to reveal additional buttons. Some browsers can be configured to not reveal scrollbars unless the user interaction with the active area. This will reduce the cognitive load the user.

When the buttons wrap, there will be undesirable borders for the buttons. This is intentional as it mirrors the old tiny-mce editor. Until we are able to update tiny-mce to the latest stable release, the result is the compromise


### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-04-23 at 12 46 19 PM](https://user-images.githubusercontent.com/1241836/115910109-0f7b7000-a432-11eb-91b3-35156614fd13.png)|![Screen Shot 2021-04-23 at 12 46 30 PM](https://user-images.githubusercontent.com/1241836/115910121-13a78d80-a432-11eb-8d93-fe398b58d1a5.png)|


## Test notes
<!-- General notes here surrounding this change -->
Turn on the link and check the pages listed in the Estimate Impact
Verify that the editor's buttons wrap when there is overflow in the toolbar

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- (MEDIUM) Reduce size of the tiny-mce editor buttons. Also allows the buttons to wrap to multiple lines.
    - [ ] Coaching session edit form
    - [ ] Podcast episode edit form
    - [ ] Product post page
    - [ ] Offer edit form

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[BUILD-1025](https://github.com/Kajabi/kajabi-products/pull/18735)