### PR TITLE
Stray copytext whitespace

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,7 +1,6 @@
 <button
-  class="sage-copy-btn"
-  data-js-copy-button="<%= component.value.html_safe %>
-  <%= component.generated_css_classes %>"
+  class="sage-copy-btn <%= component.generated_css_classes %>"
+  data-js-copy-button="<%= component.value.html_safe %>"
   <%= component.generated_html_attributes.html_safe %>
 >
   <%= sage_component SageCopyText, { value: component.value, semibold: component.semibold.present? && component.semibold } %>


### PR DESCRIPTION
## Description

This PR fixes a bug in Copy buttons where a formatting error led to undesired whitespace in the copied content.


## Testing in `sage-lib`

See Copy Text and verify that the copy button still performs as expected (but now should not contain extra whitespace after copied content).


## Testing in `kajabi-products`

(LOW) Fixes a bug in Copy buttons where a formatting error led to undesired whitespace in the copied content. See any copy buttons in the app to verify they behave as expected but also 
   - [ ] Fixes MAN-1550 where additional whitespace was coming through in copy text buttons as a part of the Custom Domain nameserver setup step.

