### PR TITLE
temp: hide focus/blur listeners

### DIFF
--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -12,18 +12,21 @@ Sage.tooltip = (function() {
   // Functions
   // ==================================================
 
+  // TODO: Reverting tooltip reveal on focus/blur until further investigation of persistent focus
+  // can resolve it lingering when it shouldn't.
+
   function init(el) {
     el.addEventListener("mouseenter", buildToolTip);
-    el.addEventListener("focus", buildToolTip);
+    // el.addEventListener("focus", buildToolTip);
     el.addEventListener("mouseleave", removeTooltip);
-    el.addEventListener("blur", removeTooltip);
+    // el.addEventListener("blur", removeTooltip);
   }
 
   function unbind(el) {
     el.removeEventListener("mouseenter", buildToolTip);
-    el.removeEventListener("focus", buildToolTip);
+    // el.removeEventListener("focus", buildToolTip);
     el.removeEventListener("mouseleave", removeTooltip);
-    el.removeEventListener("blur", removeTooltip);
+    // el.removeEventListener("blur", removeTooltip);
   }
 
   // tooltip template


### PR DESCRIPTION
## Description

Quick patch to hide recent additional of focus/blur listeners on tooltip until further investigation.

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`

1. (BREAKING) Fixes a regression from earlier where tooltips persist when modal or dropdowns are activated (focus remains)
   - [ ] Verify that patch fixes known issue.
