### PR TITLE
PanelControls: rework sort conditional

### DIFF
--- a/docs/app/views/examples/components/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_preview.html.erb
@@ -72,6 +72,30 @@ search_filter_toolbar = %(
   </div>
 ).html_safe
 
+sort_items = [
+  {
+    value: "Name",
+    attributes: {
+      "href": "#",
+      "data-js-list-sort-by": "name"
+    },
+  },
+  {
+    value: "Email",
+    attributes: {
+      "href": "#",
+      "data-js-list-sort-by": "email"
+    },
+  },
+  {
+    value: "Join date",
+    attributes: {
+      "href": "#",
+      "data-js-list-sort-by": "join_date"
+    },
+  }
+]
+
 actions_items = [
   {
     value: "Delete",
@@ -114,7 +138,26 @@ actions_items = [
     show_pagination: false,
     show_sort: true,
     bulk_action_items: actions_items,
-  } %>
+  } do %>
+    <% content_for :sage_panel_controls_sort do %>
+      <%= sage_component SageDropdown, {
+        trigger_type: "select",
+        align: "right",
+        customized: true,
+        contained: true,
+        css_classes: "sage-dropdown--sort sage-panel-controls__sorts",
+        items: sort_items
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: "",
+          css_classes: "sage-dropdown__trigger-selected-value",
+          icon: { style: "right", name: "caret-down" }
+        } %>
+        <label class="sage-dropdown__trigger-label">Sort</label>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <h3 class="t-sage-heading-6">Pagination</h3>
@@ -156,6 +199,24 @@ actions_items = [
         hide_pages: true,
       } %>
     <% end %>
+    <% content_for :sage_panel_controls_sort do %>
+      <%= sage_component SageDropdown, {
+        trigger_type: "select",
+        align: "right",
+        customized: true,
+        contained: true,
+        css_classes: "sage-dropdown--sort sage-panel-controls__sorts",
+        items: sort_items
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: "",
+          css_classes: "sage-dropdown__trigger-selected-value",
+          icon: { style: "right", name: "caret-down" }
+        } %>
+        <label class="sage-dropdown__trigger-label">Sort</label>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -193,6 +254,24 @@ actions_items = [
         window: 2,
         hide_pages: true,
       } %>
+    <% end %>
+    <% content_for :sage_panel_controls_sort do %>
+      <%= sage_component SageDropdown, {
+        trigger_type: "select",
+        align: "right",
+        customized: true,
+        contained: true,
+        css_classes: "sage-dropdown--sort sage-panel-controls__sorts",
+        items: sort_items
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: "",
+          css_classes: "sage-dropdown__trigger-selected-value",
+          icon: { style: "right", name: "caret-down" }
+        } %>
+        <label class="sage-dropdown__trigger-label">Sort</label>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/docs/app/views/examples/components/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_preview.html.erb
@@ -72,30 +72,6 @@ search_filter_toolbar = %(
   </div>
 ).html_safe
 
-sort_items = [
-  {
-    value: "Name",
-    attributes: {
-      "href": "#",
-      "data-js-list-sort-by": "name"
-    },
-  },
-  {
-    value: "Email",
-    attributes: {
-      "href": "#",
-      "data-js-list-sort-by": "email"
-    },
-  },
-  {
-    value: "Join date",
-    attributes: {
-      "href": "#",
-      "data-js-list-sort-by": "join_date"
-    },
-  }
-]
-
 actions_items = [
   {
     value: "Delete",
@@ -138,7 +114,6 @@ actions_items = [
     show_pagination: false,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
   } %>
 <% end %>
 
@@ -150,7 +125,6 @@ actions_items = [
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
   } do %>
     <% content_for :sage_panel_controls_pagination do %>
       <%= sage_component SagePagination, {
@@ -173,7 +147,6 @@ actions_items = [
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
   } do %>
     <% content_for :sage_panel_controls_pagination do %>
       <%= sage_component SagePagination, {
@@ -204,7 +177,6 @@ actions_items = [
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
     target: "demo-table",
   } do %>
     <% content_for :sage_panel_controls_tabs do %>

--- a/docs/app/views/examples/components/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_props.html.erb
@@ -60,19 +60,6 @@ Array<{
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md('`sort_items`') %></td>
-  <td><%= md('The list of items to populate in the sort dropdown.') %></td>
-  <td>
-    <%= md('```
-Array<{
-  attributes: Hash,
-  value: String,
-}>
-    ') %>
-  </td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`show_pagination`') %></td>
   <td><%= md('TBD') %>
   </td>
@@ -84,8 +71,6 @@ Array<{
   <td>
     <%= md('
       Whether or not to render the sorting dropdown.
-      If set to `true`, the `sort_items`
-      should also be provided to populate the dropdown.
     ') %>
   </td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/components/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_props.html.erb
@@ -60,6 +60,19 @@ Array<{
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`sort_items`') %></td>
+  <td><%= md('The list of items to populate in the sort dropdown.') %></td>
+  <td>
+    <%= md('```
+Array<{
+  attributes: Hash,
+  value: String,
+}>
+    ') %>
+  </td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`show_pagination`') %></td>
   <td><%= md('TBD') %>
   </td>
@@ -71,6 +84,8 @@ Array<{
   <td>
     <%= md('
       Whether or not to render the sorting dropdown.
+      If set to `true`, the `sort_items`
+      should also be provided to populate the dropdown.
     ') %>
   </td>
   <td><%= md('Boolean') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -11,16 +11,12 @@ class SagePanelControls < SageComponent
     show_expand_collapse: [:optional, TrueClass],
     show_pagination: [:optional, TrueClass],
     show_sort: [:optional, TrueClass],
-    sort_items: [:optional, [[{
-      attributes: [:optional, Hash],
-      value: String,
-    }]]],
     start_expanded: [:optional, TrueClass],
     target: [:optional, String],
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown )
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort)
   end
 end
 
@@ -35,11 +31,4 @@ end
     :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},
    {:value=>"Set marketing",
     :attributes=>
-     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
- :sort_items=>
-  [{:value=>"Name",
-    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
-   {:value=>"Email",
-    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
-   {:value=>"Join date",
-    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
+     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}]}

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -43,3 +43,4 @@ end
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
    {:value=>"Join date",
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
+    

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -20,7 +20,7 @@ class SagePanelControls < SageComponent
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort)
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort )
   end
 end
 
@@ -36,11 +36,10 @@ end
    {:value=>"Set marketing",
     :attributes=>
      {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
-     :sort_items=>
-      [{:value=>"Name",
-        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
-       {:value=>"Email",
-        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
-       {:value=>"Join date",
-        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
-        
+ :sort_items=>
+  [{:value=>"Name",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
+   {:value=>"Email",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
+   {:value=>"Join date",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -11,6 +11,10 @@ class SagePanelControls < SageComponent
     show_expand_collapse: [:optional, TrueClass],
     show_pagination: [:optional, TrueClass],
     show_sort: [:optional, TrueClass],
+    sort_items: [:optional, [[{
+      attributes: [:optional, Hash],
+      value: String,
+    }]]],
     start_expanded: [:optional, TrueClass],
     target: [:optional, String],
   })
@@ -31,4 +35,12 @@ end
     :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},
    {:value=>"Set marketing",
     :attributes=>
-     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}]}
+     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
+     :sort_items=>
+      [{:value=>"Name",
+        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
+       {:value=>"Email",
+        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
+       {:value=>"Join date",
+        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
+        

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -20,7 +20,7 @@ class SagePanelControls < SageComponent
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort )
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort)
   end
 end
 
@@ -43,4 +43,3 @@ end
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
    {:value=>"Join date",
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
-    

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -2,6 +2,7 @@
 show_secondary_toolbar = component.show_pagination || component.show_sort || component.show_expand_collapse
 show_default_controls = component.show_bulk_actions || show_secondary_toolbar
 bulk_action_items = component.bulk_action_items.present? ? component.bulk_action_items : []
+sort_items = component.sort_items.present? ? component.sort_items : []
 item_count_text = component.item_count_label.present? ? component.item_count_label : ""
 %>
 <div class="
@@ -73,9 +74,7 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
           <% end %>
           
           <% if content_for? :sage_panel_controls_sort %>
-            <div class="sage-panel-controls__sort">
-              <%= content_for :sage_panel_controls_sort %>
-            </div>
+            <%= content_for :sage_panel_controls_sort %>
           <% end %>
 
           <% if component.show_expand_collapse %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -2,7 +2,6 @@
 show_secondary_toolbar = component.show_pagination || component.show_sort || component.show_expand_collapse
 show_default_controls = component.show_bulk_actions || show_secondary_toolbar
 bulk_action_items = component.bulk_action_items.present? ? component.bulk_action_items : []
-sort_items = component.sort_items.present? ? component.sort_items : []
 item_count_text = component.item_count_label.present? ? component.item_count_label : ""
 %>
 <div class="
@@ -72,23 +71,11 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
               <%= content_for :sage_panel_controls_pagination %>
             </div>
           <% end %>
-          <% if component.show_sort %>
-            <%= sage_component SageDropdown, {
-              trigger_type: "select",
-              align: "right",
-              css_classes: "sage-panel-controls__sorts",
-              customized: true,
-              custom_modifier: "sort",
-              items: sort_items
-            } do %>
-              <%= sage_component SageButton, {
-                style: "secondary",
-                value: "",
-                css_classes: "sage-dropdown__trigger-selected-value",
-                icon: { style: "right", name: "caret-down" }
-              } %>
-              <label class="sage-dropdown__trigger-label">Sort</label>
-            <% end %>
+          
+          <% if content_for? :sage_panel_controls_sort %>
+            <div class="sage-panel-controls__sort">
+              <%= content_for :sage_panel_controls_sort %>
+            </div>
           <% end %>
 
           <% if component.show_expand_collapse %>

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -346,6 +346,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   &.sage-dropdown__trigger--options {
     min-width: auto;
   }
+
+  > .sage-btn {
+    line-height: 28px;
+  }
 }
 
 .sage-dropdown__trigger--select,

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -352,6 +352,12 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 }
 
+.sage-dropdown__trigger--select {
+  .sage-btn {
+    font-weight: sage-font-weight(regular);
+  }
+}
+
 .sage-dropdown__trigger--select,
 .sage-dropdown__trigger--select-labeled {
   :not(.sage-dropdown--customized) > & {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -348,7 +348,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   > .sage-btn {
-    line-height: 28px;
+    line-height: sage-line-height(md),
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -348,7 +348,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   > .sage-btn {
-    line-height: sage-line-height(md),
+    line-height: sage-line-height(md);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_pagination.scss
@@ -23,7 +23,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   flex-grow: 1;
 
   .sage-panel-controls__default-controls & {
-    margin-right: sage-spacing(sm);
+    margin-right: sage-spacing(md);
   }
 }
 


### PR DESCRIPTION
## Ticket
This work is related to [BUILD-1114](https://kajabi.atlassian.net/browse/BUILD-1114)

## Related 
[PR for BUILD updates to panel controls](https://github.com/Kajabi/kajabi-products/pull/19067)

## Description
In BUILD, the sort dropdown, as part of panel controls, needs to refresh the page. Due to this necessary functionality, the Sage Panel Control component needs to allow for custom dropdown's. Prior to this PR, the Panel Controls component forced the use of a non-page-refresh version of the of the dropdown. 

## Screenshots
**Before**
![before](https://user-images.githubusercontent.com/24237393/119152215-bb09e700-ba15-11eb-97ca-64447b08f8cc.png)
**After**
![Screen Shot 2021-05-20 at 2 07 22 PM](https://user-images.githubusercontent.com/24237393/119152138-a594bd00-ba15-11eb-8fad-3386709e233f.png)


## Testing in `sage-lib`
1. Navigate to **[panel controls](http://localhost:4100/?path=/docs/sage-panelcontrols--default)**
2. Confirm that the Sort dropdowns are present and functional

## Testing in `kajabi-products`
1. Navigate to Products / Podcasts
2. Select Episodes (must have episodes)
3. Confirm that the Podcast Sort functionality is working

(BREAKING) Work affects any use of the SagePanelControls component used within `kajabi-products`. Any `show_sort` will need to be converted to a dropdown within a `content_for` in order to be functional after update.

- [ ] Landing pages is using a sort that should be updated to work with the content_for
- [ ] Podcasts / Episode list should be verified as noted in the Testing in `kajabi-products` section

