### PR TITLE
Stat Box Updates

### DIFF
--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -1,6 +1,10 @@
 <%= sage_component SageStatBox, {
-  change: { type: "up", value: "30%" },
-  data: 65536,
+  change: { 
+    type: "positive", 
+    value: "30%", 
+    icon: "",
+  },
+  data: "1,342",
   link: {
     href: "#",
     value: "View More",

--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -2,7 +2,6 @@
   change: { 
     type: "positive", 
     value: "30%", 
-    icon: "",
   },
   data: "1,342",
   link: {

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -9,7 +9,7 @@
   <td><%= md('Sets the `type` and `value` properties for the label.') %></td>
   <td><%= md('```
   {
-    type: "up, down, neutral",
+    type: "positive, negative, neutral",
     value: String
   }
   ```') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -2,7 +2,6 @@ class SageStatBox < SageComponent
   set_attribute_schema({
     custom_label: [:optional, NilClass, String],
     change: [:optional, {
-      icon: String,
       type: Set.new(["positive", "negative", "neutral"]),
       value: String,
     }],

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -2,10 +2,11 @@ class SageStatBox < SageComponent
   set_attribute_schema({
     custom_label: [:optional, NilClass, String],
     change: [:optional, {
-      type: Set.new(["up", "down", "neutral"]),
+      icon: String,
+      type: Set.new(["positive", "negative", "neutral"]),
       value: String,
     }],
-    data: Integer,
+    data: String,
     link: [:optional, {
       href: String,
       value: String,

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -1,14 +1,13 @@
 <% 
 change_value = component.change.present? ? component.change[:value] : "No change"
 change_type = component.change.present? ? component.change[:type] : "neutral"
-change_icon = component.change.present? ? component.change[:icon] : ""
 label_configs = { color: "draft", value: change_value } 
 if change_type == "positive"
-  label_configs = { color: "published", value: change_value, icon: change_icon } 
+  label_configs = { color: "published", value: change_value, icon: "caret-up" } 
 elsif change_type == "negative"
-  label_configs = { color: "danger", value: change_value, icon: change_icon } 
+  label_configs = { color: "danger", value: change_value, icon: "caret-down" } 
 elsif change_type == "neutral"
-  label_configs = { color: "draft", value: change_value, icon: change_icon } 
+  label_configs = { color: "draft", value: change_value, } 
 end
 %>
 <article

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -20,7 +20,7 @@ end
       <%= component.popover.html_safe %>
     <% end %>
   </header>
-  <main class="sage-stat-box__body sage-grid-template-te">
+  <div class="sage-stat-box__body sage-grid-template-te">
     <p class="sage-stat-box__data">
       <%= component.data %>
       <% if component.timeframe.present? %>
@@ -32,7 +32,7 @@ end
     <% elsif component.change.present? %>
       <%= sage_component SageLabel, label_configs %>
     <% end %>
-  </main>
+  </div>
   <% if component.link.present? %>
     <footer class="sage-stat-box__footer">
       <a class="sage-stat-box__link" href="<%= component.link[:href] %>"><%= component.link[:value] %></a>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -1,13 +1,14 @@
 <% 
 change_value = component.change.present? ? component.change[:value] : "No change"
 change_type = component.change.present? ? component.change[:type] : "neutral"
+change_icon = component.change.present? ? component.change[:icon] : ""
 label_configs = { color: "draft", value: change_value } 
-if change_type == "up"
-  label_configs = { color: "published", value: change_value, icon: "caret-up" } 
-elsif change_type == "down"
-  label_configs = { color: "danger", value: change_value, icon: "caret-down" } 
+if change_type == "positive"
+  label_configs = { color: "published", value: change_value, icon: change_icon } 
+elsif change_type == "negative"
+  label_configs = { color: "danger", value: change_value, icon: change_icon } 
 elsif change_type == "neutral"
-  label_configs = { color: "draft", value: change_value } 
+  label_configs = { color: "draft", value: change_value, icon: change_icon } 
 end
 %>
 <article
@@ -20,11 +21,13 @@ end
       <%= component.popover.html_safe %>
     <% end %>
   </header>
-  <main class="sage-stat-box__body sage-grid-template-ete">
-    <p class="sage-stat-box__data"><%= component.data %></p>
-    <% if component.timeframe.present? %>
-      <span class="sage-stat-box__timeframe"><%= component.timeframe %></span>
-    <% end %>
+  <main class="sage-stat-box__body sage-grid-template-te">
+    <p class="sage-stat-box__data">
+      <%= component.data %>
+      <% if component.timeframe.present? %>
+        <span class="sage-stat-box__timeframe"><%= component.timeframe %></span>
+      <% end %>
+    </p>
     <% if component.custom_label.present? %>
       <%= component.custom_label.html_safe %>
     <% elsif component.change.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -6,7 +6,7 @@
 
 .sage-stat-box {
   // Styles here
-  @include sage-card();
+  @include sage-card($grid: false);
 }
 
 .sage-stat-box__body,
@@ -26,6 +26,7 @@
 .sage-stat-box__title {
   @extend %t-sage-body-small-med;
   margin-right: sage-spacing(xs);
+  color: sage-color(charcoal, 200);
 }
 
 .sage-stat-box__data {
@@ -34,10 +35,13 @@
 
 .sage-stat-box__timeframe {
   @extend %t-sage-body-xsmall;
+  margin-left: sage-spacing(xs);
+  color: sage-color(charcoal, 100);
 }
 
 .sage-stat-box__link {
   @extend %t-sage-body-med;
+  margin-top: sage-spacing(xs);
   &::after {
     @include sage-icon-base(arrow-right);
     margin-left: sage-spacing(xs);

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -194,8 +194,10 @@
 ///
 /// Adds the basic default card setup including grid, spacing, and border treatment
 ///
-@mixin sage-card() {
-  @include sage-grid-card();
+@mixin sage-card($grid: true) {
+  @if ($grid) {
+    @include sage-grid-card();
+  }
 
   padding: sage-spacing(card);
   border: sage-border();

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '../Icon';
 import { Label } from '../Label';
 import { LABEL_COLORS, TYPE } from './configs'; // component configurations as needed
 
@@ -14,16 +13,14 @@ export const StatBox = ({
   title,
 }) => {
   const renderLabelStatus = () => {
-    let icon = null;
+    const icon = change.icon || null;
     let color;
 
     switch (change.type) {
-      case StatBox.TYPE.UP:
-        icon = Icon.ICONS.CARET_UP;
+      case StatBox.TYPE.POSITIVE:
         color = StatBox.LABEL_COLORS.PUBLISHED;
         break;
-      case StatBox.TYPE.DOWN:
-        icon = Icon.ICONS.CARET_DOWN;
+      case StatBox.TYPE.NEGATIVE:
         color = StatBox.LABEL_COLORS.DANGER;
         break;
       default:
@@ -42,11 +39,13 @@ export const StatBox = ({
         <h2 className="sage-stat-box__title">{title}</h2>
         {popover}
       </header>
-      <main className="sage-stat-box__body sage-grid-template-ete">
-        <p className="sage-stat-box__data">{data}</p>
-        {timeframe && (
-          <span className="sage-stat-box__timeframe">{timeframe}</span>
-        )}
+      <main className="sage-stat-box__body sage-grid-template-te">
+        <p className="sage-stat-box__data">
+          {data}
+          {timeframe && (
+            <span className="sage-stat-box__timeframe">{timeframe}</span>
+          )}
+        </p>
         {customLabel || (change && (renderLabelStatus()))}
       </main>
       {link && (
@@ -63,22 +62,24 @@ StatBox.TYPE = TYPE;
 
 StatBox.defaultProps = {
   change: {
-    type: StatBox.TYPE.DOWN,
-    value: '38%',
+    icon: null,
+    type: StatBox.TYPE.DEFAULT,
+    value: null,
   },
   customLabel: null,
   link: {
     href: null,
-    value: 'View More',
+    value: null,
   },
   popover: null,
-  timeframe: 'Current',
+  timeframe: null,
 };
 
 StatBox.propTypes = {
   customLabel: PropTypes.node,
-  data: PropTypes.number.isRequired,
+  data: PropTypes.string.isRequired,
   change: PropTypes.shape({
+    icon: PropTypes.string.isRequired,
     type: PropTypes.oneOf(Object.values(StatBox.TYPE)).isRequired,
     value: PropTypes.string.isRequired,
   }),

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon } from '../Icon';
 import { Label } from '../Label';
 import { LABEL_COLORS, TYPE } from './configs'; // component configurations as needed
 
@@ -13,14 +14,16 @@ export const StatBox = ({
   title,
 }) => {
   const renderLabelStatus = () => {
-    const icon = change.icon || null;
+    let icon = null;
     let color;
 
     switch (change.type) {
       case StatBox.TYPE.POSITIVE:
+        icon = Icon.ICONS.CARET_UP;
         color = StatBox.LABEL_COLORS.PUBLISHED;
         break;
       case StatBox.TYPE.NEGATIVE:
+        icon = Icon.ICONS.CARET_DOWN;
         color = StatBox.LABEL_COLORS.DANGER;
         break;
       default:
@@ -62,7 +65,6 @@ StatBox.TYPE = TYPE;
 
 StatBox.defaultProps = {
   change: {
-    icon: null,
     type: StatBox.TYPE.DEFAULT,
     value: null,
   },
@@ -79,7 +81,6 @@ StatBox.propTypes = {
   customLabel: PropTypes.node,
   data: PropTypes.string.isRequired,
   change: PropTypes.shape({
-    icon: PropTypes.string.isRequired,
     type: PropTypes.oneOf(Object.values(StatBox.TYPE)).isRequired,
     value: PropTypes.string.isRequired,
   }),

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -42,7 +42,7 @@ export const StatBox = ({
         <h2 className="sage-stat-box__title">{title}</h2>
         {popover}
       </header>
-      <main className="sage-stat-box__body sage-grid-template-te">
+      <div className="sage-stat-box__body sage-grid-template-te">
         <p className="sage-stat-box__data">
           {data}
           {timeframe && (
@@ -50,7 +50,7 @@ export const StatBox = ({
           )}
         </p>
         {customLabel || (change && (renderLabelStatus()))}
-      </main>
+      </div>
       {link && (
         <footer className="sage-stat-box__footer">
           <a className="sage-stat-box__link" href={link.href}>{link.value}</a>

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -8,16 +8,11 @@ export default {
   argTypes: {
     // As needed, use this for elaboration of token properties
     // such as shown below for icons
-    ...selectArgs({
-      // icon: SageTokens.ICONS,
-      change: {
-        type: StatBox.TYPE
-      }
-    }),
+    ...selectArgs({}),
   },
   args: {
     // As needed, provide overall story defaults here
-    data: 65535,
+    data: '401',
     change: {
       type: StatBox.TYPE.DEFAULT,
       value: '54%',

--- a/packages/sage-react/lib/StatBox/configs.js
+++ b/packages/sage-react/lib/StatBox/configs.js
@@ -6,6 +6,6 @@ export const LABEL_COLORS = {
 
 export const TYPE = {
   DEFAULT: 'neutral',
-  DOWN: 'down',
-  UP: 'up',
+  NEGATIVE: 'negative',
+  POSITIVE: 'positive',
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes Stat Box styling to be more in line with Figma mockup. Data attribute has been updated to type "String."

[Stat Box in Figma](https://www.figma.com/file/9Km09NjlZHYWsMP7EGT8tI/%5BWIP%5D-Sage-3-%E2%80%94-Admin-Components?node-id=3435%3A5)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="460" alt="statbox" src="https://user-images.githubusercontent.com/14791307/118686509-ab965e00-b7c9-11eb-9323-cdc2461aae96.png">|<img width="428" alt="Screen Shot 2021-05-18 at 3 36 16 PM" src="https://user-images.githubusercontent.com/14791307/118720149-de9f1880-b7ee-11eb-8be9-7a6b699cfffb.png">

## Testing in `sage-lib`

### Rails
- View [Rails component](http://localhost:4000/pages/component/stat_box)
- Check that component UI exists and nothing is broken

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-statbox--default)
- Check that component UI exists and nothing is broken

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates styling and data attribute. No effect on existing work in Kajabi Products.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[MAN-1385](https://kajabi.atlassian.net/browse/MAN-1385)