### PR TITLE
[Button] add medium font weight to small buttons

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -415,7 +415,7 @@ $-btn-interactive-label-icon-size: rem(24px);
 }
 
 .sage-btn--small {
-  @extend %t-sage-body-small;
+  @extend %t-sage-body-small-med;
 }
 
 // TODO: Investigate deprecating the float setting here


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `font-weight: 500` to the small buttons

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-07-02 at 1 01 06 PM](https://user-images.githubusercontent.com/1241836/124313386-6d18f080-db36-11eb-83de-0e530007a067.png)|![Screen Shot 2021-07-02 at 1 00 43 PM](https://user-images.githubusercontent.com/1241836/124313407-72763b00-db36-11eb-9179-04ca17293a5f.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
View the Catalog items view and see the small buttons beneath the title and verify that `font-weight: 500`

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Updates the font-weight of the action links in Catalog Items
   - [ ] Podcast Index Page


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
