### PR TITLE
Dropdown - inner button icon alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -432,6 +432,11 @@ $-btn-interactive-label-icon-size: rem(24px);
 .sage-btn__truncate-text {
   @include truncate;
   pointer-events: none;
+
+  .sage-dropdown__trigger & {
+    display: inline-flex;
+    align-items: center;
+  }
 }
 
 // Button groups allow for several buttons together to be spaced appropriately


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] resolve alignment when a button w/icon child is present

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-10 at 1 03 15 PM](https://user-images.githubusercontent.com/1241836/121576550-1a905c80-c9ee-11eb-87e1-a3e02df9a0c1.png)|![Screen Shot 2021-06-10 at 1 13 48 PM](https://user-images.githubusercontent.com/1241836/121576568-1e23e380-c9ee-11eb-96c8-9c8fbc9ba71d.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
There is no instance within `sage-lib` 

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Affects dropdown with buttons with icons as triggers.
   - [ ] Outline Edit page -> select category field


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
