### PR TITLE
Only allow assignment for assignable component attributes

### DIFF
--- a/docs/lib/sage_rails/app/helpers/sage_component_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_component_helper.rb
@@ -1,11 +1,12 @@
 module SageComponentHelper
   def sage_component(component, attributes, &block)
-    validate_sage_component_attributes(component, attributes)
+    relevant_attributes = attributes.slice(*component::ATTRIBUTE_SCHEMA.keys)
+    validate_sage_component_attributes(component, relevant_attributes)
 
     component.new({
       context: self,
       content: block_given? ? capture(&block) : nil
-    }.merge(attributes)).render
+    }.merge(relevant_attributes)).render
   end
 
   def sage_component_section(name, &block)


### PR DESCRIPTION
## Description
This ensures that no unassignable attributes will attempt to be assigned when instantiating a component. An attempt to assign unassignable attributes will result in an `ActiveModel::UnknownAttributeError` which will typically present as an `ActionView::TemplateError` when encountered during rendering. This allows for a more graceful "failure" where unassignable attributes will be (silently) ignored, similar to how invalid HTML attributes are treated.

We'll still validate the full schema in non-production environments, but only while passing in assignable attributes.

## Testing in `sage-lib`
Attempt to render a component with attributes not supported by the components schema. Rather than failing, Sage should simply ignore the unknown attributes.

## Testing in `kajabi-products`
Attempt to render a component with attributes not supported by the components schema. Rather than failing, Sage should simply ignore the unknown attributes.

## Related
N/A
