### PR TITLE
Sortable Dropdown Interaction Investigation

### DIFF
--- a/packages/sage-system/lib/init.js
+++ b/packages/sage-system/lib/init.js
@@ -6,7 +6,7 @@ Sage.init = function(elementNamesToInitLegacy) {
   // Initers
   // ==================================================
 
-  let initDocumentPresenceListener = function(elParentSelector, initFunc, unbindFunc) {
+  const initDocumentPresenceListener = function(elParentSelector, initFunc, unbindFunc) {
     // Arrive.js: https://github.com/uzairfarooq/arrive
     const ARRIVE_SETTINGS = {
       fireOnAttributesModification: false,
@@ -19,13 +19,14 @@ Sage.init = function(elementNamesToInitLegacy) {
     });
 
     if (unbindFunc) {
-      document.leave(elParentSelector, ARRIVE_SETTINGS, function() {
-        unbindFunc(this);
+      document.leave(elParentSelector, ARRIVE_SETTINGS, function(el) {
+        // Confirm the element has been removed before unbinding, DOM re-ordering of a parent can trigger a 'leave' event.
+        if (!document.body.contains(el)) unbindFunc(this);
       });
     }
   }
 
-  let initDocumentEventListener = function(eventName, handlerFunc) {
+  const initDocumentEventListener = function(eventName, handlerFunc) {
     document.addEventListener(eventName, handlerFunc);
   }
 


### PR DESCRIPTION
## Description
**Solution:**
Confirm the element has been removed before unbinding, DOM re-ordering of a parent can trigger a 'leave' event.

**Reported:**
Once a row has been sorted (SageSortable) the dropdown (SageDropdown) on the left, the dropdown no longer displays its panel on click.

**Issue:**
The presence-listening package (Arrive.js backed by the browsers MutationObserver API internally) is detecting that the SageDropdown DOM node has been removed from the DOM when Sage Sortable (using Sortable.js) rearranges the document structure in a dragging state. Following the completion of the dragging state the SageDropdown JS remains unbound.

https://user-images.githubusercontent.com/565743/116938400-ba610a80-ac38-11eb-9aa7-feae3d2f7d66.mp4




## Screenshots
n/a


## Testing in `sage-lib`
Test to ensure a Dropdown can be used within Sortable and that is no unusual behavior.
http://localhost:4000/pages/component/sortable

## Testing in `kajabi-products`
1. LOW, this fixing a bug related to SageDropdowns inside of Sortable elements. An unbind event was being fired to due the way the Sortable package is manipulating the DOM. Test in the Coaching Program show view confirm a Coaching Program Session's dropown can be clicked after having been dragged.


## Related
n/a
