### PR TITLE
Stat Box Null View

### DIFF
--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -1,13 +1,23 @@
+
+<h3 class="t-sage-heading-6">Default with Data</h3>
 <%= sage_component SageStatBox, {
   change: { 
     type: "positive", 
     value: "30%", 
   },
   data: "1,342",
+  has_data: true,
   link: {
     href: "#",
     value: "View More",
   },
   timeframe: "in last 30 days",
+  title: "Completed",
+} %>
+
+<h3 class="t-sage-heading-6">Null View</h3>
+<%= sage_component SageStatBox, {
+  data: "No insights to show",
+  has_data: false,
   title: "Completed",
 } %>

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -1,10 +1,4 @@
 <tr>
-  <td><%= md('`custom_label`') %></td>
-  <td><%= md('Optional custom label or content.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`change`') %></td>
   <td><%= md('Sets the `type` and `value` properties for the label.') %></td>
   <td><%= md('```
@@ -16,9 +10,21 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`custom_label`') %></td>
+  <td><%= md('Optional custom label or content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`data`') %></td>
   <td><%= md('Numeric data displayed.') %></td>
-  <td><%= md('Integer') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`has_data`') %></td>
+  <td><%= md('Boolean that determines styling for `data`.') %></td>
+  <td><%= md('Bool') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -6,6 +6,7 @@ class SageStatBox < SageComponent
       value: String,
     }],
     data: String,
