### PR TITLE
BUILD-1145: podcast search not working

### DIFF
--- a/packages/sage-system/lib/search.js
+++ b/packages/sage-system/lib/search.js
@@ -57,6 +57,7 @@ Sage.search = (function() {
       searchParams.delete('search');
     } else {
       searchParams.set('search', value);
+      searchParams.delete('page');
     }
 
     window.location.search = searchParams.toString();


### PR DESCRIPTION
## Description
Podcast episode search was not working when you searched for something on a page different than what the episode was on. This was because adding the search filter on top of a pagination tried to look for that search result on that specific page. The solution was to remove the `page` key from the `URLSearchParams`.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2021-05-25 at 2 35 33 PM](https://user-images.githubusercontent.com/15473295/119571970-e0c12400-bd66-11eb-876f-e048d9436dc0.png) | ![Screen Shot 2021-05-25 at 2 36 20 PM](https://user-images.githubusercontent.com/15473295/119571993-ed457c80-bd66-11eb-892e-4c08f8af7e0c.png) |


## Testing in `sage-lib`
I don't think the current Sage public docs show any examples of actual search results, so doesn't seem like you need to test here.


## Testing in `kajabi-products`
(**MEDIUM**)
1. Create a podcast (can be either episodic or serial)
2. Generate at least 30 published episodes, so that the pagination kicks in
3. Name one of your episodes something easy to remember (`EX// "dogs are cool"`), since the automatically generated ones use the `lorem ipsum` fillers.
4. Navigate to a page other than the first one
5. In the search bar, enter your episode's name
6. You should get a search result with your episode

   - [x] One more examples of the component in use to either test the change or verify the change has not had adverse effects.
**I tested this on the sage product admin view of the product list**


## Related
BUILD-1145
