### PR TITLE
Sage Rails Icon Component

### DIFF
--- a/docs/app/helpers/elements_helper.rb
+++ b/docs/app/helpers/elements_helper.rb
@@ -111,6 +111,15 @@ module ElementsHelper
         react_component_slug: "sage-textarea--default"
       },
       {
+        title: "icon",
+        description: "Display a standalone icon with a customizble size, color, and more!", 
+        scss: "todo",
+        rails: "todo",
+        react: "todo",
+        a11y: "todo",
+        react_component_slug: "sage-icon--default"
+      },
+      {
         title: "icon_card",
         description: "A simple component that allows an icon to be rendered on a field with a unified color scheme applied.",
         scss: "done",

--- a/docs/app/helpers/elements_helper.rb
+++ b/docs/app/helpers/elements_helper.rb
@@ -112,7 +112,7 @@ module ElementsHelper
       },
       {
         title: "icon",
-        description: "Display a standalone icon with a customizble size, color, and more!", 
+        description: "Display a standalone icon with a customizble size, color, and more! Our library of icons is available under the #{link_to("Design section's Icons page", pages_design_path(:icon))}.".html_safe, 
         scss: "todo",
         rails: "todo",
         react: "todo",

--- a/docs/app/views/examples/elements/icon/_preview.html.erb
+++ b/docs/app/views/examples/elements/icon/_preview.html.erb
@@ -1,0 +1,26 @@
+<h3>Basic Usage</h3>
+<%= sage_component SageIcon, { icon: "pen" } %>
+
+<h3>Colors</h3>
+<table class="sage-table">
+  <% SageTokens::COLORS.each do | color | %>
+    <tr>
+      <td><%= color %></td>
+      <td>
+        <%= sage_component SageIcon, { icon: "pen", color: color } %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<h3>Sizes</h3>
+<table class="sage-table">
+  <% SageTokens::ICON_SIZES.each do | size | %>
+    <tr>
+      <td><%= size == "md" ? "Default (#{size})" : size %></td>
+      <td>
+        <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size) } %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/docs/app/views/examples/elements/icon/_preview.html.erb
+++ b/docs/app/views/examples/elements/icon/_preview.html.erb
@@ -1,26 +1,22 @@
 <h3>Basic Usage</h3>
-<%= sage_component SageIcon, { icon: "pen" } %>
+<%= sage_component SageIcon, { icon: "pen", label: "Edit" } %>
 
 <h3>Colors</h3>
-<table class="sage-table">
+<%= sage_component SageCardList, {} do %>
   <% SageTokens::COLORS.each do | color | %>
-    <tr>
-      <td><%= color %></td>
-      <td>
-        <%= sage_component SageIcon, { icon: "pen", color: color } %>
-      </td>
-    </tr>
+    <%= sage_component SageCardListItem, { grid_template: "et" } do %>
+      <%= sage_component SageIcon, { icon: "pen", color: color } %>
+      <%= color %>
+    <% end %>
   <% end %>
-</table>
+<% end %>
 
 <h3>Sizes</h3>
-<table class="sage-table">
+<%= sage_component SageCardList, {} do %>
   <% SageTokens::ICON_SIZES.each do | size | %>
-    <tr>
-      <td><%= size == "md" ? "Default (#{size})" : size %></td>
-      <td>
-        <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size) } %>
-      </td>
-    </tr>
+    <%= sage_component SageCardListItem, { grid_template: "et" } do %>
+      <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size) } %>
+      <%= size == "md" ? "Default (#{size})" : size %>
+    <% end %>
   <% end %>
-</table>
+<% end %>

--- a/docs/app/views/examples/elements/icon/_props.html.erb
+++ b/docs/app/views/examples/elements/icon/_props.html.erb
@@ -1,0 +1,25 @@
+<tr>
+  <td><%= md('`color`') %></td>
+  <td><%= md('Which color to use to render the icon. See Sage Colors under "Design."') %></td>
+  <td><%= md('Color slider values such as "primary", "prmary-100".') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Which icon to display. See Sage Icons under "Design."') %></td>
+  <td><%= md('`String` for desired icon.') %></td>
+  <td><%= md('--') %></td>
+</tr>
+<tr>
+  <td><%= md('`label`') %></td>
+  <td><%= md('An optional accessible label to use for the icon. Otherwise, `aria-hidden` is turned on.') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`size`') %></td>
+  <td><%= md('Adjusts the size of the icon.') %></td>
+  <td><%= md("`#{SageTokens::ICON_SIZES.inspect()}`") %>
+  </td>
+  <td><%= md('`nil` (Default is "md" size)') %></td>
+</tr>

