### PR TITLE
Table: border not touching edge of panel parent

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -247,7 +247,7 @@ $-table-sort-indicator-direction: rem(7px);
   .sage-panel & {
     @include overflow-scroll();
     overflow-y: visible;
-    max-width: calc(100% + #{ 2 * $-table-cell-padding-card});
+    max-width: calc(100% + #{ 2 * sage-spacing(md)});
   }
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Resolve issue in which the the top border of a table doesn't touch the edge edge of the panel

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-04-28 at 11 04 04 AM](https://user-images.githubusercontent.com/1241836/116437171-c866f380-a812-11eb-9a72-6567d234f7e0.png)|![Screen Shot 2021-04-28 at 10 58 26 AM](https://user-images.githubusercontent.com/1241836/116437183-cd2ba780-a812-11eb-8771-e0fb7f96c99f.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the panel controls page and scroll down to the `Kitchen Sink` example
- Verify that border for the table reaches the right side of the container

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) This affect every instance of a scrollable table existing panel.
   - [ ] Podcast Index


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
