### PR TITLE
Popover react positions and sync to 3.0

### DIFF
--- a/docs/app/views/examples/components/popover/_preview.html.erb
+++ b/docs/app/views/examples/components/popover/_preview.html.erb
@@ -57,7 +57,6 @@ positions = [
     href: "#",
     name: "Learn more about a thing",
   },
-  custom_content_class: "demo-custom-popover-panel"
 } do %>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -90,12 +89,14 @@ positions = [
     name: "Learn more",
   }
 } do %>
-  <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-    <p>This is a block of content.</p>
-    <p>This is a block of content.</p>
-    <p>This is a block of content.</p>
-    <p>This is a block of content.</p>
-  </div>
+  <%= content_for :sage_popover_media do %>
+    <%= image_tag("card-placeholder-lg.png", alt: "") %>
+  <% end %>
+
+  <p>
+    We can add graphics as well as freeform content blocks inside Popovers.
+    We can even provide a custom css class on the content container for additional finesse.
+  </p>
 <% end %>
 
 <%= sage_component SageCardBlock, {} do %>
@@ -106,12 +107,12 @@ positions = [
 <% end %>
 
 <%= sage_component SagePopover, {
-  custom_content_class: "u-popover-customized",
+  custom_content_class: "demo-custom-popover-panel",
   icon: "question-circle",
   trigger_value: "Open Menu",
   trigger_icon_only: true,
 } do %>
-  <p>I can put whatever content I want in here and use the cusotm class as a hook to style it like a good 'ol BEM mixin!</p>
+  <p>I can put whatever content I want in here and use the custom class as a hook to style it like a good 'ol BEM mixin!</p>
 <% end %>
 
 <%= sage_component SageCardBlock, {} do %>
@@ -122,12 +123,13 @@ positions = [
 <% end %>
 
 <%= sage_component SagePopover, {
+  custom_content_class: "demo-custom-popover-panel",
   icon: "send-message",
   trigger_icon_only: false,
   trigger_value: "Send Test Email",
   popover_position: "bottom",
 } do %>
-  <form>
+  <form style="width: 100%">
     <div class="sage-input">
       <input type="email" id="form__email1" class="sage-input__field" name="form__email1" placeholder="Email Address" required>
       <label for="form__email1" class="sage-input__label">Email Address</label>
@@ -160,12 +162,10 @@ positions = [
         name: "Learn more",
       }
     } do %>
-      <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-        <p>This is a block of content.</p>
-        <p>This is a block of content.</p>
-        <p>This is a block of content.</p>
-        <p>This is a block of content.</p>
-      </div>
+      <p>This is a block of content.</p>
+      <p>This is a block of content.</p>
+      <p>This is a block of content.</p>
+      <p>This is a block of content.</p>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/popover/_preview.html.erb
+++ b/docs/app/views/examples/components/popover/_preview.html.erb
@@ -1,3 +1,46 @@
+<%
+positions = [
+  {
+    setting: "top",
+    label: "Top",
+    icon: "arrow-up",
+  },
+  {
+    setting: "top-right",
+    label: "Top Right",
+    icon: {
+      name: "arrow-up",
+      style: "right",
+    }
+  },
+  {
+    setting: "right",
+    label: "Right",
+    icon: {
+      name: "arrow-right",
+      style: "right",
+    },
+  },
+  {
+    setting: "bottom",
+    label: "Bottom",
+    icon: "arrow-down",
+  },
+  {
+    setting: "bottom-right",
+    label: "Bottom Right",
+    icon: {
+      name: "arrow-down",
+      style: "right",
+    }
+  },
+  {
+    setting: "left",
+    label: "Left",
+    icon: "arrow-left",
+  }
+]
+%>
 <%= sage_component SageCardBlock, {} do %>
   <%= sage_component SageLabel, {
     color: "draft",
@@ -13,12 +56,21 @@
   link: {
     href: "#",
     name: "Learn more about a thing",
-  }
+  },
+  custom_content_class: "demo-custom-popover-panel"
 } do %>
