### PR TITLE
Catalog Item - move link spacing to the right of catalog items links

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_catalog_item.scss
@@ -45,7 +45,7 @@ $-catalogue-item-image-height-mobile: rem(120px);
         "img title aside"
         "img content aside";
     }
-  
+
     @media (max-width: sage-breakpoint(md-min)) {
       grid-template-columns: 1fr min-content;
       grid-template-rows: $-catalogue-item-image-height-mobile auto auto;
@@ -112,8 +112,8 @@ $-catalogue-item-image-height-mobile: rem(120px);
   align-self: flex-start;
   flex-flow: row wrap;
 
-  > * + * {
-    margin-left: sage-spacing();
+  > :not(:last-child) {
+    margin-right: sage-spacing();
   }
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] move spacing to the right of the catalog item links

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-14 at 4 07 07 PM](https://user-images.githubusercontent.com/1241836/121960858-4718e100-cd2c-11eb-8fdb-07cf15d51625.png)|![Screen Shot 2021-06-14 at 4 16 31 PM](https://user-images.githubusercontent.com/1241836/121960868-4b44fe80-cd2c-11eb-9553-a26949fb59d7.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the catalog item page and verify that, when sizing down, the items are aligned to the left side of the parent element

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) This update has no visual change. The margin for catalog item links is moved from the left to the right for responsive alignment
   - [ ] Podcast Index page


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
