### PR TITLE
Textarea - update border-color to match spec when value is present

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_form_textarea.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_textarea.scss
@@ -128,10 +128,6 @@ $-textarea-color-success: map-get($sage-field-colors, success);
     }
   }
 
-  &:valid:not(:placeholder-shown):not(:focus):not(:active) {
-    border-color: currentColor;
-  }
-
   // TODO: add support for Simpleform classes
   .sage-textarea--error &,
   &:required:not(:placeholder-shown):not(:valid) {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - updated to the `border-color` when a value is present based on the spec. In the spec the default state and state with a value have the same `border-color`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2021-04-29_at_7_40_07_AM](https://user-images.githubusercontent.com/1241836/116566502-708cc300-a8cc-11eb-91af-37575c39b5f5.png)|![Screen_Shot_2021-04-29_at_9_18_16_AM](https://user-images.githubusercontent.com/1241836/116566523-7387b380-a8cc-11eb-902f-591f72abcd75.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the local textarea page:
- rails: http://localhost:4000/pages/element/form_textarea
- react: http://localhost:4100/?path=/story/sage-textarea--textarea-with-state
Click into the textarea and add text.
Either click off of tab out.
Verify that the border-color returns to the color of the default state

## Testing in `kajabi-products`
1. (MEDIUM) This affects every `<textarea>` field in the app, but should only affect a visual change that field has a value
   - [ ] New Offers Modal
   - [ ] Coaching Program Edit Details Modal


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
https://github.com/Kajabi/kajabi-products/pull/18834