-  <p>This is a block of content.</p>
-  <p>This is a block of content.</p>
-  <p>This is a block of content.</p>
-  <p>This is a block of content.</p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Mauris erat urna, eleifend quis mollis ut, vehicula vitae elit.
+    Quisque elementum risus congue, placerat tellus vulputate, ornare neque.
+    Mauris eu quam nisi.
+  </p>
+  <p>
+    Ut elementum, nulla sit amet viverra vulputate, mi risus dignissim odio, vel aliquam lorem mi nec diam.
+    Donec bibendum tincidunt est, non ultricies nisi efficitur eget.
+    Integer et libero aliquam, efficitur ante ac, auctor dolor.
+    Vivamus aliquet vehicula sollicitudin.
+  </p>
 <% end %>
 
 <%= sage_component SageCardBlock, {} do %>
@@ -95,82 +147,25 @@
   } %>
 <% end %>
 
-<div class="sage-card__row">
-
-  <%= sage_component SagePopover, {
-    title: "Popover Top",
-    icon: "arrow-up",
-    trigger_icon_only: false,
-    trigger_value: "Top",
-    popover_position: "top",
-    link: {
-      href: "#",
-      name: "Learn more",
-    }
-  } do %>
-    <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-    </div>
+<%= sage_component SageCardRow, { grid_template: "oo" } do %>
+  <% positions.each do | position | %>
+    <%= sage_component SagePopover, {
+      title: "Popover #{position[:label]}",
+      icon: position[:icon],
+      trigger_icon_only: false,
+      trigger_value: position[:label],
+      popover_position: position[:setting],
+      link: {
+        href: "#",
+        name: "Learn more",
+      }
+    } do %>
+      <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
+        <p>This is a block of content.</p>
+        <p>This is a block of content.</p>
+        <p>This is a block of content.</p>
+        <p>This is a block of content.</p>
+      </div>
+    <% end %>
   <% end %>
-
-  <%= sage_component SagePopover, {
-    title: "Popover Right",
-    icon: "arrow-right",
-    trigger_icon_only: false,
-    trigger_value: "Right",
-    popover_position: "right",
-    link: {
-      href: "#",
-      name: "Learn more",
-    }
-  } do %>
-    <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-    </div>
-  <% end %>
-
-  <%= sage_component SagePopover, {
-    title: "Popover Bottom",
-    icon: "arrow-down",
-    trigger_icon_only: false,
-    trigger_value: "Bottom",
-    popover_position: "bottom",
-    link: {
-      href: "#",
-      name: "Learn more",
-    }
-  } do %>
-    <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-    </div>
-  <% end %>
-
-  <%= sage_component SagePopover, {
-    title: "Popover Left",
-    icon: "arrow-left",
-    trigger_icon_only: false,
-    trigger_value: "Left",
-    popover_position: "left",
-    link: {
-      href: "#",
-      name: "Learn more",
-    }
-  } do %>
-    <div class="t-sage-body-small sage-spacer-bottom-xs t-sage--color-charcoal">
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-      <p>This is a block of content.</p>
-    </div>
-  <% end %>
-
-</div>
+<% end %>

--- a/docs/app/views/examples/components/popover/_props.html.erb
+++ b/docs/app/views/examples/components/popover/_props.html.erb
@@ -1,10 +1,4 @@
 <tr>
-  <td><%= md('`DEPRECATED: body`') %></td>
-  <td><%= md('DEPRECATED: User `content` block instead.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`custom_content_class`') %></td>
   <td>
     <%= md('
@@ -23,12 +17,6 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`id`') %></td>
-  <td><%= md('`id` attribute for the panel.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`link`') %></td>
   <td><%= md('If provided, this turns on the actions area with a link that points to the provided URL.') %></td>
   <td>
@@ -37,7 +25,7 @@
   href: String,
   name: String,
 }
-') %>
+```') %>
   </td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/popover/_props.html.erb
+++ b/docs/app/views/examples/components/popover/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td><%= md('`body`') %></td>
-  <td><%= md('The content to display inside the popover panel.') %></td>
+  <td><%= md('`DEPRECATED: body`') %></td>
+  <td><%= md('DEPRECATED: User `content` block instead.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -33,25 +33,19 @@
   <td><%= md('If provided, this turns on the actions area with a link that points to the provided URL.') %></td>
   <td>
 <%= md('```
-Array<{
+{
   href: String,
   name: String,
-}>
+}
 ') %>
   </td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`link`') %></td>
