### PR TITLE
Modal: add JS events on "open"

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -37,7 +37,7 @@
   <%# Standard Modal %>
   <%= sage_component SageModal, { id: "cool-modal" } do %>
     <%= sage_component SageModalContent, {
-      title: "Example Modal" 
+      title: "Example Modal"
     } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
@@ -74,9 +74,9 @@
 
   <%# Standard Modal with Header Image %>
   <%= sage_component SageModal, { id: "cool-modal-header-image" } do %>
-    <%= sage_component SageModalContent, { 
-      header_image: "/assets/card-placeholder-sm.png", 
-      title: "Example Modal" 
+    <%= sage_component SageModalContent, {
+      header_image: "/assets/card-placeholder-sm.png",
+      title: "Example Modal"
     } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
@@ -389,3 +389,194 @@
   <% end %>
 
 <% end %>
+
+<%= sage_component SagePanelStack, {} do %>
+  <h3 class="t-sage-heading-6">Events (monitor in browser console)</h3>
+  <p>Use these events for hooking into modal functionality using JS event listeners.</p>
+
+  <%= sage_component SageTable, {
+    striped: true,
+    responsive: true,
+    headers: [
+      "Event name",
+      "Event type",
+      "Description"
+    ],
+    rows: [
+      {
+        col_1: md("`sage.modal.active`"),
+        col_2: "global",
+        col_3: md("Fires when **any** modal has been opened")
+      },
+      {
+        col_1: md("`sage.modal.closeAll`"),
+        col_2: "global",
+        col_3: md("Fires when **any** modal has been closed")
+      },
+      {
+        col_1: md("`sage.modal.opening`"),
+        col_2: "instance",
+        col_3: "Fires immediately when a modal has been opened"
+      },
+      {
+        col_1: md("`sage.modal.open`"),
+        col_2: "instance",
+        col_3: md("Fires after a modal has loaded. If `animate` is enabled, this event will run upon completion of the modal\'s animation. Otherwise, this event will run immediately along with `sage.modal.opening`.")
+      },
+    ]
+  } %>
+
+  <%= sage_component SageButtonGroup, { gap: :sm, spacer: { bottom: :sm }} do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "'sage.modal.active'",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-event-active",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "'sage.modal.opening'",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-event-opening",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "'sage.modal.open'",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-event-open",
+      }
+    } %>
+  <% end %>
+
+  <%# Event-enabled Modals %>
+  <%= sage_component SageModal, { id: "cool-modal-event-open", disable_background_blur: true, animate: true, css_classes: "custom-class-name-here" } do %>
+    <%= sage_component SageModalContent, { title: "Example 'Open' Event Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= sage_component SageModal, { id: "cool-modal-event-opening", disable_background_blur: true, animate: true } do %>
+    <%= sage_component SageModalContent, { title: "Example 'Opening' Event Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= sage_component SageModal, { id: "cool-modal-event-close", disable_background_blur: true, animate: true } do %>
+    <%= sage_component SageModalContent, { title: "Example 'CloseAll' Event Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+<% end %>
+
+<script>
+  (function() {
+    const modalOpeningExample = document.querySelector("[data-js-modal=cool-modal-event-opening]");
+    const modalOpenExample = document.querySelector("[data-js-modal=cool-modal-event-open]");
+
+    document.addEventListener("sage.modal.active", function(e) {
+      console.info("sage.modal.active global event fired", e);
+    });
+    modalOpeningExample.addEventListener("sage.modal.opening", function(e) {
+      console.info("sage.modal.opening event fired", e);
+    });
+    modalOpenExample.addEventListener("sage.modal.open", function(e) {
+      console.info("sage.modal.open event fired", e);
+    });
+    document.addEventListener("sage.modal.closeAll", function(e) {
+      console.info("sage.modal.closeAll global event fired", e);
+    });
+  })();
+</script>

--- a/docs/app/views/examples/components/modal/_props.html.erb
+++ b/docs/app/views/examples/components/modal/_props.html.erb
@@ -106,18 +106,27 @@
 </tr>
 <tr>
   <td colspan="4">
-    <strong>Use these events for hooking into modal functionality using your own JS event listeners.</strong>
+    <em>Global/window events</em>
+  </td>
+</tr>
+<tr>
+  <td><%= md('`sage.modal.active`') %></td>
+  <td colspan="3"><%= md('This event is fired immediately when any modal has been opened.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage.modal.closeAll`') %></td>
+  <td colspan="3"><%= md('Fires on when a modal has been closed, either from actuating a button, `esc` keypress, or clicking a modal\'s backdrop.') %></td>
+</tr>
+<tr>
+  <td colspan="4">
+    <em>Individual modal events</em>
   </td>
 </tr>
 <tr>
   <td><%= md('`sage.modal.opening`') %></td>
-  <td colspan="3"><%= md('This event is fired immediately when a modal has been opened.') %></td>
+  <td colspan="3"><%= md('This modal event is fired immediately when a modal has been opened.') %></td>
 </tr>
 <tr>
   <td><%= md('`sage.modal.open`') %></td>
   <td colspan="3"><%= md('Fired *after* a modal has completed its loading animation. Note that if `animate` has not been enabled, this event will fire at the same time as `sage.modal.opening`.') %></td>
-</tr>
-<tr>
-  <td><%= md('`sage.modal.closeAll`') %></td>
-  <td colspan="3"><%= md('Fires when a modal has been closed, either from actuating a button, `esc` keypress, or clicking a modal\'s backdrop.') %></td>
 </tr>

--- a/docs/app/views/examples/components/modal/_props.html.erb
+++ b/docs/app/views/examples/components/modal/_props.html.erb
@@ -99,3 +99,25 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="4">
+    <strong>Events</strong>
+  </td>
+</tr>
+<tr>
+  <td colspan="4">
+    <strong>Use these events for hooking into modal functionality using your own JS event listeners.</strong>
+  </td>
+</tr>
+<tr>
+  <td><%= md('`sage.modal.opening`') %></td>
+  <td colspan="3"><%= md('This event is fired immediately when a modal has been opened.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage.modal.open`') %></td>
+  <td colspan="3"><%= md('Fired *after* a modal has completed its loading animation. Note that if `animate` has not been enabled, this event will fire at the same time as `sage.modal.opening`.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage.modal.closeAll`') %></td>
+  <td colspan="3"><%= md('Fires when a modal has been closed, either from actuating a button, `esc` keypress, or clicking a modal\'s backdrop.') %></td>
+</tr>

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -14,6 +14,7 @@ Sage.modal = (function() {
   const SELECTOR_FOCUSABLE_ELEMENTS = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])';
   const MODAL_ACTIVE_CLASS = 'sage-modal--active';
   const EVENT_CLOSEALL = 'sage.modal.closeAll';
+  const EVENT_ACTIVE = 'sage.modal.active';
   const EVENT_OPENING = 'sage.modal.opening';
   const EVENT_OPEN = 'sage.modal.open';
   let SELECTOR_LAST_FOCUSED;
@@ -102,17 +103,18 @@ Sage.modal = (function() {
   }
 
   function dispatchOpenEvents(el) {
-    document.dispatchEvent(new Event(EVENT_OPENING));
+    document.dispatchEvent(new Event(EVENT_ACTIVE));
+    el.dispatchEvent(new Event(EVENT_OPENING));
 
     if (el.dataset.sageAnimate !== undefined) {
       const modalContainer = el.querySelector(".sage-modal__container");
       modalContainer.ontransitionend = (e) => {
         if ((e.propertyName === "transform") && el.classList.contains(MODAL_ACTIVE_CLASS)) {
-          document.dispatchEvent(new Event(EVENT_OPEN));
+          el.dispatchEvent(new Event(EVENT_OPEN));
         }
       };
     } else {
-      document.dispatchEvent(new Event(EVENT_OPEN));
+      el.dispatchEvent(new Event(EVENT_OPEN));
     }
   }
 

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -4,19 +4,19 @@ Sage.modal = (function() {
   // Variables
   // ==================================================
 
-  const SELECTOR_MODAL = 'data-js-modal';
-  const SELECTOR_MODAL_CONTAINER = 'data-js-modal-container';
-  const SELECTOR_MODAL_DISABLE_CLOSE = 'data-js-modal-disable-close';
-  const SELECTOR_MODAL_REMOTE_URL = 'data-js-remote-url';
-  const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = 'data-js-modal-remove-content-on-close';
-  const SELECTOR_MODAL_CLOSE = 'data-js-modal-close';
-  const SELECTOR_MODALTRIGGER = 'data-js-modaltrigger';
-  const SELECTOR_FOCUSABLE_ELEMENTS = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])';
-  const MODAL_ACTIVE_CLASS = 'sage-modal--active';
-  const EVENT_CLOSEALL = 'sage.modal.closeAll';
-  const EVENT_ACTIVE = 'sage.modal.active';
-  const EVENT_OPENING = 'sage.modal.opening';
-  const EVENT_OPEN = 'sage.modal.open';
+  const SELECTOR_MODAL = "data-js-modal";
+  const SELECTOR_MODAL_CONTAINER = "data-js-modal-container";
+  const SELECTOR_MODAL_DISABLE_CLOSE = "data-js-modal-disable-close";
+  const SELECTOR_MODAL_REMOTE_URL = "data-js-remote-url";
+  const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = "data-js-modal-remove-content-on-close";
+  const SELECTOR_MODAL_CLOSE = "data-js-modal-close";
+  const SELECTOR_MODALTRIGGER = "data-js-modaltrigger";
+  const SELECTOR_FOCUSABLE_ELEMENTS = "a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type='text']:not([disabled]), input[type='radio']:not([disabled]), input[type='checkbox']:not([disabled]), select:not([disabled])";
+  const MODAL_ACTIVE_CLASS = "sage-modal--active";
+  const EVENT_CLOSEALL = "sage.modal.closeAll";
+  const EVENT_ACTIVE = "sage.modal.active";
+  const EVENT_OPENING = "sage.modal.opening";
+  const EVENT_OPEN = "sage.modal.open";
   let SELECTOR_LAST_FOCUSED;
 
   // ==================================================
@@ -27,7 +27,7 @@ Sage.modal = (function() {
     // If a modal has 'data-js-modal-disable-close' return early and don't init any handlers
     if (el.hasAttribute(SELECTOR_MODAL_DISABLE_CLOSE)) return;
 
-    el.addEventListener('click', function(evt){
+    el.addEventListener("click", function(evt) {
       let el = evt.target;
 
       // A JS Event is dispatched to call closeModal,
@@ -35,18 +35,18 @@ Sage.modal = (function() {
       // and perform cleanup actions like removing the modal's content.
 
       // Modal Container has been clicked
-      if ( el.hasAttribute(SELECTOR_MODAL) ) {
+      if (el.hasAttribute(SELECTOR_MODAL)) {
         dispatchCloseAll();
 
       // Modal Close Button has been clicked
-      } else if ( el.hasAttribute(SELECTOR_MODAL_CLOSE) || evt.target.parentElement.hasAttribute(SELECTOR_MODAL_CLOSE) ) {
+      } else if (el.hasAttribute(SELECTOR_MODAL_CLOSE) || evt.target.parentElement.hasAttribute(SELECTOR_MODAL_CLOSE)) {
         dispatchCloseAll();
       }
     });
   }
 
   function initTrigger(el) {
-    el.addEventListener('click', function(evt){
+    el.addEventListener("click", function(evt) {
       let modalId = evt.target.getAttribute(SELECTOR_MODALTRIGGER) || evt.target.parentElement.getAttribute(SELECTOR_MODALTRIGGER);
       openModal(modalId);
     });
@@ -70,21 +70,21 @@ Sage.modal = (function() {
     SELECTOR_LAST_FOCUSED = document.activeElement;
     modal.classList.add(MODAL_ACTIVE_CLASS);
     modal.setAttribute("open", "");
-    document.addEventListener('keyup', onModalKeypress);
-    modal.addEventListener('keydown', focusTrap.bind(focusableEls));
+    document.addEventListener("keyup", onModalKeypress);
+    modal.addEventListener("keydown", focusTrap.bind(focusableEls));
   }
 
   function focusTrap(evt) {
     let firstFocusableEl = this[0];
     let lastFocusableEl = this[this.length - 1];
     let KEYCODE_TAB = 9;
-    var isTabPressed = (evt.key === 'Tab' || evt.keyCode === KEYCODE_TAB);
+    var isTabPressed = (evt.key === "Tab" || evt.keyCode === KEYCODE_TAB);
 
     if (!isTabPressed) {
       return;
     }
 
-    if ( evt.shiftKey ) /* shift + tab */ {
+    if (evt.shiftKey) /* shift + tab */ {
       if (document.activeElement === firstFocusableEl) {
         lastFocusableEl.focus();
         evt.preventDefault();
@@ -99,7 +99,7 @@ Sage.modal = (function() {
 
   function dispatchCloseAll() {
     document.dispatchEvent(new Event(EVENT_CLOSEALL));
-    document.removeEventListener('keyup', onModalKeypress);
+    document.removeEventListener("keyup", onModalKeypress);
   }
 
   function dispatchOpenEvents(el) {
@@ -121,7 +121,7 @@ Sage.modal = (function() {
   function closeModal(el) {
     el.classList.remove(MODAL_ACTIVE_CLASS);
     el.removeAttribute("open");
-    el.removeEventListener('keydown', focusTrap);
+    el.removeEventListener("keydown", focusTrap);
     SELECTOR_LAST_FOCUSED.focus();
     removeModalContents(el);
   }
@@ -131,11 +131,11 @@ Sage.modal = (function() {
     let url = el.getAttribute(SELECTOR_MODAL_REMOTE_URL);
     const xhr = new XMLHttpRequest();
 
-    xhr.addEventListener('load', (evt) => {
+    xhr.addEventListener("load", (evt) => {
       elContainer.innerHTML = evt.currentTarget.response;
     }, { once: true });
 
-    xhr.open('GET', url, true);
+    xhr.open("GET", url, true);
     xhr.send();
   }
 


### PR DESCRIPTION
## Description
Provides `sage.modal.active`, `sage.modal.opening` and `sage.modal.open` as events. No visual changes apply.

Not certain if this is (yet) needed with the React version of the modal as events and state are handled a bit differently.


Available for global (window) event listeners:
- `sage.modal.active` global event, runs when any modal has been opened

Available for instance (element) event listeners:
- `sage.modal.opening` scoped to modal, fires immediately on open
- `sage.modal.open` scoped to modal, fires following `transitionend` when a modal has been set to `animate`. Otherwise, the event is fired simultaneously with `sage.modal.opening`.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
1. With the branch running locally, navigate to the [modal docs page](http://localhost:4000/pages/component/modal)
2. Open the console in your browser devtools
3. Click on the event-enabled button examples on the modal docs page
4. Verify that all events are being sent as expected


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Modal: adds new events on "open" for JS listeners. Not expected to affect current usage, but the following checks are recommended to make ensure functionality is working as expected.
   - [x] Offers -> New offer (Offer setup modal, requires `comm_offer_setup_modal_ui` feature flag   
   - [x] Products: New Product modal
   - [x] Newsletters: Add Newsletter modal
   - [x] Website -> Navigation: New Navigation Menu modal

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
- closes #450 
