### PR TITLE
Copy button: fill container

### DIFF
--- a/docs/app/views/examples/components/copy_text/_preview.html.erb
+++ b/docs/app/views/examples/components/copy_text/_preview.html.erb
@@ -10,3 +10,6 @@
 
 <h3 class="t-sage-heading-6">Copy Button</h3>
 <%= sage_component SageCopyButton, { value: "me.ns.cloudflare.com", semibold: true } %>
+
+<h3 class="t-sage-heading-6">Copy Button (fill container)</h3>
+<%= sage_component SageCopyButton, { fill_container: true, value: "me.ns.cloudflare.com", semibold: true } %>

--- a/docs/app/views/examples/components/copy_text/_props.html.erb
+++ b/docs/app/views/examples/components/copy_text/_props.html.erb
@@ -10,3 +10,9 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td><%= md('`fill_container` (CopyButton only)') %></td>
+  <td><%= md('Sets the CopyButton component to fill its container.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_copy_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_copy_button.rb
@@ -1,5 +1,6 @@
 class SageCopyButton < SageComponent
   set_attribute_schema({
+    fill_container: [:optional, TrueClass],
     semibold: [:optional, TrueClass],
     value: String,
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,5 +1,5 @@
 <button
-  class="sage-copy-btn <%= component.generated_css_classes %>"
+  class="sage-copy-btn <%= "sage-copy-btn--fill-container" if component.fill_container %> <%= component.generated_css_classes %>"
   data-js-copy-button="<%= component.value.html_safe %>"
   <%= component.generated_html_attributes.html_safe %>
 >

--- a/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
@@ -27,6 +27,10 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
     background-color: sage-color(grey, 100);
     border-color: sage-color(grey, 500);
   }
+
+  .sage-copy-btn--fill-container & {
+    width: 100%;
+  }
 }
 
 .sage-copy-text-card {
@@ -66,6 +70,11 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
   &:hover::before {
     color: $-copy-text-color-hover;
   }
+}
+
+.sage-copy-btn--fill-container {
+  width: 100%;
+  text-align: left;
 }
 
 .sage-copy-text--semibold,

--- a/packages/sage-react/lib/CopyButton/CopyButton.jsx
+++ b/packages/sage-react/lib/CopyButton/CopyButton.jsx
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { CopyText } from '../CopyText';
 
-export const CopyButton = ({ children, className, semibold }) => {
+export const CopyButton = ({ children, className, fillContainer, semibold }) => {
   const classNames = classnames(
     'sage-copy-btn',
     className,
+    {
+      'sage-copy-btn--fill-container': fillContainer,
+    }
   );
 
   const copyBlockRef = useRef(null);
@@ -33,11 +36,13 @@ export const CopyButton = ({ children, className, semibold }) => {
 CopyButton.defaultProps = {
   children: null,
   className: null,
+  fillContainer: false,
   semibold: true,
 };
 
 CopyButton.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  fillContainer: PropTypes.bool,
   semibold: PropTypes.bool,
 };


### PR DESCRIPTION
## Description

Adds a new optional parameter to CopyButton to allow it to fill its container when desired.


## Screenshots

![Screen Shot 2021-06-01 at 6 21 42 PM](https://user-images.githubusercontent.com/17955295/120397467-5e0c0c00-c306-11eb-86bc-0dd10f0bbd42.png)


## Testing in `sage-lib`

See Components > Copy Text

## Testing in `kajabi-products`
1. (LOW) Adds a new property to Copy Button allowing it to fill its container. No impact on existing uses.
