### PR TITLE
Parsley - remove error list until there's an error in a form field

### DIFF
--- a/packages/sage-assets/lib/stylesheets/vendor/_parsley.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_parsley.scss
@@ -11,6 +11,20 @@ $-parsley-box-shadow-size: map-get($sage-field-configs, box-shadow-size);
 $-parsley-border-width: map-get($sage-field-configs, border-width);
 $-parsley-color-success: map-get($sage-field-colors, success);
 
+.sage-input .parsley-errors-list,
+.sage-textarea .parsley-errors-list,
+.sage-select .parsley-errors-list,
+.sage-checkbox .parsley-errors-list,
+.sage-radio .parsley-errors-list,
+.sage-choice .parsley-errors-list,
+.sage-type .parsley-errors-list {
+  display: none;
+
+  &.filled {
+    display: block;
+  }
+}
+
 .sage-input__field {
   &.parsley-error {
     color: inherit;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove the error list under the form field until an error occurs

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  before  |  after  |
|--------|--------|
|![Screen Shot 2021-05-27 at 10 23 40 AM](https://user-images.githubusercontent.com/1241836/119856461-57316380-bed8-11eb-80d2-9121220fabc0.png)|![Screen Shot 2021-05-27 at 10 22 25 AM](https://user-images.githubusercontent.com/1241836/119856491-5d274480-bed8-11eb-94bf-735ac4e0e38e.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Can't check in `sage-lib` as parsley adds error states dynamically

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (MEDIUM) Affects all forms that require parsley validation remove the error list until an error occurs
   - [ ] Podcast Episode Edit form
   - [ ] New Podcast Episode form
   - [ ] New Coaching Program Session form
   - [ ] Add Newsletter form
   - [ ] Add Newsletter Issue form


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[PR for BUILD-1158](https://github.com/Kajabi/kajabi-products/pull/19231)