### PR TITLE
[SAGE-581] added `content_for` sections to the properties view

### DIFF
--- a/docs/app/views/examples/components/alert/_props.html.erb
+++ b/docs/app/views/examples/components/alert/_props.html.erb
@@ -34,3 +34,12 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_alert_actions`') %></td>
+  <td><%= md('This area holds the action links for the component.') %></td>
+  <td colspan="2"><%= md('`link_to`(s)') %></td>
+</tr>

--- a/docs/app/views/examples/components/assistant/_props.html.erb
+++ b/docs/app/views/examples/components/assistant/_props.html.erb
@@ -15,3 +15,12 @@
   <td><%= md('`Boolean`') %></td>
   <td><%= md('null') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_assistant_actions`') %></td>
+  <td><%= md('This area holds link to the sage gem .') %></td>
+  <td colspan="2"><%= md('`link_to`(s)') %></td>
+</tr>

--- a/docs/app/views/examples/components/catalog_item/_props.html.erb
+++ b/docs/app/views/examples/components/catalog_item/_props.html.erb
@@ -22,3 +22,12 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_aside`') %></td>
+  <td><%= md('This area holds the dropdown menu for this component.') %></td>
+  <td colspan="2"><%= md('`SageDropdown`') %></td>
+</tr>

--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -89,3 +89,17 @@ Array<{
   <td><%= md('`data-sage-dropdown-exit`') %></td>
   <td><%= md('This `data-attribute` can be used within custom dropdown panels to allow elements to close the dropdown panel.') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_dropdown_custom_panel_content`') %></td>
+  <td><%= md('This area holds custom panel content and replaces the default content layout. The cta buttons for this resides within `sage_dropdown_custom_panel_footer`.') %></td>
+  <td colspan="2"><%= md('`ul.sage-dropdown__menu.sage-dropdown__menu--fixed-height`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_dropdown_custom_panel_footer`') %></td>
+  <td><%= md('This area holds the dropdown menu for this component. The items that are referenced  reside within `sage_dropdown_custom_panel_content`.') %></td>
+  <td colspan="2"><%= md('`SageButtonGroup`') %></td>
+</tr>

