### PR TITLE
[Sage-491] interaction pattern

### DIFF
--- a/docs/app/views/examples/components/icon_card/_preview.html.erb
+++ b/docs/app/views/examples/components/icon_card/_preview.html.erb
@@ -33,13 +33,11 @@
 <h3 class="t-sage-heading-6">Icon Card - round</h3>
 <div class="sage-row">
   <% SageTokens::STATUSES.each do | color | %>
-    <div class="sage-col-2">
-      <%= sage_component SageIconCard, {
-        color: color,
-        icon: "file",
-        label: "File graphic",
-        round: true
-      } %>
-    </div>
+    <%= sage_component SageIconCard, {
+      color: color,
+      icon: "file",
+      label: "File graphic",
+      round: true
+    } %>
   <% end %>
 </div>

--- a/docs/app/views/examples/components/link/_preview.html.erb
+++ b/docs/app/views/examples/components/link/_preview.html.erb
@@ -95,4 +95,6 @@
 
 <h3 class="t-sage-heading-6">Subtext links</h3>
 
-<a href="//example.com" class="sage-link--subtext">Link for placement in subtext</a>
+<a href="//example.com" class="sage-link sage-link--subtext">
+  <span class="t-sage--truncate">Link for placement in subtext</span>
+</a>

--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -128,7 +128,11 @@
       id: "id",
       url_update: "update/endpoint",
     } do %>
-      <a href="#">Field 1</a>
+      <div>
+        <a class="sage-link" href="#">
+          <span class="t-sage--truncate">Field 1</span>
+        </a>
+      </div>
       <%= sage_component SageDropdown, {
         align: "right",
         items: [
@@ -179,7 +183,11 @@
       id: "id",
       url_update: "update/endpoint",
     } do %>
-      <a href="#">Field 1</a>
+      <div>
+        <a class="sage-link" href="#">
+          <span class="t-sage--truncate">Field 1</span>
+        </a>
+      </div>
       <span>Field 2</span>
       <%= sage_component SageDropdown, {
         align: "right",

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_alert.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_alert.html.erb
@@ -1,10 +1,10 @@
-<div 
+<div
   class="
-    sage-alert<%= component.color ? " 
+    sage-alert<%= component.color ? "
     sage-alert--#{component.color}" : ""%>
     <% if component.raised %> sage-alert--raised<% end %>
     <%= component.generated_css_classes %>
-  " 
+  "
   <%= component.generated_html_attributes.html_safe %>
 >
   <i class="sage-alert__icon <%= component.icon_name %>" aria-hidden="true"></i>
@@ -22,6 +22,15 @@
     <% end %>
   </div>
   <% if component.dismissable %>
-      <button type="button" class="sage-alert__close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <%= sage_component SageButton, {
+      value: "Close",
+      icon: {
+        style: "only",
+        name: "remove"
+      },
+      subtle: true,
+      small: true,
+      css_classes: "sage-alert__close"
+    } %>
     <% end %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_banner.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_banner.html.erb
@@ -23,14 +23,12 @@
   <% end %>
 
   <% if component.link.present? %>
-    <a
-      class="sage-banner__link sage-btn--subtle"
-      <% component.link[:attributes].each do |key, value| %>
-        <%= "#{key}='#{value}'".html_safe %>
-      <% end if component.link[:attributes]&.is_a?(Hash) %>
-    >
-      <%= component.link[:name] %>
-    </a>
+    <%= sage_component SageButton, {
+      value: component.link[:name],
+      subtle: true,
+      css_classes: "sage-banner__link",
+      attributes: component.link[:attributes]
+    } %>
   <% end %>
 
   <%= component.content if component.content.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_banner.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_banner.html.erb
@@ -1,4 +1,4 @@
-<% if component.banner_context.present? %>
+  <% if component.banner_context.present? %>
   <div class="
     sage-banner-wrapper
     <%= "sage-banner-wrapper--context-#{component.banner_context}" if component.banner_context.present? %>
@@ -24,7 +24,7 @@
 
   <% if component.link.present? %>
     <a
-      class="sage-banner__link"
+      class="sage-banner__link sage-btn--subtle"
       <% component.link[:attributes].each do |key, value| %>
         <%= "#{key}='#{value}'".html_safe %>
       <% end if component.link[:attributes]&.is_a?(Hash) %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -10,8 +10,10 @@
   <%= component.generated_html_attributes.html_safe %>
 >
   <strong class="sage-catalog-item__title">
-    <<%= link_tag %> class="t-sage-heading-6" href="<%= component.href %>">
-      <%= component.title %>
+    <<%= link_tag %> class="t-sage-heading-6 sage-link" href="<%= component.href %>">
+      <span class="t-sage-truncate">
+        <%= component.title %>
+      </span>
     </<%= link_tag %>>
   </strong>
   <% if component.content.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -11,7 +11,7 @@
 >
   <strong class="sage-catalog-item__title">
     <<%= link_tag %> class="t-sage-heading-6 sage-link" href="<%= component.href %>">
-      <span class="t-sage-truncate">
+      <span class="t-sage--truncate">
         <%= component.title %>
       </span>
     </<%= link_tag %>>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -9,7 +9,6 @@
       "data-js-accordion": "header",
       "aria-expanded": "false",
     },
-    full_width: true,
   } %>
   <div class="
       <% if component.body_bordered.present? %>sage-expandable-card__body-bordered<% else %>sage-expandable-card__body<% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
@@ -6,17 +6,19 @@
     <p>
       <%= component.description %>
     </p>
-    
+
     <% if component.button %>
       <%= component.button.html_safe %>
     <% end %>
   </div>
-  <a 
+  <a
     <% component.cta_attributes.each do |key, value| %>
       <%= "#{key}='#{value}'".html_safe %>
     <% end if component.cta_attributes&.is_a?(Hash) %>
     class="sage-hero__artwork"
   >
-    <img class="sage-hero__artwork-image" <%= "aria-hidden=true" if component.alt_text.blank? %> src=<%= component.image%> alt="<%= component.alt_text %>" />
+    <span class="sage-hero__artwork-image-container">
+      <img class="sage-hero__artwork-image" <%= "aria-hidden=true" if component.alt_text.blank? %> src=<%= component.image%> alt="<%= component.alt_text %>" />
+    </span>
   </a>
 </article>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -1,48 +1,57 @@
+<%
+label = %(
+  <span class="t-sage--truncate">
+    #{component.label}
+  </span>
+).html_safe
+%>
 <% if component.help_link && component.show_label %>
   <a
     href="<%= component.url %>"
-    class="sage-link--help"
+    class="sage-link sage-link--help"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>
   >
-    <%= component.label %>
+    <%= label %>
   </a>
 <% elsif component.help_link && !component.show_label %>
   <a
     href="<%= component.url %>"
-    class="sage-link--help-icon-only"
+    class="sage-link sage-link--help-icon-only"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>
   >
-    <span class="visually-hidden"><%= component.label %></span>
+    <span class="visually-hidden"><%= label %></span>
   </a>
 <% elsif !component.external && !component.launch %>
   <a
+    class="sage-link"
     href="<%= component.url %>"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>
   >
-    <%= component.label %>
+    <%= label %>
   </a>
 <% elsif !component.external && component.launch %>
   <a
     href="<%= component.url %>"
-    class="sage-link--launch"
+    class="sage-link sage-link--launch"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>
   >
-    <%= component.label %>
+    <%= label %>
   </a>
 <% elsif component.external && component.launch %>
   <a
+    class="sage-link"
     href="<%= component.url %>"
     target="_blank"
     rel="noopener noreferrer"
@@ -51,15 +60,15 @@
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>
   >
