### PR TITLE
Modal - update spacing between adjacent p tags

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -54,6 +54,11 @@
         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       </p>
 
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
       <% content_for :sage_footer do %>
         <% content_for :sage_footer_aside do %>
           <%= sage_component SageButton, {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -124,6 +124,10 @@ $-modal-header-image-size: rem(28px);
     margin-bottom: 0;
   }
 
+  p + p {
+    margin-top: sage-spacing(xs);
+  }
+
   @include clearfix;
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -125,7 +125,7 @@ $-modal-header-image-size: rem(28px);
   }
 
   p + p {
-    margin-top: sage-spacing(xs);
+    margin-top: sage-spacing();
   }
 
   @include clearfix;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-05-24 at 2 13 12 PM](https://user-images.githubusercontent.com/1241836/119396242-3b407e80-bc9a-11eb-9f9b-ec1b2205f916.png)|![Screen Shot 2021-05-24 at 2 12 57 PM](https://user-images.githubusercontent.com/1241836/119396253-3e3b6f00-bc9a-11eb-92cc-46d2ddcca321.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the modal page and click on the Standard Modal demo
Verify that the spacing between the adjacent `<p>` tags matching the spec value, which is `24px`

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Update spacing between `<p>` tags within modal content. This affect any of the modals since there are no instances of adjacent `<p>` tags currently within any modal in the app.
   - [ ] Delete confirmation modal once sagified - Podcast episode delete episode modal
   - [ ] Delete confirmation modal text match once sagified - Site delete modal


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[BUILD-1112: https://github.com/Kajabi/kajabi-products/pull/19033/