### PR TITLE
Switch - update message alignment on bordered variant and click target

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -137,7 +137,7 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
 
     &::after {
       content: "" ;
-      z-index: sage-z-index(default);
+      z-index: sage-z-index(default, 1);
       position: absolute;
       top: 0;
       left: 0;

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -95,6 +95,7 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
   @extend %t-sage-body-xsmall;
 
   .sage-switch--toggle-right & {
+    margin-left: 0;
     padding-left: 0;
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] Update message alignment for the bordered variant of the switch component
- [x] Resolve issue with message interfering with clickable area

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
##### message alignment
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-11 at 10 33 09 AM](https://user-images.githubusercontent.com/1241836/121712663-9ac3ca00-caa1-11eb-8612-e5f191c89968.png)|![Screen Shot 2021-06-11 at 10 36 07 AM](https://user-images.githubusercontent.com/1241836/121712675-9e575100-caa1-11eb-969b-41d30b6e76f5.png)|

##### updated label click area
|  Before  |  After  |
|--------|--------|
|![switchMessageBefore](https://user-images.githubusercontent.com/1241836/121716602-d2347580-caa5-11eb-9076-38f2106793d0.gif)|![switchMessageAfter](https://user-images.githubusercontent.com/1241836/121716612-d52f6600-caa5-11eb-8c1b-e008bbdfbed5.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Switch component rails page and verify that the message in the bordered variant is aligned properly
Visit the Switch Rails and React pages to verify that click on the message / hint clicks the form element label

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) This is a minor alignment fix on switch components with an associated hint
   - [ ] Unable to currently locate one, but a form element with the `:hint` arg populated


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
