### PR TITLE
Rails components - statuses token

### DIFF
--- a/docs/app/views/examples/components/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/alert/_preview.html.erb
@@ -14,7 +14,7 @@
 
 <!-- Success -->
 <%= sage_component SageAlert, {
-  color: "success",
+  color: "published",
   title: "Account settings updated",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-check-circle",
@@ -72,7 +72,7 @@
 
 <!-- Success -->
 <%= sage_component SageAlert, {
-  color: "success",
+  color: "published",
   title: "Account settings updated",
   desc: "Make sure you know how these changes affect you.",
   icon_name: "sage-icon-check-circle",

--- a/docs/app/views/examples/components/card_highlight/_preview.html.erb
+++ b/docs/app/views/examples/components/card_highlight/_preview.html.erb
@@ -23,7 +23,7 @@
 
 <h4>Colors</h4>
 <%= sage_component SagePanelTiles, { tiles_in_row: 3 } do %>
-  <% ["charcoal", "grey", "purple", "sage", "yellow", "orange", "red"].each do | color | %>
+  <% SageTokens::COLORS.each do | color | %>
     <%= sage_component SageCard, {} do %>
       <p>Highlighted with <%= color %></p>
       <%= sage_component SageCardHighlight, { color: color } %>

--- a/docs/app/views/examples/components/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/components/catalog_item/_preview.html.erb
@@ -23,7 +23,7 @@
         <%= sage_component SageDropdown, {
           align: "right",
           items: [{
-            value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+            value: sage_component(SageLabel, { color: "published", value: "Publish" }),
             attributes: { "href": "#" },
           }, {
             value: sage_component(SageLabel, { color: "info", value: "Drip" }),
@@ -96,7 +96,7 @@
         <%= sage_component SageDropdown, {
           align: "right",
           items: [{
-            value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+            value: sage_component(SageLabel, { color: "published", value: "Publish" }),
             attributes: { "href": "#" },
           }, {
             value: sage_component(SageLabel, { color: "info", value: "Drip" }),
@@ -168,7 +168,7 @@
         <%= sage_component SageDropdown, {
           align: "right",
           items: [{
-            value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+            value: sage_component(SageLabel, { color: "published", value: "Publish" }),
             attributes: { "href": "#" },
           }, {
             value: sage_component(SageLabel, { color: "info", value: "Drip" }),

--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -105,7 +105,7 @@
     align: "right",
     panel_size: "small",
     items: [{
-      value: sage_component(SageLabel, { color: "success", value: "Publish" }),
+      value: sage_component(SageLabel, { color: "published", value: "Publish" }),
       attributes: {},
     }, {
       value: sage_component(SageLabel, { color: "info", value: "Drip" }),

--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -23,13 +23,7 @@
 
 <h3>Background Colors</h3>
 <%= sage_component SageCardList, {} do %>
-  <% [
-    "draft",
-    "published",
-    "info",
-    "warning",
-    "danger"
-  ].each do | color | %>
+  <% SageTokens::STATUSES.each do | color | %>
     <%= sage_component SageCardListItem, { grid_template: "et" } do %>
       <%= sage_component SageIcon, { icon: "pen", card_color: color } %>
       <%= color %>

--- a/docs/app/views/examples/components/icon_card/_preview.html.erb
+++ b/docs/app/views/examples/components/icon_card/_preview.html.erb
@@ -1,12 +1,6 @@
 <h3 class="t-sage-heading-6">Icon Card</h3>
 <div class="sage-row">
-  <% [
-  "draft",
-  "published",
-  "info",
-  "warning",
-  "danger"
-].each do | color | %>
+  <% SageTokens::STATUSES.each do | color | %>
     <div class="sage-col-2">
       <%= sage_component SageIconCard, {
         color: color,

--- a/docs/app/views/examples/shared/_rules.html.erb
+++ b/docs/app/views/examples/shared/_rules.html.erb
@@ -2,7 +2,7 @@
   <%= sage_component SagePanelTiles, { tiles_in_row: 2 } do %>
     <%= sage_component SageCard, {} do %> 
       <%= sage_component SageLabel, {
-        color: "success",
+        color: "published",
         value: "Do",
       } %>
       <%= do_content %>

--- a/docs/app/views/pages/grid_templates.html.erb
+++ b/docs/app/views/pages/grid_templates.html.erb
@@ -101,7 +101,7 @@ dots = [
   %(<i class="sage-icon-check-circle t-sage--color-sage"></i>).html_safe,
   sage_component(SageLabel, { value: "In progress", color: "warning" }).html_safe,
   %(<i class="sage-icon-star t-sage--color-orange"></i>).html_safe,
-  sage_component(SageLabel, { value: "Verified", color: "success" }).html_safe,
+  sage_component(SageLabel, { value: "Verified", color: "published" }).html_safe,
   %(<span class="t-sage-body-small-semi">$5.99</span>).html_safe,
   %(<i class="sage-icon-dot-menu-horizontal t-sage--color-grey"></i>).html_safe
 ]

--- a/docs/lib/sage_rails/app/sage_components/sage_alert.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_alert.rb
@@ -1,6 +1,6 @@
 class SageAlert < SageComponent
   set_attribute_schema({
-    color: [:optional, Set.new(["info", "success", "warning", "danger"])],
+    color: [:optional, SageSchemas::STATUSES],
     desc: [:optional, String],
     dismissable: [:optional, TrueClass],
     icon_name: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -1,7 +1,7 @@
 class SageAvatar < SageComponent
   set_attribute_schema({
     centered: [:optional, TrueClass],
-    color: [:optional, NilClass, Set.new(["purple", "sage", "yellow", "orange", "red"])],
+    color: [:optional, NilClass, SageSchemas::COLORS],
     initials: String,
     size: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar_group.rb
@@ -1,7 +1,7 @@
 class SageAvatarGroup < SageComponent
   set_attribute_schema({
     items: [[
-      color: [:optional, NilClass, Set.new(["purple", "sage", "yellow", "orange", "red"])],
+      color: [:optional, NilClass, SageSchemas::COLORS],
       css_classes: [:optional, String],
       initials: String,
     ]]

--- a/docs/lib/sage_rails/app/sage_components/sage_card_highlight.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_highlight.rb
@@ -1,6 +1,6 @@
 class SageCardHighlight < SageComponent
   set_attribute_schema({
-    color: [:optional, Set.new(["primary", "grey", "charcoal", "purple", "sage", "yellow", "orange", "red"])],
+    color: [:optional, SageSchemas::COLORS],
     custom_color: [:optional, String],
     position: [:optional, Set.new(["top", "right", "bottom", "left"])],
     value: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon.rb
@@ -1,7 +1,7 @@
 class SageIcon < SageComponent
   set_attribute_schema({
     color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
-    card_color: [:optional, Set.new(["draft", "published", "info", "locked", "warning", "danger"])],
+    card_color: [:optional, SageSchemas::STATUSES],
     icon: SageSchemas::ICON,
     label: [:optional, NilClass, String],
     size: [:optional, NilClass, SageSchemas::ICON_SIZE]

--- a/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
@@ -2,7 +2,7 @@ class SageIconCard < SageComponent
   set_attribute_schema({
     attributes: [:optional, NilClass, Hash],
     background_color: [:optional, String],
-    color: [:optional, Set.new(["draft", "published", "info", "locked", "warning", "danger"])],
+    color: [:optional, SageSchemas::STATUSES],
     foreground_color: [:optional, String],
     icon: String,
     label: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_label.rb
@@ -1,12 +1,11 @@
 class SageLabel < SageComponent
   set_attribute_schema({
     container_attributes: [:optional, Hash],
-    color: Set.new(["danger", "draft", "info", "locked", "published", "success", "warning"]),
+    color: [:optional, SageSchemas::STATUSES],
     icon: [:optional, String],
     interactive_type: [:optional, Set.new([:dropdown, :default, :secondary_button])],
     secondary_button: [:optional, String, TrueClass, {
       attributes:       [:optional, NilClass, Hash],
-      css_classes:      [:optional, NilClass, String],
       icon:             [:optional, String],
       value:            [:optional, String],
     }],

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -3,11 +3,15 @@ module SageSchemas
   
   ICON_SIZE = Set.new(SageTokens::ICON_SIZES)
 
+  COLORS = Set.new(SageTokens::COLORS)
+  
   COLOR_SLIDER = Set.new(SageTokens::COLOR_SLIDERS)
 
   CONTAINER_SIZE = Set.new(SageTokens::CONTAINER_SIZES)
 
   GRID_TEMPLATE = Set.new(SageTokens::GRID_TEMPLATES)
+  
+  STATUSES = Set.new(SageTokens::STATUSES)
 
   SPACER = {
     top: [:optional, Set.new(SageTokens::SPACER_SIZES)],

--- a/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
@@ -175,4 +175,6 @@ module SageTokens
   ICON_SIZES = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl"]
 
   SPACER_SIZES = [:xs, :sm, :md, :lg, :xl, "2xs", "xs", "sm", "md", "lg", "xl", "2xl", "stage", "panel", "card", "stack"]
+
+  STATUSES = ["danger", "draft", "info", "locked", "published", "warning"]
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_transaction_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_transaction_card.rb
@@ -2,7 +2,7 @@ class SageTransactionCard < SageComponent
   set_attribute_schema({
     amount: [:optional, String],
     amount_color: [:optional, Set.new(["sage", "red"])],
-    label_color: [:optional, Set.new(["published", "draft", "danger", "info", "warning", "locked"])],
+    label_color: [:optional, SageSchemas::STATUSES],
     label_text: [:optional, String],
     name: [:optional, String],
     name_href: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label_secondary_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label_secondary_button.html.erb
@@ -1,6 +1,5 @@
 <%= sage_component SageButton, {
   attributes: component.attributes,
-  css_classes: component.css_classes.present? ? component.css_classes : nil,
   icon: {
     name: component.icon.present? ? component.icon : "remove",
     style: "only"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -23,7 +23,6 @@
       sage-radio
       <%= component.has_border ? "sage-radio--has-border" : "" %>
       <%= component.has_error ? "sage-radio--error" : "" %>
-      <%= component.css_classes if component.css_classes.present? %>
     "
   >
     <input

--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -7,13 +7,13 @@
 
 $-alert-colors: (
   info: primary,
-  success: sage,
+  published: sage,
   warning: yellow,
   danger: red,
 );
 $-alert-icon-colors: (
   info: primary,
-  success: sage,
+  published: sage,
   warning: orange,
   danger: red,
 );


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
This PR added a token reduce the number of hard-coded references to the status tied to the `_color_combo.scss` file. 
This PR also cleanups a couple references to `css_classes` in `.html.erb` files

## Screenshots
No visual difference


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
There should be no breaking change. In sage verify that any value used with the updated token exist. If it doesn't the page will fail.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (MEDIUM) This unifies status colors into a token. There is no change to the app since the strings within the property don't change

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
PR update references: https://github.com/Kajabi/kajabi-products/pull/18886