+    has_data: [:optional, TrueClass],
     link: [:optional, {
       href: String,
       value: String,

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -1,4 +1,6 @@
-<% 
+<%
+# Set up label configs for Sage Label as default
+
 change_value = component.change.present? ? component.change[:value] : "No change"
 change_type = component.change.present? ? component.change[:type] : "neutral"
 label_configs = { color: "draft", value: change_value } 
@@ -21,7 +23,8 @@ end
     <% end %>
   </header>
   <div class="sage-stat-box__body sage-grid-template-te">
-    <p class="sage-stat-box__data">
+    <p class="sage-stat-box__data
+    <%= "sage-stat-box__data--no-data" if !component.has_data %>">
       <%= component.data %>
       <% if component.timeframe.present? %>
         <span class="sage-stat-box__timeframe"><%= component.timeframe %></span>

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -23,14 +23,21 @@
   align-items: center;
 }
 
+.sage-stat-box__title,
+.sage-stat-box__data--no-data {
+  color: sage-color(charcoal, 200);
+}
+
 .sage-stat-box__title {
   @extend %t-sage-body-small-med;
   margin-right: sage-spacing(xs);
-  color: sage-color(charcoal, 200);
 }
 
 .sage-stat-box__data {
   @extend %t-sage-heading-5;
+}
+.sage-stat-box__data--no-data {
+  @extend %t-sage-body-small;
 }
 
 .sage-stat-box__timeframe {

--- a/packages/sage-assets/lib/stylesheets/index.scss
+++ b/packages/sage-assets/lib/stylesheets/index.scss
@@ -28,7 +28,6 @@
 @import "utilities/spacer";
 
 // Components
-@import "components/stat_box";
 @import "components/chart_legend";
 @import "components/chart_summary";
 @import "components/alert";
@@ -82,6 +81,7 @@
 @import "components/search";
 @import "components/sidebar";
 @import "components/sortable";
+@import "components/stat_box";
 @import "components/status_icon";
 @import "components/switch";
 @import "components/tab";

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -6,8 +6,9 @@ import { LABEL_COLORS, TYPE } from './configs'; // component configurations as n
 
 export const StatBox = ({
   customLabel,
-  data,
   change,
+  data,
+  hasData,
   link,
   popover,
   timeframe,
@@ -43,7 +44,7 @@ export const StatBox = ({
         {popover}
       </header>
       <div className="sage-stat-box__body sage-grid-template-te">
-        <p className="sage-stat-box__data">
+        <p className={`sage-stat-box__data ${!hasData ? 'sage-stat-box__data--no-data' : null}`}>
           {data}
           {timeframe && (
             <span className="sage-stat-box__timeframe">{timeframe}</span>
@@ -69,6 +70,7 @@ StatBox.defaultProps = {
     value: null,
   },
   customLabel: null,
+  hasData: true,
   link: {
     href: null,
     value: null,
@@ -78,15 +80,16 @@ StatBox.defaultProps = {
 };
 
 StatBox.propTypes = {
+  change: PropTypes.shape({
+    type: PropTypes.oneOf(Object.values(StatBox.TYPE)),
+    value: PropTypes.string,
+  }),
   customLabel: PropTypes.node,
   data: PropTypes.string.isRequired,
-  change: PropTypes.shape({
-    type: PropTypes.oneOf(Object.values(StatBox.TYPE)).isRequired,
-    value: PropTypes.string.isRequired,
-  }),
+  hasData: PropTypes.bool,
   link: PropTypes.shape({
-    href: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired,
+    href: PropTypes.string,
+    value: PropTypes.string,
   }),
   popover: PropTypes.node,
   timeframe: PropTypes.string,

--- a/packages/sage-react/lib/StatBox/StatBox.spec.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.spec.jsx
@@ -10,8 +10,7 @@ describe('Sage StatBox', () => {
 
   beforeEach(() => {
     defaultProps = {
-      data: 65535,
-      link: { href: '#', value: 'View More' },
+      data: '4,010',
       title: 'In Progress',
     };
 

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -1,31 +1,33 @@
 import React from 'react';
-import { selectArgs } from '../story-support/helpers';
 import { StatBox } from './StatBox';
 
 export default {
   title: 'Sage/StatBox',
   component: StatBox,
-  argTypes: {
-    // As needed, use this for elaboration of token properties
-    // such as shown below for icons
-    ...selectArgs({}),
-  },
-  args: {
-    // As needed, provide overall story defaults here
-    data: '401',
-    change: {
-      type: StatBox.TYPE.DEFAULT,
-      value: '54%',
-    },
-    link: {
-      href: '#',
-      value: 'View More',
-    },
-    timeframe: 'in last 30 days',
-    title: 'In Progress',
-  }
 };
 const Template = (args) => <StatBox {...args} />;
 
 // The default story; add more as needed by duplicating this line and adjusting as needed.
 export const Default = Template.bind({});
+Default.args = {
+  change: {
+    type: StatBox.TYPE.POSITIVE,
+    value: '38%',
+  },
+  data: '4,010',
+  link: {
+    value: 'View More',
+    href: '#'
+  },
+  timeframe: 'in last 30 days',
+  title: 'In Progress'
+};
+
+export const NullView = Template.bind({});
+NullView.args = {
+  change: null,
+  data: 'No insights to show',
+  hasData: false,
+  link: null,
+  title: 'In Progress'
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a null view styling to Stat Box `data` attribute.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="729" alt="Screen Shot 2021-05-25 at 1 15 45 PM" src="https://user-images.githubusercontent.com/14791307/119548019-65a64080-bd5b-11eb-9ca9-3968b949f03e.png">

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
A new attribute `has_data` has been added that adds `sage-stat-box__data--no-data` to the existing `sage-stat-box__data` paragraph tag when `has_data` is `false`. Changes styling to match the null view styles in the [Figma file](https://www.figma.com/file/YlkC24Qlp0UbLVXmQZIvYR/CRM-Dashboard?node-id=762%3A3193)

### Rails
- View [Rails component](http://localhost:4000/pages/component/stat_box)
- Check that component UI exists and nothing is broken
- Check that null view renders as expected when `has_data` is set to `false`

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-statbox--default)
- Check that component UI exists and nothing is broken
- Check that null view renders as expected when `hasData` is set to `false`

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates styling based on new attribute. No effect on existing work in Kajabi Products.