### PR TITLE
Dialog element - resolve color inheritance

### DIFF
--- a/packages/sage-assets/lib/stylesheets/vendor/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_reboot.scss
@@ -72,6 +72,10 @@ li {
   margin-bottom: 0;
 }
 
+dialog {
+  color: inherit;
+}
+
 abbr[title],
 abbr[data-original-title] {
   -webkit-text-decoration: underline dotted;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Browser prefixes are hardcoding a color for `<dialog>` elements, screwing up the inheritance for the child colors
![Screen Shot 2021-04-28 at 9 00 56 AM](https://user-images.githubusercontent.com/1241836/116419005-3f47c080-a802-11eb-95d0-283838fc1a14.png)

### Screenshots
<!-- OPTIONAL but recommended for any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-04-28 at 9 11 37 AM](https://user-images.githubusercontent.com/1241836/116419092-54bcea80-a802-11eb-95cc-67c362838d52.png)|![Screen Shot 2021-04-28 at 9 11 43 AM](https://user-images.githubusercontent.com/1241836/116419101-58507180-a802-11eb-8628-3346ddbbb60d.png)|


## Test notes
<!-- General notes here surrounding this change -->
- Visit sage modal page and click on a modal trigger
- Inspect the modal
- In the DOM inspector, select the `<dialog>` element and toggle the `color: inherit` property to see the change

### Estimated impact
<!-- REQUIRED: describe impact level (LOW/MEDIUM/HIGH/BREAKING) and examples of affected areas.
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(MEDIUM) This will be a visible change to all modal content color 
- [ ] Import Podcast modal
- [ ] Distribution View Steps modal
- [ ] New Podcast Episode modal



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
