### PR TITLE
Indicator - add prop to show text representation of the current page

### DIFF
--- a/docs/app/views/examples/components/indicator/_preview.html.erb
+++ b/docs/app/views/examples/components/indicator/_preview.html.erb
@@ -4,3 +4,12 @@
   label: "Page",
   num_items: 5,
 } %>
+
+
+<h3 class="t-sage-heading-6">Show Text</h3>
+<%= sage_component SageIndicator, {
+  current_item: 2,
+  label: "Page",
+  num_items: 5,
+  show_text: true
+} %>

--- a/docs/app/views/examples/components/indicator/_props.html.erb
+++ b/docs/app/views/examples/components/indicator/_props.html.erb
@@ -18,7 +18,7 @@
 </tr>
 <tr>
   <td><%= md('`show_text`') %></td>
-  <td><%= md('When enabled, this replaced the indicator dots with a text representation of the current page.') %></td>
+  <td><%= md('When enabled, this replaces the indicator dots with text to represent the current page.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/indicator/_props.html.erb
+++ b/docs/app/views/examples/components/indicator/_props.html.erb
@@ -16,3 +16,9 @@
   <td><%= md('Integer') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td><%= md('`show_text`') %></td>
+  <td><%= md('When enabled, this replaced the indicator dots with a text representation of the current page.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -49,6 +49,15 @@
         } %>
       <% end %>
 
+      <% content_for :sage_header_indicator do %>
+        <%= sage_component SageIndicator, {
+          current_item: 2,
+          label: "Page",
+          num_items: 5,
+          show_text: true
+        } %>
+      <% end %>
+
       <p class="t-sage-body">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/docs/lib/sage_rails/app/sage_components/sage_indicator.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_indicator.rb
@@ -3,5 +3,6 @@ class SageIndicator < SageComponent
     current_item: [:optional, Integer],
     label: [:optional, String],
     num_items: [:optional, Integer],
+    show_text: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal_content.rb
@@ -6,6 +6,6 @@ class SageModalContent < SageComponent
   })
 
   def sections
-    %w(header_aside footer footer_aside)
+    %w(header_aside header_indicator footer footer_aside)
   end
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_indicator.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_indicator.html.erb
@@ -1,11 +1,19 @@
 <% num_items = component.num_items.present? ? component.num_items : 0 %>
 
-<ul class="sage-indicator-list <%= component.generated_css_classes %>" aria-label="<%= "Showing #{component.label} #{component.current_item} of #{component.num_items}"%>" <%= component.generated_html_attributes.html_safe %>>
-  <% for i in 1...(num_items + 1) %>
-    <li class="sage-indicator<%= " sage-indicator--current" if component.current_item == i %>">
-      <span class="visually-hidden">
-        <%= "#{component.label} #{i}" %>
-      </span>
-    </li>
-  <% end %>
-</ul>
+<% if component.show_text %>
+  <p class="sage-indicator-text <%= component.generated_css_classes %>"
+    <%= component.generated_html_attributes.html_safe %>
+  >
+    <%= "#{component.label} #{component.current_item} of #{component.num_items}" %>
+  </p>
+<% else %>
+  <ul class="sage-indicator-list <%= component.generated_css_classes %>" aria-label="<%= "Showing #{component.label} #{component.current_item} of #{component.num_items}"%>" <%= component.generated_html_attributes.html_safe %>>
+    <% for i in 1...(num_items + 1) %>
+      <li class="sage-indicator<%= " sage-indicator--current" if component.current_item == i %>">
+        <span class="visually-hidden">
+          <%= "#{component.label} #{i}" %>
+        </span>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -3,9 +3,14 @@
     <% if component.header_image.present? %>
       <img class="sage-modal__header-image" src=<%= component.header_image %> alt="" aria-hidden="true"/>
     <% end %>
-    <h1 class="t-sage-heading-4">
-      <%= component.title %>
-    </h1>
+    <div class="sage-modal__header-text">
+      <h1 class="t-sage-heading-4">
+        <%= component.title %>
+      </h1>
+      <% if content_for?(:sage_header_indicator) %>
+        <%= content_for :sage_header_indicator %>
+      <% end %>
+    </div>
     <% if content_for?(:sage_header_aside) %>
       <aside class="sage-modal__header-aside">
         <%= content_for :sage_header_aside %>
@@ -22,9 +27,9 @@
   <% end %>
 <% end %>
 
-<div 
+<div
   class="
-    sage-modal__content 
+    sage-modal__content
     <%= "sage-modal__content--spacing-#{component.spacing}" if component.spacing.present? %>
     <%= component.generated_css_classes %>"
   <%= component.generated_html_attributes.html_safe %>

--- a/packages/sage-assets/lib/stylesheets/components/_indicator.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_indicator.scss
@@ -27,6 +27,13 @@ $-indicator-size: rem(7px);
     margin-right: 8px;
   }
 }
+.sage-indicator-text {
+  margin-top: sage-spacing(2xs);
+
+  .sage-modal & {
+    margin-top: sage-spacing(2xs);
+  }
+}
 
 .sage-indicator--current {
   background-color: sage-color(grey, 500);

--- a/packages/sage-assets/lib/stylesheets/components/_indicator.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_indicator.scss
@@ -27,9 +27,8 @@ $-indicator-size: rem(7px);
     margin-right: 8px;
   }
 }
-.sage-indicator-text {
-  margin-top: sage-spacing(2xs);
 
+.sage-indicator-text {
   .sage-modal & {
     margin-top: sage-spacing(2xs);
   }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add a text variant for the indicator component based on the current page

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  On demo site  |  In modal header  |
|--------|--------|
|![Screen Shot 2021-06-02 at 1 13 27 PM](https://user-images.githubusercontent.com/1241836/120531548-5d29b780-c3a4-11eb-82f1-fef1732912e7.png)|<img width="527" alt="Screen_Shot_2021-06-02_at_11_10_33_AM" src="https://user-images.githubusercontent.com/1241836/120531646-79c5ef80-c3a4-11eb-8de3-3577f351c116.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the Indicator component page and see the `show-text` variant
- Visit the modal page and click on the standard modal, then verify that the modal indicator is place correctly

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) This is a new property and has no current affect with the app


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