--- a/docs/app/views/examples/components/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/components/feature_toggle/_props.html.erb
@@ -57,6 +57,12 @@ Array<{
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
-
-
-
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_feature_toggle_input`') %></td>
+  <td><%= md('This area holds the switch form element for the component.') %></td>
+  <td colspan="2"><%= md('`SageSwitch`') %></td>
+</tr>

--- a/docs/app/views/examples/components/modal/_props.html.erb
+++ b/docs/app/views/examples/components/modal/_props.html.erb
@@ -130,3 +130,27 @@
   <td><%= md('`sage.modal.open`') %></td>
   <td colspan="3"><%= md('Fired *after* a modal has completed its loading animation. Note that if `animate` has not been enabled, this event will fire at the same time as `sage.modal.opening`.') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_header_aside`') %></td>
+  <td><%= md('This area holds the button that closes the modal. This resides in the header of the component.') %></td>
+  <td colspan="2"><%= md('`SageButton`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_header_indicator`') %></td>
+  <td><%= md('This area holds the page indicator for the modal. This is to be used on multi-page modals.') %></td>
+  <td colspan="2"><%= md('`SageIndicator`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_footer`') %></td>
+  <td><%= md('This area holds the cta buttons for the component.') %></td>
+  <td colspan="2"><%= md('`SageButton`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_footer_aside`') %></td>
+  <td><%= md('This area holds the cancel or close modal button in the footer of the component.') %></td>
+  <td colspan="2"><%= md('`SageButton`') %></td>
+</tr>

--- a/docs/app/views/examples/components/null_view/_props.html.erb
+++ b/docs/app/views/examples/components/null_view/_props.html.erb
@@ -28,3 +28,12 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_null_view_actions`') %></td>
+  <td><%= md('This area holds action buttons for the component.') %></td>
+  <td colspan="2"><%= md('`SageButtonGroup`') %></td>
+</tr>

--- a/docs/app/views/examples/components/page_heading/_props.html.erb
+++ b/docs/app/views/examples/components/page_heading/_props.html.erb
@@ -29,8 +29,8 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td colspan="2"><%= md('**`content_for`**') %></td>
-  <td colspan="2"><%= md('**`SageComponent`**') %></td>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
 </tr>
 <tr>
   <td><%= md('`sage_breadcrumbs`') %></td>

--- a/docs/app/views/examples/components/page_heading/_props.html.erb
+++ b/docs/app/views/examples/components/page_heading/_props.html.erb
@@ -28,3 +28,32 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**`content_for`**') %></td>
+  <td colspan="2"><%= md('**`SageComponent`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_breadcrumbs`') %></td>
+  <td><%= md('This area holds the breadcrumbs at the top of the component.') %></td>
+  <td colspan="2"><%= md('`SageBreadcrumbs`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_page_heading_toolbar`') %></td>
+  <td><%= md('This area holds the buttons that will navigate to subpages.') %></td>
+  <td colspan="2"><%= md('`SageButton`(s)') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_page_heading_actions`') %></td>
+  <td><%= md('This area holds the cta buttons for the component.') %></td>
+  <td colspan="2"><%= md('`SageButton`(s)') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_page_heading_intro`') %></td>
+  <td><%= md('This area holds the page intro text') %></td>
+  <td colspan="2"><%= md('`<p>`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_page_heading_image`') %></td>
+  <td><%= md('This area holds the page heading image') %></td>
+  <td colspan="2"><%= md('`<img>`, `image_tag()`') %></td>
+</tr>

--- a/docs/app/views/examples/components/panel_controls/_props.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_props.html.erb
@@ -109,3 +109,32 @@ Array<{
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_panel_controls_pagination`') %></td>
+  <td><%= md('This area holds the pagination for the component.') %></td>
+  <td colspan="2"><%= md('`SagePagination`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_panel_controls_toolbar`') %></td>
+  <td><%= md('This area holds the buttons that will navigate to subpages.') %></td>
+  <td colspan="2"><%= md('`SageSearch`, `SageDropdown`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_panel_controls_tabs`') %></td>
+  <td><%= md('This area holds the tabs linking to sub pages.') %></td>
+  <td colspan="2"><%= md('`SageDropdown`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_panel_controls_tabs_dropdown`') %></td>
+  <td><%= md('This area holds the dropdown that navigates between Products. This resides next to the tabs at the top of the component.') %></td>
+  <td colspan="2"><%= md('`SageDropdown`') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_panel_controls_sort`') %></td>
+  <td><%= md('This area holds the sort dropdown.') %></td>
+  <td colspan="2"><%= md('`SageDropdown`') %></td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
@@ -8,7 +8,7 @@ class SagePageHeading < SageComponent
   })
 
   def sections
-    %w(breadcrumbs page_heading_toolbar page_heading_actions page_heading_intro page_heading_image help_content)
+    %w(breadcrumbs page_heading_toolbar page_heading_actions page_heading_intro page_heading_image)
   end
 
 end


### PR DESCRIPTION
[SAGE-581](https://github.com/Kajabi/sage-lib/issues/581)
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] added references to the `content_for`s to the bottom of the Property view. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-16 at 8 04 11 AM](https://user-images.githubusercontent.com/1241836/122224161-76893400-ce79-11eb-9745-d235dcba7588.png)|![Screen Shot 2021-06-16 at 8 04 01 AM](https://user-images.githubusercontent.com/1241836/122224177-79842480-ce79-11eb-985f-fdf1e9596275.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Check the following rails page and click on the Property tab to verify: 
- Alert
- Assistant
- Catalog Item
- Dropdown
- Feature Toggle
- Modal
- Null View
- Page Heading
- Panel Controls

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Documentation only, nothing affected within the app

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