-  <td><%= md('If provided, this turns on the actions area with a link that points to the provided URL.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`popover_position`') %></td>
   <td><%= md('Where to position the popover panel in relation to the trigger button.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`right`') %></td>
+  <td><%= md("`\"#{SageTokens::POPOVER_POSITIONS.join("\"`, `\"")}\"`") %></td>
+  <td><%= md('`"right"`') %></td>
 </tr>
 <tr>
   <td><%= md('`title`') %></td>

--- a/docs/app/views/examples/components/popover/_props.html.erb
+++ b/docs/app/views/examples/components/popover/_props.html.erb
@@ -65,3 +65,15 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td colspan="4"><strong>Content Slots</strong></td>
+</tr>
+<tr>
+  <td><%= md('`:sage_popover_media`') %></td>
+  <td><%= md('
+  Slot into which graphics or other media can be placed.
+  Additional styling may be needed in such customized contexts.
+  ') %></td>
+  <td></td>
+  <td></td>
+</tr>

--- a/docs/lib/sage-frontend/stylesheets/docs/_example.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_example.scss
@@ -179,3 +179,7 @@ $-example-code-preview-button-bg: rgba(sage-color(primary, 500), 0.75);
   display: flex;
   gap: sage-spacing(xs);
 }
+
+.demo-custom-popover-panel {
+  width: rem(400px);
+}

--- a/docs/lib/sage_rails/app/sage_components/sage_popover.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_popover.rb
@@ -13,4 +13,8 @@ class SagePopover < SageComponent
     trigger_icon_only: [:optional, TrueClass],
     trigger_value: [:optional, String],
   })
