### PR TITLE
Sage Button - Custom Content

### DIFF
--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -86,6 +86,14 @@ demo_configs = [
         },
         disabled: disabled
       } %>
+
+      <!-- Primary button (custom content) -->
+      <%= sage_component SageButton, {
+        style: config[:style],
+        disabled: disabled
+      } do %>
+        <strong>Custom</strong> <em>content</em>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -154,6 +154,15 @@ demo_configs = [
         subtle: true,
         small: size
       } %>
+
+      <!-- Primary button (custom content) -->
+      <%= sage_component SageButton, {
+        style: config[:style],
+        subtle: true,
+        small: size
+      } do %>
+        <strong>Custom</strong> <em>content</em>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button.rb
@@ -10,6 +10,6 @@ class SageButton < SageComponent
     small:            [:optional, NilClass, TrueClass],
     style:            [:optional, NilClass, Set.new(["primary", "secondary", "danger"])],
     subtle:           [:optional, NilClass, TrueClass],
-    value:            String,
+    value:            [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -17,6 +17,7 @@
     <%= "sage-btn--#{component.style}" if component.style %>
     <%= "sage-btn--align-end" if (component.align == "end") %>
     <%= "sage-btn--icon-#{component.icon[:style]}-#{component.icon[:name]}" if component.icon %>
+    <%= "sage-btn--custom-content" if component.content %>
     <%= component.generated_css_classes %>
   "
 >

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -17,7 +17,6 @@
     <%= "sage-btn--#{component.style}" if component.style %>
     <%= "sage-btn--align-end" if (component.align == "end") %>
     <%= "sage-btn--icon-#{component.icon[:style]}-#{component.icon[:name]}" if component.icon %>
-    <%= "sage-btn--custom-content" if component.content %>
     <%= component.generated_css_classes %>
   "
 >
@@ -27,12 +26,14 @@
     </span>
   <% else %>
     <% if component.value %>
-    <span class="sage-btn__truncate-text">
-      <%# if the component.value is an empty string, add a `&nbsp;` to prevent height collapse %>
-      <%= (component.value.strip.empty? ? "&nbsp;" : component.value).html_safe %>
-    </span>
+      <span class="sage-btn__truncate-text">
+        <%# if the component.value is an empty string, add a `&nbsp;` to prevent height collapse %>
+        <%= (component.value.strip.empty? ? "&nbsp;" : component.value).html_safe %>
+      </span>
     <% elsif component.content %>
-      <%= component.content %>
+      <span class="sage-btn__custom-content">
+        <%= component.content %>
+      </span>
     <% end %>
   <% end %>
 </<%= html_tag %>>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -25,9 +25,13 @@
       <%= component.value.html_safe %>
     </span>
   <% else %>
+    <% if component.value %>
     <span class="sage-btn__truncate-text">
       <%# if the component.value is an empty string, add a `&nbsp;` to prevent height collapse %>
       <%= (component.value.strip.empty? ? "&nbsp;" : component.value).html_safe %>
     </span>
+    <% elsif component.content %>
+      <%= component.content %>
+    <% end %>
   <% end %>
 </<%= html_tag %>>

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -439,10 +439,6 @@ $-btn-interactive-label-icon-size: rem(24px);
   }
 }
 
-.sage-btn--custom-content {
-  display: inline-block;
-}
-
 // Button groups allow for several buttons together to be spaced appropriately
 .sage-btn-group {
   display: flex;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -439,6 +439,10 @@ $-btn-interactive-label-icon-size: rem(24px);
   }
 }
 
+.sage-btn--custom-content {
+  display: inline-block;
+}
+
 // Button groups allow for several buttons together to be spaced appropriately
 .sage-btn-group {
   display: flex;


### PR DESCRIPTION
## Description
This PR makes the `value` prop optional and adds the ability to provide custom content and components to the body of the Sage Button component.

This feature will be necessary to accommodate the new design for the user dropdown that will reside in the top right of the application frame.

## Testing in `sage-lib`
1. Visit http://0.0.0.0:4000/pages/component/button and ensure that the `Custom content` example renders as expected.

## Testing in `kajabi-products`
1. **LOW** As this is a new feature, it should not affect current implementations, however testing in areas that use buttons should be done to be safe.
   - [ ] Settings - Site Details/Blog Settings/Marketing Details
   - [ ] Website page
   - [ ] Products page