### PR TITLE
[SAGE-497] Label - align to spec

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -177,7 +177,8 @@ $-btn-interactive-label-icon-size: rem(24px);
     border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
 
     &::before {
-      font-size: sage-font-size(body-sm);
+      margin-top: 1px; /* needed as sage-font-size(sm) is equates 13px and not 14px. This 1px is accounting for that 1px */
+      font-size: sage-font-size(sm);
     }
 
     &::after {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -174,7 +174,11 @@ $-btn-interactive-label-icon-size: rem(24px);
     right: 0;
     width: $-btn-interactive-label-icon-size;
     margin: auto 0;
-    border-radius: 0 sage-border(radius) sage-border(radius) 0;
+    border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
+
+    &::before {
+      font-size: sage-font-size(body-sm);
+    }
 
     &::after {
       width: $-btn-interactive-label-icon-size;
@@ -184,10 +188,6 @@ $-btn-interactive-label-icon-size: rem(24px);
 
     &:first-child:not(:last-child) {
       margin-right: sage-spacing(xs);
-    }
-
-    &:last-child:not(:first-child) {
-      margin-left: sage-spacing(xs);
     }
 
     + & {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -177,7 +177,7 @@ $-btn-interactive-label-icon-size: rem(24px);
     border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
 
     &::before {
-      margin-top: 1px; /* needed as sage-font-size(sm) is equates 13px and not 14px. This 1px is accounting for that 1px */
+      transform: translateY(1px); /* needed as sage-font-size(sm) equates to 13px, not 14px. This 1px is accounting for that 1px */
       font-size: sage-font-size(sm);
     }
 

--- a/packages/sage-assets/lib/stylesheets/components/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_label.scss
@@ -6,7 +6,7 @@
 
 
 $-label-interactive-icon-size: rem(24px);
-$-label-interactive-icon-size-small: rem(28px);
+$-label-interactive-icon-size-decor: rem(28px);
 $-label-padding: 0 sage-spacing(xs);
 $-label-border-radius: sage-border(radius-x-large);
 $-label-inset-border: 0 0 0 1px inset;
@@ -31,7 +31,7 @@ $-label-inset-border: 0 0 0 1px inset;
 }
 
 .sage-label__value {
-  @extend %t-sage-body-small-semi;
+  @extend %t-sage-body-small-med;
 
   appearance: none;
   display: flex;
@@ -89,7 +89,7 @@ $-label-inset-border: 0 0 0 1px inset;
 
   #{$-color-modifier}.sage-label--interactive {
     &.sage-label--interactive-right-cta-affordance .sage-label__value {
-      padding-right: $-label-interactive-icon-size-small;
+      padding-right: $-label-interactive-icon-size-decor;
     }
 
     .sage-label__value {
@@ -132,13 +132,12 @@ $-label-inset-border: 0 0 0 1px inset;
       justify-content: center;
       position: absolute;
       right: 0;
-      width: $-label-interactive-icon-size-small;
+      width: $-label-interactive-icon-size-decor;
       min-height: $-label-interactive-icon-size;
       margin: auto 0;
       border-radius: 0 $-label-border-radius $-label-border-radius 0;
 
       &::before {
-        font-weight: sage-font-weight(bold);
         color: sage-color-combo($-color-name, default, foreground);
       }
 

--- a/packages/sage-assets/lib/stylesheets/components/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_label.scss
@@ -31,7 +31,7 @@ $-label-inset-border: 0 0 0 1px inset;
 }
 
 .sage-label__value {
-  @extend %t-sage-body-small-med;
+  @extend %t-sage-body-small-semi;
 
   appearance: none;
   display: flex;
@@ -109,7 +109,7 @@ $-label-inset-border: 0 0 0 1px inset;
       color: sage-color-combo($-color-name, default, foreground);
 
       &:hover {
-        background-color: sage-color-combo($-color-name, default, icon-background-accent);
+        background-color: sage-color-combo($-color-name, default, background-accent);
       }
 
       &:focus {
@@ -117,14 +117,8 @@ $-label-inset-border: 0 0 0 1px inset;
       }
     }
 
-    &:hover {
-      .sage-label__value {
-        background-color: sage-color-combo($-color-name, default, background-accent);
-      }
-
-      .sage-btn::before {
-        color: sage-color-combo($-color-name, default, foreground-accent);
-      }
+    .sage-label__value:hover {
+      background-color: sage-color-combo($-color-name, default, background-accent);
     }
 
     .sage-label__decor-icon {


### PR DESCRIPTION
Closes [SAGE-497](https://github.com/Kajabi/sage-lib/pull/497)
Dependent on [SAGE-554](https://github.com/Kajabi/sage-lib/pull/554)
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] align label to spec
    - [x] update interactive border-radius
    - [x] reduce label text font-weight

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-21 at 8 51 06 AM](https://user-images.githubusercontent.com/1241836/122773540-0fe78a00-d26e-11eb-8fd8-a715beb1cef6.png)|![Screen Shot 2021-06-21 at 8 50 26 AM](https://user-images.githubusercontent.com/1241836/122773561-12e27a80-d26e-11eb-9811-886e33b7d709.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the label rails and react page 

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Label component adjusted to latest specs. Label changes will occur as a result in kajabi-products but no adverse effects expected.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
