### PR TITLE
Pagination Suffix Adjustment

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_pagination.html.erb
@@ -61,6 +61,9 @@
     <% unless component.hide_counter %>
       <span class="sage-pagination__count sage-pagination__count--solo">
         <%= component.page_count component.items %>
+        <% if component.page_count_suffix %>
+          <span class="sage-pagination__count-suffix"><%= component.page_count_suffix %></span>
+        <% end %>
       </span>
     <% end %>
   </div>


### PR DESCRIPTION
## Description
Addresses a bug found during the development of new payments page design in kajabi-products.
The design calls for the suffix text to be displayed even if the page count = 1.
Currently, the suffix is only displayed if the count is > 1.


## Screenshots
There will be no visual updates with these changes.

## Testing in `sage-lib`
Verify code updates allow for suffix to be displayed if page count = 1.


## Testing in `kajabi-products`
1. (**LOW**) Allows pagination suffix to be displayed if page count = 1.
   - [ ] Should not affect any current implementation but a quick sanity check of any page that has pagination should be done.
