### PR TITLE
Panel controls bulk actions alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -385,7 +385,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   white-space: nowrap;
   pointer-events: none;
 
-  @include position(($-dropdown-height / 2), unset, unset, ($-dropdown-trigger-padding-x - $-dropdown-trigger-padding-label));
+  @include position(50%, unset, unset, ($-dropdown-trigger-padding-x - $-dropdown-trigger-padding-label));
   @include truncate();
 
   .sage-dropdown--value-selected & {


### PR DESCRIPTION
## Description
Corrects positioning of panel controls dropdown button alignment with bulk actions label (as noted in https://github.com/Kajabi/kajabi-products/pull/19781)


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  |Before  |  After  |
|-----|---|--------|
| dropdown closed|![alignment-before](https://user-images.githubusercontent.com/816579/125130576-166f6180-e0b6-11eb-9c2d-73dcf16baff7.png)|![alignment-after](https://user-images.githubusercontent.com/816579/125130587-1b341580-e0b6-11eb-8bc4-24be36ba8f4d.png)|
|dropdown open|![contacts-before](https://user-images.githubusercontent.com/816579/125131078-0310c600-e0b7-11eb-93fc-fec90d1eaae0.png)|![contacts-after](https://user-images.githubusercontent.com/816579/125131089-06a44d00-e0b7-11eb-94b2-2b3d10aca02b.png)|


## Testing in `sage-lib`
1. Navigate to Panel Controls
2. Confirm that the bulk actions selection and dropdown in the "Kitchen Sink" example are vertically aligned

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Panel controls: bulk actions dropdown trigger/button alignment adjustments
   - [ ] People (Contacts) list bulk selection (must have "Say hello to the new People page" enabled in Labs)


## Related
- Closes #617 
