### PR TITLE
Update state color settings

### DIFF
--- a/docs/app/views/examples/components/transaction_card/_preview.html.erb
+++ b/docs/app/views/examples/components/transaction_card/_preview.html.erb
@@ -8,6 +8,5 @@
   related_property: "Total Product Blueprint",
   related_property_href: "https://kajabi.com",
   transaction_state: "New",
-  transaction_state_color: "info",
   transaction_time: "10:32pm",
 } %>

--- a/docs/app/views/examples/components/transaction_card/_props.html.erb
+++ b/docs/app/views/examples/components/transaction_card/_props.html.erb
@@ -26,7 +26,7 @@
   <td><%= md('`amount_color`') %></td>
   <td><%= md('Color that can be applied to the transaction amount.') %></td>
   <td><%= md('`"red"`, `"sage"`') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md('`nil` (charcoal)') %></td>
 </tr>
 <tr>
   <td><%= md('`label_color`') %></td>
@@ -61,8 +61,8 @@
 <tr>
   <td><%= md('`transaction_state_color`') %></td>
   <td><%= md('Color that can be applied to the transaction_state.') %></td>
-  <td><%= md('`"info"`, `"red"`') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md('`"sage"`, `"red"`') %></td>
+  <td><%= md('`nil` (charcoal)') %></td>
 </tr>
 <tr>
   <td><%= md('`transacton_time`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_transaction_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_transaction_card.rb
@@ -10,7 +10,7 @@ class SageTransactionCard < SageComponent
     related_property: [:optional, String],
     related_property_href: [:optional, String],
     transaction_state: [:optional, String],
-    transaction_state_color: [:optional, Set.new(["info", "red"])],
+    transaction_state_color: [:optional, Set.new(["sage", "red"])],
     transaction_time: [:optional, String],
   })
 end

--- a/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
@@ -5,6 +5,7 @@
 ////
 
 
+
 .sage-transaction-card {
   @include sage-card();
   position: relative;
@@ -50,16 +51,21 @@
 .sage-transaction-card__amount--sage {
   color: sage-color(sage, 300);
 }
+
 .sage-transaction-card__amount--red {
   color: sage-color(red, 300);
 }
 
 .sage-transaction-card__state {
   @extend %t-sage-body-small;
+
+  color: sage-color(charcoal, 400);
 }
-.sage-transaction-card__state--info {
-  color: sage-color(primary, 400);
-}
+
 .sage-transaction-card__state--red {
   color: sage-color(red, 300);
+}
+
+.sage-transaction-card__state--sage {
+  color: sage-color(sage, 300);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
@@ -5,7 +5,6 @@
 ////
 
 
-
 .sage-transaction-card {
   @include sage-card();
   position: relative;

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -7,17 +7,17 @@ import { Label } from '../Label';
 import { AMOUNT_COLORS, LABEL_COLORS, STATE_COLORS } from './configs';
 
 export const TransactionCard = ({
+  amount,
+  amountColor,
   labelColor,
   labelText,
-  transactionState,
-  transactionStateColor,
   name,
   nameHref,
   nameTag,
-  amount,
-  amountColor,
   relatedProperty,
   relatedPropertyHref,
+  transactionState,
+  transactionStateColor,
   transactionTime,
 }) => {
   const NameTag = nameTag;
@@ -58,31 +58,31 @@ TransactionCard.AMOUNT_COLORS = AMOUNT_COLORS;
 TransactionCard.STATE_COLORS = STATE_COLORS;
 
 TransactionCard.defaultProps = {
-  labelText: '--',
+  amount: '0.00',
+  amountColor: null,
   labelColor: LABEL_COLORS.PUBLISHED,
-  transactionState: null,
-  transactionStateColor: null,
+  labelText: '--',
   name: '--',
   nameHref: null,
   nameTag: 'h4',
-  amount: '0.00',
-  amountColor: null,
   relatedProperty: '--',
   relatedPropertyHref: null,
+  transactionState: null,
+  transactionStateColor: null,
   transactionTime: '--',
 };
 
 TransactionCard.propTypes = {
-  labelText: PropTypes.string,
+  amount: PropTypes.string,
+  amountColor: PropTypes.oneOf(Object.values(TransactionCard.AMOUNT_COLORS)),
   labelColor: PropTypes.oneOf(Object.values(TransactionCard.LABEL_COLORS)),
-  transactionState: PropTypes.string,
-  transactionStateColor: PropTypes.oneOf(Object.values(TransactionCard.STATE_COLORS)),
+  labelText: PropTypes.string,
   name: PropTypes.string,
   nameHref: PropTypes.string,
   nameTag: PropTypes.string,
-  amount: PropTypes.string,
-  amountColor: PropTypes.oneOf(Object.values(TransactionCard.AMOUNT_COLORS)),
   relatedProperty: PropTypes.string,
   relatedPropertyHref: PropTypes.string,
+  transactionState: PropTypes.string,
+  transactionStateColor: PropTypes.oneOf(Object.values(TransactionCard.STATE_COLORS)),
   transactionTime: PropTypes.string,
 };

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.story.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.story.jsx
@@ -9,7 +9,7 @@ export default {
     ...selectArgs({
       amountColor: TransactionCard.AMOUNT_COLORS,
       labelColor: TransactionCard.LABEL_COLORS,
-      stateColor: TransactionCard.STATE_COLORS,
+      transactionStateColor: TransactionCard.STATE_COLORS,
     }),
   },
   args: {
@@ -17,7 +17,7 @@ export default {
     amountColor: TransactionCard.AMOUNT_COLORS.DEFAULT,
     labelColor: TransactionCard.LABEL_COLORS.PUBLISHED,
     labelText: 'Multi-Payment',
-    transactionStateColor: TransactionCard.STATE_COLORS.INFO,
+    transactionStateColor: TransactionCard.STATE_COLORS.SAGE,
     transactionState: 'New',
     name: 'Lilly Jones',
     nameHref: 'https://kajabi.com',

--- a/packages/sage-react/lib/TransactionCard/configs.js
+++ b/packages/sage-react/lib/TransactionCard/configs.js
@@ -15,6 +15,6 @@ export const LABEL_COLORS = {
 
 export const STATE_COLORS = {
   DEFAULT: null,
+  SAGE: 'sage',
   RED: 'red',
-  INFO: 'info',
 };


### PR DESCRIPTION
## Description

Makes a color change to Transaction card: blue color will not be used but a green on is needed for the state color.

## Testing in `sage-lib`

See Transaction Card and the new state color configs.

## Testing in `kajabi-products`

(LOW/MEDIUM/HIGH/BREAKING) Non-breaking color change to Transaction Card. Does not affect any existing uses.