-    <%= component.label %>
+    <%= label %>
   </a>
 <% elsif component.external && !component.launch %>
   <a
     href="<%= component.url %>"
     target="_blank"
-    class="sage-link--no-launch"
+    class="sage-link sage-link--no-launch"
     rel="noopener noreferrer"
-    <% component.attributes.each do |key, value| %> 
+    <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -3,13 +3,13 @@
 
 change_value = component.change.present? ? component.change[:value] : "No change"
 change_type = component.change.present? ? component.change[:type] : "neutral"
-label_configs = { color: "draft", value: change_value } 
+label_configs = { color: "draft", value: change_value }
 if change_type == "positive"
-  label_configs = { color: "published", value: change_value, icon: "caret-up" } 
+  label_configs = { color: "published", value: change_value, icon: "caret-up" }
 elsif change_type == "negative"
-  label_configs = { color: "danger", value: change_value, icon: "caret-down" } 
+  label_configs = { color: "danger", value: change_value, icon: "caret-down" }
 elsif change_type == "neutral"
-  label_configs = { color: "draft", value: change_value, } 
+  label_configs = { color: "draft", value: change_value, }
 end
 %>
 <article
@@ -38,7 +38,17 @@ end
   </div>
   <% if component.link.present? %>
     <footer class="sage-stat-box__footer">
-      <a class="sage-stat-box__link" href="<%= component.link[:href] %>"><%= component.link[:value] %></a>
+      <%= sage_component SageButton, {
+        style: "primary",
+        subtle: true,
+        value: component.link[:value],
+        icon: { name: "arrow-right", style: "right" },
+        subtle: true,
+        css_classes: "sage-stat-box__link",
+        attributes: {
+          href: component.link[:href]
+        }
+      } %>
     </footer>
   <% end %>
 </article>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_status_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_status_icon.html.erb
@@ -5,6 +5,7 @@
     <%= component.generated_css_classes %>
   "
   data-js-tooltip="<%= component.value %>"
+  tabindex=0
   <%= component.generated_html_attributes.html_safe %>
 >
   <span class="visually-hidden">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
@@ -12,22 +12,24 @@
     <% end %>
   </div>
   <div class="sage-transaction-card__body">
-    <<%= html_tag %> class="sage-transaction-card__name">
-      <% if component.name_href.present? %>
-        <a class="sage-link sage-transaction-card__name-link" href="<%= component.name_href %>">
-          <span class="t-sage--truncate">
-            <%= component.name %>
-          </span>
-        </a>
-      <% else %>
-        <div class="sage-transaction-card__name-text">
-          <span class="sage-btn__truncate-text">
-            <%= component.name %>
-          </span>
-        </div>
-      <% end %>
-    </<%= html_tag %>>
-    <div class="sage-transaction-card__amount<%= " sage-transaction-card__amount--#{component.amount_color}" if component.amount_color.present? %>"><%= component.amount %></div>
+    <div className="sage-transaction-card__body-group">
+      <<%= html_tag %> class="sage-transaction-card__name">
+        <% if component.name_href.present? %>
+          <a class="sage-link sage-transaction-card__name-link" href="<%= component.name_href %>">
+            <span class="t-sage--truncate">
+              <%= component.name %>
+            </span>
+          </a>
+        <% else %>
+          <div class="sage-transaction-card__name-text">
+            <span class="sage-btn__truncate-text">
+              <%= component.name %>
+            </span>
+          </div>
+        <% end %>
+      </<%= html_tag %>>
+      <div class="sage-transaction-card__amount<%= " sage-transaction-card__amount--#{component.amount_color}" if component.amount_color.present? %>"><%= component.amount %></div>
+    </div>
   </div>
   <div class="sage-transaction-card__footer">
     <% if component.related_property_href.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
@@ -12,42 +12,40 @@
     <% end %>
   </div>
   <div class="sage-transaction-card__body">
-    <div class="sage-transaction-card__body-group">
-      <<%= html_tag %> class="sage-transaction-card__name">
-        <% if component.name_href.present? %>
-          <a class="sage-transaction-card__name-link" href="<%= component.name_href %>">
+    <<%= html_tag %> class="sage-transaction-card__name">
+      <% if component.name_href.present? %>
+        <a class="sage-link sage-transaction-card__name-link" href="<%= component.name_href %>">
+          <span class="t-sage--truncate">
             <%= component.name %>
-          </a>
-        <% else %>
-          <%= component.name %>
-        <% end %>
-      </<%= html_tag %>>
-      <div class="sage-transaction-card__amount<%= " sage-transaction-card__amount--#{component.amount_color}" if component.amount_color.present? %>">
-        <%= component.amount %>
-      </div>
-    </div>
-    <div class="sage-transaction-card__body-group">
-      <% if component.related_property_href.present? %>
-        <%= sage_component SageButton, {
-          attributes: { href: component.related_property_href },
-          css_classes: "sage-transaction-card__product",
-          icon: { name: "tag", style: "left" },
-          subtle: true,
-          style: "secondary",
-          small: true,
-          value: component.related_property,
-        } %>
+          </span>
+        </a>
       <% else %>
-        <%= sage_component SageProperty, {
-          css_classes: "sage-transaction-card__product",
-          icon: "tag", 
-          value: component.related_property,
-        } %>
+        <div class="sage-transaction-card__name-text">
+          <span class="sage-btn__truncate-text">
+            <%= component.name %>
+          </span>
+        </div>
       <% end %>
-      <%= sage_component SageProperty, {
-        css_classes: "sage-transaction-card__time",
-        value: component.transaction_time
+    </<%= html_tag %>>
+    <div class="sage-transaction-card__amount<%= " sage-transaction-card__amount--#{component.amount_color}" if component.amount_color.present? %>"><%= component.amount %></div>
+  </div>
+  <div class="sage-transaction-card__footer">
+    <% if component.related_property_href.present? %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        small: true,
+        subtle: true,
+        value: component.related_property,
+        icon: { name: "tag", style: "left" },
+        subtle: true,
+        css_classes: "sage-stat-box__link",
+        attributes: {
+          href: component.related_property_href
+        }
       } %>
-    </div>
+    <% else %>
+      <%= sage_component SageProperty, { icon: "tag", value: component.related_property } %>
+    <% end %>
+    <%= sage_component SageProperty, { value: component.transaction_time } %>
   </div>
 </article>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
@@ -1,5 +1,4 @@
 <% html_tag = component.name_tag ? component.name_tag : "h4" %>
