### PR TITLE
fix(property): remove catalog reference in property CSS

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_property.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_property.scss
@@ -12,12 +12,6 @@
   align-items: center;
   color: sage-color(charcoal, 200);
 
-  .sage-catalog-item__content & {
-    &:not(:last-child) {
-      margin-right: sage-spacing();
-    }
-  }
-
   .sage-property-group & + & {
     margin-left: sage-spacing(md);
   }


### PR DESCRIPTION
## Description

`margin-right` getting added to `sage-catalog-item__content` children when there is already a selector setup for `* + * margin-left`


## Screenshots
|  Before  |  After  |
|--------|--------|
|<img width="1587" alt="118331269-febc9800-b4cd-11eb-9afa-8ad750635a60" src="https://user-images.githubusercontent.com/24237393/118544449-08870b00-b71b-11eb-9602-32f0e11be971.png">|![after](https://user-images.githubusercontent.com/24237393/118702066-12bc0e80-b7da-11eb-9ec9-77cbdfba8ea0.png)|


## Testing in `sage-lib`

There are no cases of `sage-catalog-item__content` being used as a parent to a `sage-property` component in `sage-lib`

## Testing in `kajabi-products`
**Switch to this branch:`BUILD-1130_subscribers_tab_link` via PR: https://github.com/Kajabi/kajabi-products/pull/19055/**
1. Navigate to Podcasts 
2. Observe a podcast with subscribers
3. Verify that the space between the date and the subscribers icon is not double what it should be

## Impact
(**LOW**) Visual change in `sage-property` spacing does not cause issues with users
