### PR TITLE
Next version bump (~v3.27.0)

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -54,6 +54,11 @@
         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       </p>
 
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
       <% content_for :sage_footer do %>
         <% content_for :sage_footer_aside do %>
           <%= sage_component SageButton, {

--- a/docs/app/views/examples/components/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/components/page_heading/_preview.html.erb
@@ -76,6 +76,10 @@
   spacer: { bottom: :xl },
   secondary_text: "1 Email in Sequence",
 } do %>
+
+    <% content_for :sage_page_heading_image do %>
+      <img src="/assets/card-placeholder-sm.png" alt=""/>
+    <% end %>
     <% content_for :sage_page_heading_toolbar do %>
       <%= sage_component SageButton, {
         style: "secondary",

--- a/docs/app/views/examples/components/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/components/page_heading/_preview.html.erb
@@ -172,6 +172,9 @@
         value: "Settings",
       }%>
     <% end %>
+    <% content_for :sage_page_heading_image do %>
+      <img src="/assets/card-placeholder-sm.png" alt=""/>
+    <% end %>
     <% content_for :sage_page_heading_intro do %>
       <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nemo dolorum esse modi ut ipsa corporis.</p>
     <% end %>

--- a/docs/app/views/examples/components/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_preview.html.erb
@@ -72,6 +72,30 @@ search_filter_toolbar = %(
   </div>
 ).html_safe
 
+sort_items = [
+  {
+    value: "Name",
+    attributes: {
+      "href": "#",
+      "data-js-list-sort-by": "name"
+    },
+  },
+  {
+    value: "Email",
+    attributes: {
+      "href": "#",
+      "data-js-list-sort-by": "email"
+    },
+  },
+  {
+    value: "Join date",
+    attributes: {
+      "href": "#",
+      "data-js-list-sort-by": "join_date"
+    },
+  }
+]
+
 actions_items = [
   {
     value: "Delete",
@@ -114,7 +138,26 @@ actions_items = [
     show_pagination: false,
     show_sort: true,
     bulk_action_items: actions_items,
-  } %>
+  } do %>
+    <% content_for :sage_panel_controls_sort do %>
+      <%= sage_component SageDropdown, {
+        trigger_type: "select",
+        align: "right",
+        customized: true,
+        contained: true,
+        css_classes: "sage-dropdown--sort sage-panel-controls__sorts",
+        items: sort_items
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: "",
+          css_classes: "sage-dropdown__trigger-selected-value",
+          icon: { style: "right", name: "caret-down" }
+        } %>
+        <label class="sage-dropdown__trigger-label">Sort</label>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <h3 class="t-sage-heading-6">Pagination</h3>
@@ -156,6 +199,24 @@ actions_items = [
         hide_pages: true,
       } %>
     <% end %>
+    <% content_for :sage_panel_controls_sort do %>
+      <%= sage_component SageDropdown, {
+        trigger_type: "select",
+        align: "right",
+        customized: true,
+        contained: true,
+        css_classes: "sage-dropdown--sort sage-panel-controls__sorts",
+        items: sort_items
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: "",
+          css_classes: "sage-dropdown__trigger-selected-value",
+          icon: { style: "right", name: "caret-down" }
+        } %>
+        <label class="sage-dropdown__trigger-label">Sort</label>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -193,6 +254,24 @@ actions_items = [
         window: 2,
         hide_pages: true,
       } %>
+    <% end %>
+    <% content_for :sage_panel_controls_sort do %>
+      <%= sage_component SageDropdown, {
+        trigger_type: "select",
+        align: "right",
+        customized: true,
+        contained: true,
+        css_classes: "sage-dropdown--sort sage-panel-controls__sorts",
+        items: sort_items
+      } do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: "",
+          css_classes: "sage-dropdown__trigger-selected-value",
+          icon: { style: "right", name: "caret-down" }
+        } %>
+        <label class="sage-dropdown__trigger-label">Sort</label>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/docs/app/views/examples/components/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_preview.html.erb
@@ -72,30 +72,6 @@ search_filter_toolbar = %(
   </div>
 ).html_safe
 
