### PR TITLE
fix(panel figure): corrects an invalid calc default value

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -7,7 +7,7 @@ $-panel-figure-padding: sage-spacing(lg);
 $-panel-figure-default-background-color: sage-color(grey, 100);
 
 :root {
-  --sage-figure-aspect-ratio: auto;
+  --sage-figure-aspect-ratio: 1;
   --sage-figure-background-color: #{$-panel-figure-default-background-color};
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -3,13 +3,6 @@
 ///
 /// @group sage/components/panel
 ////
-$-panel-figure-padding: sage-spacing(lg);
-$-panel-figure-default-background-color: sage-color(grey, 100);
-
-:root {
-  --sage-figure-aspect-ratio: 1;
-  --sage-figure-background-color: #{$-panel-figure-default-background-color};
-}
 
 .sage-panel {
   @include sage-panel;

--- a/packages/sage-assets/lib/stylesheets/components/_panel_figure.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel_figure.scss
@@ -3,6 +3,13 @@
 ///
 /// @group sage/components/panel-figure
 ////
+$-panel-figure-padding: sage-spacing(lg);
+$-panel-figure-default-background-color: sage-color(grey, 100);
+
+:root {
+  --sage-figure-aspect-ratio: 1.77; // 16 /8
+  --sage-figure-background-color: #{$-panel-figure-default-background-color};
+}
 
 .sage-panel__figure {
   display: flex;

--- a/packages/sage-assets/lib/stylesheets/components/_panel_figure.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel_figure.scss
@@ -7,7 +7,7 @@ $-panel-figure-padding: sage-spacing(lg);
 $-panel-figure-default-background-color: sage-color(grey, 100);
 
 :root {
-  --sage-figure-aspect-ratio: 1.77; // 16 /8
+  --sage-figure-aspect-ratio: 1.78; // 16 / 9
   --sage-figure-background-color: #{$-panel-figure-default-background-color};
 }
 


### PR DESCRIPTION
## Description
An invalid default 'auto' value in a css `calc` function is causing webpack builds to fail in our CI. This hotfix modifies the css custom property to an integer value rather than a keyword.

There must be a significant difference in configuration between feature branches and `master` because this didn't get flagged until the docs deployment was triggered.


## Screenshots

<details>
<summary>CircleCI</summary>
<a href="https://app.circleci.com/pipelines/github/Kajabi/sage-lib/3023/workflows/ff340172-9a0b-4886-b203-76e789e2308a/jobs/3249" target="_top">View full output</a>
<img src="https://user-images.githubusercontent.com/816579/125547158-070195ea-f90b-4edc-8974-f60cf3107e4d.png">
</details>



## Testing in `sage-lib`
- Ensure panel figure displays and functions as expected


## Testing in `kajabi-products`
- (LOW) New customization options added to Panel Figure. No impact on current uses.


## Related
#624 
