### PR TITLE
Style changes for the null-view component

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_null_view.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_null_view.scss
@@ -17,7 +17,7 @@
   padding: sage-spacing();
   @media screen and (min-width: sage-breakpoint(lg-max)) {
     grid-template-columns: auto 1fr;
-    grid-gap: 5rem;
+    grid-gap: rem(80px);
   }
 }
 
@@ -27,7 +27,7 @@
   flex-direction: column;
   justify-content: center;
   flex-wrap: wrap;
-  max-width: 450px;
+  max-width: rem(450px);
   @media screen and (min-width: sage-breakpoint(lg-max)) {
     order: 1;
     align-items: flex-start;
@@ -40,7 +40,7 @@
 
 .sage-null-view__title {
   @extend %t-sage-heading-1;
-  margin-bottom: sage-spacing(xs);
+  margin-bottom: sage-spacing(sm);
 }
 
 .sage-null-view__graphic {

--- a/packages/sage-assets/lib/stylesheets/components/_null_view.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_null_view.scss
@@ -10,11 +10,11 @@
   grid-auto-flow: dense;
   grid-template-columns: auto;
   grid-gap: sage-spacing(lg);
+  justify-content: center;
   max-width: rem(960px);
   margin-left: auto;
   margin-right: auto;
   padding: sage-spacing();
-  justify-content: center;
   @media screen and (min-width: sage-breakpoint(lg-max)) {
     grid-template-columns: auto 1fr;
     grid-gap: 5rem;

--- a/packages/sage-assets/lib/stylesheets/components/_null_view.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_null_view.scss
@@ -9,25 +9,29 @@
   display: grid;
   grid-auto-flow: dense;
   grid-template-columns: auto;
-  grid-gap: sage-spacing();
+  grid-gap: sage-spacing(lg);
   max-width: rem(960px);
   margin-left: auto;
   margin-right: auto;
   padding: sage-spacing();
+  justify-content: center;
   @media screen and (min-width: sage-breakpoint(lg-max)) {
     grid-template-columns: auto 1fr;
-    grid-gap: 128px;
+    grid-gap: 5rem;
   }
 }
 
 .sage-null-view__content {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   flex-direction: column;
   justify-content: center;
   flex-wrap: wrap;
+  max-width: 450px;
   @media screen and (min-width: sage-breakpoint(lg-max)) {
     order: 1;
+    align-items: flex-start;
+    max-width: none;
   }
   .sage-null-view--reversed & {
     order: 2;
@@ -36,7 +40,7 @@
 
 .sage-null-view__title {
   @extend %t-sage-heading-1;
-  margin-bottom: sage-spacing();
+  margin-bottom: sage-spacing(xs);
 }
 
 .sage-null-view__graphic {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->

Fixes alignment of the null-view component for below the `1200` breakpoint. This will center-align elements and shrink the width of the null-view content container. Also, adds polish for spacing and padding for the null-view component

## Screenshots
### Before:
**Desktop View:** 
![image](https://user-images.githubusercontent.com/21964614/117074574-5f86ec00-ace8-11eb-90aa-ef87eb04730d.png)
**< Tablet View:**
![image](https://user-images.githubusercontent.com/21964614/117075074-14b9a400-ace9-11eb-8f2a-f8ca670d4701.png)

### After
**Desktop View:** 
![image](https://user-images.githubusercontent.com/21964614/117074184-de2f5980-ace7-11eb-9265-f262daa10270.png)
**<Tablet View:** 
![image](https://user-images.githubusercontent.com/21964614/117074277-fe5f1880-ace7-11eb-85a4-8c6b7d71097a.png)
## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
1. Navigate to `podcasts` tab
2. Make sure to delete all podcasts
3. Design should align with screenshots above

LOW, this only changes the visual aesthetic of the null view component and will affects all null view components found in Kajabi Products Repo. In case of more comprehensive regression testing, the implementations of the null view are listed below: 

- `Design` tab, for when an active theme hasn't been selected for new accounts
- `Email Campaigns`
- `Events`
- `Newslwtters`
- `Pages > Landing Pages`
- `Pages > Pipelines`