### PR TITLE
Passing down common props

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -18,7 +18,12 @@ class SageComponent
     @generated_html_attributes ||= ""
   end
 
+  def css_classes
+    @css_classes ||= ""
+  end
+
   def css_classes=(classes_string)
+    @css_classes = classes_string
     generated_css_classes << classes_string
   end
 
@@ -35,7 +40,12 @@ class SageComponent
   #
   #   USAGE:
   #   sage_component <CLASSNAME>, { spacer: { bottom: :lg } }
+  def spacer
+    @spacer ||= {}
+  end
+
   def spacer=(spacer_hash)
+    @spacer = spacer_hash
     spacer_hash.each do |key, value|
       generated_css_classes << " sage-spacer-#{key}#{value != :md ? "-#{value}" : ""}"
     end
@@ -46,13 +56,23 @@ class SageComponent
   #
   #   USAGE:
   #   sage_component <CLASSNAME>, { html_attributes: { "id": "my-cool-identifier" } }
+  def html_attributes
+    @html_attributes ||= {}
+  end
+
   def html_attributes=(html_attributes_hash)
+    @html_attributes = html_attributes_hash
     html_attributes_hash.each do |key, value|
       generated_html_attributes << " #{key}=\"#{value.to_s}\""
     end
   end
 
+  def test_id
+    @test_id ||= nil
+  end
+
   def test_id=(id_string)
+    @test_id = id_string
     if id_string
       generated_html_attributes << " data-kjb-element=\"#{id_string}\""
     end


### PR DESCRIPTION
## Description

This PR adds getter methods to SageComponent for common properties so that they can be accessed within the component template, particularly for the sake of passing them down to child components. The following can now be accessed within a template view

- `css_classes` (previously only compiled into `generated_css_classes`)
- `html_attributes` (previously only compiled into `generated_html_attributes`)
- `spacer` (previously only compiled into `generated_css_classes`)
- `test_id` (previously only compiled into `generated_html_attributes`)


## Testing in `sage-lib`

Validate any components still render these props as expected

## Testing in `kajabi-products`
(LOW/MEDIUM/HIGH/BREAKING) Internal change to root SageComponent making properties available to templates. No changes expected in components.
