### PR TITLE
Toolbar, Radio, Checkbox responsive type fixes

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -99,9 +99,15 @@ $-btn-interactive-label-icon-size: rem(24px);
 
 
 // stylelint-disable max-nesting-depth
+:root {
+  --icon-block-padding: #{rem(6px)};
+
+  @media screen and (min-width: sage-breakpoint(lg-min)) {
+    --icon-block-padding: #{rem(4px)};
+  }
+}
 
 .sage-btn {
-  --icon-block-padding: #{rem(6px)}; // actually applied in the icon building loop in core/_icon.scss
   @extend %t-sage-body-med;
   @include sage-button-style-reset();
   @include sage-focus-outline;
@@ -407,8 +413,6 @@ $-btn-interactive-label-icon-size: rem(24px);
 
 .sage-btn--small {
   @extend %t-sage-body-small;
-
-  --icon-block-padding: #{rem(4px)};
 }
 
 // TODO: Investigate deprecating the float setting here

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -55,6 +55,7 @@ $-checkbox-focus-outline-color: sage-color(primary);
   }
 
   .sage-panel-controls__bulk-actions > & {
+    align-items: center;
     position: relative;
     z-index: sage-z-index(default);
     padding: rem(6px) sage-spacing(xs);
@@ -277,7 +278,18 @@ $-checkbox-focus-outline-color: sage-color(primary);
     }
   }
 
-  &:not(.sage-checkbox--standalone) {
-    margin-top: 4px;
+  .sage-checkbox & {
+    @media (max-width: sage-breakpoint(md-max)) {
+      margin-top: sage-spacing(2xs);
+    }
+
+    @media (min-width: sage-breakpoint(lg-min)) {
+      margin-top: sage-spacing(3xs);
+    }
+  }
+
+  &.sage-checkbox, // spcificity that should apply only to `--standalone` variation
+  .sage-panel-controls__bulk-actions-checkbox & {
+    margin-top: 0;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -59,7 +59,9 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   .sage-panel-controls__bulk-actions > &,
-  .sage-panel-controls__toolbar-btn-group > & {
+  .sage-panel-controls__bulk-actions > &.sage-dropdown--contained,
+  .sage-panel-controls__toolbar-btn-group > &,
+  .sage-panel-controls__toolbar-btn-group > &.sage-dropdown--contained {
     border-radius: 0;
 
     &:first-child {

--- a/packages/sage-assets/lib/stylesheets/components/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel_controls.scss
@@ -91,10 +91,6 @@
   }
 }
 
-.sage-panel-controls__bulk-actions-checkbox {
-  min-height: rem(40px);
-}
-
 .sage-panel-controls__bulk-actions-dropdown {
   display: none;
 

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -204,8 +204,6 @@ $-radio-focus-outline-color: currentColor;
   }
 
   &:not(.sage-radio--standalone) {
-    margin-top: 5px;
-
     .sage-radio--has-border & {
       position: absolute;
       margin-top: 0;
@@ -214,6 +212,16 @@ $-radio-focus-outline-color: currentColor;
     .sage-radio--has-border &::after,
     .sage-radio--has-border &::before {
       border-color: transparent;
+    }
+  }
+
+  .sage-radio & {
+    @media (max-width: sage-breakpoint(md-max)) {
+      margin-top: rem(6px);
+    }
+
+    @media (min-width: sage-breakpoint(lg-min)) {
+      margin-top: sage-spacing(2xs);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adjust some alignment and sizing issues in the aftermath of recent responsive type updates.

- Radio buttons offset is adjusted to align with responsive type
- Checkbox offset is adjusted to align with responsive type
- Icons inside buttons offset is adjusted to align in relation to button size and responsive type
- Toolbar borders and sizing adjusted

Fixes 


## Testing in `sage-lib`

See the Checkbox, Radio, and Button components. Resize window to around 990px and see that alignment is as expected above and below as type sizes change.

See Panel Controls. While other responsive issue abound with this component, note at least that the button and search bar sizes and alignment remain consistent above and below the 990px breakpoint.

## Testing in `kajabi-products`
(LOW) Radio, Checkbox, Button, and Panel Control Toolbars adjusted to better align with new responsive type.
   - [ ] See the header of the table in People/Contacts list. Search bar should now appear same size as surrounding buttons. Bulk actions checkbox should appear aligned centered on type before and after selecting all. Fixes [MAN-1477](https://kajabi.atlassian.net/browse/MAN-1477?atlOrigin=eyJpIjoiZTdiYTU4ODFmMTYyNDc1Njg4ZDBiYzJjMGNiNDQyMmQiLCJwIjoiaiJ9)