+
+  def sections
+    %w(popover_media)
+  end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_popover.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_popover.rb
@@ -1,6 +1,5 @@
 class SagePopover < SageComponent
   set_attribute_schema({
-    body: [:optional, String],
     custom_content_class: [:optional, String],
     icon: [:optional, String, {
       name: Set.new(SageTokens::ICONS),

--- a/docs/lib/sage_rails/app/sage_components/sage_popover.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_popover.rb
@@ -2,10 +2,13 @@ class SagePopover < SageComponent
   set_attribute_schema({
     body: [:optional, String],
     custom_content_class: [:optional, String],
-    icon: [:optional, String],
+    icon: [:optional, String, {
+      name: Set.new(SageTokens::ICONS),
+      style: Set.new(["left", "right", "only"]),
+    }],
     id: [:optional, String],
     link: [:optional, {href: String, name: String}],
-    popover_position: [:optional, String],
+    popover_position: [:optional, Set.new(SageTokens::POPOVER_POSITIONS)],
     title: [:optional, String],
     trigger_icon_only: [:optional, TrueClass],
     trigger_value: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
@@ -266,6 +266,8 @@ module SageTokens
 
   ICON_SIZES = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl"]
 
+  POPOVER_POSITIONS = ["top", "top-right", "right", "bottom", "bottom-right", "left"]
+
   SPACER_SIZES = [:xs, :sm, :md, :lg, :xl, "2xs", "xs", "sm", "md", "lg", "xl", "2xl", "stage", "panel", "card", "stack"]
 
   STATUSES = ["danger", "draft", "info", "locked", "published", "warning"]

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_popover.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_popover.html.erb
@@ -38,16 +38,22 @@ position = component.popover_position.present? ? component.popover_position : "r
   <%= sage_component SageButton, button_attributes %>
   <div class="sage-popover__overlay" data-js-popover--overlay></div>
   <div class="sage-popover__panel">
-    <% if component.title.present? %>
-      <div class="sage-popover__title">
-        <%= component.title %>
+    <% if content_for? :sage_popover_media %>
+      <div class="sage-popover__media">
+        <%= content_for :sage_popover_media %>
       </div>
     <% end %>
+
     <div class="
         sage-popover__content
         <%= "sage-popover__content--custom #{component.custom_content_class}" if component.custom_content_class.present? %>
       "
     >
+      <% if component.title.present? %>
+        <div class="sage-popover__title">
+          <%= component.title %>
+        </div>
+      <% end %>
       <%= component.content %>
     </div>
     <% if component.link %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_popover.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_popover.html.erb
@@ -1,51 +1,42 @@
+<%
+
+button_attributes = {
+  value: component.trigger_value,
+  style: "secondary",
+  css_classes: "sage-popover__button",
+  subtle: true,
+  attributes: {
+    "aria-haspopup": true,
+    "aria-controls": "sage-popover",
+    "aria-expanded": false,
+    "data-js-popover--trigger": ""
+  },
+}
+
+if component.icon.present?
+  icon = component.icon.is_a?(Hash) ? component.icon : {
+    style: "left",
+    name: component.icon
+  }
+  if component.trigger_icon_only
+    icon[:style] = "only"
+  end
+  button_attributes[:icon] = icon
+end
+
+position = component.popover_position.present? ? component.popover_position : "right"
+%>
 <div 
   class="
     sage-popover
+    <%= "sage-popover--#{position}" %>
     <%= component.generated_css_classes %>
   " 
   data-js-popover 
-  data-js-popover--position="<%= component.popover_position ? component.popover_position : "right" %>"
   <%= component.generated_html_attributes.html_safe %>
 >
-
-  <% if component.trigger_icon_only %>
-    <%= sage_component SageButton, {
-      value: component.trigger_value,
-      style: "secondary",
-      css_classes: "sage-popover__button",
-      subtle: true,
-      icon: {
-        style: "only",
-        name: component.icon
-      },
-      attributes: {
-        "aria-haspopup": true,
-        "aria-controls": "sage-popover",
-        "aria-expanded": false,
-        "data-js-popover--trigger": "",
-      },
-    } %>
-  <% else %>
-    <%= sage_component SageButton, {
-      value: component.trigger_value,
-      style: "secondary",
-      css_classes: "sage-popover__button",
-      subtle: true,
-      icon: {
-        style: "left",
-        name: component.icon
-      },
-      attributes: {
-        "aria-haspopup": true,
-        "aria-controls": "sage-popover",
-        "aria-expanded": false,
-        "data-js-popover--trigger": ""
-      },
-    } %>
-  <% end %>
-
+  <%= sage_component SageButton, button_attributes %>
   <div class="sage-popover__overlay" data-js-popover--overlay></div>
-
   <div class="sage-popover__panel">
     <% if component.title.present? %>
       <div class="sage-popover__title">
@@ -78,5 +69,4 @@
       </div>
     <% end %>
   </div>
-
 </div>

--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -6,16 +6,21 @@
 
 
 $-popover-overlay-z-index: sage-z-index(modal);
-$-popover-panel-min-size: rem(250px);
+$-popover-panel-padding: sage-spacing(sm);
+$-popover-panel-min-size: sage-container(xs);
+$-popover-panel-contentmin-size: $-popover-panel-min-size - $-popover-panel-padding;
 $-popover-panel-max-size: rem(350px);
-$-popover-panel-offset-top: sage-spacing(2xs);
-$-popover-panel-offset-left: sage-spacing(md);
-$-popover-panel-offset: sage-spacing(xs);
+$-popover-panel-offset: sage-spacing(sm);
 
 
 .sage-popover {
   display: inline-flex;
   position: relative;
+
+  .docs-panel & {
+    justify-self: start;
+    width: min-content;
+  }
 }
 
 .sage-popover__actions {
@@ -30,10 +35,9 @@ $-popover-panel-offset: sage-spacing(xs);
   visibility: hidden;
   z-index: sage-z-index(modal);
   position: absolute;
-  width: 100%;
+  width: auto;
   min-width: $-popover-panel-min-size;
-  max-width: $-popover-panel-max-size;
-  padding: sage-spacing(sm);
+  padding: $-popover-panel-padding;
   background-color: sage-color(white);
   background-clip: padding-box;
   box-shadow: sage-shadow();
@@ -78,9 +82,9 @@ $-popover-panel-offset: sage-spacing(xs);
   position: relative;
 }
 
-.sage-popover__content:not(.sage-popover__content--custom) {
+.sage-popover__content {
   @extend %t-sage-body-small;	
-  @include sage-grid-stack();	
+  @include sage-grid-stack();
 
   color: sage-color(charcoal, 100);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -7,7 +7,7 @@
 
 $-popover-overlay-z-index: sage-z-index(modal);
 $-popover-panel-padding: sage-spacing(sm);
-$-popover-panel-min-size: sage-container(xs);
+$-popover-panel-min-size: sage-container(sm);
 $-popover-panel-contentmin-size: $-popover-panel-min-size - $-popover-panel-padding;
 $-popover-panel-max-size: rem(350px);
 $-popover-panel-offset: sage-spacing(sm);
@@ -24,14 +24,14 @@ $-popover-panel-offset: sage-spacing(sm);
 }
 
 .sage-popover__actions {
-  margin-top: sage-spacing(card);
-
   > a {
     max-width: 100%;
   }
 }
 
 .sage-popover__panel {
+  @include sage-grid-card();
+
   visibility: hidden;
   z-index: sage-z-index(modal);
   position: absolute;
@@ -86,7 +86,17 @@ $-popover-panel-offset: sage-spacing(sm);
   @extend %t-sage-body-small;	
   @include sage-grid-stack();
 
-  color: sage-color(charcoal, 100);
+  color: sage-color(charcoal, 200);
+}
+
+.sage-popover__media {
+  overflow: hidden;
+  width: 100%;
+  border-radius: sage-border(radius-small);
+
+  img {
+    max-width: 100%;
+  }
 }
 
 .sage-popover__overlay {
@@ -102,7 +112,5 @@ $-popover-panel-offset: sage-spacing(sm);
 }
 
 .sage-popover__title {
-  @extend %t-sage-heading-5;
-
-  margin-bottom: sage-spacing(card);
+  @extend %t-sage-heading-6;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -10,6 +10,7 @@ $-popover-panel-min-size: rem(250px);
 $-popover-panel-max-size: rem(350px);
 $-popover-panel-offset-top: sage-spacing(2xs);
 $-popover-panel-offset-left: sage-spacing(md);
+$-popover-panel-offset: sage-spacing(xs);
 
 
 .sage-popover {
@@ -29,8 +30,6 @@ $-popover-panel-offset-left: sage-spacing(md);
   visibility: hidden;
   z-index: sage-z-index(modal);
   position: absolute;
-  top: $-popover-panel-offset-top;
-  left: $-popover-panel-offset-left;
   width: 100%;
   min-width: $-popover-panel-min-size;
   max-width: $-popover-panel-max-size;
@@ -42,6 +41,36 @@ $-popover-panel-offset-left: sage-spacing(md);
 
   .sage-popover--is-expanded & {
     visibility: visible;
+  }
+
+  .sage-popover--top & {
+    bottom: calc(100% + #{$-popover-panel-offset});
+    left: 0;
+  }
+  
+  .sage-popover--top-right & {
+    bottom: calc(100% + #{$-popover-panel-offset});
+    right: 0;
+  }
+  
+  .sage-popover--right & {
+    top: 0;
+    left: calc(100% + #{$-popover-panel-offset});
+  }
+  
+  .sage-popover--bottom & {
+    top: calc(100% + #{$-popover-panel-offset});
+    left: 0;
+  }
+  
+  .sage-popover--bottom-right & {
+    top: calc(100% + #{$-popover-panel-offset});
+    right: 0;
+  }
+  
+  .sage-popover--left & {
+    top: 0;
+    right: calc(100% + #{$-popover-panel-offset});
   }
 }
 

--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import uuid from 'react-uuid';
@@ -13,6 +13,7 @@ export const Popover = ({
   icon,
   iconOnly,
   label,
+  media,
   moreLinkURL,
   moreLinkText,
   position,
@@ -85,10 +86,13 @@ export const Popover = ({
         tabIndex={-1}
       />
       <div className="sage-popover__panel">
-        {title && (
-          <h5 className="sage-popover__title">{title}</h5>
+        {media && (
+          <div className="sage-popoever__media">{media}</div>
         )}
         <div className={contentClassNames}>
+          {title && (
+            <h5 className="sage-popover__title">{title}</h5>
+          )}
           {children}
         </div>
         {moreLinkURL && (
@@ -120,6 +124,7 @@ Popover.defaultProps = {
   icon: SageTokens.ICONS.QUESTION_CIRCLE,
   iconOnly: true,
   label: 'Learn more',
+  media: null,
   moreLinkURL: null,
   moreLinkText: 'Learn more',
   position: Popover.POSITIONS.BOTTOM,
@@ -133,6 +138,7 @@ Popover.propTypes = {
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   iconOnly: PropTypes.bool,
   label: PropTypes.string,
+  media: PropTypes.node,
   moreLinkURL: PropTypes.string,
   moreLinkText: PropTypes.string,
   position: PropTypes.oneOf(Object.values(Popover.POSITIONS)),

--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import uuid from 'react-uuid';
 import { Button } from '../Button';
 import { SageTokens } from '../configs';
+import { POPOVER_POSITIONS } from './configs';
 
 export const Popover = ({
   className,
@@ -14,6 +15,7 @@ export const Popover = ({
   label,
   moreLinkURL,
   moreLinkText,
+  position,
   title,
   ...rest
 }) => {
@@ -38,6 +40,7 @@ export const Popover = ({
     className,
     {
       'sage-popover--is-expanded': selfActive,
+      [`sage-popover--${position}`]: position,
     }
   );
 
@@ -108,6 +111,8 @@ export const Popover = ({
   );
 };
 
+Popover.POSITIONS = POPOVER_POSITIONS;
+
 Popover.defaultProps = {
   className: null,
   children: null,
@@ -117,6 +122,7 @@ Popover.defaultProps = {
   label: 'Learn more',
   moreLinkURL: null,
   moreLinkText: 'Learn more',
+  position: Popover.POSITIONS.BOTTOM,
   title: null,
 };
 
@@ -129,5 +135,6 @@ Popover.propTypes = {
   label: PropTypes.string,
   moreLinkURL: PropTypes.string,
   moreLinkText: PropTypes.string,
+  position: PropTypes.oneOf(Object.values(Popover.POSITIONS)),
   title: PropTypes.string,
 };

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -9,6 +9,7 @@ export default {
   argTypes: {
     ...selectArgs({
       icon: SageTokens.ICONS,
+      position: Popover.POSITIONS,
     }),
   },
   args: {
@@ -17,7 +18,8 @@ export default {
     iconOnly: true,
     moreLinkURL: '//example.com',
     moreLinkText: 'Link text',
-    title: 'Amazing popover'
+    title: 'Amazing popover',
+    position: Popover.POSITIONS.BOTTOM,
   }
 };
 
@@ -26,7 +28,7 @@ export const Default = Template.bind({});
 Default.decorators = [
   (Story) => (
     <>
-      <div style={{ minHeight: 150 }}>
+      <div style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', }}>
         <Story />
       </div>
     </>

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -20,6 +20,22 @@ export default {
     moreLinkText: 'Link text',
     title: 'Amazing popover',
     position: Popover.POSITIONS.BOTTOM,
+    children: (
+      <>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Mauris erat urna, eleifend quis mollis ut, vehicula vitae elit.
+          Quisque elementum risus congue, placerat tellus vulputate, ornare neque.
+          Mauris eu quam nisi.
+        </p>
+        <p>
+          Ut elementum, nulla sit amet viverra vulputate, mi risus dignissim odio, vel aliquam lorem mi nec diam.
+          Donec bibendum tincidunt est, non ultricies nisi efficitur eget.
+          Integer et libero aliquam, efficitur ante ac, auctor dolor.
+          Vivamus aliquet vehicula sollicitudin.
+        </p>
+      </>
+    )
   }
 };
 

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -29,7 +29,8 @@ export default {
           Mauris eu quam nisi.
         </p>
         <p>
-          Ut elementum, nulla sit amet viverra vulputate, mi risus dignissim odio, vel aliquam lorem mi nec diam.
+          Ut elementum, nulla sit amet viverra vulputate,
+          mi risus dignissim odio, vel aliquam lorem mi nec diam.
           Donec bibendum tincidunt est, non ultricies nisi efficitur eget.
           Integer et libero aliquam, efficitur ante ac, auctor dolor.
           Vivamus aliquet vehicula sollicitudin.
@@ -44,7 +45,15 @@ export const Default = Template.bind({});
 Default.decorators = [
   (Story) => (
     <>
-      <div style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', }}>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%'
+        }}
+      >
         <Story />
       </div>
     </>

--- a/packages/sage-react/lib/Popover/configs.js
+++ b/packages/sage-react/lib/Popover/configs.js
@@ -1,0 +1,8 @@
+export const POPOVER_POSITIONS = {
+  TOP: 'top',
+  RIGHT: 'right',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+  TOP_RIGHT: 'top-right',
+  BOTTOM_RIGHT: 'bottom-right',
+};

--- a/packages/sage-system/lib/popover.js
+++ b/packages/sage-system/lib/popover.js
@@ -6,7 +6,6 @@ Sage.popover = (function() {
   const SELECTOR_PARENT = 'data-js-popover';
   const SELECTOR_OVERLAY = 'data-js-popover--overlay';
   const SELECTOR_TRIGGER = 'data-js-popover--trigger';
-  const SELECTOR_POSITION = 'data-js-popover--position';
 
   const CLASS_ACTIVE = 'sage-popover--is-expanded';
   const ATTRIBUTE_ARIA_EXPANDED = 'aria-expanded';
@@ -32,54 +31,18 @@ Sage.popover = (function() {
     const elParent = evt.currentTarget;
     const elChild = elParent.children[0];
     const popoverPanel = elChild.parentNode.querySelector(".sage-popover__panel");
-    const options = {
-      triggerWidth: elChild.offsetWidth,
-      triggerHeight: elChild.offsetHeight,
-      popoverPanelHeight: popoverPanel.offsetHeight,
-      popoverPanelWidth: popoverPanel.offsetWidth,
-      position: elChild.parentNode.getAttribute(SELECTOR_POSITION)
-    };
 
     if (evt.target.hasAttribute(SELECTOR_TRIGGER) || evt.target.parentNode.hasAttribute(SELECTOR_TRIGGER)) {
       if (isExpanded(elParent) || isExpanded(elChild.parentNode)) {
         closePopoverPanel(elParent);
       } else {
         openPopoverPanel(elParent);
-        positionPopoverPanel(popoverPanel, options)
       }
     }
     // if the clicked element is the overlay, close the previously opened popover
     if (evt.target.hasAttribute(SELECTOR_OVERLAY)) {
       closePopoverPanel(elParent);
     }
-  }
-
-  function positionPopoverPanel(popoverPanel, options) {
-
-    let dist = 8,
-        top,
-        left;
-
-    switch (options.position) {
-      case "left":
-        top = 0;
-        left = -options.popoverPanelWidth - (dist * 2);
-      break;
-      case "top":
-        top = -options.popoverPanelHeight - dist;
-        left = 0;
-      break;
-      case "bottom":
-        top = options.triggerHeight + dist;
-        left = 0;
-        break;
-      default:
-      case "right":
-        top = 0;
-        left = options.triggerWidth + (dist * 2);
-    }
-    popoverPanel.style.left = left + "px";
-    popoverPanel.style.top = top + "px";
   }
 
   function handleKeydown(evt) {


### PR DESCRIPTION
## Description

This PR makes some changes to Popovers:

- Adjusts how they're positioned using CSS directly rather than JS and adds new `bottom-right` and `top-right` options.
- Adds position settings to React component that previously lacked them.
- Syncs the component with 3.0: type and spacing adjustments
- Adds a `:sage_popover_media` slot and `media` prop.

## Screenshots

**Default appearance with new type and spacing**

![Screen Shot 2021-07-08 at 2 11 29 PM](https://user-images.githubusercontent.com/17955295/124983897-90481200-e006-11eb-8d8b-02c085b3a656.png)

**New graphic slot**

![Screen Shot 2021-07-08 at 2 11 17 PM](https://user-images.githubusercontent.com/17955295/125098754-50843780-e0a5-11eb-9fac-400098a07994.png)


**New position options**

![Screen Shot 2021-07-08 at 2 00 36 PM](https://user-images.githubusercontent.com/17955295/124983931-9938e380-e006-11eb-96ee-893638c6e86e.png)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
1. (LOW) Styling and options updates for Popovers. UXD validated the following with no regressions in `kajabi-products`:
   - [ ] Custom Domain... (i) and (?) beside headings and at top right of panels
   - [ ] Email broadcasts editor... [icon] Send test email: functions as expected but a small style followup will be added to adjust width of included elements. Similar components exist in Newsletters and other places in Emails.


## Related

Closes #614 
Closes #516 
