### PR TITLE
Allow `type` attribute on Button component

### DIFF
--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
 demo_configs = [
   {
     heading: "Primary (regular and disabled)",
@@ -32,6 +32,16 @@ demo_configs = [
         value: "Button",
         style: config[:style],
         disabled: disabled
+      } %>
+
+      <!-- Primary submit button -->
+      <%= sage_component SageButton, {
+        value: "Submit",
+        style: config[:style],
+        disabled: disabled,
+        attributes: {
+          type: "submit"
+        }
       } %>
 
       <!-- Primary button (link) -->
@@ -209,7 +219,7 @@ demo_configs = [
 <p>
   Regular buttons allow for a "raised" shadow treatement to be toggled on or off.
   This is on by default for "Primary" button styles and can be toggled off with "no_shadow".
-  For the other styles it is off by default but can be toggled on with "raised".  
+  For the other styles it is off by default but can be toggled on with "raised".
 </p>
 <%= sage_component SageButtonGroup, { gap: :md, spacer: { bottom: :md } } do %>
   <%= sage_component SageButton, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -1,11 +1,11 @@
 <% is_button = !component.attributes&.has_key?(:href) %>
 <% html_tag = is_button ? "button" : "a" %>
+<% merged_attributes = (is_button ? { :type => "button" } : {}).merge((component.attributes || {})) %>
 
 <<%= html_tag %>
-  <%= "type=button" if is_button %>
-  <% component.attributes.each do |key, value| %>
+  <% merged_attributes.each do |key, value| %>
     <%= "#{key}=\"#{value}\"".html_safe %>
-  <% end if component.attributes&.is_a?(Hash) %>
+  <% end if merged_attributes&.is_a?(Hash) %>
   <%= "aria-disabled=true disabled" if component.disabled %>
   class="
     sage-btn


### PR DESCRIPTION
## Description
This PR enables setting the `type` attribute on the Rails Sage Button Component.

## Testing in `sage-lib`
Check http://0.0.0.0:4000/pages/component/button and ensure that the `Button` and `Submit` example have the appropriate `type` attributes.

## Testing in `kajabi-products`
1. (LOW) This is a new feature and should not affect current Button implementations, however we need to ensure that the Sage buttons in use still default to `type="submit"`:
   - [x] Offers: New Offers button (/admin/sites/1/offers)
   - [ ] Email Campaigns: New Email Campaign button (admin/sites/1/email_campaigns)
   - [ ] People: Add Contacts button - should be a link (admin/sites/1/contacts)

## Related
https://github.com/Kajabi/sage-lib/issues/567