-sort_items = [
-  {
-    value: "Name",
-    attributes: {
-      "href": "#",
-      "data-js-list-sort-by": "name"
-    },
-  },
-  {
-    value: "Email",
-    attributes: {
-      "href": "#",
-      "data-js-list-sort-by": "email"
-    },
-  },
-  {
-    value: "Join date",
-    attributes: {
-      "href": "#",
-      "data-js-list-sort-by": "join_date"
-    },
-  }
-]
-
 actions_items = [
   {
     value: "Delete",
@@ -138,7 +114,6 @@ actions_items = [
     show_pagination: false,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
   } %>
 <% end %>
 
@@ -150,7 +125,6 @@ actions_items = [
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
   } do %>
     <% content_for :sage_panel_controls_pagination do %>
       <%= sage_component SagePagination, {
@@ -173,7 +147,6 @@ actions_items = [
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
   } do %>
     <% content_for :sage_panel_controls_pagination do %>
       <%= sage_component SagePagination, {
@@ -204,7 +177,6 @@ actions_items = [
     show_pagination: true,
     show_sort: true,
     bulk_action_items: actions_items,
-    sort_items: sort_items,
     target: "demo-table",
   } do %>
     <% content_for :sage_panel_controls_tabs do %>

--- a/docs/app/views/examples/components/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_props.html.erb
@@ -60,19 +60,6 @@ Array<{
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md('`sort_items`') %></td>
-  <td><%= md('The list of items to populate in the sort dropdown.') %></td>
-  <td>
-    <%= md('```
-Array<{
-  attributes: Hash,
-  value: String,
-}>
-    ') %>
-  </td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`show_pagination`') %></td>
   <td><%= md('TBD') %>
   </td>
@@ -84,8 +71,6 @@ Array<{
   <td>
     <%= md('
       Whether or not to render the sorting dropdown.
-      If set to `true`, the `sort_items`
-      should also be provided to populate the dropdown.
     ') %>
   </td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/components/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_props.html.erb
@@ -60,6 +60,19 @@ Array<{
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`sort_items`') %></td>
+  <td><%= md('The list of items to populate in the sort dropdown.') %></td>
+  <td>
+    <%= md('```
+Array<{
+  attributes: Hash,
+  value: String,
+}>
+    ') %>
+  </td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`show_pagination`') %></td>
   <td><%= md('TBD') %>
   </td>
@@ -71,6 +84,8 @@ Array<{
   <td>
     <%= md('
       Whether or not to render the sorting dropdown.
+      If set to `true`, the `sort_items`
+      should also be provided to populate the dropdown.
     ') %>
   </td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -1,13 +1,23 @@
+
+<h3 class="t-sage-heading-6">Default with Data</h3>
 <%= sage_component SageStatBox, {
   change: { 
     type: "positive", 
     value: "30%", 
   },
   data: "1,342",
+  has_data: true,
   link: {
     href: "#",
     value: "View More",
   },
   timeframe: "in last 30 days",
+  title: "Completed",
+} %>
+
+<h3 class="t-sage-heading-6">Null View</h3>
+<%= sage_component SageStatBox, {
+  data: "No insights to show",
+  has_data: false,
   title: "Completed",
 } %>

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -1,10 +1,4 @@
 <tr>
-  <td><%= md('`custom_label`') %></td>
-  <td><%= md('Optional custom label or content.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`change`') %></td>
   <td><%= md('Sets the `type` and `value` properties for the label.') %></td>
   <td><%= md('```
@@ -16,9 +10,21 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`custom_label`') %></td>
+  <td><%= md('Optional custom label or content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`data`') %></td>
   <td><%= md('Numeric data displayed.') %></td>
-  <td><%= md('Integer') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`has_data`') %></td>
+  <td><%= md('Boolean that determines styling for `data`.') %></td>
+  <td><%= md('Bool') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -1,34 +1,70 @@
 <%
-sample_data = [
+people_data = [
   {
-    value_1: "Venenatis Condimentum",
-    value_2: "Ridiculus",
-    value_3: "Sem Elit",
-    value_4: "Nibh Aenean",
-    value_5: "Sem Elit"
+    initials: 'AF',
+    name: 'Albert Flores',
+    email: 'albertflores@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["green", "house"],
+    status: 'published'
   },
   {
-    value_1: "Nullam Porta",
-    value_2: "Adipiscing Ligula",
-    value_3: "Euismod Etiam",
-    value_4: "Malesuada",
-    value_5: "Etiam"
+    initials: 'EP',
+    name: 'Eleanor Pena',
+    email: 'e_pena@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["red"],
+    status: 'draft'
   },
   {
-    value_1: "Ridiculus",
-    value_2: "Cras Malesuada",
-    value_3: "Commodo",
-    value_4: "Cursus Pharetra",
-    value_5: "Fringilla"
+    initials: 'LJ',
+    name: 'Lily Jones',
+    email: 'lilyjones@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["house"],
+    status: 'warning'
   },
   {
-    value_1: "Pharetra Mattis",
-    value_2: "Magna",
-    value_3: "Elit Inceptos",
-    value_4: "Cursus Pharetra",
-    value_5: "Dolor Fringilla"
+    initials: 'KM',
+    name: 'Kathryn Murphy',
+    email: 'katmurphy@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["red", "house"],
+    status: 'locked'
+  },
+  {
+    initials: 'DR',
+    name: 'Darelene Robertson',
+    email: 'd_robertson@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: [],
+    status: 'danger'
+  },
+  {
+    initials: 'RE',
+    name: 'Ralph Edwards',
+    email: 'ralphedwards@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: [],
+    status: 'draft'
+  },
+  {
+    initials: 'JW',
+    name: 'Jenny Wilson',
+    email: 'jennywilson@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: [],
+    status: 'published'
   }
 ]
+
 sample_table = {
   headers: [
     "Cras Porta",
@@ -37,7 +73,36 @@ sample_table = {
     "Mollis",
     "Ridiculus"
   ],
-  rows: sample_data
+  rows: [
+    {
+      value_1: "Venenatis Condimentum",
+      value_2: "Ridiculus",
+      value_3: "Sem Elit",
+      value_4: "Nibh Aenean",
+      value_5: "Sem Elit"
+    },
+    {
+      value_1: "Nullam Porta",
+      value_2: "Adipiscing Ligula",
+      value_3: "Euismod Etiam",
+      value_4: "Malesuada",
+      value_5: "Etiam"
+    },
+    {
+      value_1: "Ridiculus",
+      value_2: "Cras Malesuada",
+      value_3: "Commodo",
+      value_4: "Cursus Pharetra",
+      value_5: "Fringilla"
+    },
+    {
+      value_1: "Pharetra Mattis",
+      value_2: "Magna",
+      value_3: "Elit Inceptos",
+      value_4: "Cursus Pharetra",
+      value_5: "Dolor Fringilla"
+    }
+  ]
 }
 %>
 
@@ -173,22 +238,59 @@ and not completely aligned with SageTable yet.
 It is safe to use, but should be tracked against future updates.
 ") %>
 
-<%= sage_table_for sample_data, striped: true, sortable: true, responsive: true do |t| %>
-  <% t.column :value_1, label: "Cras Porta", data_type: "string" do |c| %>
-    <%= sage_component SageButton, {
-      subtle: true,
-      style: "primary",
-      value: c[:value_1],
-      attributes: {
-        href: "#test",
-      },
+<%= sage_table_for people_data, striped: true, sortable: true, responsive: true, caption: "<p>Testing <b>stuff</b></p>".html_safe do |t| %>
+  <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
+    <%= sage_component SageCheckbox, {
+      label_text: 'Select row',
+      standalone: true,
+      id: "table-row-#{c[:initials]}",
     } %>
   <% end %>
-  <% t.column :value_2, label: "Dapibus Ridiculus" do |c| %>
-    <strong><%= c[:value_2] %></strong>
-    <%= c[:value_3] %>
+
+  <% t.column :initials, label: "", data_type: "avatar" do |c| %>
+    <%= sage_component SageAvatar, {
+      initials: c[:initials],
+      color: SageTokens::COLORS[rand(7)],
+    } %>
   <% end %>
-  <% t.column :actions, label: "Actions", data_type: "string" do |c| %>
+
+  <% t.column :name, label: "Name", strong: true, truncate: true do |c| %>
+    <span data-js-tooltip="<%= c[:name] %>">
+      <%= c[:name] %>
+    </span>
+  <% end %>
+
+  <% t.column :email, label: "Email", truncate: true do |c| %>
+    <span data-js-tooltip="<%= c[:email] %>">
+      <%= c[:email] %>
+    </span>
+  <% end %>
+
+  <% t.column :price, label: "Price", style: "width: 140px", hide: { md: true } do |c| %>
+    <%= c[:price] %>
+  <% end %>
+
+  <% t.column :amount, label: "Amount", style: "width: 100px", hide: { md: true } do |c| %>
+    <%= c[:amount] %>
+  <% end %>
+
+  <% t.column :labels, label: "Labels", style: "width: 150px",  hide: { sm: true } do |c| %>
+    <% c[:labels].each do |label| %>
+      <%= sage_component SageLabel, { 
+        value: label,
+        color: "info",
+      } %>
+    <% end %>
+  <% end %>
+
+  <% t.column :status, label: "Status",style: "width: 100px",  hide: { sm: true } do |c| %>
+    <%= sage_component SageLabel, { 
+      value: c[:status].titlecase,
+      color: c[:status],
+      } %>
+  <% end %>
+
+  <% t.column :actions, label: "Actions",style: "width: 100px",  data_type: "string" do |c| %>
     <%= sage_component SageButtonGroup, {} do %>
       <%= sage_component SageButton, {
         subtle: true,
@@ -196,7 +298,8 @@ It is safe to use, but should be tracked against future updates.
         icon: { name: 'pen', style: 'only' },
         style: 'primary',
         attributes: {
-          href: "?edit=#edit"
+          href: "?edit=#edit",
+          "data-js-tooltip": "Edit",
         }
       } %>
       <%= sage_component SageButton, {
@@ -205,7 +308,8 @@ It is safe to use, but should be tracked against future updates.
         icon: { name: 'trash', style: 'only' },
         style: 'danger',
         attributes: {
-          href: "?remove=#delete"
+          href: "?remove=#delete",
+          "data-js-tooltip": "Delete",
         }
       } %>
     <% end %>

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -274,7 +274,7 @@ It is safe to use, but should be tracked against future updates.
     <%= c[:amount] %>
   <% end %>
 
-  <% t.column :labels, label: "Labels", style: "width: 150px",  hide: { sm: true } do |c| %>
+  <% t.column :labels, label: "Labels", style: "width: 150px", hide: { sm: true } do |c| %>
     <% c[:labels].each do |label| %>
       <%= sage_component SageLabel, { 
         value: label,
@@ -283,14 +283,14 @@ It is safe to use, but should be tracked against future updates.
     <% end %>
   <% end %>
 
-  <% t.column :status, label: "Status",style: "width: 100px",  hide: { sm: true } do |c| %>
+  <% t.column :status, label: "Status", style: "width: 100px", hide: { sm: true } do |c| %>
     <%= sage_component SageLabel, { 
       value: c[:status].titlecase,
       color: c[:status],
       } %>
   <% end %>
 
-  <% t.column :actions, label: "Actions",style: "width: 100px",  data_type: "string" do |c| %>
+  <% t.column :actions, label: "Actions", style: "width: 100px" do |c| %>
     <%= sage_component SageButtonGroup, {} do %>
       <%= sage_component SageButton, {
         subtle: true,

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -173,8 +173,8 @@ and not completely aligned with SageTable yet.
 It is safe to use, but should be tracked against future updates.
 ") %>
 
-<%= sage_table_for sample_data, striped: true, sortable: true, responsive: true, reset_below: true do |t| %>
-  <% t.column :name, label: "Cras Porta", data_type: "string" do |c| %>
+<%= sage_table_for sample_data, striped: true, sortable: true, responsive: true do |t| %>
+  <% t.column :value_1, label: "Cras Porta", data_type: "string" do |c| %>
     <%= sage_component SageButton, {
       subtle: true,
       style: "primary",
@@ -184,7 +184,7 @@ It is safe to use, but should be tracked against future updates.
       },
     } %>
   <% end %>
-  <% t.column :phone, label: "Dapibus Ridiculus" do |c| %>
+  <% t.column :value_2, label: "Dapibus Ridiculus" do |c| %>
     <strong><%= c[:value_2] %></strong>
     <%= c[:value_3] %>
   <% end %>

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -1,4 +1,34 @@
 <%
+sample_data = [
+  {
+    value_1: "Venenatis Condimentum",
+    value_2: "Ridiculus",
+    value_3: "Sem Elit",
+    value_4: "Nibh Aenean",
+    value_5: "Sem Elit"
+  },
+  {
+    value_1: "Nullam Porta",
+    value_2: "Adipiscing Ligula",
+    value_3: "Euismod Etiam",
+    value_4: "Malesuada",
+    value_5: "Etiam"
+  },
+  {
+    value_1: "Ridiculus",
+    value_2: "Cras Malesuada",
+    value_3: "Commodo",
+    value_4: "Cursus Pharetra",
+    value_5: "Fringilla"
+  },
+  {
+    value_1: "Pharetra Mattis",
+    value_2: "Magna",
+    value_3: "Elit Inceptos",
+    value_4: "Cursus Pharetra",
+    value_5: "Dolor Fringilla"
+  }
+]
 sample_table = {
   headers: [
     "Cras Porta",
@@ -7,36 +37,7 @@ sample_table = {
     "Mollis",
     "Ridiculus"
   ],
-  rows: [
-    {
-      value_1: "Venenatis Condimentum",
-      value_2: "Ridiculus",
-      value_3: "Sem Elit",
-      value_4: "Nibh Aenean",
-      value_5: "Sem Elit"
-    },
-    {
-      value_1: "Nullam Porta",
-      value_2: "Adipiscing Ligula",
-      value_3: "Euismod Etiam",
-      value_4: "Malesuada",
-      value_5: "Etiam"
-    },
-    {
-      value_1: "Ridiculus",
-      value_2: "Cras Malesuada",
-      value_3: "Commodo",
-      value_4: "Cursus Pharetra",
-      value_5: "Fringilla"
-    },
-    {
-      value_1: "Pharetra Mattis",
-      value_2: "Magna",
-      value_3: "Elit Inceptos",
-      value_4: "Cursus Pharetra",
-      value_5: "Dolor Fringilla"
-    }
-  ]
+  rows: sample_data
 }
 %>
 
@@ -167,3 +168,55 @@ sample_table = {
     ]
   ]
 } %>
+
+<h3>Using `sage_table_for`</h3>
+<%= md("
+As an alterative to directly calling the SageTable component,
+a helper variation is available that allows for formatting table columns
+in a more compositional fashion. This involves calling `sage_table_for` with a collection,
+and then using `t.column ... do |c|` blocks to provide templates for each column of data.
+See the \"Properties\" tab for documentation of the available parameters.
+
+**NOTE:** This is an MVP implementation based on a helper written earlier for `kajabi-products`
+and not completely aligned with SageTable yet.
+It is safe to use, but should be tracked against future updates.
+") %>
+
+<%= sage_table_for sample_data, striped: true, sortable: true, responsive: true, reset_below: true do |t| %>
+  <% t.column :name, label: "Cras Porta", data_type: "string" do |c| %>
+    <%= sage_component SageButton, {
+      subtle: true,
+      style: "primary",
+      value: c[:value_1],
+      attributes: {
+        href: "#test",
+      },
+    } %>
+  <% end %>
+  <% t.column :phone, label: "Dapibus Ridiculus" do |c| %>
+    <strong><%= c[:value_2] %></strong>
+    <%= c[:value_3] %>
+  <% end %>
+  <% t.column :actions, label: "Actions", data_type: "string" do |c| %>
+    <%= sage_component SageButtonGroup, {} do %>
+      <%= sage_component SageButton, {
+        subtle: true,
+        value: 'Edit',
+        icon: { name: 'pen', style: 'only' },
+        style: 'primary',
+        attributes: {
+          href: "?edit=#edit"
+        }
+      } %>
+      <%= sage_component SageButton, {
+        subtle: true,
+        value: 'Delete',
+        icon: { name: 'trash', style: 'only' },
+        style: 'danger',
+        attributes: {
+          href: "?remove=#delete"
+        }
+      } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -56,15 +56,6 @@ sample_table = {
   striped: true
 } %>
 
-<h3 class="t-sage-heading-6">Sortable table</h3>
-<%= sage_component SageTable, {
-  headers: sample_table[:headers],
-  rows: sample_table[:rows],
-  caption: "NOTE: this example is for mockup purposes only and does not implement sorting cells",
-  sortable: true,
-  striped: true
-} %>
-
 <h3 class="t-sage-heading-6">Table with highlighted rows and block cells</h3>
 <%= sage_component SageTable, {
   caption: %(

--- a/docs/app/views/examples/components/table/_props.html.erb
+++ b/docs/app/views/examples/components/table/_props.html.erb
@@ -64,3 +64,58 @@
   <td><%= md('String:') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="4">
+    <%= md('**Alternate:** `sage_table_for`') %>
+  </td>
+</tr>
+<tr>
+  <td><%= md('`collection`') %></td>
+  <td><%= md('A collection from which the table data will be formatted.') %></td>
+  <td><%= md('Array of Objects') %></td>
+  <td><%= md('Required') %></td>
+</tr>
+<tr>
+  <td><%= md('`options`') %></td>
+  <td><%= md('
+  A set of options that match the following options from SageTable above:
+
+  - `reset_above`
+  - `reset_below`
+  - `responsive`
+  - `sortable`
+  - `striped`  
+') %></td>
+  <td><%= md('See properties above') %></td>
+  <td><%= md('Varies') %></td>
+</tr>
+<tr>
+  <td colspan="4">
+    <%= md('**Alternate column formatter:** `t.column`') %>
+  </td>
+</tr>
+<tr>
+  <td><%= md('`attribute`') %></td>
+  <td><%= md('
+  An alias/identifier for the column/attribute. While this does not have to align to a property from the collection itself,
+  if `sortable` is on, those that do align with collection property will result in a sortable link being rendered.
+') %></td>
+  <td><%= md('Symbol') %></td>
+  <td><%= md('Required') %></td>
+</tr>
+<tr>
+  <td><%= md('`options`') %></td>
+  <td><%= md('
+  A set of options for the columns including:
+
+  - `label <string>` -- Content for the header of the column.
+  - `style <hash>` -- style attributes to render on cells.
+  - `class_name <string>` -- CSS class name to render on body cells (not on header cell).
+  - `data_type <"checkbox" | "avatar">` -- A data type from among the existing presets that will result in a sage cell format class applied to apply some default styling for that data type.
+  - `truncate <boolean>` -- Whether or not to truncate the cell if its content does not fit (rather than wrap).
+  - `align <"right" | nil>` -- Alignment direction for cells (body and header)
+  - `header_class <string>` -- CSS class name to render on header cells.
+') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/table/_props.html.erb
+++ b/docs/app/views/examples/components/table/_props.html.erb
@@ -1,10 +1,4 @@
 <tr>
-  <td><%= md('Block cells') %></td>
-  <td><%= md('`.sage-table-cell__block` creates vertical block layouts within table cells. These layouts can include `.sage-table-cell__heading` and `.sage-table-cell__body` content areas.') %></td>
-  <td><%= md('String:') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`caption`') %></td>
   <td><%= md('Sets the caption for the component.') %></td>
   <td><%= md('Boolean') %></td>
@@ -12,7 +6,7 @@
 </tr>
 <tr>
   <td><%= md('`condensed`') %></td>
-  <td><%= md('`.sage-table--condensed` decreased vertical padding between items in the component.') %></td>
+  <td><%= md('Decreases vertical padding between items in the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -23,14 +17,14 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`reset-above`') %></td>
-  <td><%= md('`.sage-table--reset-above` resets the top margin of the component.') %></td>
+  <td><%= md('`reset_above`') %></td>
+  <td><%= md('Resets the top margin of the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`reset-below`') %></td>
-  <td><%= md('`.sage-table--reset-below` resets the bottom margin of the component.') %></td>
+  <td><%= md('`reset_below`') %></td>
+  <td><%= md('Resets the bottom margin of the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -48,20 +42,14 @@
 </tr>
 <tr>
   <td><%= md('`selectable`') %></td>
-  <td><%= md('`.sage-table--selectable` adds a background color when a user hovers over rows.') %></td>
+  <td><%= md('Adds a background color when a user hovers over rows.') %></td>
   <td><%= md('String:') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`striped`') %></td>
-  <td><%= md('`.sage-table--striped` adds a background color to odd-numbered rows.') %></td>
+  <td><%= md('Adds a background color to odd-numbered rows.') %></td>
   <td><%= md('Boolean') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
-  <td><%= md('Truncated cells') %></td>
-  <td><%= md('`.sage-table-cell--truncate` on individual cells truncates their content at smaller viewport sizes, displaying ellipses (&hellip;) in place of overflowing content. Take care not to use this with important pieces of information that should be displayed to users at all times.') %></td>
-  <td><%= md('String:') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -80,11 +68,15 @@
   <td><%= md('
   A set of options that match the following options from SageTable above:
 
+  - `condensed`
   - `reset_above`
   - `reset_below`
   - `responsive`
-  - `sortable`
   - `striped`  
+
+  Also available, unique to `sage_table_for`:
+
+  - `sortable` -- enables sorting links and direction indicators on sorted columns.
 ') %></td>
   <td><%= md('See properties above') %></td>
   <td><%= md('Varies') %></td>
@@ -108,13 +100,15 @@
   <td><%= md('
   A set of options for the columns including:
 
-  - `label <string>` -- Content for the header of the column.
-  - `style <hash>` -- style attributes to render on cells.
+  - `align <"right" | "center" | nil>` -- Alignment direction for cells (body and header)
   - `class_name <string>` -- CSS class name to render on body cells (not on header cell).
-  - `data_type <"checkbox" | "avatar">` -- A data type from among the existing presets that will result in a sage cell format class applied to apply some default styling for that data type.
-  - `truncate <boolean>` -- Whether or not to truncate the cell if its content does not fit (rather than wrap).
-  - `align <"right" | nil>` -- Alignment direction for cells (body and header)
+  - `data_type <"checkbox" | "avatar">` -- Special cell data types to apply some preset styling for special cases.
   - `header_class <string>` -- CSS class name to render on header cells.
+  - `hide <{ sm: boolean, md: boolean, lg: boolean}>` -- Set only the desired breakpoint to `true` to hide a given columnn at and below that breakpoint.
+  - `label <string>` -- Content for the header of the column.
+  - `strong <boolean>` -- Renders cell with strong style: weight of 500 and darker color.
+  - `style <string>` -- style attributes to render on cells.
+  - `truncate <boolean>` -- Whether or not to truncate the cell if its content does not fit (rather than wrap).
 ') %></td>
   <td><%= md('Hash') %></td>
   <td><%= md('`nil`') %></td>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -1,45 +1,4 @@
 <%
-sample_data = [
-  {
-    value_1: "Venenatis Condimentum",
-    value_2: "Ridiculus",
-    value_3: "Sem Elit",
-    value_4: "Nibh Aenean",
-    value_5: "Sem Elit"
-  },
-  {
-    value_1: "Nullam Porta",
-    value_2: "Adipiscing Ligula",
-    value_3: "Euismod Etiam",
-    value_4: "Malesuada",
-    value_5: "Etiam"
-  },
-  {
-    value_1: "Ridiculus",
-    value_2: "Cras Malesuada",
-    value_3: "Commodo",
-    value_4: "Cursus Pharetra",
-    value_5: "Fringilla"
-  },
-  {
-    value_1: "Pharetra Mattis",
-    value_2: "Magna",
-    value_3: "Elit Inceptos",
-    value_4: "Cursus Pharetra",
-    value_5: "Dolor Fringilla"
-  }
-]
-sample_table = {
-  headers: [
-    "Cras Porta",
-    "Dapibus Ridiculus",
-    "Purus",
-    "Mollis",
-    "Ridiculus"
-  ],
-  rows: sample_data
-}
-
 people_data = [
   {
     initials: 'AF',
@@ -115,101 +74,82 @@ Use this scratchpad to test out elements and components in context. Just be sure
 <% end %>
 
 <%= sage_component SagePanel, {} do %>
-  <%= sage_component SageCard, {} do %>
-    <h3>Using `sage_table_for`</h3>
-    <%= sage_table_for people_data, striped: true, sortable: true, responsive: true, caption: "<p>Testing <b>stuff</b></p>".html_safe do |t| %>
-      
-      <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
-        <%= sage_component SageCheckbox, {
-          label_text: 'Select row',
-          standalone: true,
-          id: "table-row-#{c[:initials]}",
-        } %>
-      <% end %>
+  <%= sage_table_for people_data, striped: true, sortable: true, responsive: true, caption: "<p>Testing <b>stuff</b></p>".html_safe do |t| %>
+    
+    <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
+      <%= sage_component SageCheckbox, {
+        label_text: 'Select row',
+        standalone: true,
+        id: "table-row-#{c[:initials]}",
+      } %>
+    <% end %>
 
-      <% t.column :initials, label: "", data_type: "avatar" do |c| %>
-        <%= sage_component SageAvatar, {
-          initials: c[:initials],
-          color: SageTokens::COLORS[rand(7)],
-        } %>
-      <% end %>
+    <% t.column :initials, label: "", data_type: "avatar" do |c| %>
+      <%= sage_component SageAvatar, {
+        initials: c[:initials],
+        color: SageTokens::COLORS[rand(7)],
+      } %>
+    <% end %>
 
-      <% t.column :name, label: "Name", strong: true, truncate: true do |c| %>
-        <span data-js-tooltip="<%= c[:name] %>">
-          <%= c[:name] %>
-        </span>
-      <% end %>
+    <% t.column :name, label: "Name", strong: true, truncate: true do |c| %>
+      <span data-js-tooltip="<%= c[:name] %>">
+        <%= c[:name] %>
+      </span>
+    <% end %>
 
-      <% t.column :email, label: "Email", truncate: true do |c| %>
-        <span data-js-tooltip="<%= c[:email] %>">
-          <%= c[:email] %>
-        </span>
-      <% end %>
+    <% t.column :email, label: "Email", truncate: true do |c| %>
+      <span data-js-tooltip="<%= c[:email] %>">
+        <%= c[:email] %>
+      </span>
+    <% end %>
 
-      <% t.column :price, label: "Price", style: "width: 140px", hide: { md: true } do |c| %>
-        <%= c[:price] %>
-      <% end %>
+    <% t.column :price, label: "Price", style: "width: 140px", hide: { md: true } do |c| %>
+      <%= c[:price] %>
+    <% end %>
 
-      <% t.column :amount, label: "Amount", style: "width: 100px", hide: { md: true } do |c| %>
-        <%= c[:amount] %>
-      <% end %>
+    <% t.column :amount, label: "Amount", style: "width: 100px", hide: { md: true } do |c| %>
+      <%= c[:amount] %>
+    <% end %>
 
-      <% t.column :labels, label: "Labels", style: "width: 150px",  hide: { sm: true } do |c| %>
-        <% c[:labels].each do |label| %>
-          <%= sage_component SageLabel, { 
-            value: label,
-            color: "info",
-          } %>
-        <% end %>
-      <% end %>
-
-      <% t.column :status, label: "Status",style: "width: 100px",  hide: { sm: true } do |c| %>
+    <% t.column :labels, label: "Labels", style: "width: 150px",  hide: { sm: true } do |c| %>
+      <% c[:labels].each do |label| %>
         <%= sage_component SageLabel, { 
-          value: c[:status].titlecase,
-          color: c[:status],
-          } %>
-      <% end %>
-
-      <% t.column :actions, label: "Actions",style: "width: 100px",  data_type: "string" do |c| %>
-        <%= sage_component SageButtonGroup, {} do %>
-          <%= sage_component SageButton, {
-            subtle: true,
-            value: 'Edit',
-            icon: { name: 'pen', style: 'only' },
-            style: 'primary',
-            attributes: {
-              href: "?edit=#edit",
-              "data-js-tooltip": "Edit",
-            }
-          } %>
-          <%= sage_component SageButton, {
-            subtle: true,
-            value: 'Delete',
-            icon: { name: 'trash', style: 'only' },
-            style: 'danger',
-            attributes: {
-              href: "?remove=#delete",
-              "data-js-tooltip": "Delete",
-            }
-          } %>
-        <% end %>
+          value: label,
+          color: "info",
+        } %>
       <% end %>
     <% end %>
 
-    <h3 class="t-sage-heading-6">Responsive table</h3>
-    <%= sage_component SageTable, {
-      headers: sample_table[:headers],
-      rows: sample_table[:rows],
-      caption: "Responsive tables require the use of two parent containers",
-    } %>
+    <% t.column :status, label: "Status",style: "width: 100px",  hide: { sm: true } do |c| %>
+      <%= sage_component SageLabel, { 
+        value: c[:status].titlecase,
+        color: c[:status],
+        } %>
+    <% end %>
 
-    <h3 class="t-sage-heading-6">Striped table</h3>
-    <%= sage_component SageTable, {
-      headers: sample_table[:headers],
-      rows: sample_table[:rows],
-      caption: "Striped tables display a background color on odd-numbered rows",
-      striped: true
-    } %>
-
+    <% t.column :actions, label: "Actions",style: "width: 100px",  data_type: "string" do |c| %>
+      <%= sage_component SageButtonGroup, {} do %>
+        <%= sage_component SageButton, {
+          subtle: true,
+          value: 'Edit',
+          icon: { name: 'pen', style: 'only' },
+          style: 'primary',
+          attributes: {
+            href: "?edit=#edit",
+            "data-js-tooltip": "Edit",
+          }
+        } %>
+        <%= sage_component SageButton, {
+          subtle: true,
+          value: 'Delete',
+          icon: { name: 'trash', style: 'only' },
+          style: 'danger',
+          attributes: {
+            href: "?remove=#delete",
+            "data-js-tooltip": "Delete",
+          }
+        } %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -1,3 +1,111 @@
+<%
+sample_data = [
+  {
+    value_1: "Venenatis Condimentum",
+    value_2: "Ridiculus",
+    value_3: "Sem Elit",
+    value_4: "Nibh Aenean",
+    value_5: "Sem Elit"
+  },
+  {
+    value_1: "Nullam Porta",
+    value_2: "Adipiscing Ligula",
+    value_3: "Euismod Etiam",
+    value_4: "Malesuada",
+    value_5: "Etiam"
+  },
+  {
+    value_1: "Ridiculus",
+    value_2: "Cras Malesuada",
+    value_3: "Commodo",
+    value_4: "Cursus Pharetra",
+    value_5: "Fringilla"
+  },
+  {
+    value_1: "Pharetra Mattis",
+    value_2: "Magna",
+    value_3: "Elit Inceptos",
+    value_4: "Cursus Pharetra",
+    value_5: "Dolor Fringilla"
+  }
+]
+sample_table = {
+  headers: [
+    "Cras Porta",
+    "Dapibus Ridiculus",
+    "Purus",
+    "Mollis",
+    "Ridiculus"
+  ],
+  rows: sample_data
+}
+
+people_data = [
+  {
+    initials: 'AF',
+    name: 'Albert Flores',
+    email: 'albertflores@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["green", "house"],
+    status: 'published'
+  },
+  {
+    initials: 'EP',
+    name: 'Eleanor Pena',
+    email: 'e_pena@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["red"],
+    status: 'draft'
+  },
+  {
+    initials: 'LJ',
+    name: 'Lily Jones',
+    email: 'lilyjones@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["house"],
+    status: 'warning'
+  },
+  {
+    initials: 'KM',
+    name: 'Kathryn Murphy',
+    email: 'katmurphy@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: ["red", "house"],
+    status: 'locked'
+  },
+  {
+    initials: 'DR',
+    name: 'Darelene Robertson',
+    email: 'd_robertson@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: [],
+    status: 'danger'
+  },
+  {
+    initials: 'RE',
+    name: 'Ralph Edwards',
+    email: 'ralphedwards@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: [],
+    status: 'draft'
+  },
+  {
+    initials: 'JW',
+    name: 'Jenny Wilson',
+    email: 'jennywilson@example.com',
+    price: '$420.00 USD',
+    amount: '1',
+    labels: [],
+    status: 'published'
+  }
+]
+%>
 <%= content_for :heading do %>
 <%= md("
 # Sandbox
@@ -6,3 +114,102 @@ Use this scratchpad to test out elements and components in context. Just be sure
 ") %>
 <% end %>
 
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SageCard, {} do %>
+    <h3>Using `sage_table_for`</h3>
+    <%= sage_table_for people_data, striped: true, sortable: true, responsive: true, caption: "<p>Testing <b>stuff</b></p>".html_safe do |t| %>
+      
+      <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
+        <%= sage_component SageCheckbox, {
+          label_text: 'Select row',
+          standalone: true,
+          id: "table-row-#{c[:initials]}",
+        } %>
+      <% end %>
+
+      <% t.column :initials, label: "", data_type: "avatar" do |c| %>
+        <%= sage_component SageAvatar, {
+          initials: c[:initials],
+          color: SageTokens::COLORS[rand(7)],
+        } %>
+      <% end %>
+
+      <% t.column :name, label: "Name", strong: true, truncate: true do |c| %>
+        <span data-js-tooltip="<%= c[:name] %>">
+          <%= c[:name] %>
+        </span>
+      <% end %>
+
+      <% t.column :email, label: "Email", truncate: true do |c| %>
+        <span data-js-tooltip="<%= c[:email] %>">
+          <%= c[:email] %>
+        </span>
+      <% end %>
+
+      <% t.column :price, label: "Price", style: "width: 140px", hide: { md: true } do |c| %>
+        <%= c[:price] %>
+      <% end %>
+
+      <% t.column :amount, label: "Amount", style: "width: 100px", hide: { md: true } do |c| %>
+        <%= c[:amount] %>
+      <% end %>
+
+      <% t.column :labels, label: "Labels", style: "width: 150px",  hide: { sm: true } do |c| %>
+        <% c[:labels].each do |label| %>
+          <%= sage_component SageLabel, { 
+            value: label,
+            color: "info",
+          } %>
+        <% end %>
+      <% end %>
+
+      <% t.column :status, label: "Status",style: "width: 100px",  hide: { sm: true } do |c| %>
+        <%= sage_component SageLabel, { 
+          value: c[:status].titlecase,
+          color: c[:status],
+          } %>
+      <% end %>
+
+      <% t.column :actions, label: "Actions",style: "width: 100px",  data_type: "string" do |c| %>
+        <%= sage_component SageButtonGroup, {} do %>
+          <%= sage_component SageButton, {
+            subtle: true,
+            value: 'Edit',
+            icon: { name: 'pen', style: 'only' },
+            style: 'primary',
+            attributes: {
+              href: "?edit=#edit",
+              "data-js-tooltip": "Edit",
+            }
+          } %>
+          <%= sage_component SageButton, {
+            subtle: true,
+            value: 'Delete',
+            icon: { name: 'trash', style: 'only' },
+            style: 'danger',
+            attributes: {
+              href: "?remove=#delete",
+              "data-js-tooltip": "Delete",
+            }
+          } %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <h3 class="t-sage-heading-6">Responsive table</h3>
+    <%= sage_component SageTable, {
+      headers: sample_table[:headers],
+      rows: sample_table[:rows],
+      caption: "Responsive tables require the use of two parent containers",
+    } %>
+
+    <h3 class="t-sage-heading-6">Striped table</h3>
+    <%= sage_component SageTable, {
+      headers: sample_table[:headers],
+      rows: sample_table[:rows],
+      caption: "Striped tables display a background color on odd-numbered rows",
+      striped: true
+    } %>
+
+  <% end %>
+<% end %>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -75,7 +75,6 @@ Use this scratchpad to test out elements and components in context. Just be sure
 
 <%= sage_component SagePanel, {} do %>
   <%= sage_table_for people_data, striped: true, sortable: true, responsive: true, caption: "<p>Testing <b>stuff</b></p>".html_safe do |t| %>
-    
     <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
       <%= sage_component SageCheckbox, {
         label_text: 'Select row',
@@ -111,7 +110,7 @@ Use this scratchpad to test out elements and components in context. Just be sure
       <%= c[:amount] %>
     <% end %>
 
-    <% t.column :labels, label: "Labels", style: "width: 150px",  hide: { sm: true } do |c| %>
+    <% t.column :labels, label: "Labels", style: "width: 150px", hide: { sm: true } do |c| %>
       <% c[:labels].each do |label| %>
         <%= sage_component SageLabel, { 
           value: label,
@@ -120,14 +119,14 @@ Use this scratchpad to test out elements and components in context. Just be sure
       <% end %>
     <% end %>
 
-    <% t.column :status, label: "Status",style: "width: 100px",  hide: { sm: true } do |c| %>
+    <% t.column :status, label: "Status", style: "width: 100px", hide: { sm: true } do |c| %>
       <%= sage_component SageLabel, { 
         value: c[:status].titlecase,
         color: c[:status],
         } %>
     <% end %>
 
-    <% t.column :actions, label: "Actions",style: "width: 100px",  data_type: "string" do |c| %>
+    <% t.column :actions, label: "Actions", style: "width: 100px" do |c| %>
       <%= sage_component SageButtonGroup, {} do %>
         <%= sage_component SageButton, {
           subtle: true,

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -6,13 +6,3 @@ Use this scratchpad to test out elements and components in context. Just be sure
 ") %>
 <% end %>
 
-<%= sage_component SageModal, { id: "whatevz", html_attributes: { "data-something": "who knwows"} } do %>
-  <%= sage_component SageModalContent, { html_attributes: {"data-hey-there": "what up?"} } do %>
-  <%= sage_component SageLabel, {
-    color: 'info',
-    value: 'hey',
-    html_attributes: { "data-dog": "woof woof woof" }
-  } %>
-    Hey Mom
-  <% end %>
-<% end %>

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -63,16 +63,18 @@ module SageTableHelper
   end
 
   class SageTableFor
-    attr_reader :columns, :template, :id, :class_name, :collection, :row_proc, :sortable, :responsive, :striped
+    attr_reader :columns, :template, :id, :class_name, :collection, :row_proc, :sortable, :responsive, :striped, :reset_above, :reset_below
     delegate :content_tag, :tag, to: :template
 
     def initialize(template, collection, opts={})
       @template = template
       @collection = collection
       @class_name = opts[:class]
+      @reset_above = opts[:reset_above]
+      @reset_below = opts[:reset_below]
+      @responsive = opts[:responsive]
       @sortable = opts[:sortable]
       @striped = opts[:striped]
-      @responsive = opts[:responsive]
       @id = opts[:id]
       @columns = []
     end
@@ -87,17 +89,34 @@ module SageTableHelper
     end
 
     def contents
+      wrapper_classes = "sage-table-wrapper"
+      wrapper_classes << " sage-table-wrapper--reset-above" if reset_above
+      wrapper_classes << " sage-table-wrapper--reset-below" if reset_below
+      wrapper_classes << " sage-table-wrapper--scroll" if responsive
+      
+      content_tag "div", class: wrapper_classes do
+        if responsive
+          content_tag "div", class: "sage-table-wrapper__overflow" do
+            table_contents
+          end
+        else
+          table_contents
+        end
+      end
+    end
+
+    protected
+
+    def table_contents
       table_classes = "sage-table"
       table_classes << " sage-table--sortable" if sortable
       table_classes << " sage-table--striped" if striped
-      table_classes << class_name
+      table_classes << " #{class_name}" if striped
 
       content_tag "table", id: id, class: table_classes do
         head + body
       end
     end
-
-    protected
 
     def head
       content_tag "thead" do
@@ -118,7 +137,7 @@ module SageTableHelper
       col_class << " sage-table-cell--truncate" if c.truncate
       col_class << " sage-table-cell--align-#{c.align}" if c.align
       col_class << " sage-table-cell--#{c.data_type}" if c.data_type
-      col_class << " #{c.class_name}"
+      col_class << " #{c.header_class}"
 
       content_tag "th", class: col_class do
         c.title

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -1,0 +1,169 @@
+module SageTableHelper
+
+  class SageColumn
+    attr_reader :template, :attribute, :block, :title, :label, :opts
+    delegate :sage_table_sortable_header_link, to: :template
+
+    def initialize(template, attribute, block, opts={})
+      @attribute = attribute.to_sym
+      @block = block || Proc.new { |r| r.send(attribute).to_s }
+      @template = template
+      @opts = opts
+      @label = opts[:label] || attribute.to_s.titleize
+
+      if template.try(:sortable?, attribute)
+        @title = sortable_title
+      else
+        @title = label
+      end
+    end
+
+    def value_for(record)
+      block.call record
+    end
+
+    def style
+      opts[:style]
+    end
+
+    def class_name
+      opts[:class]
+    end
+
+    def data_type
+      opts[:data_type]
+    end
+
+    def truncate
+      opts[:truncate]
+    end
+
+    def align
+      opts[:align]
+    end
+
+    def header_class
+      opts[:header_class]
+    end
+
+    protected
+
+    def sortable_title
+      sage_table_sortable_header_link label, attribute
+    end
+
+    def current?
+      attribute.to_s == template.sort_column
+    end
+
+    def asc?
+      template.sort_direction == "asc"
+    end
+
+  end
+
+  class SageTableFor
+    attr_reader :columns, :template, :id, :class_name, :collection, :row_proc, :sortable, :responsive, :striped
+    delegate :content_tag, :tag, to: :template
+
+    def initialize(template, collection, opts={})
+      @template = template
+      @collection = collection
+      @class_name = opts[:class]
+      @sortable = opts[:sortable]
+      @striped = opts[:striped]
+      @responsive = opts[:responsive]
+      @id = opts[:id]
+      @columns = []
+    end
+
+    def row_options(&block)
+      @row_proc = block
+    end
+
+    def column(attr, opts={})
+      block = Proc.new if block_given?
+      columns << SageColumn.new(template, attr, block, opts)
+    end
+
+    def contents
+      table_classes = "sage-table"
+      table_classes << " sage-table--sortable" if sortable
+      table_classes << " sage-table--striped" if striped
+      table_classes << class_name
+
+      content_tag "table", id: id, class: table_classes do
+        head + body
+      end
+    end
+
+    protected
+
+    def head
+      content_tag "thead" do
+        content_tag "tr" do
+          columns.map { |c| column_header(c) }.join.html_safe
+        end
+      end
+    end
+
+    def body
+      content_tag "tbody" do
+        collection.map { |r| row(r) }.join.html_safe
+      end
+    end
+
+    def column_header(c)
+      col_class = "sage-table__header sage-table-cell"
+      col_class << " sage-table-cell--truncate" if c.truncate
+      col_class << " sage-table-cell--align-#{c.align}" if c.align
+      col_class << " sage-table-cell--#{c.data_type}" if c.data_type
+      col_class << " #{c.class_name}"
+
+      content_tag "th", class: col_class do
+        c.title
+      end
+    end
+
+    def row(record)
+      content_tag "tr", row_proc.call(record) do
+        columns.map do |c|
+          col_class = "sage-table-cell"
+          col_class << " sage-table-cell--truncate" if c.truncate
+          col_class << " sage-table-cell--align-#{c.align}" if c.align
+          col_class << " sage-table-cell--#{c.data_type}" if c.data_type
+          col_class << " #{c.class_name}"
+
+          content_tag "td", style: c.style, class: col_class do
+            c.value_for(record)
+          end
+        end.join.html_safe
+      end
+    end
+
+    def row_proc
+      @row_proc ||= Proc.new do |record|
+        {}
+      end
+    end
+  end
+
+  def sage_table_for(collection, opts={})
+    table = SageTableFor.new self, collection, opts
+    yield table if block_given?
+
+    table.contents
+  end
+
+  def sage_table_sortable_header_link(label, attribute)
+    current = attribute.to_s == sort_column
+    asc = sort_direction == "asc"
+    next_direction = asc ? "desc" : "asc"
+
+    css_class = "sage-table__sort-link"
+    css_class << " sage-table__sort-link--selected" if current
+    css_class << " sage-table__sort-link--ascending" if asc
+
+    link_to label, unsafe_params.merge({ sort: attribute, direction: next_direction }), class: css_class
+  end
+end

--- a/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
@@ -8,7 +8,7 @@ class SagePageHeading < SageComponent
   })
 
   def sections
-    %w(breadcrumbs page_heading_toolbar page_heading_actions page_heading_intro help_content)
+    %w(breadcrumbs page_heading_toolbar page_heading_actions page_heading_intro page_heading_image help_content)
   end
 
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -11,16 +11,12 @@ class SagePanelControls < SageComponent
     show_expand_collapse: [:optional, TrueClass],
     show_pagination: [:optional, TrueClass],
     show_sort: [:optional, TrueClass],
-    sort_items: [:optional, [[{
-      attributes: [:optional, Hash],
-      value: String,
-    }]]],
     start_expanded: [:optional, TrueClass],
     target: [:optional, String],
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown )
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort)
   end
 end
 
@@ -35,11 +31,4 @@ end
     :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},
    {:value=>"Set marketing",
     :attributes=>
-     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
- :sort_items=>
-  [{:value=>"Name",
-    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
-   {:value=>"Email",
-    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
-   {:value=>"Join date",
-    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
+     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}]}

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -43,3 +43,4 @@ end
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
    {:value=>"Join date",
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
+    

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -20,7 +20,7 @@ class SagePanelControls < SageComponent
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort)
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort )
   end
 end
 
@@ -36,11 +36,10 @@ end
    {:value=>"Set marketing",
     :attributes=>
      {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
-     :sort_items=>
-      [{:value=>"Name",
-        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
-       {:value=>"Email",
-        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
-       {:value=>"Join date",
-        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
-        
+ :sort_items=>
+  [{:value=>"Name",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
+   {:value=>"Email",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
+   {:value=>"Join date",
+    :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -11,6 +11,10 @@ class SagePanelControls < SageComponent
     show_expand_collapse: [:optional, TrueClass],
     show_pagination: [:optional, TrueClass],
     show_sort: [:optional, TrueClass],
+    sort_items: [:optional, [[{
+      attributes: [:optional, Hash],
+      value: String,
+    }]]],
     start_expanded: [:optional, TrueClass],
     target: [:optional, String],
   })
@@ -31,4 +35,12 @@ end
     :attributes=>{:href=>"#", :"data-js-list-action"=>"delete_selected"}},
    {:value=>"Set marketing",
     :attributes=>
-     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}]}
+     {:href=>"#", :"data-js-list-action"=>"set_marketing_unsubscribed"}}],
+     :sort_items=>
+      [{:value=>"Name",
+        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"name"}},
+       {:value=>"Email",
+        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
+       {:value=>"Join date",
+        :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
+        

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_controls.rb
@@ -20,7 +20,7 @@ class SagePanelControls < SageComponent
   })
 
   def sections
-    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort )
+    %w(panel_controls_pagination panel_controls_toolbar panel_controls_tabs panel_controls_tabs_dropdown panel_controls_sort)
   end
 end
 
@@ -43,4 +43,3 @@ end
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"email"}},
    {:value=>"Join date",
     :attributes=>{:href=>"#", :"data-js-list-sort-by"=>"join_date"}}]}
-    

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -6,6 +6,7 @@ class SageStatBox < SageComponent
       value: String,
     }],
     data: String,
+    has_data: [:optional, TrueClass],
     link: [:optional, {
       href: String,
       value: String,

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -8,7 +8,6 @@ class SageTable < SageComponent
     responsive: [:optional, TrueClass],
     rows: [:optional, Array],
     selectable: [:optional, TrueClass],
-    sortable: [:optional, TrueClass],
     striped: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,7 +1,6 @@
 <button
-  class="sage-copy-btn"
-  data-js-copy-button="<%= component.value.html_safe %>
-  <%= component.generated_css_classes %>"
+  class="sage-copy-btn <%= component.generated_css_classes %>"
+  data-js-copy-button="<%= component.value.html_safe %>"
   <%= component.generated_html_attributes.html_safe %>
 >
   <%= sage_component SageCopyText, { value: component.value, semibold: component.semibold.present? && component.semibold } %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -1,4 +1,10 @@
-<section class="sage-page-heading <%= "sage-page-heading--no-secondary-text" if component.secondary_text.blank? %> <%= component.generated_css_classes %>" <%= component.generated_html_attributes.html_safe %>>
+<section
+  class="sage-page-heading
+    <%= "sage-page-heading--no-secondary-text" if component.secondary_text.blank? %>
+    <%= "sage-page-heading--has-image" if content_for? :sage_page_heading_image %>
+    <%= component.generated_css_classes %>"
+  <%= component.generated_html_attributes.html_safe %>
+>
   <% if content_for? :sage_breadcrumbs %>
     <div class="sage-page-heading__crumbs">
       <%= content_for :sage_breadcrumbs %>
@@ -34,6 +40,11 @@
       <% end %>
     <% end %>
   </h1>
+  <% if content_for? :sage_page_heading_image %>
+    <div class="sage-page-heading__image">
+      <%= content_for :sage_page_heading_image %>
+    </div>
+  <% end %>
   <% if content_for? :sage_page_heading_actions %>
     <div class="sage-page-heading__actions">
       <%= content_for :sage_page_heading_actions %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -2,6 +2,7 @@
 show_secondary_toolbar = component.show_pagination || component.show_sort || component.show_expand_collapse
 show_default_controls = component.show_bulk_actions || show_secondary_toolbar
 bulk_action_items = component.bulk_action_items.present? ? component.bulk_action_items : []
+sort_items = component.sort_items.present? ? component.sort_items : []
 item_count_text = component.item_count_label.present? ? component.item_count_label : ""
 %>
 <div class="
@@ -73,9 +74,7 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
           <% end %>
           
           <% if content_for? :sage_panel_controls_sort %>
-            <div class="sage-panel-controls__sort">
-              <%= content_for :sage_panel_controls_sort %>
-            </div>
+            <%= content_for :sage_panel_controls_sort %>
           <% end %>
 
           <% if component.show_expand_collapse %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -2,7 +2,6 @@
 show_secondary_toolbar = component.show_pagination || component.show_sort || component.show_expand_collapse
 show_default_controls = component.show_bulk_actions || show_secondary_toolbar
 bulk_action_items = component.bulk_action_items.present? ? component.bulk_action_items : []
-sort_items = component.sort_items.present? ? component.sort_items : []
 item_count_text = component.item_count_label.present? ? component.item_count_label : ""
 %>
 <div class="
@@ -72,23 +71,11 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
               <%= content_for :sage_panel_controls_pagination %>
             </div>
           <% end %>
-          <% if component.show_sort %>
-            <%= sage_component SageDropdown, {
-              trigger_type: "select",
-              align: "right",
-              css_classes: "sage-panel-controls__sorts",
-              customized: true,
-              custom_modifier: "sort",
-              items: sort_items
-            } do %>
-              <%= sage_component SageButton, {
-                style: "secondary",
-                value: "",
-                css_classes: "sage-dropdown__trigger-selected-value",
-                icon: { style: "right", name: "caret-down" }
-              } %>
-              <label class="sage-dropdown__trigger-label">Sort</label>
-            <% end %>
+          
+          <% if content_for? :sage_panel_controls_sort %>
+            <div class="sage-panel-controls__sort">
+              <%= content_for :sage_panel_controls_sort %>
+            </div>
           <% end %>
 
           <% if component.show_expand_collapse %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -1,4 +1,6 @@
-<% 
+<%
+# Set up label configs for Sage Label as default
+
 change_value = component.change.present? ? component.change[:value] : "No change"
 change_type = component.change.present? ? component.change[:type] : "neutral"
 label_configs = { color: "draft", value: change_value } 
@@ -21,7 +23,8 @@ end
     <% end %>
   </header>
   <div class="sage-stat-box__body sage-grid-template-te">
-    <p class="sage-stat-box__data">
+    <p class="sage-stat-box__data
+    <%= "sage-stat-box__data--no-data" if !component.has_data %>">
       <%= component.data %>
       <% if component.timeframe.present? %>
         <span class="sage-stat-box__timeframe"><%= component.timeframe %></span>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -17,7 +17,6 @@ is_responsive = component.responsive.present? ? component.responsive : true
       <%= "sage-table--striped" if component.striped %>
       <%= "sage-table--selectable" if component.selectable %>
       <%= "sage-table--condensed" if component.condensed %>
-      <%= "sage-table--sortable" if component.sortable %>
     "
     <%= component.generated_html_attributes.html_safe %>
   >
@@ -37,9 +36,7 @@ is_responsive = component.responsive.present? ? component.responsive : true
                 <%= "#{key}=#{value}" %>
               <% end if header&.is_a?(Hash) && header[:html_attributes].present? %>
             >
-              <% if component.sortable %><a href="#" class="sage-table__sort-link"><% end %>
               <%= header&.is_a?(Hash) ? header[:value].html_safe : header.html_safe %>
-              <% if component.sortable %></a><% end %>
             </th>
           <% end %>
         </tr>

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -98,9 +98,6 @@ $-checkbox-focus-outline-color: sage-color(primary);
   .sage-table td > & {
     display: block;
   }
-  .sage-table td:first-child > & {
-    margin-left: sage-spacing(xs);
-  }
 }
 
 .sage-checkbox__label {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -346,6 +346,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   &.sage-dropdown__trigger--options {
     min-width: auto;
   }
+
+  > .sage-btn {
+    line-height: 28px;
+  }
 }
 
 .sage-dropdown__trigger--select,

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -352,6 +352,12 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 }
 
+.sage-dropdown__trigger--select {
+  .sage-btn {
+    font-weight: sage-font-weight(regular);
+  }
+}
+
 .sage-dropdown__trigger--select,
 .sage-dropdown__trigger--select-labeled {
   :not(.sage-dropdown--customized) > & {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -348,7 +348,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   > .sage-btn {
-    line-height: 28px;
+    line-height: sage-line-height(md),
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -348,7 +348,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   > .sage-btn {
-    line-height: sage-line-height(md),
+    line-height: sage-line-height(md);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -124,6 +124,10 @@ $-modal-header-image-size: rem(28px);
     margin-bottom: 0;
   }
 
+  p + p {
+    margin-top: sage-spacing(xs);
+  }
+
   @include clearfix;
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -125,7 +125,7 @@ $-modal-header-image-size: rem(28px);
   }
 
   p + p {
-    margin-top: sage-spacing(xs);
+    margin-top: sage-spacing();
   }
 
   @include clearfix;

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -20,18 +20,17 @@ $-page-heading-image-height-mobile: rem(120px);
       "toolbar"
       "secondary";
 
-      &.sage-page-heading--has-image {
-        grid-template-areas:
-          "crumbs"
-          "image"
-          "title"
-          "intro"
-          "actions"
-          "toolbar"
-          "secondary";
-        grid-template-rows: auto $-page-heading-image-height-mobile auto auto auto auto auto;
-      }
-
+    &.sage-page-heading--has-image {
+      grid-template-areas:
+        "crumbs"
+        "image"
+        "title"
+        "intro"
+        "actions"
+        "toolbar"
+        "secondary";
+      grid-template-rows: auto $-page-heading-image-height-mobile auto auto auto auto auto;
+    }
   }
 
   @media (min-width: sage-breakpoint(md-min)) {

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -4,6 +4,9 @@
 /// @group sage
 ////
 
+$-page-heading-image-height-min: rem(64px);
+$-page-heading-image-width: rem(150px);
+$-page-heading-image-height-mobile: rem(120px);
 
 .sage-page-heading {
   display: grid;
@@ -11,12 +14,24 @@
   @media (max-width: sage-breakpoint(sm-max)) {
     grid-template-areas:
       "crumbs"
-      "image"
       "title"
       "intro"
       "actions"
       "toolbar"
       "secondary";
+
+      &.sage-page-heading--has-image {
+        grid-template-areas:
+          "crumbs"
+          "image"
+          "title"
+          "intro"
+          "actions"
+          "toolbar"
+          "secondary";
+        grid-template-rows: auto $-page-heading-image-height-mobile auto auto auto auto auto;
+      }
+
   }
 
   @media (min-width: sage-breakpoint(md-min)) {
@@ -40,7 +55,7 @@
         "image title actions"
         "image intro intro"
         "image toolbar secondary";
-      grid-template-columns: 180px 1fr auto;
+      grid-template-columns: $-page-heading-image-width 1fr auto;
     }
   }
 }
@@ -57,13 +72,24 @@
 }
 
 .sage-page-heading__image {
+  position: relative;
   grid-area: image;
+  overflow: hidden;
+  min-height: $-page-heading-image-height-min;
+  background: sage-color(grey, 200);
+  border-radius: sage-border(radius);
+  border: sage-border();
 
   img {
+    position: absolute;
+    transform: translateY(-50%);
+    top: 50%;
     width: 100%;
-    height: auto;
   }
 
+  @media (max-width: sage-breakpoint(sm-max)) {
+    margin-bottom: sage-spacing(sm);
+  }
   @media (min-width: sage-breakpoint(md-min)) {
     margin-right: sage-spacing(sm);
   }

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -9,8 +9,9 @@
   display: grid;
 
   @media (max-width: sage-breakpoint(sm-max)) {
-    grid-template-areas: 
+    grid-template-areas:
       "crumbs"
+      "image"
       "title"
       "intro"
       "actions"
@@ -33,6 +34,14 @@
         "intro intro"
         "toolbar toolbar";
     }
+    &.sage-page-heading--has-image {
+      grid-template-areas:
+        "crumbs crumbs crumbs"
+        "image title actions"
+        "image intro intro"
+        "image toolbar secondary";
+      grid-template-columns: 180px 1fr auto;
+    }
   }
 }
 
@@ -45,6 +54,19 @@
   grid-area: intro;
   margin-top: sage-spacing(sm);
   color: sage-color(charcoal, 400);
+}
+
+.sage-page-heading__image {
+  grid-area: image;
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+
+  @media (min-width: sage-breakpoint(md-min)) {
+    margin-right: sage-spacing(sm);
+  }
 }
 
 .sage-page-heading__crumbs {

--- a/packages/sage-assets/lib/stylesheets/components/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_pagination.scss
@@ -23,7 +23,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   flex-grow: 1;
 
   .sage-panel-controls__default-controls & {
-    margin-right: sage-spacing(sm);
+    margin-right: sage-spacing(md);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -23,14 +23,21 @@
   align-items: center;
 }
 
+.sage-stat-box__title,
+.sage-stat-box__data--no-data {
+  color: sage-color(charcoal, 200);
+}
+
 .sage-stat-box__title {
   @extend %t-sage-body-small-med;
   margin-right: sage-spacing(xs);
-  color: sage-color(charcoal, 200);
 }
 
 .sage-stat-box__data {
   @extend %t-sage-heading-5;
+}
+.sage-stat-box__data--no-data {
+  @extend %t-sage-body-small;
 }
 
 .sage-stat-box__timeframe {

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -41,8 +41,7 @@ $-table-checkbox-width: rem(20px);
 $-table-avatar-width: rem(32px);
 
 
-// stylelint-disable selector-max-compound-selectors
-// stylelint-disable max-nesting-depth
+// stylelint-disable selector-max-compound-selectors, max-nesting-depth, selector-no-qualifying-type
 
 .sage-table {
   width: 100%;

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -6,22 +6,22 @@
 
 
 // Borders and sizing
-$-table-border: rem(1px) solid sage-color(grey);
 $-table-header-border: rem(1px) solid sage-color(grey, 300);
 $-table-cell-padding-xs: sage-spacing(xs);
 $-table-cell-padding-card: sage-spacing(sm);
 $-table-cell-padding-panel: sage-spacing();
-$-table-heading-padding-sm: sage-spacing(sm) rem(12px);
-$-table-heading-padding-lg: sage-spacing(sm) rem(12px);
+$-table-padding: rem(12px);
 $-table-max-width: none;
 
 // Text
 $-table-caption-font-size: "%t-sage-body-small";
 $-table-caption-alignment: center;
-$-table-cell-font-color: sage-color(charcoal, 400);
-$-table-cell-type-spec: "%t-sage-body-small";
-$-table-heading-font-color: sage-color(charcoal, 400);
-$-table-heading-type-spec: "%t-sage-body-small-semi";
+$-table-cell-font-color: sage-color(charcoal, 200);
+$-table-cell-type-spec: "%t-sage-body";
+$-table-cell-font-color-strong: sage-color(charcoal, 400);
+$-table-cell-type-spec-strong: "%t-sage-body-med";
+$-table-heading-font-color: sage-color(charcoal, 500);
+$-table-heading-type-spec: "%t-sage-heading-6";
 
 // Overflow gradient
 $-table-overflow-indicator-width: sage-spacing(sm);
@@ -32,11 +32,13 @@ $-table-overflow-indicator-gradient: linear-gradient(90deg, $-table-overflow-ind
 
 // Other
 $-table-row-color-stripe: sage-color(grey, 100);
-$-table-row-color-hover: sage-color(grey, 200);
+$-table-row-color-hover: sage-color(primary, 100);
 $-table-cell-focus: sage-color(charcoal);
 $-table-cell-truncate-width: 6.5em;
 $-table-sort-indicator-width: rem(5px);
 $-table-sort-indicator-direction: rem(7px);
+$-table-checkbox-width: rem(20px);
+$-table-avatar-width: rem(32px);
 
 
 // stylelint-disable selector-max-compound-selectors
@@ -60,7 +62,7 @@ $-table-sort-indicator-direction: rem(7px);
     th {
       @extend #{$-table-heading-type-spec};
 
-      padding: sage-spacing(sm) $-table-cell-padding-panel / 2;
+      padding: $-table-padding;
 
       &:first-child {
         padding-left: $-table-cell-padding-panel;
@@ -94,7 +96,7 @@ $-table-sort-indicator-direction: rem(7px);
     @extend #{$-table-cell-type-spec};
 
     // Cells should split the desired padding in half to make total desired space
-    padding: $-table-cell-padding-panel / 2;
+    padding: $-table-padding;
     color: inherit;
 
     // First and last cells in a row get the full outer spacing
@@ -104,6 +106,12 @@ $-table-sort-indicator-direction: rem(7px);
 
     &:last-child {
       padding-right: $-table-cell-padding-panel;
+    }
+
+    &.sage-table-cell--strong {
+      @extend #{$-table-cell-type-spec-strong};
+    
+      color: $-table-cell-font-color-strong;
     }
   }
 }
@@ -212,24 +220,18 @@ $-table-sort-indicator-direction: rem(7px);
     margin-left: -1 * $-table-cell-padding-card;
     margin-right: -1 * $-table-cell-padding-card;
 
-    td {
-      padding: $-table-cell-padding-card / 2;
+    td:first-child {
+      padding-left: $-table-cell-padding-card;
+    }
 
-      &:first-child {
-        padding-left: $-table-cell-padding-card;
-      }
-
-      &:last-child {
-        padding-right: $-table-cell-padding-card;
-      }
+    td:last-child {
+      padding-right: $-table-cell-padding-card;
     }
 
     thead,
     tfoot {
       th,
       td {
-        padding: sage-spacing(xs) $-table-cell-padding-card / 2;
-
         &:first-child {
           padding-left: $-table-cell-padding-card;
         }
@@ -292,23 +294,27 @@ $-table-sort-indicator-direction: rem(7px);
 }
 
 // Text overflow treatment in individual cells
-.sage-table-cell--truncate {
-  overflow: hidden;
+.sage-table-cell--truncate,
+.sage-table-cell__truncated-content {
+  @include truncate();
+
   max-width: $-table-cell-truncate-width;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .sage-table-cell--checkbox {
-  width: rem(64px);
+  width: $-table-checkbox-width;
 }
 
 .sage-table-cell--avatar {
-  width: rem(52px);
+  width: $-table-avatar-width;
 }
 
 .sage-table-cell--align-right {
   text-align: right;
+}
+
+.sage-table-cell--align-center {
+  text-align: center;
 }
 
 // Stacked block content within cells

--- a/packages/sage-assets/lib/stylesheets/index.scss
+++ b/packages/sage-assets/lib/stylesheets/index.scss
@@ -28,7 +28,6 @@
 @import "utilities/spacer";
 
 // Components
-@import "components/stat_box";
 @import "components/chart_legend";
 @import "components/chart_summary";
 @import "components/alert";
@@ -82,6 +81,7 @@
 @import "components/search";
 @import "components/sidebar";
 @import "components/sortable";
+@import "components/stat_box";
 @import "components/status_icon";
 @import "components/switch";
 @import "components/tab";

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -6,8 +6,9 @@ import { LABEL_COLORS, TYPE } from './configs'; // component configurations as n
 
 export const StatBox = ({
   customLabel,
-  data,
   change,
+  data,
+  hasData,
   link,
   popover,
   timeframe,
@@ -43,7 +44,7 @@ export const StatBox = ({
         {popover}
       </header>
       <div className="sage-stat-box__body sage-grid-template-te">
-        <p className="sage-stat-box__data">
+        <p className={`sage-stat-box__data ${!hasData ? 'sage-stat-box__data--no-data' : null}`}>
           {data}
           {timeframe && (
             <span className="sage-stat-box__timeframe">{timeframe}</span>
@@ -69,6 +70,7 @@ StatBox.defaultProps = {
     value: null,
   },
   customLabel: null,
+  hasData: true,
   link: {
     href: null,
     value: null,
@@ -78,15 +80,16 @@ StatBox.defaultProps = {
 };
 
 StatBox.propTypes = {
+  change: PropTypes.shape({
+    type: PropTypes.oneOf(Object.values(StatBox.TYPE)),
+    value: PropTypes.string,
+  }),
   customLabel: PropTypes.node,
   data: PropTypes.string.isRequired,
-  change: PropTypes.shape({
-    type: PropTypes.oneOf(Object.values(StatBox.TYPE)).isRequired,
-    value: PropTypes.string.isRequired,
-  }),
+  hasData: PropTypes.bool,
   link: PropTypes.shape({
-    href: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired,
+    href: PropTypes.string,
+    value: PropTypes.string,
   }),
   popover: PropTypes.node,
   timeframe: PropTypes.string,

--- a/packages/sage-react/lib/StatBox/StatBox.spec.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.spec.jsx
@@ -10,8 +10,7 @@ describe('Sage StatBox', () => {
 
   beforeEach(() => {
     defaultProps = {
-      data: 65535,
-      link: { href: '#', value: 'View More' },
+      data: '4,010',
       title: 'In Progress',
     };
 

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -1,31 +1,33 @@
 import React from 'react';
-import { selectArgs } from '../story-support/helpers';
 import { StatBox } from './StatBox';
 
 export default {
   title: 'Sage/StatBox',
   component: StatBox,
-  argTypes: {
-    // As needed, use this for elaboration of token properties
-    // such as shown below for icons
-    ...selectArgs({}),
-  },
-  args: {
-    // As needed, provide overall story defaults here
-    data: '401',
-    change: {
-      type: StatBox.TYPE.DEFAULT,
-      value: '54%',
-    },
-    link: {
-      href: '#',
-      value: 'View More',
-    },
-    timeframe: 'in last 30 days',
-    title: 'In Progress',
-  }
 };
 const Template = (args) => <StatBox {...args} />;
 
 // The default story; add more as needed by duplicating this line and adjusting as needed.
 export const Default = Template.bind({});
+Default.args = {
+  change: {
+    type: StatBox.TYPE.POSITIVE,
+    value: '38%',
+  },
+  data: '4,010',
+  link: {
+    value: 'View More',
+    href: '#'
+  },
+  timeframe: 'in last 30 days',
+  title: 'In Progress'
+};
+
+export const NullView = Template.bind({});
+NullView.args = {
+  change: null,
+  data: 'No insights to show',
+  hasData: false,
+  link: null,
+  title: 'In Progress'
+};

--- a/packages/sage-react/lib/Tabs/TabsItem.jsx
+++ b/packages/sage-react/lib/Tabs/TabsItem.jsx
@@ -37,8 +37,6 @@ export const TabsItem = ({
   const isRadioType = type && type === CHOICE_TYPES.RADIO;
   const baseClass = `sage-${itemStyleProtected}`;
 
-  console.log(isChoice, verticalAlignIcon, (isIconType || isRadioType));
-
   const classNames = classnames(
     className,
     {


### PR DESCRIPTION
1. #534 (LOW) Removes stray `console.log` in TabsItem which was causing a glut of logs in new Product Admin. No other impact on usage.
1. #537 (LOW) Fixes a bug in Copy buttons where a formatting error led to undesired whitespace in the copied content. See any copy buttons in the app to verify they behave as expected but also 
   - [ ] Fixes MAN-1550 where additional whitespace was coming through in copy text buttons as a part of the Custom Domain nameserver setup step.
 1. #536 (LOW) Update spacing between `<p>` tags within modal content. This affect any of the modals since there are no instances of adjacent `<p>` tags currently within any modal in the app.
    - [ ] Delete confirmation modal once sagified - Podcast episode delete episode modal
    - [ ] Delete confirmation modal text match once sagified - Site delete modal
1. #489 (BREAKING) Use of the sort within the SagePanelControls component as part of kajabi-products. Any show_sort will need to be converted to a dropdown within a content_for in order to be functional after update. The following two locations in kajabi-products, after version is updated, will have a sort to be verified.
    - [ ] Landing pages is using a sort that should be updated to work with the content_for
    - [ ] Podcasts / Episode list should be verified as noted in the Testing in kajabi-products section
1. #541 (LOW) Updates Stat Box data attribute styling based on new attribute. No effect on existing work in Kajabi Products.
1. #539 (LOW) Add a conditional image to the page heading component. This is a new feature and doesn't affect anything currently in the app.
1. #540 (LOW/MEDIUM/HIGH/BREAKING) Updates appearance and some settings on Sage Tables. No impact expected on existing tables. Verify the following sample tables still appear as expected (now matching design specs in colors, spacing, and type sizes):
   - [ ] People list
   - [ ] Newsletters list
   - [ ] Podcasts episodes list