-
 <article class="sage-transaction-card <%= component.generated_css_classes %>" <%= component.generated_html_attributes.html_safe %>>
   <div class="sage-transaction-card__header">
     <%= sage_component SageLabel, {
@@ -12,42 +11,44 @@
     <% end %>
   </div>
   <div class="sage-transaction-card__body">
-    <div className="sage-transaction-card__body-group">
+    <div class="sage-transaction-card__body-group">
       <<%= html_tag %> class="sage-transaction-card__name">
         <% if component.name_href.present? %>
           <a class="sage-link sage-transaction-card__name-link" href="<%= component.name_href %>">
             <span class="t-sage--truncate">
-              <%= component.name %>
+            <%= component.name %>
             </span>
           </a>
         <% else %>
-          <div class="sage-transaction-card__name-text">
-            <span class="sage-btn__truncate-text">
-              <%= component.name %>
-            </span>
-          </div>
+          <%= component.name %>
         <% end %>
       </<%= html_tag %>>
-      <div class="sage-transaction-card__amount<%= " sage-transaction-card__amount--#{component.amount_color}" if component.amount_color.present? %>"><%= component.amount %></div>
+      <div class="sage-transaction-card__amount<%= " sage-transaction-card__amount--#{component.amount_color}" if component.amount_color.present? %>">
+        <%= component.amount %>
+      </div>
     </div>
-  </div>
-  <div class="sage-transaction-card__footer">
-    <% if component.related_property_href.present? %>
-      <%= sage_component SageButton, {
-        style: "secondary",
-        small: true,
-        subtle: true,
-        value: component.related_property,
-        icon: { name: "tag", style: "left" },
-        subtle: true,
-        css_classes: "sage-stat-box__link",
-        attributes: {
-          href: component.related_property_href
-        }
+    <div class="sage-transaction-card__body-group">
+      <% if component.related_property_href.present? %>
+        <%= sage_component SageButton, {
+          attributes: { href: component.related_property_href },
+          css_classes: "sage-transaction-card__product",
+          icon: { name: "tag", style: "left" },
+          subtle: true,
+          style: "secondary",
+          small: true,
+          value: component.related_property,
+        } %>
+      <% else %>
+        <%= sage_component SageProperty, {
+          css_classes: "sage-transaction-card__product",
+          icon: "tag",
+          value: component.related_property,
+        } %>
+      <% end %>
+      <%= sage_component SageProperty, {
+        css_classes: "sage-transaction-card__time",
+        value: component.transaction_time
       } %>
-    <% else %>
-      <%= sage_component SageProperty, { icon: "tag", value: component.related_property } %>
-    <% end %>
-    <%= sage_component SageProperty, { value: component.transaction_time } %>
+    </div>
   </div>
 </article>

--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -99,6 +99,8 @@ $-alert-icon-colors: (
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
       color: sage-color($color, 400);
+      @include sage-focus-outline($outline-offset-inline: 3px, $outline-offset-block: 3px);
+      @include sage-focus-outline--update-color(sage-color($color, 400));
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -86,7 +86,7 @@ $-alert-icon-colors: (
 }
 
 .sage-alert__close {
-  overflow: hidden;
+  align-self: flex-start;
   height: rem(20px);
   width: rem(20px);
   padding: 0;
@@ -95,11 +95,13 @@ $-alert-icon-colors: (
   background-color: transparent;
   border: 0;
   appearance: none;
+
   @each $name, $color in $-alert-colors {
     .sage-alert--#{$name} & {
       color: sage-color($color, 400);
     }
   }
+
   &:hover {
     opacity: 0.7;
   }
@@ -107,4 +109,11 @@ $-alert-icon-colors: (
 
 .sage-alert__actions {
   display: flex;
+
+  @each $name, $color in $-alert-colors {
+    .sage-alert--#{$name} & > a {
+      @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
+      @include sage-focus-outline--update-color(sage-color($color, 400));
+    }
+  }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_banner.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_banner.scss
@@ -105,8 +105,6 @@ $-banner-el-icon: "before";
 }
 
 .sage-banner__link {
-  @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
-
   color: inherit;
   text-decoration: underline;
 

--- a/packages/sage-assets/lib/stylesheets/components/_banner.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_banner.scss
@@ -112,7 +112,7 @@ $-banner-el-icon: "before";
     text-decoration: underline;
   }
 
-  @include sage-focus-outline();
+  // @include sage-focus-outline();
 }
 
 .sage-banner__close {
@@ -122,6 +122,7 @@ $-banner-el-icon: "before";
 
 .sage-banner__close,
 .sage-banner__link {
+  @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
   @include sage-focus-outline--update-color(map-get(map-get($-banner-colors, default), text));
 
   &:hover {

--- a/packages/sage-assets/lib/stylesheets/components/_banner.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_banner.scss
@@ -105,39 +105,42 @@ $-banner-el-icon: "before";
 }
 
 .sage-banner__link {
+  @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
+
   color: inherit;
   text-decoration: underline;
 
   &:hover {
     text-decoration: underline;
   }
-
-  // @include sage-focus-outline();
 }
 
-.sage-banner__close {
+.sage-banner__close.sage-btn--subtle {
+  @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 0);
+
   right: sage-spacing(card);
   // Note: `position: absolute` is set in sage button
 }
 
 .sage-banner__close,
 .sage-banner__link {
-  @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
-  @include sage-focus-outline--update-color(map-get(map-get($-banner-colors, default), text));
+  &.sage-btn--subtle {
+    @include sage-focus-outline--update-color(map-get(map-get($-banner-colors, default), text));
 
-  &:hover {
-    color: map-get(map-get($-banner-colors, default), text-hover);
-  }
-
-  @each $name, $configs in $-banner-colors {
-    /* stylelint-disable max-nesting-depth */
-    .sage-banner--#{$name} & {
-      @include sage-focus-outline--update-color(map-get($configs, text));
-
-      &:hover {
-        color: map-get($configs, text-hover);
-      }
+    &:hover {
+      color: map-get(map-get($-banner-colors, default), text-hover);
     }
-    /* stylelint-enable max-nesting-depth */
+
+    @each $name, $configs in $-banner-colors {
+      /* stylelint-disable max-nesting-depth */
+      .sage-banner.sage-banner--#{$name} & {
+        @include sage-focus-outline--update-color(map-get($configs, text));
+
+        &:hover {
+          color: map-get($configs, text-hover);
+        }
+      }
+      /* stylelint-enable max-nesting-depth */
+    }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_breadcrumbs.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_breadcrumbs.scss
@@ -70,6 +70,11 @@ $-breadcrumb-disabled-color: sage-color(grey, 500);
 
     @include sage-tab-underline(".sage-breadcrumbs__link--current");
   }
+
+  .sage-breadcrumbs:not(.sage-breadcrumbs--progressbar) & {
+    @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
+    @include sage-focus-outline--update-color(sage-color(primary));
+  }
 }
 
 .sage-breadcrumbs__link--current {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -396,6 +396,11 @@ $-btn-interactive-label-icon-size: rem(24px);
         color: map-get($-styles, disabled);
         background-color: transparent;
       }
+
+      &[class*="icon-only"] {
+        @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 0);
+        @include sage-focus-outline--update-color(map-get($-styles, default));
+      }
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -406,8 +406,10 @@ $-btn-interactive-label-icon-size: rem(24px);
           @include sage-focus-outline--update-color(map-get($-styles, default));
 
           position: absolute; /* this keeps the button inside a label within the visual bounds of the label component */
-          border-top-left-radius: 0;
-          border-bottom-left-radius: 0;
+
+          &::after {
+            border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0
+          }
         }
       }
     }

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -408,7 +408,7 @@ $-btn-interactive-label-icon-size: rem(24px);
           position: absolute; /* this keeps the button inside a label within the visual bounds of the label component */
 
           &::after {
-            border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0
+            border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
           }
         }
       }

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -179,7 +179,7 @@ $-btn-interactive-label-icon-size: rem(24px);
     &::after {
       width: $-btn-interactive-label-icon-size;
       height: $-btn-interactive-label-icon-size;
-      border-radius: 0 sage-border(radius) sage-border(radius) 0;
+      border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
     }
 
     &:first-child:not(:last-child) {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -400,6 +400,15 @@ $-btn-interactive-label-icon-size: rem(24px);
       &[class*="icon-only"] {
         @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 0);
         @include sage-focus-outline--update-color(map-get($-styles, default));
+
+        .sage-label & {
+          @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
+          @include sage-focus-outline--update-color(map-get($-styles, default));
+
+          position: absolute; /* this keeps the button inside a label within the visual bounds of the label component */
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
       }
     }
   }

--- a/packages/sage-assets/lib/stylesheets/components/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_catalog_item.scss
@@ -24,6 +24,10 @@ $-catalogue-item-image-height-mobile: rem(120px);
   border-top: sage-border(light);
   border-bottom: sage-border(light);
 
