### PR TITLE
Testing attribute and `generated_html_attributes` cleanup

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -4,6 +4,7 @@ class SageComponent
   attr_accessor :content
 
   ATTRIBUTE_SCHEMA = {
+    test_id: [:optional, NilClass, String],
     html_attributes: [:optional, Hash],
     spacer: [:optional, SageSchemas::SPACER],
     css_classes: [:optional, NilClass, String],
@@ -48,6 +49,12 @@ class SageComponent
   def html_attributes=(html_attributes_hash)
     html_attributes_hash.each do |key, value|
       generated_html_attributes << " #{key}=\"#{value.to_s}\""
+    end
+  end
+
+  def test_id=(id_string)
+    if id_string
+      generated_html_attributes << " data-kjb-element=\"#{id_string}\""
     end
   end
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -19,6 +19,7 @@
     <%= "sage-btn--icon-#{component.icon[:style]}-#{component.icon[:name]}" if component.icon %>
     <%= component.generated_css_classes %>
   "
+  <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.icon&.dig(:style) == "only" %>
     <span class="visually-hidden">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card_divider.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card_divider.html.erb
@@ -4,4 +4,5 @@
     <%= "sage-card__divider--full-bleed" if component.bleed %>
     <%= component.generated_css_classes %>
   "
+  <%= component.generated_html_attributes.html_safe %>
 />

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_chart_legend.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_chart_legend.html.erb
@@ -1,4 +1,7 @@
-<ul class="sage-chart-legend  <%= component.generated_css_classes %>" <%= component.generated_html_attributes.html_safe %>>
+<ul
+  class="sage-chart-legend  <%= component.generated_css_classes %>"
+  <%= component.generated_html_attributes.html_safe %>
+>
   <% component.items.each do | item | %>
     <li
       class="sage-chart-legend__item"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
@@ -18,6 +18,7 @@
     <%= "disabled" if component.disabled %>
     <%= "required" if component.required %>
     aria-label="<%= component.label_text %>"
+    <%= component.generated_html_attributes.html_safe %>
   >
 <% else %>
   <div class="
@@ -26,6 +27,7 @@
       <%= component.has_error ? "sage-checkbox--error" : "" %>
       <%= component.generated_css_classes %>
     "
+    <%= component.generated_html_attributes.html_safe %>
   >
     <input
       id="<%= component.id %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -40,6 +40,7 @@ end
   <% if component.radio_configs.present? %>
     for="<%= component.radio_configs[:id] %>"
   <% end %>
+  <%= component.generated_html_attributes.html_safe %>
 >
    <% if component.radio_configs.present? %>
     <div class="sage-choice__radio visually-hidden">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_container.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_container.html.erb
@@ -5,6 +5,8 @@ size = component.size.present? ? component.size : "full"
     sage-container
     sage-container--<%= size %>
     <%= component.generated_css_classes %>
-  " <%= component.generated_html_attributes.html_safe %>>
+  "
+  <%= component.generated_html_attributes.html_safe %>
+>
   <%= component.content %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
@@ -1,6 +1,10 @@
 <% html_tag = component.title_tag ? component.title_tag : "h5" %>
  
-<div <%= component.id ? "id=#{component.id}" : "" %> class="sage-form-section <%= component.generated_css_classes %>" <%= component.generated_html_attributes.html_safe %>>
+<div
+  class="sage-form-section <%= component.generated_css_classes %>"
+  <%= "id=#{component.id}" if component.id.present? %>
+  <%= component.generated_html_attributes.html_safe %>
+>
   <div class="sage-form-section__info">
     <% if component.title.present? %>
       <<%= html_tag %> class="sage-form-section__title t-sage-heading-5">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_textarea.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_textarea.html.erb
@@ -2,7 +2,9 @@
     sage-textarea
     <%= " sage-textarea--error" if component.has_error %>
     <%= component.generated_css_classes %>
-  " <%= component.generated_html_attributes.html_safe %>>
+  "
+  <%= component.generated_html_attributes.html_safe %>
+>
   <%# <textarea declaration needs to be on a single line. The line breaks bleeding into the <textarea> as content causing unexpected placeholder behavior %>
   <textarea class="sage-textarea__field" id="<%= component.id %>"<%= " name=#{ component.name.present? ? component.name : component.id }" %> placeholder="<%= component.placeholder %>" <%= "disabled" if component.disabled -%>><%- component.content if component.content.present? -%></textarea>
   <%- if component.label_text.present? -%><label for="<%= component.id %>" class="sage-textarea__label"><%= component.label_text -%></label><% end -%>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon_card.html.erb
@@ -19,6 +19,7 @@ style = {
   <% if component.background_color.present? or component.foreground_color.present? %>
     style="<%= style %>"
   <% end %>
+  <%= component.generated_html_attributes.html_safe %>
 >
   <i
     class="sage-icon-<%= component.icon %><%= size %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_indicator.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_indicator.html.erb
@@ -7,7 +7,11 @@
     <%= "#{component.label} #{component.current_item} of #{component.num_items}" %>
   </p>
 <% else %>
-  <ul class="sage-indicator-list <%= component.generated_css_classes %>" aria-label="<%= "Showing #{component.label} #{component.current_item} of #{component.num_items}"%>" <%= component.generated_html_attributes.html_safe %>>
+  <ul
+    class="sage-indicator-list <%= component.generated_css_classes %>"
+    aria-label="<%= "Showing #{component.label} #{component.current_item} of #{component.num_items}"%>"
+    <%= component.generated_html_attributes.html_safe %>
+  >
     <% for i in 1...(num_items + 1) %>
       <li class="sage-indicator<%= " sage-indicator--current" if component.current_item == i %>">
         <span class="visually-hidden">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label_secondary_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label_secondary_button.html.erb
@@ -1,5 +1,6 @@
 <%= sage_component SageButton, {
   attributes: component.attributes,
+  html_attributes: component.html_attributes,
   icon: {
     name: component.icon.present? ? component.icon : "remove",
     style: "only"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label_secondary_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label_secondary_button.html.erb
@@ -1,6 +1,5 @@
 <%= sage_component SageButton, {
   attributes: component.attributes,
-  html_attributes: component.html_attributes,
   icon: {
     name: component.icon.present? ? component.icon : "remove",
     style: "only"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -1,17 +1,69 @@
 <% if component.help_link && component.show_label %>
-  <a href="<%= component.url %>" class="sage-link--help" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
+  <a
+    href="<%= component.url %>"
+    class="sage-link--help"
+    <% component.attributes.each do |key, value| %>
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
+    <%= component.generated_html_attributes.html_safe %>
+  >
+    <%= component.label %>
+  </a>
 <% elsif component.help_link && !component.show_label %>
-  <a href="<%= component.url %>" class="sage-link--help-icon-only" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %>
-  <% end if component.attributes&.is_a?(Hash) %>>
+  <a
+    href="<%= component.url %>"
+    class="sage-link--help-icon-only"
+    <% component.attributes.each do |key, value| %>
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
+    <%= component.generated_html_attributes.html_safe %>
+  >
     <span class="visually-hidden"><%= component.label %></span>
   </a>
 <% elsif !component.external && !component.launch %>
-  <a href="<%= component.url %>" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>
-  ><%= component.label %></a>
+  <a
+    href="<%= component.url %>"
+    <% component.attributes.each do |key, value| %>
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
+    <%= component.generated_html_attributes.html_safe %>
+  >
+    <%= component.label %>
+  </a>
 <% elsif !component.external && component.launch %>
-  <a href="<%= component.url %>" class="sage-link--launch" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
+  <a
+    href="<%= component.url %>"
+    class="sage-link--launch"
+    <% component.attributes.each do |key, value| %>
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
+    <%= component.generated_html_attributes.html_safe %>
+  >
+    <%= component.label %>
+  </a>
 <% elsif component.external && component.launch %>
-  <a href="<%= component.url %>" target="_blank" rel="noopener noreferrer" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
+  <a
+    href="<%= component.url %>"
+    target="_blank"
+    rel="noopener noreferrer"
+    <% component.attributes.each do |key, value| %>
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
+    <%= component.generated_html_attributes.html_safe %>
+  >
+    <%= component.label %>
+  </a>
 <% elsif component.external && !component.launch %>
-  <a href="<%= component.url %>" target="_blank" class="sage-link--no-launch" rel="noopener noreferrer" <% component.attributes.each do |key, value| %> <%= "#{key}=\"#{value}\"".html_safe %><% end if component.attributes&.is_a?(Hash) %>><%= component.label %></a>
+  <a
+    href="<%= component.url %>"
+    target="_blank"
+    class="sage-link--no-launch"
+    rel="noopener noreferrer"
+    <% component.attributes.each do |key, value| %> 
+      <%= "#{key}=\"#{value}\"".html_safe %>
+    <% end if component.attributes&.is_a?(Hash) %>
+    <%= component.generated_html_attributes.html_safe %>
+  >
+    <%= component.label %>
+  </a>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -10,7 +10,8 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
   <% if component.show_pagination %>sage-panel-controls--show-pagination<% end %>
   <%= component.generated_css_classes %>" 
   data-js-panel-controls="<%= component.target %>"
-  <%= component.generated_html_attributes.html_safe %>>
+  <%= component.generated_html_attributes.html_safe %>
+>
   <% if content_for? :sage_panel_controls_tabs %>
     <div class="sage-panel-controls__tabs">
       <%= content_for :sage_panel_controls_tabs %>
@@ -28,6 +29,7 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
       <%= content_for :sage_panel_controls_toolbar %>
     </div>
   <% end %>
+
   <% if show_default_controls %>
     <div class="sage-panel-controls__default-controls">
       <% if component.show_bulk_actions %>
@@ -58,7 +60,6 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
             <label class="sage-dropdown__trigger-label">Actions</label>
           <% end %>
         </div>
-
       <% elsif component.item_count_label.present? %>
         <p class="sage-panel-controls__item-count-label">
           <%= item_count_text %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_divider.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_divider.html.erb
@@ -4,4 +4,5 @@
     <%= "sage-panel__divider--full-bleed" if component.bleed %>
     <%= component.generated_css_classes %>
   "
+  <%= component.generated_html_attributes.html_safe %>
 />

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -17,6 +17,7 @@
     <%= "disabled" if component.disabled %>
     <%= "required" if component.required %>
     aria-label="<%= component.label_text %>"
+    <%= component.generated_html_attributes.html_safe %>
   />
 <% else %>
   <div class="
@@ -24,6 +25,7 @@
       <%= component.has_border ? "sage-radio--has-border" : "" %>
       <%= component.has_error ? "sage-radio--error" : "" %>
     "
+    <%= component.generated_html_attributes.html_safe %>
   >
     <input
       id="<%= component.id %>"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sidebar.html.erb
@@ -11,7 +11,8 @@ end
   " 
   id="<%= id %>" 
   data-js-sidebar="<%= id %>" 
-  <%= component.generated_html_attributes.html_safe %>>
+  <%= component.generated_html_attributes.html_safe %>
+>
   <div class="sage-sidebar__body">
     <%= component.content %>
   </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
@@ -1,20 +1,20 @@
 <% if component.standalone %>
   <input 
-      type="<%= component.type %>" 
-      id="<%= component.id %>" 
-      class="
-        sage-switch
-        sage-switch--standalone
-        <%= component.has_error ? "sage-switch--error" : "" %>
-        <%= component.generated_css_classes %>
-      " 
-      name="<%= component.name %>" 
-      value="<%= component.id %>"
-      <%= "checked" if component.checked %>
-      <%= "disabled" if component.disabled %>
-      <%= "required" if component.required %>
-      <%= component.generated_html_attributes.html_safe %>
-    >
+    type="<%= component.type %>" 
+    id="<%= component.id %>" 
+    class="
+      sage-switch
+      sage-switch--standalone
+      <%= component.has_error ? "sage-switch--error" : "" %>
+      <%= component.generated_css_classes %>
+    " 
+    name="<%= component.name %>" 
+    value="<%= component.id %>"
+    <%= "checked" if component.checked %>
+    <%= "disabled" if component.disabled %>
+    <%= "required" if component.required %>
+    <%= component.generated_html_attributes.html_safe %>
+  />
 <% else %>
   <div class="
       sage-switch

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
@@ -20,6 +20,7 @@ html_tag = is_button ? "button" : "a"
   data-sage-active-class="<%= css_active_class %>"
   role="tab"
   aria-controls="<%= component.target.present? %>"
+  <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.text.present? %>
     <%= component.text.html_safe %>


### PR DESCRIPTION
## Description

This is one part of an effort to a) implement a testing id on all components and b) tidy up how general attributes are provided on elements. This one accomplishes the following:

- [x] Ensure all Rails elements output `generated_html_attributes`, even though some also use `attributes` in addition to the centralized `html_attributes` available from `SageComponent`
- [x] Add a `test_id` attribute to all Rails components that outputs the value into `generated_html_attributes` with `data-kjb-element-"[value]"`

Followup work will include:

- [ ] #604 and #605 Deprecating uses of `attributes` in favor of `html_attributes`
- [ ] #603 Add a similar `testId` property on all React components.
- [ ] #602 Document common attributes in the site such as `html_attributes`, `css_classes`, and `test_id`


## Testing in `sage-lib`

Observe changes do not break any existing component pages and experiment locally with the new `test_id` attribute.

## Testing in `kajabi-products`

(LOW) Additional attribute added for specs and other automated testing. No impact expected on existing component usage.


## Related
- #591 
- #479 