### PR TITLE
Added file-loader to deps of sage-assets

### DIFF
--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^0.11.3",
     "nodemon": "2.0.6",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Description
Same problem we had here: https://github.com/Kajabi/sage-lib/pull/465 except this time its the `file-loader` in `sage-assets`

![image](https://user-images.githubusercontent.com/1512028/117999000-08959e00-b30a-11eb-92f5-ec0759a1fae6.png)


## Solution
Added `file-loader` dependency to `sage-assets` package.json