+  > * {
+    min-width: 0; /* to prevent grid blowout */
+  }
+
   &:only-child {
     border: 0;
   }
@@ -39,7 +43,7 @@ $-catalogue-item-image-height-mobile: rem(120px);
 
   &.sage-catalog-item--img {
     @media (min-width: sage-breakpoint(md-min)) {
-      grid-template-columns: $-catalogue-item-image-width 1fr min-content;
+      grid-template-columns: $-catalogue-item-image-width minmax(0, 1fr) min-content;
       grid-template-rows: auto auto;
       grid-template-areas:
         "img title aside"
@@ -68,7 +72,6 @@ $-catalogue-item-image-height-mobile: rem(120px);
 .sage-catalog-item__title {
   display: flex;
   grid-area: title;
-  overflow: hidden;
 
   @media (min-width: sage-breakpoint(md-min)) {
     align-self: flex-end;
@@ -76,10 +79,6 @@ $-catalogue-item-image-height-mobile: rem(120px);
 
   @media (max-width: sage-breakpoint(md-min)) {
     align-self: center;
-  }
-
-  > * {
-    @include truncate;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -180,8 +180,8 @@ $-checkbox-focus-outline-color: sage-color(primary);
   // focus outline
   &::before {
     transform: translate3d(-50%, -50%, 0) scale(0.94);
-    width: calc(100% + (#{$-checkbox-focus-outline-width * 2px} + #{$-checkbox-focus-outline-size * 2}));
-    height: calc(100% + (#{$-checkbox-focus-outline-width * 2px} + #{$-checkbox-focus-outline-size * 2}));
+    width: calc(100% + (#{$-checkbox-focus-outline-width * 1px} + #{$-checkbox-focus-outline-size * 2}));
+    height: calc(100% + (#{$-checkbox-focus-outline-width * 1px} + #{$-checkbox-focus-outline-size * 2}));
     border: ($-checkbox-focus-outline-width * 1px) solid $-checkbox-focus-outline-color;
     border-radius: $-checkbox-border-radius-outer;
     pointer-events: none;

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -187,7 +187,8 @@ $-checkbox-focus-outline-color: sage-color(primary);
     pointer-events: none;
     opacity: 0;
 
-    .sage-panel-controls__bulk-actions--checked & {
+    .sage-panel-controls__bulk-actions--checked &,
+    .sage-dropdown__item-control:focus-within & {
       display: none;
     }
   }

--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -56,15 +56,16 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   }
 
   &:hover {
+    @include sage-focus-outline--update-color(sage-color(grey, 400));
+
     color: $-choice-color-active;
-    background-color: sage-color(grey, 100);
   }
 
   &:focus {
     outline: none;
 
     &::after {
-      border-color: sage-color(grey, 400);
+      border-color: sage-color(primary, 300);
     }
   }
 
@@ -73,7 +74,11 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     color: $-choice-color-active;
 
     &::after {
-      border-color: sage-color(primary);
+      border-color: sage-color(primary, 300);
+    }
+
+    &:hover::after {
+      border-color: sage-color(primary, 400);
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
@@ -59,6 +59,7 @@ $-copy-text-color-hover: sage-color(charcoal, 500);
   align-items: center;
   max-width: 100%;
   padding-right: sage-spacing(2xs);
+  border-radius: sage-border(radius);
 
   &::before {
     @include sage-icon-base(copy);

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -10,7 +10,6 @@ $-dropdown-width: rem(280px);
 $-dropdown-width-small: rem(200px);
 $-dropdown-item-focus-line-spacing-x: sage-spacing(sm);
 
-$-dropdown-option-el-underline: "after";
 $-dropdown-option-menu-size: rem(40px);
 
 $-dropdown-panel-max-height: rem(400px);
@@ -40,13 +39,12 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
     box-shadow: map-get($sage-toolbar-button-borders, default);
     border: 0;
 
-    @include sage-focus-outline--update-color(transparent);
-
     &:hover {
       box-shadow: map-get($sage-toolbar-button-borders, hover);
       background-color: sage-color(white);
     }
 
+    &:focus,
     &:focus-within {
       box-shadow: map-get($sage-toolbar-button-borders, focus);
     }
@@ -108,19 +106,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
   @extend %t-sage-body;
 
-  &::#{$-dropdown-option-el-underline} {
-    $-focus-offset: 50%;
-    content: "";
-    display: block;
-    position: absolute;
-    right: $-focus-offset;
-    bottom: 0;
-    left: $-focus-offset;
-    border-bottom: 2px solid transparent;
-    transition: map-get($sage-transitions, default);
-    transition-property: border-bottom-color, left, right;
-  }
-
   &:hover:not(.sage-dropdown__item--heading) {
     color: sage-color(charcoal, 500);
     background-color: sage-color(grey, 200);
@@ -130,18 +115,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   &:focus-within {
     outline: none;
 
-    &::#{$-dropdown-option-el-underline} {
-      right: $-dropdown-item-focus-line-spacing-x;
-      left: $-dropdown-item-focus-line-spacing-x;
-    }
-  }
-
-  &:focus-within::#{$-dropdown-option-el-underline} {
-    border-bottom-color: currentColor;
-  }
-
-  &:active::#{$-dropdown-option-el-underline} {
-    border-bottom-color: sage-color(primary);
+    @include sage-focus-outline--update-color(sage-color(primary, 300));
   }
 }
 
@@ -154,8 +128,9 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__item--disabled {
-  &:active::#{$-dropdown-option-el-underline} {
-    border-bottom-color: transparent;
+  &:active {
+    // @include sage-focus-shadow($focus-shadow-inset: true);
+    @include sage-focus-outline--update-color(sage-color(primary, 300));
   }
 }
 
@@ -171,6 +146,8 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 .sage-dropdown__item-control {
   @include sage-button-style-reset();
+  @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
+  @include sage-focus-outline--update-color(sage-color(primary, 300));
 
   display: flex;
   position: relative;
@@ -180,8 +157,17 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   text-align: left;
   user-select: none;
 
-  &:focus {
-    outline: 0;
+  &::after {
+    border-radius: 0;
+  }
+
+  &:focus-within {
+    @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
+    @include sage-focus-outline--update-color(sage-color(primary, 300));
+
+    &::after {
+      opacity: 1;
+    }
   }
 
   .sage-dropdown__item--with-options > & {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -157,7 +157,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   text-align: left;
   user-select: none;
 
-  &::after {
+  .sage-dropdown &::after {
     border-radius: 0;
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -129,7 +129,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 .sage-dropdown__item--disabled {
   &:active {
-    // @include sage-focus-shadow($focus-shadow-inset: true);
     @include sage-focus-outline--update-color(sage-color(primary, 300));
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -16,10 +16,6 @@ $-expandable-card-padding-xs: sage-spacing(xs);
 .sage-expandable-card__body-bordered {
   margin-top: sage-spacing(xs);
 
-  [aria-expanded] + & {
-    overflow: hidden;
-  }
-
   [aria-expanded="false"] + & {
     height: 0;
     margin: 0;
@@ -48,6 +44,8 @@ $-expandable-card-padding-xs: sage-spacing(xs);
 }
 
 .sage-expandable-card__trigger {
+  display: inline-flex;
+
   &::before {
     justify-content: center;
     margin-right: rem(4px);

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -120,10 +120,6 @@ $-input-transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
     color: sage-color(charcoal, 100);
   }
 
-  &:hover:not(:disabled) {
-    border-color: currentColor;
-  }
-
   &:focus:not(:disabled),
   &:active:not(:disabled) {
     outline: none;
@@ -138,6 +134,10 @@ $-input-transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
       @include floating-label-active();
       color: $-input-color-success;
     }
+  }
+
+  &:hover:not(:disabled) {
+    border-color: currentColor;
   }
 
   &:valid:not(:placeholder-shown) {

--- a/packages/sage-assets/lib/stylesheets/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_select.scss
@@ -136,6 +136,14 @@ $-select-padding-label: map-get($sage-field-configs, padding-label);
       box-shadow: $-select-border-box-shadow-size $-select-color-error;
     }
   }
+
+  &:hover:not(:disabled) {
+    border-color: $-select-color-default;
+
+    .sage-select--error {
+      border-color: currentColor;
+    }
+  }
 }
 
 .sage-select__message {

--- a/packages/sage-assets/lib/stylesheets/components/_form_textarea.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_textarea.scss
@@ -99,10 +99,6 @@ $-textarea-color-success: map-get($sage-field-colors, success);
     color: sage-color(charcoal, 100);
   }
 
-  &:hover:not(:disabled) {
-    border-color: currentColor;
-  }
-
   &:focus:not(:disabled),
   &:active:not(:disabled) {
     border-color: $-textarea-color-success;
@@ -117,6 +113,10 @@ $-textarea-color-success: map-get($sage-field-colors, success);
       @include floating-label-textarea-active();
       color: $-textarea-color-success;
     }
+  }
+
+  &:hover:not(:disabled) {
+    border-color: currentColor;
   }
 
   /* Separated so IE/Edge does not ignore focus styles. Note that Edge will not support these states */

--- a/packages/sage-assets/lib/stylesheets/components/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_hero.scss
@@ -67,11 +67,38 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   grid-area: artwork;
   position: relative;
   overflow: hidden;
+  outline: none;
 
   @media (max-width: sage-breakpoint(sm-max)) {
     height: 0;
     padding-top: $-hero-mobile-aspect-ratio;
   }
+
+  &:hover::after {
+    background-color: $-hero-play-icon-background-color-hover;
+  }
+
+  &:focus {
+    border: 3px solid sage-color(primary);
+  }
+}
+
+.sage-hero__artwork-image {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+
+  @media (min-width: sage-breakpoint(md-min)) {
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.sage-hero__artwork-image-container {
+  display: block;
+  width: 100%;
+  height: 100%;
 
   &::before {
     @include sage-icon-base(play);
@@ -97,21 +124,5 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
     border-radius: 50%;
     background-color: $-hero-play-icon-background-color;
     transition: background-color 0.2s ease;
-  }
-
-  &:hover::after {
-    background-color: $-hero-play-icon-background-color-hover;
-  }
-}
-
-.sage-hero__artwork-image {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 100%;
-
-  @media (min-width: sage-breakpoint(md-min)) {
-    height: 100%;
-    object-fit: cover;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_label.scss
@@ -99,6 +99,10 @@ $-label-inset-border: 0 0 0 1px inset;
       &:hover:not(:focus):not(:active):not(:disabled):not(.disabled) {
         color: sage-color-combo($-color-name, default, foreground-accent);
       }
+
+      &::after {
+        border-radius: $-label-border-radius;
+      }
     }
 
     .sage-btn {
@@ -131,7 +135,7 @@ $-label-inset-border: 0 0 0 1px inset;
       width: $-label-interactive-icon-size-small;
       min-height: $-label-interactive-icon-size;
       margin: auto 0;
-      border-radius: 0 sage-border(radius) sage-border(radius) 0;
+      border-radius: 0 $-label-border-radius $-label-border-radius 0;
 
       &::before {
         font-weight: sage-font-weight(bold);
@@ -141,7 +145,7 @@ $-label-inset-border: 0 0 0 1px inset;
       &::after {
         width: $-label-interactive-icon-size;
         height: $-label-interactive-icon-size;
-        border-radius: 0 sage-border(radius) sage-border(radius) 0;
+        border-radius: 0 $-label-border-radius $-label-border-radius 0;
       }
 
       &:focus {

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -5,8 +5,18 @@
 ////
 
 
-.sage-link--launch,
-.sage-type a[target="_blank"]:not(.sage-link--no-launch):not([class*="icon-right-launch"]) {
+.sage-link {
+  display: inline-flex;
+  position: relative;
+  max-width: 100%;
+  min-width: 0; /* the is needed so that truncation work when the link doesn't have an explicit width set  */
+
+  @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
+  @include sage-focus-outline--update-color(sage-color(primary));
+}
+
+.sage-link--launch .t-sage--truncate,
+.sage-type a[target="_blank"]:not(.sage-link--no-launch):not([class*="icon-right-launch"]) .t-sage--truncate {
   &::after {
     margin-left: sage-spacing(2xs);
     margin-right: sage-spacing(2xs);
@@ -21,7 +31,6 @@
   &::before {
     @include sage-icon-base(question-circle, lg);
 
-    transform: translateY(rem(1px));
     color: sage-color(grey, 500);
   }
 
@@ -49,7 +58,14 @@
   }
 }
 
+.sage-link--help-icon-only {
+  @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 2px);
+  @include sage-focus-outline--update-color(sage-color(primary));
+}
+
 .sage-link--subtext {
+  @include sage-focus-outline--update-color(currentColor);
+
   display: inline-block;
   position: relative;
   padding: 0 sage-spacing(2xs);
@@ -65,7 +81,5 @@
   &:focus {
     color: sage-color(charcoal, 400);
     text-decoration: none;
-    box-shadow: 0 0 0 2px currentColor;
-    outline: 0;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -61,9 +61,9 @@ $-nav-icon-size: rem(20px);
 }
 
 .sage-nav__link--active::after {
-  opacity: 1;
-  border-color: sage-color(primary);
   transform: translate3d(-50%, -50%, 0) scale(1);
+  border-color: sage-color(primary);
+  opacity: 1;
 }
 
 .sage-nav__link--sub {

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -42,7 +42,7 @@ $-nav-icon-size: rem(20px);
 
 .sage-nav__link,
 .sage-nav__link--active {
-  @include sage-focus-outline($outline-offset-inline: 0, $outline-offset-block: 0);
+  @include sage-focus-outline($outline-offset-inline: 0, $outline-offset-block: -1);
   @include sage-focus-outline--update-color(sage-color(primary));
 
   display: flex;

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -40,7 +40,11 @@ $-nav-icon-size: rem(20px);
   }
 }
 
-.sage-nav__link {
+.sage-nav__link,
+.sage-nav__link--active {
+  @include sage-focus-outline($outline-offset-inline: 0, $outline-offset-block: 0);
+  @include sage-focus-outline--update-color(sage-color(primary));
+
   display: flex;
   align-items: center;
   padding: rem(10px) rem(12px);
@@ -54,11 +58,12 @@ $-nav-icon-size: rem(20px);
   &:focus {
     background-color: $-nav-color-background-hover;
   }
+}
 
-  &:focus {
-    box-shadow: inset 0 0 0 2px $-nav-color-focus;
-    outline: none;
-  }
+.sage-nav__link--active::after {
+  opacity: 1;
+  border-color: sage-color(primary);
+  transform: translate3d(-50%, -50%, 0) scale(1);
 }
 
 .sage-nav__link--sub {

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -61,14 +61,6 @@ $-radio-focus-outline-color: currentColor;
   padding: sage-spacing(card);
   border: sage-border();
   border-radius: sage-border(radius);
-
-  &:focus-within {
-    box-shadow: 0 0 0 ($-radio-focus-outline-width * 1px) $-radio-color-focus-outline;
-  }
-
-  &.sage-radio--error:focus-within {
-    box-shadow: 0 0 0 ($-radio-focus-outline-width * 1px) $-radio-color-focus-outline-error;
-  }
 }
 
 .sage-radio__label {
@@ -169,7 +161,7 @@ $-radio-focus-outline-color: currentColor;
   &:focus:not(:disabled),
   &:active:not(:disabled) {
     outline: none;
-    
+
     &::before {
       transform: translate3d(-50%, -50%, 0) scale(1);
       border-color: $-radio-color-focus-outline;
@@ -207,11 +199,6 @@ $-radio-focus-outline-color: currentColor;
     .sage-radio--has-border & {
       position: absolute;
       margin-top: 0;
-    }
-
-    .sage-radio--has-border &::after,
-    .sage-radio--has-border &::before {
-      border-color: transparent;
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -72,6 +72,15 @@ $-search-icon: "::before";
     }
   }
 
+  .sage-dropdown__panel & {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+
+    &:focus-within {
+      box-shadow: inset map-get($sage-toolbar-button-borders, focus);
+    }
+  }
+
   .sage-panel-controls__toolbar & {
     flex: 1;
   }

--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -30,25 +30,14 @@ $-search-icon: "::before";
   &:not(.sage-search--contained) {
     border-bottom: 1px solid sage-color(grey, 300);
 
-    &::after {
-      content: "";
-      display: block;
-      position: absolute;
-      bottom: rem(-1px);
-      left: 50%;
-      right: 50%;
-      z-index: 3;
-      height: 0;
-      border-bottom: rem(2px) solid sage-color(primary);
-      transition: map-get($sage-transitions, default);
-      transition-property: left, right, opacity;
+    &:hover {
+      border-bottom: 1px solid sage-color(grey, 400);
     }
+  }
 
-    &:focus-within::after {
-      left: 0;
-      right: 0;
-      opacity: 1;
-    }
+  &:focus-within {
+    border-radius: sage-border(radius);
+    box-shadow: map-get($sage-toolbar-button-borders, focus);
   }
 
   &.sage-search--contained {

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -49,8 +49,4 @@
 .sage-stat-box__link {
   @extend %t-sage-body-med;
   margin-top: sage-spacing(xs);
-  &::after {
-    @include sage-icon-base(arrow-right);
-    margin-left: sage-spacing(xs);
-  }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_status_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_status_icon.scss
@@ -15,7 +15,7 @@
   transition: color map-get($sage-transitions, default), background-color map-get($sage-transitions, default);
   cursor: help;
 
-  @include sage-focus-outline;
+  @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 4px);
   @include sage-focus-outline--update-color(sage-color(charcoal, 200));
 
   &:hover:not(:focus):not(:active) {
@@ -31,6 +31,10 @@
     &:not(:last-child) {
       margin-right: sage-spacing(sm);
     }
+  }
+
+  & + & {
+    margin-left: sage-spacing(2xs);
   }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -48,14 +48,6 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     padding: sage-spacing(card);
     border: sage-border();
     border-radius: sage-border(radius);
-
-    // &:focus-within {
-    //   box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-color;
-    // }
-
-    // &.sage-switch--error:focus-within {
-    //   box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-error-color;
-    // }
   }
 
   &.sage-switch--toggle-right {
@@ -119,11 +111,6 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
 
   .sage-switch--has-border & {
     position: absolute;
-
-    // &::after,
-    // &::before {
-    //   border-color: transparent;
-    // }
   }
 
   + .sage-switch__label {
@@ -199,11 +186,6 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
       border-color: sage-color(red);
     }
   }
-
-  // .sage-switch--has-border:not(.sage-switch--standalone) &::after,
-  // .sage-switch--has-border:not(.sage-switch--standalone) &::before {
-  //   border-color: transparent;
-  // }
 
   // checked
   &:checked {

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -49,13 +49,13 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     border: sage-border();
     border-radius: sage-border(radius);
 
-    &:focus-within {
-      box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-color;
-    }
+    // &:focus-within {
+    //   box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-color;
+    // }
 
-    &.sage-switch--error:focus-within {
-      box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-error-color;
-    }
+    // &.sage-switch--error:focus-within {
+    //   box-shadow: 0 0 0 ($-switch-focus-outline-width * 1px) $-switch-focus-outline-error-color;
+    // }
   }
 
   &.sage-switch--toggle-right {
@@ -120,10 +120,10 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
   .sage-switch--has-border & {
     position: absolute;
 
-    &::after,
-    &::before {
-      border-color: transparent;
-    }
+    // &::after,
+    // &::before {
+    //   border-color: transparent;
+    // }
   }
 
   + .sage-switch__label {
@@ -200,10 +200,10 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     }
   }
 
-  .sage-switch--has-border:not(.sage-switch--standalone) &::after,
-  .sage-switch--has-border:not(.sage-switch--standalone) &::before {
-    border-color: transparent;
-  }
+  // .sage-switch--has-border:not(.sage-switch--standalone) &::after,
+  // .sage-switch--has-border:not(.sage-switch--standalone) &::before {
+  //   border-color: transparent;
+  // }
 
   // checked
   &:checked {

--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -15,7 +15,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
 .sage-tab {
   @include sage-button-style-reset();
 
-  display: flex;
+  display: inline-flex;
   position: relative;
   align-items: center;
   overflow: hidden;
@@ -68,7 +68,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
         z-index: 2;
         right: rem(-32px);
         color: sage-color(charcoal, 100);
-  
+
         @include sage-icon-base(right-small, xl);
       }
     }

--- a/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
@@ -12,17 +12,26 @@ $-transaction-card-state-max-width: rem(80px);
 
   position: relative;
   width: 100%;
+
+  > * {
+    min-width: 0;
+  }
 }
 
 
 .sage-transaction-card__body {
   @include sage-grid-stack;
 
-  min-width: 0;
 }
 
 .sage-transaction-card__body-group {
   width: 100%;
+}
+
+.sage-transaction-card__footer {
+  > :first-child {
+    max-width: 100%;
+  }
 }
 
 .sage-transaction-card__body-group,
@@ -58,7 +67,6 @@ $-transaction-card-state-max-width: rem(80px);
 
 .sage-transaction-card__name {
   @extend %t-sage-heading-6;
-  @include truncate;
 
   max-width: 100%;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
@@ -53,7 +53,7 @@ $-typeahead-item-height: rem(68px);
 
 .sage-typeahead__item-trigger {
   @include sage-button-style-reset;
-  @include sage-focus-outline($outline-offset-block: -6px, $outline-offset-inline: -6px, $outline-animation-speed: 0.05s);
+  @include sage-focus-outline($outline-offset-block: -2px, $outline-offset-inline: -2px, $outline-animation-speed: 0.05s);
   @include sage-focus-outline--update-color(sage-color(primary));
 
   display: grid;
@@ -68,6 +68,20 @@ $-typeahead-item-height: rem(68px);
   align-items: center;
   padding: sage-spacing(md) sage-spacing(sm);
   text-align: left;
+
+  &::after {
+    border-radius: 0;
+  }
+
+  .sage-typeahead__item:first-child &::after {
+    border-top-left-radius: sage-border(radius);
+    border-top-right-radius: sage-border(radius);
+  }
+
+  .sage-typeahead__item:last-child &::after {
+    border-bottom-left-radius: sage-border(radius);
+    border-bottom-right-radius: sage-border(radius);
+  }
 
   > * {
     @include truncate;

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -158,6 +158,7 @@
       transform $outline-animation-speed ease-in-out;
     pointer-events: none;
     opacity: 0;
+    will-change: transform;
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -144,6 +144,7 @@
     $-offset-inline: $outline-width * 2 + $outline-offset-inline * 2;
 
     content: "";
+    z-index: sage-z-index(default, 1);
     position: absolute;
     left: 50%;
     top: 50%;
@@ -157,7 +158,6 @@
       transform $outline-animation-speed ease-in-out;
     pointer-events: none;
     opacity: 0;
-    z-index: sage-z-index(default, 1);
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -128,8 +128,8 @@
 ///
 @mixin sage-focus-outline(
   $outline-width: 2px,
-  $outline-offset-block: 4px,
-  $outline-offset-inline: 4px,
+  $outline-offset-block: 2px,
+  $outline-offset-inline: 2px,
   $outline-animation-speed: 0.2s
 ) {
   position: relative;
@@ -157,6 +157,7 @@
       transform $outline-animation-speed ease-in-out;
     pointer-events: none;
     opacity: 0;
+    z-index: sage-z-index(default, 1);
   }
 
   &:focus:not(:disabled):not([aria-disabled="true"]),

--- a/packages/sage-react/lib/HelpLink/HelpLink.jsx
+++ b/packages/sage-react/lib/HelpLink/HelpLink.jsx
@@ -10,7 +10,7 @@ export const HelpLink = ({
   ...rest
 }) => (
   <Link
-    className={`${labelIsVisible ? 'sage-link--help' : 'sage-link--help-icon-only'} ${className || ''}`}
+    className={`${labelIsVisible ? 'sage-link sage-link--help' : 'sage-link sage-link--help-icon-only'} ${className || ''}`}
     tag={linkTag}
     {...rest}
   >

--- a/packages/sage-react/lib/Link/Link.jsx
+++ b/packages/sage-react/lib/Link/Link.jsx
@@ -21,12 +21,16 @@ export const Link = ({
       {tooltip ? (
         <Tooltip {...tooltip}>
           <SelfTag {...rest}>
-            {children}
+            <span className="t-sage--truncate">
+              {children}
+            </span>
           </SelfTag>
         </Tooltip>
       ) : (
         <SelfTag {...rest}>
-          {children}
+          <span className="t-sage--truncate">
+            {children}
+          </span>
         </SelfTag>
       )}
     </>

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { SageTokens } from '../configs';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
 import { Label } from '../Label';
 import { LABEL_COLORS, TYPE } from './configs'; // component configurations as needed
 

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -54,7 +54,16 @@ export const StatBox = ({
       </div>
       {link && (
         <footer className="sage-stat-box__footer">
-          <a className="sage-stat-box__link" href={link.href}>{link.value}</a>
+          <Button
+            color={Button.COLORS.PRIMARY}
+            href={link.href}
+            icon={SageTokens.ICONS.ARROW_RIGHT}
+            iconPosition={Button.ICON_POSITIONS.RIGHT}
+            subtle={true}
+            className="sage-stat-box__link"
+          >
+            {link.value}
+          </Button>
         </footer>
       )}
     </article>

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Property } from '../Property';
+import { Button } from '../Button';
 import { Link } from '../Link';
 import { Label } from '../Label';
-import { AMOUNT_COLORS, LABEL_COLORS, STATE_COLORS } from './configs';
 import { SageTokens } from '../configs';
-import { Button } from '../Button';
+import { AMOUNT_COLORS, LABEL_COLORS, STATE_COLORS } from './configs';
 
 export const TransactionCard = ({
   amount,
@@ -47,40 +47,33 @@ export const TransactionCard = ({
         </div>
       </div>
       <div className="sage-transaction-card__body">
-        <div className="sage-transaction-card__body-group">
-          <NameTag className="sage-transaction-card__name">
-            {nameHref ? (
-              <Link
-                href={nameHref}
-                className="sage-transaction-card__name-link"
-              >
-                {name}
-              </Link>
-            ) : name}
-          </NameTag>
-          {amount && (
-            <div className={amountClassNames}>
-              {amount}
-            </div>
-          )}
-        </div>
-        <div className="sage-transaction-card__body-group">
-          {relatedPropertyHref ? (
-            <Button
-              className="sage-transaction-card__product"
-              color={Button.COLORS.SECONDARY}
-              href={relatedPropertyHref}
-              icon={SageTokens.ICONS.TAG}
-              small={true}
-              subtle={true}
-            >
-              {relatedProperty}
-            </Button>
-          ) : (
-            <Property className="sage-transaction-card__product" icon={SageTokens.ICONS.TAG}>{relatedProperty}</Property>
-          )}
-          <Property className="sage-transaction-card__time">{transactionTime}</Property>
-        </div>
+        <NameTag className="sage-transaction-card__name">
+          {nameHref ? (
+            <Link href={nameHref} className="sage-link sage-transaction-card__name-link">
+              <span className="t-sage--truncate">{name}</span>
+            </Link>
+          ) : name}
+        </NameTag>
+        {amount && (
+          <div className={`sage-transaction-card__amount${amountColor ? ` sage-transaction-card__amount--${amountColor}` : ''}`}>
+            {amount}
+          </div>
+        )}
+      </div>
+      <div className="sage-transaction-card__footer">
+        {relatedPropertyHref ? (
+          <Button
+            color={Button.COLORS.SECONDARY}
+            href={relatedPropertyHref}
+            icon={SageTokens.ICONS.TAG}
+            iconPosition={Button.ICON_POSITIONS.LEFT}
+            small={true}
+            subtle={true}
+          >
+            {relatedProperty}
+          </Button>
+        ) : <Property icon={Icon.ICONS.TAG}>{relatedProperty}</Property>}
+        <Property>{transactionTime}</Property>
       </div>
     </article>
   );

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Property } from '../Property';
+import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { Link } from '../Link';
 import { Label } from '../Label';
@@ -23,13 +24,6 @@ export const TransactionCard = ({
   transactionTime,
 }) => {
   const NameTag = nameTag;
-
-  const amountClassNames = classnames(
-    'sage-transaction-card__amount',
-    {
-      [`sage-transaction-card__amount--${amountColor}`]: amountColor,
-    }
-  );
 
   const stateClassNames = classnames(
     'sage-transaction-card__state',

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -41,18 +41,20 @@ export const TransactionCard = ({
         </div>
       </div>
       <div className="sage-transaction-card__body">
-        <NameTag className="sage-transaction-card__name">
-          {nameHref ? (
-            <Link href={nameHref} className="sage-link sage-transaction-card__name-link">
-              <span className="t-sage--truncate">{name}</span>
-            </Link>
-          ) : name}
-        </NameTag>
-        {amount && (
-          <div className={`sage-transaction-card__amount${amountColor ? ` sage-transaction-card__amount--${amountColor}` : ''}`}>
-            {amount}
-          </div>
-        )}
+        <div className="sage-transaction-card__body-group">
+          <NameTag className="sage-transaction-card__name">
+            {nameHref ? (
+              <Link href={nameHref} className="sage-link sage-transaction-card__name-link">
+                <span className="t-sage--truncate">{name}</span>
+              </Link>
+            ) : name}
+          </NameTag>
+          {amount && (
+            <div className={`sage-transaction-card__amount${amountColor ? ` sage-transaction-card__amount--${amountColor}` : ''}`}>
+              {amount}
+            </div>
+          )}
+        </div>
       </div>
       <div className="sage-transaction-card__footer">
         {relatedPropertyHref ? (

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -2,13 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Property } from '../Property';
-import { Icon } from '../Icon';
-import { Button } from '../Button';
 import { Link } from '../Link';
 import { Label } from '../Label';
-import { SageTokens } from '../configs';
 import { AMOUNT_COLORS, LABEL_COLORS, STATE_COLORS } from './configs';
-
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
 export const TransactionCard = ({
   amount,
   amountColor,
@@ -24,14 +22,18 @@ export const TransactionCard = ({
   transactionTime,
 }) => {
   const NameTag = nameTag;
-
+  const amountClassNames = classnames(
+    'sage-transaction-card__amount',
+    {
+      [`sage-transaction-card__amount--${amountColor}`]: amountColor,
+    }
+  );
   const stateClassNames = classnames(
     'sage-transaction-card__state',
     {
       [`sage-transaction-card__state--${transactionStateColor}`]: transactionStateColor,
     }
   );
-
   return (
     <article className="sage-transaction-card">
       <div className="sage-transaction-card__header">
@@ -44,41 +46,44 @@ export const TransactionCard = ({
         <div className="sage-transaction-card__body-group">
           <NameTag className="sage-transaction-card__name">
             {nameHref ? (
-              <Link href={nameHref} className="sage-link sage-transaction-card__name-link">
-                <span className="t-sage--truncate">{name}</span>
+              <Link
+                href={nameHref}
+                className="sage-link sage-transaction-card__name-link"
+              >
+                {name}
               </Link>
             ) : name}
           </NameTag>
           {amount && (
-            <div className={`sage-transaction-card__amount${amountColor ? ` sage-transaction-card__amount--${amountColor}` : ''}`}>
+            <div className={amountClassNames}>
               {amount}
             </div>
           )}
         </div>
-      </div>
-      <div className="sage-transaction-card__footer">
-        {relatedPropertyHref ? (
-          <Button
-            color={Button.COLORS.SECONDARY}
-            href={relatedPropertyHref}
-            icon={SageTokens.ICONS.TAG}
-            iconPosition={Button.ICON_POSITIONS.LEFT}
-            small={true}
-            subtle={true}
-          >
-            {relatedProperty}
-          </Button>
-        ) : <Property icon={Icon.ICONS.TAG}>{relatedProperty}</Property>}
-        <Property>{transactionTime}</Property>
+        <div className="sage-transaction-card__body-group">
+          {relatedPropertyHref ? (
+            <Button
+              className="sage-transaction-card__product"
+              color={Button.COLORS.SECONDARY}
+              href={relatedPropertyHref}
+              icon={SageTokens.ICONS.TAG}
+              small={true}
+              subtle={true}
+            >
+              {relatedProperty}
+            </Button>
+          ) : (
+            <Property className="sage-transaction-card__product" icon={SageTokens.ICONS.TAG}>{relatedProperty}</Property>
+          )}
+          <Property className="sage-transaction-card__time">{transactionTime}</Property>
+        </div>
       </div>
     </article>
   );
 };
-
 TransactionCard.LABEL_COLORS = LABEL_COLORS;
 TransactionCard.AMOUNT_COLORS = AMOUNT_COLORS;
 TransactionCard.STATE_COLORS = STATE_COLORS;
-
 TransactionCard.defaultProps = {
   amount: '0.00',
   amountColor: null,
@@ -93,7 +98,6 @@ TransactionCard.defaultProps = {
   transactionStateColor: null,
   transactionTime: '--',
 };
-
 TransactionCard.propTypes = {
   amount: PropTypes.string,
   amountColor: PropTypes.oneOf(Object.values(TransactionCard.AMOUNT_COLORS)),

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -7,6 +7,7 @@ import { Label } from '../Label';
 import { AMOUNT_COLORS, LABEL_COLORS, STATE_COLORS } from './configs';
 import { SageTokens } from '../configs';
 import { Button } from '../Button';
+
 export const TransactionCard = ({
   amount,
   amountColor,

--- a/packages/sage-react/lib/configs/classnames/links.js
+++ b/packages/sage-react/lib/configs/classnames/links.js
@@ -1,4 +1,4 @@
 export const CLASSNAMES_LINK = {
-  LAUNCH: 'sage-link--launch',
-  SUBTEXT: 'sage-link--subtext',
+  LAUNCH: 'sage-link sage-link--launch',
+  SUBTEXT: 'sage-link sage-link--subtext',
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
[SAGE-491](https://github.com/Kajabi/sage-lib/issues/491)

Previously closed original ticket for comment context: [SAGE-554](https://github.com/Kajabi/sage-lib/pull/554)
Previously closed followup ticket for comment context: [SAGE-580](https://github.com/Kajabi/sage-lib/pull/580)

- [x] - expandable card -> update `display` property, it's currently full width
- [x] - add `tabindex` to StatusIcon for keyboard focus
- [x] create focus styles for links that aren't buttons
- [x] create focus to links in TransactionCard
- [x] create focus to links in StatBox
- [x] alert - update focus state for action buttons
- [x] hero - resolve focus state on hero artwork
- [x] catalog item - resolve focus state on title
- [x] button / link truncation is not functioning properly
- [x] resolve react helpLink shadow sizing

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
##### Buttons
|  Before  |  After  |
|--------|--------|
|![buttonInteractionPatternBefore](https://user-images.githubusercontent.com/1241836/121958370-39159100-cd29-11eb-81bb-aa127fad321d.gif)|![interactiveafter](https://user-images.githubusercontent.com/1241836/124968262-00e13580-dfeb-11eb-92a2-cf881b06182e.gif)|

##### Labels
|  Before  |  After  |
|--------|--------|
|![labelInteractionPatternBefore](https://user-images.githubusercontent.com/1241836/121958410-46cb1680-cd29-11eb-82e2-a6a4bbf03b86.gif)|![interactivelabelafter](https://user-images.githubusercontent.com/1241836/124968298-0b033400-dfeb-11eb-8182-594f71b7ca1b.gif)|

##### Catalog Item Interaction
|  Before  |  After  |
|--------|--------|
|![catalogItemBefore](https://user-images.githubusercontent.com/1241836/123000223-eb2a0a00-d374-11eb-80cb-19acbdb0af3c.gif)|![interactivecatalogafter](https://user-images.githubusercontent.com/1241836/124969218-0db25900-dfec-11eb-95de-eebc738e0611.gif)|

##### Text links
|  Before  |  After  |
|--------|--------|
|![linksBefore](https://user-images.githubusercontent.com/1241836/122999217-99cd4b00-d373-11eb-91a5-b4be8795788e.gif)|![interactivelinksafter](https://user-images.githubusercontent.com/1241836/124969192-07bc7800-dfec-11eb-9a8d-dde53355586d.gif)|

##### Stat Box link
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-06-14 at 4 57 38 PM](https://user-images.githubusercontent.com/1241836/121966049-957dae00-cd33-11eb-96b1-04b7998ba5b8.png)|![Screen Shot 2021-07-08 at 12 55 52 PM](https://user-images.githubusercontent.com/1241836/124969258-199e1b00-dfec-11eb-9bf8-0f6bbc78a1e5.png)|

##### Alert action buttons
|  Before  |  After  |
|--------|--------|
|![alertFocusBefore](https://user-images.githubusercontent.com/1241836/122085516-66fde280-cdc8-11eb-8570-4abb139da61c.gif)|![interactivealertafter](https://user-images.githubusercontent.com/1241836/124969246-1440d080-dfec-11eb-9326-a44d8eaf2c94.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
[Sage 3 specs](https://www.figma.com/file/9Km09NjlZHYWsMP7EGT8tI/%5BWIP%5D-Sage-3-%E2%80%94-Admin-Components?node-id=3435%3A17) -> Elements
The best way to test is to visit all pages and tab through the docs site

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. #613 (LOW) Interaction pattern(focus state) adjusted to latest specs. Interaction pattern, namely focus states changes will occur as a result in kajabi-products but no adverse effects expected.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
