### PR TITLE
Add image prop to Avatar

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -11,6 +11,9 @@
 
   <!-- Showing custom class -->
   <%= sage_component SageAvatar, { color: "orange", initials: "KJ", css_classes: "my-custom-class" } %>
+
+  <!-- Showing profile image -->
+  <%= sage_component SageAvatar, { img: "/assets/avatar/court.png", initials: "CM" } %>
 </div>
 
 <h3>Avatar centered + custom size</h3>

--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -13,7 +13,12 @@
   <%= sage_component SageAvatar, { color: "orange", initials: "KJ", css_classes: "my-custom-class" } %>
 
   <!-- Showing profile image -->
-  <%= sage_component SageAvatar, { img: "/assets/avatar/court.png", initials: "CM" } %>
+  <%= sage_component SageAvatar, {
+    image: {
+      alt: "Court's profile image",
+      src: "/assets/avatar/court.png"
+    }
+  } %>
 </div>
 
 <h3>Avatar centered + custom size</h3>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -18,11 +18,17 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md('`img`') %></td>
-  <td><%= md('
-    The image path for displaying a profile image.
-  ') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md('`image`') %></td>
+  <td><%= md('Allows for configuration of an image.') %>
+  </td>
+  <td>
+  <%= md('```
+image: {
+  alt: String,
+  src: String,
+}
+    ') %>
+  </td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -24,7 +24,7 @@
   <td>
   <%= md('```
 image: {
-  alt: String,
+  alt: String (optional),
   src: String,
 }
     ') %>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -18,12 +18,20 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`img`') %></td>
+  <td><%= md('
+    The image path for displaying a profile image.
+  ') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`initials`') %></td>
   <td><%= md('
     The initials to display in the avatar circle
   ') %></td>
   <td><%= md('String') %></td>
-  <td><%= md('`required`') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`size`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -2,7 +2,8 @@ class SageAvatar < SageComponent
   set_attribute_schema({
     centered: [:optional, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],
-    initials: String,
+    img: [:optional, String],
+    initials: [:optional, String],
     size: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -2,7 +2,7 @@ class SageAvatar < SageComponent
   set_attribute_schema({
     centered: [:optional, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],
-    image: [:optional, {alt: String, src: String}],
+    image: [:optional, {alt: [:optional, String], src: String}],
     initials: [:optional, String],
     size: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -2,7 +2,7 @@ class SageAvatar < SageComponent
   set_attribute_schema({
     centered: [:optional, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],
-    img: [:optional, String],
+    image: [:optional, {alt: String, src: String}],
     initials: [:optional, String],
     size: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -10,7 +10,11 @@
     style="width: <%= component.size %>; height: <%= component.size %>;"
   <% end %>
 >
-  <svg class="sage-avatar__initials" viewBox="0 0 32 32">
-    <text x="16" y="20"><%= component.initials %></text>
-  </svg>
+  <% if component.img %>
+    <img alt="<%= component.initials %>" class="sage-avatar__image" src="<%= component.img %>">
+  <% else %>
+    <svg class="sage-avatar__initials" viewBox="0 0 32 32">
+      <text x="16" y="20"><%= component.initials %></text>
+    </svg>
+  <% end %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 >
   <% if component.image %>
-    <img alt="<%= component.image[:alt] %>" class="sage-avatar__image" src="<%= component.image[:src] %>">
+    <img alt="<%= component.image[:alt] || "" %>" class="sage-avatar__image" src="<%= component.image[:src] %>">
   <% else %>
     <svg class="sage-avatar__initials" viewBox="0 0 32 32">
       <text x="16" y="20"><%= component.initials %></text>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -1,17 +1,17 @@
 <div
   class="
     sage-avatar
-    <%= "sage-avatar--#{component.color}" if component.color.present? %>
-    <%= "sage-avatar--centered" if component.centered.present? && component.centered %>
+    <%= "sage-avatar--#{component.color}" if component.color %>
+    <%= "sage-avatar--centered" if component.centered %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>
-  <% if component.size.present? %>
+  <% if component.size %>
     style="width: <%= component.size %>; height: <%= component.size %>;"
   <% end %>
 >
-  <% if component.img %>
-    <img alt="<%= component.initials %>" class="sage-avatar__image" src="<%= component.img %>">
+  <% if component.image %>
+    <img alt="<%= component.image[:alt] %>" class="sage-avatar__image" src="<%= component.image[:src] %>">
   <% else %>
     <svg class="sage-avatar__initials" viewBox="0 0 32 32">
       <text x="16" y="20"><%= component.initials %></text>

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -112,7 +112,7 @@ $-avatar-group-item-sizes: (
       bottom: 0;
       left: rem(16px);
     }
-  
+
     &:nth-child(4) {
       top: rem(8px);
       right: rem(8px);
@@ -174,6 +174,7 @@ $-avatar-group-item-sizes: (
   position: relative;
   z-index: sage-z-index(default, 2);
   grid-area: full;
+  height: 100%;
   width: 100%;
   border-radius: sage-border(radius-round);
   object-fit: cover;

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -30,9 +30,9 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {image.alt && image.src
+      {image.src
         ? (
-          <img alt={image.alt} className="sage-avatar__image" src={image.src} />
+          <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
         )
         : (
           <svg className="sage-avatar__initials" viewBox="0 0 32 32">

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -30,7 +30,7 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {image.alt != null && image.src != null
+      {image?.alt !== null && image?.src !== null
         ? (
           <img alt={image.alt} className="sage-avatar__image" src={image.src} />
         )
@@ -49,7 +49,7 @@ Avatar.defaultProps = {
   centered: false,
   className: '',
   color: AVATAR_COLORS.DEFAULT,
-  image: null,
+  image: {},
   initials: null,
   size: null,
 };

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -32,11 +32,13 @@ export const Avatar = ({
     <div className={classNames} style={style} {...rest}>
       {img
         ? (
-          <img alt={initials} className="sage-avatar__image" src={img}/> )
+          <img alt={initials} className="sage-avatar__image" src={img} />
+        )
         : (
           <svg className="sage-avatar__initials" viewBox="0 0 32 32">
             <text x="16" y="20">{initials}</text>
-          </svg> )}
+          </svg>
+        )}
     </div>
   );
 };

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -23,11 +23,6 @@ export const Avatar = ({
 
   const style = {};
 
-  if (img) {
-    style.backgroundImage = `url('${img}')`;
-    style.backgroundSize = 'cover';
-  }
-
   if (size) {
     style.width = size;
     style.height = size;

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -7,7 +7,7 @@ export const Avatar = ({
   className,
   centered,
   color,
-  img,
+  image,
   initials,
   size,
   ...rest
@@ -30,9 +30,9 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {img
+      {image.alt != null && image.src != null
         ? (
-          <img alt={initials} className="sage-avatar__image" src={img} />
+          <img alt={image.alt} className="sage-avatar__image" src={image.src} />
         )
         : (
           <svg className="sage-avatar__initials" viewBox="0 0 32 32">
@@ -49,8 +49,8 @@ Avatar.defaultProps = {
   centered: false,
   className: '',
   color: AVATAR_COLORS.DEFAULT,
-  img: '',
-  initials: '',
+  image: null,
+  initials: null,
   size: null,
 };
 
@@ -58,7 +58,10 @@ Avatar.propTypes = {
   centered: PropTypes.bool,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(AVATAR_COLORS)),
-  img: PropTypes.string,
+  image: PropTypes.shape({
+    alt: PropTypes.string,
+    src: PropTypes.string
+  }),
   initials: PropTypes.string,
   size: PropTypes.string,
 };

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -7,6 +7,7 @@ export const Avatar = ({
   className,
   centered,
   color,
+  img,
   initials,
   size,
   ...rest
@@ -22,6 +23,11 @@ export const Avatar = ({
 
   const style = {};
 
+  if (img) {
+    style.backgroundImage = `url('${img}')`;
+    style.backgroundSize = 'cover';
+  }
+
   if (size) {
     style.width = size;
     style.height = size;
@@ -29,9 +35,15 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      <svg className="sage-avatar__initials" viewBox="0 0 32 32">
-        <text x="16" y="20">{initials}</text>
-      </svg>
+      {img ?
+        (
+          <img alt={initials} className="sage-avatar__image" src={img}/>
+        ) :
+        (
+          <svg className="sage-avatar__initials" viewBox="0 0 32 32">
+            <text x="16" y="20">{initials}</text>
+          </svg>
+        )}
     </div>
   );
 };
@@ -42,6 +54,7 @@ Avatar.defaultProps = {
   centered: false,
   className: '',
   color: AVATAR_COLORS.DEFAULT,
+  img: '',
   initials: '',
   size: null,
 };
@@ -50,6 +63,7 @@ Avatar.propTypes = {
   centered: PropTypes.bool,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(AVATAR_COLORS)),
+  img: PropTypes.string,
   initials: PropTypes.string,
   size: PropTypes.string,
 };

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -30,7 +30,7 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {image?.alt !== null && image?.src !== null
+      {image.alt && image.alt !== null && image.src && image.src !== null
         ? (
           <img alt={image.alt} className="sage-avatar__image" src={image.src} />
         )

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -30,15 +30,13 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {img ?
-        (
-          <img alt={initials} className="sage-avatar__image" src={img}/>
-        ) :
-        (
+      {img
+        ? (
+          <img alt={initials} className="sage-avatar__image" src={img}/> )
+        : (
           <svg className="sage-avatar__initials" viewBox="0 0 32 32">
             <text x="16" y="20">{initials}</text>
-          </svg>
-        )}
+          </svg> )}
     </div>
   );
 };

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -30,7 +30,7 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {image.alt && image.alt !== null && image.src && image.src !== null
+      {image.alt && image.src
         ? (
           <img alt={image.alt} className="sage-avatar__image" src={image.src} />
         )

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -6,6 +6,7 @@ export default {
   title: 'Sage/Avatar',
   component: Avatar,
   args: {
+    img: null,
     initials: 'QJ',
     color: Avatar.COLORS.SAGE,
     size: null,

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -6,7 +6,10 @@ export default {
   title: 'Sage/Avatar',
   component: Avatar,
   args: {
-    img: null,
+    image: {
+      alt: null,
+      src: null,
+    },
     initials: 'QJ',
     color: Avatar.COLORS.SAGE,
     size: null,


### PR DESCRIPTION
## Description
This PR adds the missing `image` prop to both the Rails and React `SageAvatar` components.

## Testing in `sage-lib`
**Rails**
1. Visit http://0.0.0.0:4000/pages/component/avatar and ensure that image example exists and is displaying properly

**React**
1. Visit http://0.0.0.0:4100/?path=/story/sage-avatar--default and ensure that the `image` prop exists and displays properly

## Testing in `kajabi-products`
1. (**LOW**) This is a new feature and should not affect existing implementations, but some logic changes were made and requires testing in the following areas:
   - [ ] People page
