### PR TITLE
Dropdown -  resolve dropdown children flashing on close

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -264,9 +264,8 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__panel {
-  position: absolute;
-  opacity: 0;
   z-index: sage-z-index(negative);
+  position: absolute;
   top: calc(100% + #{sage-spacing(xs)});
   // Temporarily removing animation as it causes
   // a positioning issue with nested fixed positioned elements
@@ -279,6 +278,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   box-shadow: sage-shadow(md);
   transition: map-get($sage-transitions, default);
   transition-property: transform, z-index;
+  opacity: 0;
 
   // In the event that this dropdown is at the bottom of the page, add some margin below
   // to prevent it from touching the bottom of the viewport/page when it expands

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -264,7 +264,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__panel {
-  visibility: hidden;
+  opacity: 0;
   position: absolute;
   z-index: sage-z-index(negative);
   top: calc(100% + #{sage-spacing(xs)});
@@ -307,7 +307,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   [aria-expanded="true"] > & {
-    visibility: visible;
+    opacity: 1;
     z-index: sage-z-index(default, 100);
     // Temporarily removing animation as it causes
     // a positioning issue with nested flex positioned elements

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -264,8 +264,8 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__panel {
-  opacity: 0;
   position: absolute;
+  opacity: 0;
   z-index: sage-z-index(negative);
   top: calc(100% + #{sage-spacing(xs)});
   // Temporarily removing animation as it causes
@@ -307,8 +307,8 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   [aria-expanded="true"] > & {
-    opacity: 1;
     z-index: sage-z-index(default, 100);
+    opacity: 1;
     // Temporarily removing animation as it causes
     // a positioning issue with nested flex positioned elements
     // transform: rotate3d(0, 0, 0, 0);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
This PR resolves an issue with the children in a dropdown panel sometimes being visible shortly after the panel is closed. In the gifs, I turned on the visibility for each repaint. In the `Before` you can see there's a second repaint occurring with the `Copy RSS Feed`. First initial performance pass, we're resolving the flash within the dropdown panel

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![dropdown-perf-before](https://user-images.githubusercontent.com/1241836/115937852-89c1e980-a45e-11eb-9224-b1262b2f4868.gif)|![dropdown-perf-after](https://user-images.githubusercontent.com/1241836/115937859-90506100-a45e-11eb-8387-271b16f4d94c.gif)|


This before & after show the before getting 2 separate style recalculations while the after now only has one, eliminating the flash in the second calculation

|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2021-04-23_at_6_22_53_PM](https://user-images.githubusercontent.com/1241836/115938832-909e2b80-a461-11eb-936e-2bf523569e42.png)|![Screen_Shot_2021-04-23_at_6_20_13_PM](https://user-images.githubusercontent.com/1241836/115938838-94ca4900-a461-11eb-96ab-71aa42aa435a.png)|

## Test notes
<!-- General notes here surrounding this change -->
- Visit the Podcast Index page in the app. 
- Click on the contextual menu for a podcast
- Click again to clone menu
- Verify that there isn't a flash of any items in the dropdown panel

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
- (LOW) Updates the property used to animate the dropdown panel
    - [ ] - Product Index
    - [x] - Podcast Index
    - [x] - Coaching Index

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