--- a/docs/app/views/examples/elements/icon/_rules_do.html.erb
+++ b/docs/app/views/examples/elements/icon/_rules_do.html.erb
@@ -1,0 +1,9 @@
+<ul>
+  <li>
+    <%= md('
+      Consider providing `label` for any icon use that describes the icon.
+      For example, the typical "+ Item" use case
+      should likely describe "+" with the `label` of "add" or something similar.
+    ') %>
+  </li>
+</ul>

--- a/docs/app/views/examples/elements/icon/_rules_do.html.erb
+++ b/docs/app/views/examples/elements/icon/_rules_do.html.erb
@@ -3,7 +3,8 @@
     <%= md('
       Consider providing `label` for any icon use that describes the icon.
       For example, the typical "+ Item" use case
-      should likely describe "+" with the `label` of "add" or something similar.
+      should likely describe "+" with the `label` of "add" or something similar. 
+      If `label` is omitted, the icon will be set up with `aria-hidden="true"`
     ') %>
   </li>
 </ul>

--- a/docs/app/views/examples/elements/icon/_rules_dont.html.erb
+++ b/docs/app/views/examples/elements/icon/_rules_dont.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <li>Vary too much with color and size without checking with Product Design. While we allow for variations they should still conform to consistency in use.</li>
+</ul>

--- a/docs/app/views/pages/icon.html.erb
+++ b/docs/app/views/pages/icon.html.erb
@@ -167,12 +167,6 @@ dialogue_icons = [
 <%= md(%(
 # Icons
 <p class="docs-heading__lead">Our icon set includes those shown below. The typical pattern for these is to use an <code>&lt;i&gt;</code> tag with a class as indicated below.</p>
-
-Note as well for accessibility that if the icon should have an
-`aria-label` attribute that describes the icon\'s
-purpose in context. However, if the icon is immediately surrounded by
-text that describes the icon, such as where the icon is purely decorative
-then `aria-hidden=\"true\"` can be used instead.
 )) %>
 <% end %>
 <%= content_for :quick_links do %>

--- a/docs/app/views/pages/icon.html.erb
+++ b/docs/app/views/pages/icon.html.erb
@@ -221,7 +221,7 @@ Marketing uses the Megaphone icon. We do not use the megaphone icon for other tr
     <div class="docs-icon-inline">
       <%= sage_component SageCardRow, { grid_template: "it" } do %>
         <i class="sage-icon-<%= icon[:name] %>-xl" aria-hidden="true"></i>
-        <p class="docs-icon-inline__label">sage-icon-<%= icon[:name] %></p>
+        <p class="docs-icon-inline__label"><%= icon[:name] %></p>
         <p class="docs-icon-inline__usage"><strong><%= icon[:action] %></strong> Actions</p>
       <% end %>
     </div>
@@ -234,7 +234,7 @@ Marketing uses the Megaphone icon. We do not use the megaphone icon for other tr
     <div class="docs-icon-inline">
       <%= sage_component SageCardRow, { grid_template: "it" } do %>
         <i class="sage-icon-<%= icon[:name] %>-xl" aria-hidden="true"></i>
-        <p class="docs-icon-inline__label">sage-icon-<%= icon[:name] %></p>
+        <p class="docs-icon-inline__label"><%= icon[:name] %></p>
         <p class="docs-icon-inline__usage"><strong><%= icon[:action] %></strong></p>
       <% end %>
     </div>
@@ -247,7 +247,7 @@ Marketing uses the Megaphone icon. We do not use the megaphone icon for other tr
     <div class="docs-icon-inline">
       <%= sage_component SageCardRow, { grid_template: "it" } do %>
         <i class="sage-icon-<%= icon[:name] %>-xl" aria-hidden="true"></i>
-        <p class="docs-icon-inline__label">sage-icon-<%= icon[:name] %></p>
+        <p class="docs-icon-inline__label"><%= icon[:name] %></p>
         <p class="docs-icon-inline__usage"><strong><%= icon[:action] %></strong> Dialogues</p>
       <% end %>
     </div>
@@ -261,7 +261,7 @@ Marketing uses the Megaphone icon. We do not use the megaphone icon for other tr
       <%= sage_component SageGridCol, { breakpoint: "md", size: "4" } do %>
         <div class="docs-icon-block">
           <i class="sage-icon-<%= icon %>-2xl" aria-hidden="true"></i>
-          <p class="docs-icon-block__label">sage-icon-<%= icon %></p>
+          <p class="docs-icon-block__label"><%= icon %></p>
         </div>
       <% end %>
     <% end %>

--- a/docs/lib/sage-frontend/stylesheets/docs/_icon.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_icon.scss
@@ -8,6 +8,7 @@
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+  align-items: center;
   margin-bottom: sage-spacing();
   padding: sage-spacing(lg) sage-spacing(sm);
   text-align: center;
@@ -16,6 +17,7 @@
 }
 
 .docs-icon-block__label {
+  margin-top: sage-spacing(xs);
   margin-bottom: 0;
   font-size: sage-font-size(xs);
   font-weight: sage-font-weight(semibold);

--- a/docs/lib/sage_rails/app/sage_components/sage_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon.rb
@@ -1,0 +1,8 @@
+class SageIcon < SageComponent
+  set_attribute_schema({
+    color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
+    icon: SageSchemas::ICON,
+    label: [:optional, NilClass, String],
+    size: [:optional, NilClass, SageSchemas::ICON_SIZE]
+  })
+end

--- a/docs/lib/sage_rails/app/sage_components/sage_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon.rb
@@ -1,6 +1,7 @@
 class SageIcon < SageComponent
   set_attribute_schema({
     color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
+    css_classes: [:optional, String],
     icon: SageSchemas::ICON,
     label: [:optional, NilClass, String],
     size: [:optional, NilClass, SageSchemas::ICON_SIZE]

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -1,0 +1,8 @@
+<i class="
+    sage-icon-<%= component.icon %><%= "-#{component.size}" if component.size.present? %>
+    <%= component.generated_css_classes %>
+    <%= "t-sage--color-#{component.color}" if component.color.present? %>
+  "
+  <%# component.label.present? ? "aria-hidden=true" : "aria-label=#{label}" %>
+  <%= component.generated_html_attributes.html_safe %>
+></i>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -1,8 +1,13 @@
 <i class="
     sage-icon-<%= component.icon %><%= "-#{component.size}" if component.size.present? %>
+    <%= component.css_classes %>
     <%= component.generated_css_classes %>
     <%= "t-sage--color-#{component.color}" if component.color.present? %>
   "
-  <%# component.label.present? ? "aria-hidden=true" : "aria-label=#{label}" %>
+  <% if component.label.present? %>
+    aria-label="<%= component.label %>"
+  <% else %>
+    aria-hidden=true
+  <% end %>
   <%= component.generated_html_attributes.html_safe %>
 ></i>

--- a/packages/sage-assets/lib/stylesheets/index.scss
+++ b/packages/sage-assets/lib/stylesheets/index.scss
@@ -11,7 +11,6 @@
 
 // Base Styles
 @import "core/fonts";
-@import "core/icons";
 @import "core/typography";
 
 // Layout
@@ -39,6 +38,7 @@
 @import "patterns/elements/form_input";
 @import "patterns/elements/form_select";
 @import "patterns/elements/form_textarea";
+@import "patterns/elements/icon";
 @import "patterns/elements/indicator";
 @import "patterns/elements/label";
 @import "patterns/elements/link";

--- a/packages/sage-assets/lib/stylesheets/patterns/elements/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/elements/_icon.scss
@@ -1,5 +1,5 @@
 ////
-/// Icons setup
+/// Icon
 ///
 /// @group sage
 ////


### PR DESCRIPTION
## Description

This PR adds a new component in Rails for displaying Sage Icons similar to the same component in React.

### Screenshots

![Screen Shot 2021-04-27 at 2 03 29 PM](https://user-images.githubusercontent.com/17955295/116291317-6e0e5a00-a762-11eb-8484-2d018498e132.png)

## Test notes

See the new Icon Element

### Estimated impact
(LOW) New Rails Icon component. No impact on implementations of manual `.sage-icon` classes or other icon uses.

