### PR TITLE
fix(modal js): prevent modal JS from erroring on close when `active: true` attribute set

### DIFF
--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -17,7 +17,7 @@ Sage.modal = (function() {
   const EVENT_ACTIVE = "sage.modal.active";
   const EVENT_OPENING = "sage.modal.opening";
   const EVENT_OPEN = "sage.modal.open";
-  let SELECTOR_LAST_FOCUSED;
+  let selectorLastFocused;
 
   // ==================================================
   // Functions
@@ -67,7 +67,7 @@ Sage.modal = (function() {
       fetchModalContent(modal);
     }
 
-    SELECTOR_LAST_FOCUSED = document.activeElement;
+    selectorLastFocused = document.activeElement;
     modal.classList.add(MODAL_ACTIVE_CLASS);
     modal.setAttribute("open", "");
     document.addEventListener("keyup", onModalKeypress);
@@ -122,7 +122,7 @@ Sage.modal = (function() {
     el.classList.remove(MODAL_ACTIVE_CLASS);
     el.removeAttribute("open");
     el.removeEventListener("keydown", focusTrap);
-    SELECTOR_LAST_FOCUSED.focus();
+    selectorLastFocused && selectorLastFocused.focus();
     removeModalContents(el);
   }
 


### PR DESCRIPTION
BUILD-1112

## Description

The modal JS fails to close if a previously selected element does not exist, in the instance of
`active: true` there is not a last focused element. This changes allows the modal JS to fallback
gracefully rather than fire errors when a close is attempted



## Screenshots
n/a


## Testing in `sage-lib`
Ensure modals which have `active :true` can be closed.


## Testing in `kajabi-products`
1. (**LOW**) Prevent modals which have `active :true` from erroring out. 
   - [ ] Check modals that modals work as expected, incoming work makes use of `active: true` in https://github.com/Kajabi/kajabi-products/pull/19033


## Related
https://github.com/Kajabi/kajabi-products/pull/19033
