### PR TITLE
Tooltip - show on either hover or focus

### DIFF
--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -14,12 +14,16 @@ Sage.tooltip = (function() {
 
   function init(el) {
     el.addEventListener("mouseenter", buildToolTip);
+    el.addEventListener("focus", buildToolTip);
     el.addEventListener("mouseleave", removeTooltip);
+    el.addEventListener("blur", removeTooltip);
   }
 
   function unbind(el) {
     el.removeEventListener("mouseenter", buildToolTip);
+    el.removeEventListener("focus", buildToolTip);
     el.removeEventListener("mouseleave", removeTooltip);
+    el.removeEventListener("blur", removeTooltip);
   }
 
   // tooltip template


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] allow tooltip to also show on focus

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![tooltiphoverbefore](https://user-images.githubusercontent.com/1241836/121058100-9b98eb00-c785-11eb-9215-93b65d0d5d77.gif)|![tooltiphoverafter](https://user-images.githubusercontent.com/1241836/121058117-9e93db80-c785-11eb-9335-2a8d13153733.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the tooltip page and tab through it. While tabbing the buttons, tooltips should now show.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Updates existing and new tooltips to show on either hover or focus. No affect to the tooltip structure or content.
   - [ ] Product Index page -> user icon within the rows
   - [ ] Offers Index page -> icons in the list

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
https://kajabi.atlassian.net/browse/BUILD-1234