### PR TITLE
Alert button positioning

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_banner.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_banner.scss
@@ -116,8 +116,8 @@ $-banner-el-icon: "before";
 }
 
 .sage-banner__close {
-  position: absolute;
   right: sage-spacing(card);
+  // Note: `position: absolute` is set in sage button
 }
 
 .sage-banner__close,

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -117,7 +117,6 @@ $-btn-interactive-label-icon-size: rem(24px);
   display: inline-flex;
   align-self: inherit;
   align-items: center;
-  position: relative;
   padding: $-padding-block sage-spacing(sm);
   text-align: left; // Prevents text alignment issue when inner text is truncated
   border: 0;
@@ -138,6 +137,10 @@ $-btn-interactive-label-icon-size: rem(24px);
   }
 
   // Contextual modifications
+  &.sage-banner__close {
+    position: absolute;
+  }
+
   .sage-dropdown--contained .sage-dropdown__trigger &,
   .sage-panel-controls__tabs-dropdown .sage-dropdown__trigger &,
   .sage-panel-controls__toolbar .sage-dropdown__trigger &,


### PR DESCRIPTION
## Description

Closes #473 , fixing a bug with positioning the close button in banners.

## Screenshots
|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2021-05-11 at 1 04 53 PM](https://user-images.githubusercontent.com/17955295/117856534-bb59f380-b259-11eb-87bb-fa98c966c686.png) | ![Screen Shot 2021-05-11 at 1 04 21 PM](https://user-images.githubusercontent.com/17955295/117856568-c6ad1f00-b259-11eb-8582-8fa8c52b563c.png) |

## Testing in `sage-lib`

Confirm the close button is positioned where expected in Banner.


## Testing in `kajabi-products`

(LOW) Fixes close button positioning in Alerts. Testing steps to be provided once a temporary patch in `kajabi-products` is reverted.

@darrellrivera can you please provide suggested QA test steps to validate that this fixes the issue you encountered?

## Related

Should allow https://github.com/Kajabi/kajabi-products/pull/18978 to be reverted.
