### PR TITLE
Update toast property name in copy-button.js

### DIFF
--- a/packages/sage-system/lib/copy-button.js
+++ b/packages/sage-system/lib/copy-button.js
@@ -15,7 +15,7 @@ Sage.copyButton = (function() {
     document.execCommand('copy');
     document.body.removeChild(el);
     ev.currentTarget.focus();
-    Sage.toast.trigger({message:'Copied to clipboard'})
+    Sage.toast.trigger({text:'Copied to clipboard'})
   };
 
 


### PR DESCRIPTION
### Description
Addresses a bug where text is not displayed in confirmation toast when clicking on the copy text button.


### Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-05-13 at 5 03 44 PM](https://user-images.githubusercontent.com/1175111/118202081-f8ff7d80-b40d-11eb-8746-bb350a6a725e.png)|![Screen Shot 2021-05-13 at 5 03 58 PM](https://user-images.githubusercontent.com/1175111/118202105-087ec680-b40e-11eb-95db-c1023f9c5603.png)|


### Testing in `sage-lib`

- Visit http://localhost:4000/pages/component/copy_text
- Click on the copy button
- Verify "Copied to clipboard" text now displays in toast confirmation.


### Testing in `kajabi-products`
1. (**LOW**) Addresses issue with confirmation toast not displaying text when clicking on the copy button.
   - [ ] Custom Email Domain Setup
   - [ ] Site Custom Domain


### Related
N/A
