### PR TITLE
Dropdown - sage bump followup

### DIFF
--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -264,6 +264,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__panel {
+  display: none;
   z-index: sage-z-index(negative);
   position: absolute;
   top: calc(100% + #{sage-spacing(xs)});
@@ -278,7 +279,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   box-shadow: sage-shadow(md);
   transition: map-get($sage-transitions, default);
   transition-property: transform, z-index;
-  display: none;
 
   // In the event that this dropdown is at the bottom of the page, add some margin below
   // to prevent it from touching the bottom of the viewport/page when it expands
@@ -307,8 +307,8 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   [aria-expanded="true"] > & {
-    z-index: sage-z-index(default, 100);
     display: block;
+    z-index: sage-z-index(default, 100);
     // Temporarily removing animation as it causes
     // a positioning issue with nested flex positioned elements
     // transform: rotate3d(0, 0, 0, 0);

--- a/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/patterns/objects/_dropdown.scss
@@ -278,7 +278,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   box-shadow: sage-shadow(md);
   transition: map-get($sage-transitions, default);
   transition-property: transform, z-index;
-  opacity: 0;
+  display: none;
 
   // In the event that this dropdown is at the bottom of the page, add some margin below
   // to prevent it from touching the bottom of the viewport/page when it expands
@@ -308,7 +308,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
   [aria-expanded="true"] > & {
     z-index: sage-z-index(default, 100);
-    opacity: 1;
+    display: block;
     // Temporarily removing animation as it causes
     // a positioning issue with nested flex positioned elements
     // transform: rotate3d(0, 0, 0, 0);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
This is followup pr to fix an issue related to dropdowns inside of panels with an `overflow: visible`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![dropdown-before](https://user-images.githubusercontent.com/1241836/116467563-708db400-a835-11eb-9076-8500902d5ba0.gif)|![dropdown-after](https://user-images.githubusercontent.com/1241836/116467582-74b9d180-a835-11eb-8394-31f601fd6dec.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Test in the app!

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (MEDIUM) This updates the clickable area of a dropdown within a panel that has a visible overflow
   - [ ] - Podcast episode index 

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
