### PR TITLE
IconCard - add round property for circular border

### DIFF
--- a/docs/app/views/examples/components/icon_card/_preview.html.erb
+++ b/docs/app/views/examples/components/icon_card/_preview.html.erb
@@ -29,3 +29,17 @@
     </div>
   <% end %>
 </div>
+
+<h3 class="t-sage-heading-6">Icon Card - round</h3>
+<div class="sage-row">
+  <% SageTokens::STATUSES.each do | color | %>
+    <div class="sage-col-2">
+      <%= sage_component SageIconCard, {
+        color: color,
+        icon: "file",
+        label: "File graphic",
+        round: true
+      } %>
+    </div>
+  <% end %>
+</div>

--- a/docs/app/views/examples/components/icon_card/_props.html.erb
+++ b/docs/app/views/examples/components/icon_card/_props.html.erb
@@ -35,6 +35,12 @@
   <td><%= md('nil') %></td>
 </tr>
 <tr>
+  <td><%= md('`round`') %></td>
+  <td><%= md('When enabled, this gives the component a 50% `border-radius`.') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('See Sage Icons.') %></td>
+</tr>
+<tr>
   <td><%= md('`size`') %></td>
   <td><%= md('The size desired for the icon.') %></td>
   <td><%= md('`"xs"`, `"sm"`, `"md"`, `"lg"`, `"xl"`, `"2xl"`, `"2xl"`, ``"3xl"`, `"3xl"`, `"4xl"`') %></td>

--- a/docs/app/views/examples/components/icon_card/_props.html.erb
+++ b/docs/app/views/examples/components/icon_card/_props.html.erb
@@ -37,8 +37,8 @@
 <tr>
   <td><%= md('`round`') %></td>
   <td><%= md('When enabled, this gives the component a 50% `border-radius`.') %></td>
-  <td><%= md('`String`') %></td>
-  <td><%= md('See Sage Icons.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`size`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon_card.rb
@@ -6,6 +6,7 @@ class SageIconCard < SageComponent
     foreground_color: [:optional, String],
     icon: String,
     label: [:optional, String],
+    round: [:optional, TrueClass],
     size: [:optional, SageSchemas::ICON_SIZE],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
@@ -10,6 +10,7 @@ style = {
   class="
     sage-icon-card
     <%= "sage-icon-card--#{color}" if color.present? %>
+    <%= "sage-icon-card--round" if component.round %>
     <%= component.generated_css_classes %>
   "
   <% component.attributes.each do |key, value| %>

--- a/packages/sage-assets/lib/stylesheets/components/_icon_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon_card.scss
@@ -29,3 +29,6 @@
     --background-color: #{sage-color-combo($-color, default, background)};
   }
 }
+.sage-icon-card--round {
+  border-radius: sage-border(radius-round);
+}

--- a/packages/sage-react/lib/IconCard/IconCard.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.jsx
@@ -19,7 +19,7 @@ export const IconCard = ({
     className,
     {
       [`sage-icon-card--${color}`]: color,
-      [`sage-icon-card--round`]: round,
+      'sage-icon-card--round': round,
     }
   );
 

--- a/packages/sage-react/lib/IconCard/IconCard.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.jsx
@@ -10,6 +10,7 @@ export const IconCard = ({
   color,
   icon,
   label,
+  round,
   size,
   ...rest
 }) => {
@@ -18,6 +19,7 @@ export const IconCard = ({
     className,
     {
       [`sage-icon-card--${color}`]: color,
+      [`sage-icon-card--round`]: round,
     }
   );
 
@@ -39,6 +41,7 @@ IconCard.defaultProps = {
   className: null,
   color: Label.COLORS.DRAFT,
   label: null,
+  round: false,
   size: Icon.SIZES.XXXL,
 };
 
@@ -47,5 +50,6 @@ IconCard.propTypes = {
   color: PropTypes.oneOf(Object.values(Label.COLORS)),
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)).isRequired,
   label: PropTypes.string,
+  round: PropTypes.bool,
   size: PropTypes.oneOf(Object.values(Icon.SIZES)),
 };

--- a/packages/sage-react/lib/IconCard/IconCard.story.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.story.jsx
@@ -16,6 +16,7 @@ export default {
   args: {
     color: IconCard.COLORS.DRAFT,
     icon: IconCard.ICONS.CHECK_CIRCLE,
+    round: false,
     size: IconCard.SIZES.MD
   }
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add property so the component displays a circular radius

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-10 at 12 58 23 PM](https://user-images.githubusercontent.com/1241836/121574206-a359c900-c9eb-11eb-9a41-b8512fa95159.png)|![Screen Shot 2021-06-10 at 12 58 01 PM](https://user-images.githubusercontent.com/1241836/121574225-a785e680-c9eb-11eb-9f15-43e16aa629a9.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Icon Card rails and react page and verify the `round` variant

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Adding a new property so doesn't affect the current implementation in the app


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
