### PR TITLE
Adding resolve-url-loader to docs devDependencies for deployment

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "npm-run-all": "^4.1.5",
+    "resolve-url-loader": "^3.1.1",
     "right-pad": "^1.0.1",
     "stylelint": "^13.3.3",
     "stylelint-config-sass-guidelines": "^7.0.0",


### PR DESCRIPTION
## Description
Deploys are currently broken

![image](https://user-images.githubusercontent.com/1512028/117213301-0ccd3300-adc1-11eb-96f2-6e23fddb4d0a.png)

### History
`resolve-url-loader` was added to `docs/config/webpack/environment.js` as a fix in this PR: https://github.com/Kajabi/sage-lib/pull/285. This appears to work correctly in local environments because `resolve-url-loader` is available through yarn workspaces (https://classic.yarnpkg.com/en/docs/workspaces/) but still needs to be part of the `docs/package.json` if it is to be installed on deployment via Git Subtree pushes (https://github.com/Kajabi/sage-lib/blob/master/package.json#L44).

### Solution
Add `resolve-url-loader` to the `docs/package.json`