### PR TITLE
Fix(button/link): Prevent duplicate launch link icon from appearing on focus/active state

### DIFF
--- a/docs/app/views/application/_home_hero.html.erb
+++ b/docs/app/views/application/_home_hero.html.erb
@@ -1,15 +1,13 @@
 <div class="docs-hero" style="background-image: url(<%= image_url "hero.jpg" %>);">
-  <%= sage_component SageContainer, { size: "md" } do %>
+  <%= sage_component SageContainer, { size: "md", css_classes: "sage-type" } do %>
     <header class="sage-header">
       <%= render "application/nav" %>
     </header>
-    <%= sage_component SageGridRow, {} do %> 
-      <%= sage_component SageGridCol, { breakpoint: "md", size: "4" } do %> 
+    <%= sage_component SageGridRow, {} do %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "4" } do %>
         <%= image_tag "sage_icon.png", style: "max-width:70px;height:auto", loading: "lazy" %>
-        <div class="sage-type">
           <h1 class="docs-hero__title">Building with Sage</h1>
           <p>Our system is our source of truth, providing everything you need to build the best experiences for all Kajabi entrepreneurs.</p>
-        </div>
         <%= sage_component SageButtonGroup, { gap: :sm, spacer: { top: :lg } } do %>
           <%= sage_component SageButton, {
             value: "Get Started",
@@ -35,7 +33,7 @@
           } %>
         <% end %>
       <% end %>
-      <%= sage_component SageGridCol, { breakpoint: "md", size: "8" } do %> 
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "8" } do %>
         <%= image_tag "sage_ui.png", class: "docs-hero__img", loading: "lazy", alt: "An example of a Sage component and its HTML markup" %>
       <% end %>
     <% end %>

--- a/docs/app/views/examples/components/link/_preview.html.erb
+++ b/docs/app/views/examples/components/link/_preview.html.erb
@@ -1,5 +1,5 @@
 <h3 class="t-sage-heading-6">Standard link</h3>
-<%= sage_component SagePanelStack, {} do %>
+<%= sage_component SagePanelStack, { css_classes: "sage-type" } do %>
   <%= sage_component SageLink, {
     url: "#",
     label: "Standard link",
@@ -30,7 +30,7 @@
 <% end %>
 
 <h3 class="t-sage-heading-6">External links</h3>
-<%= sage_component SagePanelStack, {} do %>
+<%= sage_component SagePanelStack, { css_classes: "sage-type" } do %>
   <%= sage_component SageLink, {
     url: "https://example.com",
     label: "External link",
@@ -62,7 +62,7 @@
 <% end %>
 
 <h3 class="t-sage-heading-6">Help/Info links</h3>
-<%= sage_component SagePanelStack, {} do %>
+<%= sage_component SagePanelStack, { css_classes: "sage-type" } do %>
   <%= sage_component SageLink, {
     url: "#",
     label: "Get help",

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -6,7 +6,7 @@
 
 
 .sage-link--launch,
-.sage-type a[target="_blank"]:not(.sage-link--no-launch) {
+.sage-type a[target="_blank"]:not(.sage-link--no-launch):not([class*="icon-right-launch"]) {
   &::after {
     margin-left: sage-spacing(2xs);
     margin-right: sage-spacing(2xs);


### PR DESCRIPTION
## Description
h/t to @ForrestHolt for uncovering this one:

Links with `target="_blank"` are incorrectly inheriting styles from `sage-link--launch` on `focus` and `active` states when in use with a `sage-type` container. The icon pseudo-element is being displayed in place of the link/button outline, making it difficult to read the link text.

Also addresses a couple docs-specific changes:
- Adds `sage-type` class to link previews, which had not been displaying as intended
- Moves `sage-type` class to docs hero container


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
| | Before  |  After  |
|---|-----|--------|
|Sage docs homepage hero|![sage-home-before](https://user-images.githubusercontent.com/816579/118576580-a7bcfa00-b73d-11eb-86f1-bf9db54089e9.png)|![sage-home-after](https://user-images.githubusercontent.com/816579/118576592-ad1a4480-b73d-11eb-9117-0178b78d826d.png)|
|Dashboard cycle slider|![dashboard-cycle-before](https://user-images.githubusercontent.com/816579/118575755-097c6480-b73c-11eb-8614-0610812aa29a.png)|![dashboard-cycle-after](https://user-images.githubusercontent.com/816579/118575768-10a37280-b73c-11eb-977c-dbb2e5d69e2b.gif)|
|Dashboard panel card|![dashboard-panel-bofore](https://user-images.githubusercontent.com/816579/118575903-506a5a00-b73c-11eb-8250-30d7ceba886b.png)|![dashboard-panel-after](https://user-images.githubusercontent.com/816579/118575913-56f8d180-b73c-11eb-986f-c9dde56aceb4.png)|
|Pages -> Pipelines|![pages-pipelines-nullstate-before](https://user-images.githubusercontent.com/816579/118575938-64ae5700-b73c-11eb-9ff4-ceb7354d0f69.png)|![pages-pipelines-nullstate-after](https://user-images.githubusercontent.com/816579/118575947-6a0ba180-b73c-11eb-8413-853f0333dbd7.png)|


## Testing in `sage-lib`
1. View the docs home page and focus on the "View Github Repo" link 
2. Verify that a icon pseudo-element does not display, and that the focus outline appears as expected


## Testing in `kajabi-products`
1. (LOW) Links: prevents external links with from displaying duplicate "launch" icon 
   - [ ] Admin dashboard cycle slider and panel links
   - [ ] Pages -> Pipelines: null/empty state "Learn more" link


## Related
Closes #484 
