### PR TITLE
External dropdown triggers

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -29,6 +29,7 @@ export const Dropdown = ({
   panelModifier,
   panelMaxWidth,
   panelSize,
+  panelStateToken,
   triggerButtonSubtle,
   triggerModifier,
 }) => {
@@ -84,6 +85,12 @@ export const Dropdown = ({
       window.removeEventListener('resize', onUpdate);
     };
   }, [wrapperRef, isActive, isPinned, onUpdate]);
+
+  useEffect(() => {
+    if (panelStateToken) {
+      setActive(!isActive);
+    }
+  }, [panelStateToken]);
 
   const a11yAttrs = {
     'aria-expanded': isActive,
@@ -180,6 +187,7 @@ Dropdown.defaultProps = {
   panelMaxWidth: null,
   panelModifier: 'default',
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
+  panelStateToken: null,
   triggerButtonSubtle: false,
   triggerModifier: 'default',
   label: null
@@ -206,6 +214,7 @@ Dropdown.propTypes = {
   panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
   panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
+  panelStateToken: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { selectArgs } from '../story-support/helpers';
-import { Button } from '../Button';
-import { FormSection } from '../FormSection';
-import { Input } from '../Input';
 import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
 import { OptionsDropdown } from './OptionsDropdown';
 import { defaultOptionsItems, sampleMenuItems } from './stories/story-helper';
+import { CustomPanelStory } from './stories/CustomPanelStory';
+import { BulkActionsStory } from './stories/BulkActionsStory';
 import { MultiMenuStory } from './stories/MultiMenuStory';
 import { SelectDropdownDemo } from './stories/SelectDropdownDemo';
-import { BulkActionsStory } from './stories/BulkActionsStory';
 
 export default {
   title: 'Sage/Dropdown',
@@ -26,7 +24,7 @@ export default {
   },
   args: {
     align: null,
-    className: false,
+    className: null,
     closePanelOnExit: true,
     contained: false,
     customized: false,
@@ -122,29 +120,9 @@ Multiselect.decorators = [
   )
 ];
 
-export const MenuWithCustomPanel = Template.bind({});
-MenuWithCustomPanel.args = {
-  align: 'right',
-  children: (
-    <FormSection
-      style={{
-        width: '500px',
-        padding: '24px'
-      }}
-      title="Sign in"
-      subtitle="You must sign in order to use this feature."
-    >
-      <Input type="text" label="Username" />
-      <Input type="password" label="Password" />
-      <Button color={Button.COLORS.PRIMARY} alignEnd={true}>
-        Log in
-      </Button>
-    </FormSection>
-  ),
-  icon: SageTokens.ICONS.USERS,
-  isLabelVisible: true,
-  label: 'Login',
-};
+export const MenuWithCustomPanel = () => (
+  <CustomPanelStory />
+);
 MenuWithCustomPanel.decorators = [
   (Story) => (
     <>

--- a/packages/sage-react/lib/Dropdown/stories/CustomPanelStory.jsx
+++ b/packages/sage-react/lib/Dropdown/stories/CustomPanelStory.jsx
@@ -1,7 +1,9 @@
+/* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import uuid from 'react-uuid';
 import { SageTokens } from '../../configs';
-import { Dropdown } from '../../Dropdown';
+import { Dropdown } from '..';
 import { Button } from '../../Button';
 import { Card } from '../../Card';
 import { Input } from '../../Input';
@@ -11,6 +13,16 @@ const CustomPanelBody = ({ onExit, children }) => (
     {children}
   </Card.Stack>
 );
+
+CustomPanelBody.defaultProps = {
+  children: null,
+  onExit: () => {},
+};
+
+CustomPanelBody.propTypes = {
+  children: PropTypes.node,
+  onExit: PropTypes.func,
+};
 
 export const CustomPanelStory = () => {
   const [dropdownToken, setDropdownToken] = useState(uuid());

--- a/packages/sage-react/lib/Dropdown/stories/CustomPanelStory.jsx
+++ b/packages/sage-react/lib/Dropdown/stories/CustomPanelStory.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import uuid from 'react-uuid';
+import { SageTokens } from '../../configs';
+import { Dropdown } from '../../Dropdown';
+import { Button } from '../../Button';
+import { Card } from '../../Card';
+import { Input } from '../../Input';
+
+const CustomPanelBody = ({ onExit, children }) => (
+  <Card.Stack style={{ padding: '24px' }}>
+    {children}
+  </Card.Stack>
+);
+
+export const CustomPanelStory = () => {
+  const [dropdownToken, setDropdownToken] = useState(uuid());
+
+  const onClickSubmit = () => {
+    setDropdownToken(uuid());
+  };
+
+  return (
+    <Dropdown
+      align="right"
+      icon={SageTokens.ICONS.USERS}
+      isLabelVisible={true}
+      label="Login"
+      panelStateToken={dropdownToken}
+    >
+      <CustomPanelBody>
+        <Input id={uuid()} type="text" label="Username" />
+        <Input id={uuid()} type="password" label="Password" />
+        <Button onClick={onClickSubmit} color={Button.COLORS.PRIMARY} alignEnd={true}>
+          Log in
+        </Button>
+      </CustomPanelBody>
+    </Dropdown>
+  );
+};


### PR DESCRIPTION
## Description

This PR adds a new prop to React Dropdown that allows for triggering toggling the panel from the outside without requiring it to be bound to a boolean state variable. Now simply toggle the panel's visibility by changing the value of a token string such as by using `react-uuid` to set a unique universal id and changing it when needed. 

## Testing in `sage-lib`

See the `CustomPanelStory` in storybook for an example of this usage.

## Testing in `kajabi-products`
(LOW) Adds a new property to Dropdown that allows for toggling the panel from the outside. No expected side effects for current usages. Validated by UXD by checking the various dropdowns in the People page.

## Related
Closes #582 
