### PR TITLE
Make link truncation optional

### DIFF
--- a/docs/app/views/examples/components/link/_preview.html.erb
+++ b/docs/app/views/examples/components/link/_preview.html.erb
@@ -94,7 +94,8 @@
 <% end %>
 
 <h3 class="t-sage-heading-6">Subtext links</h3>
-
-<a href="//example.com" class="sage-link sage-link--subtext">
-  <span class="t-sage--truncate">Link for placement in subtext</span>
-</a>
+<%= sage_component SageLink, {
+  css_classes: "sage-link--subtext",
+  label: "Link for placement in subtext",
+  truncate: true, url: "//example.com"
+} %>

--- a/docs/app/views/examples/components/link/_preview.html.erb
+++ b/docs/app/views/examples/components/link/_preview.html.erb
@@ -97,5 +97,6 @@
 <%= sage_component SageLink, {
   css_classes: "sage-link--subtext",
   label: "Link for placement in subtext",
-  truncate: true, url: "//example.com"
+  truncate: true,
+  url: "//example.com"
 } %>

--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -129,9 +129,7 @@
       url_update: "update/endpoint",
     } do %>
       <div>
-        <a class="sage-link" href="#">
-          <span class="t-sage--truncate">Field 1</span>
-        </a>
+        <%= sage_component SageLink, { label: "Field 1", truncate: true, url: "#" } %>
       </div>
       <%= sage_component SageDropdown, {
         align: "right",
@@ -184,9 +182,7 @@
       url_update: "update/endpoint",
     } do %>
       <div>
-        <a class="sage-link" href="#">
-          <span class="t-sage--truncate">Field 1</span>
-        </a>
+        <%= sage_component SageLink, { label: "Field 1", truncate: true, url: "#" } %>
       </div>
       <span>Field 2</span>
       <%= sage_component SageDropdown, {

--- a/docs/lib/sage_rails/app/sage_components/sage_link.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_link.rb
@@ -6,6 +6,7 @@ class SageLink < SageComponent
     label: [:optional, String],
     launch: [:optional, TrueClass],
     show_label: [:optional, TrueClass],
+    truncate: [:optional, TrueClass],
     url: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -10,11 +10,18 @@
   <%= component.generated_html_attributes.html_safe %>
 >
   <strong class="sage-catalog-item__title">
-    <<%= link_tag %> class="t-sage-heading-6 sage-link" href="<%= component.href %>">
-      <span class="t-sage--truncate">
+    <% if is_loading %>
+      <div class="t-sage-heading-6 t-sage--truncate">
         <%= component.title %>
-      </span>
-    </<%= link_tag %>>
+      </div>
+    <% else %>
+      <%= sage_component SageLink, {
+        css_classes: SageClassnames::TYPE::HEADING_6,
+        label: component.title,
+        truncate: true,
+        url: component.href,
+      } %>
+    <% end %>
   </strong>
   <% if component.content.present? %>
     <div class="sage-catalog-item__content">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -1,14 +1,17 @@
 <%
-label = %(
-  <span class="t-sage--truncate">
-    #{component.label}
-  </span>
-).html_safe
+label = component.label.html_safe
+if component.truncate
+  label = %(
+    <span class="t-sage--truncate">
+      #{component.label}
+    </span>
+  ).html_safe
+end
 %>
 <% if component.help_link && component.show_label %>
   <a
+    class="sage-link sage-link--help <%= component.generated_css_classes %>"
     href="<%= component.url %>"
-    class="sage-link sage-link--help"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
@@ -18,8 +21,8 @@ label = %(
   </a>
 <% elsif component.help_link && !component.show_label %>
   <a
+    class="sage-link sage-link--help-icon-only <%= component.generated_css_classes %>"
     href="<%= component.url %>"
-    class="sage-link sage-link--help-icon-only"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
@@ -29,7 +32,7 @@ label = %(
   </a>
 <% elsif !component.external && !component.launch %>
   <a
-    class="sage-link"
+    class="sage-link <%= component.generated_css_classes %>"
     href="<%= component.url %>"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
@@ -40,8 +43,8 @@ label = %(
   </a>
 <% elsif !component.external && component.launch %>
   <a
+    class="sage-link sage-link--launch <%= component.generated_css_classes %>"
     href="<%= component.url %>"
-    class="sage-link sage-link--launch"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
@@ -51,7 +54,7 @@ label = %(
   </a>
 <% elsif component.external && component.launch %>
   <a
-    class="sage-link"
+    class="sage-link <%= component.generated_css_classes %>"
     href="<%= component.url %>"
     target="_blank"
     rel="noopener noreferrer"
@@ -64,15 +67,15 @@ label = %(
   </a>
 <% elsif component.external && !component.launch %>
   <a
+    class="sage-link sage-link--no-launch <%= component.generated_css_classes %>"
     href="<%= component.url %>"
     target="_blank"
-    class="sage-link sage-link--no-launch"
     rel="noopener noreferrer"
     <% component.attributes.each do |key, value| %>
       <%= "#{key}=\"#{value}\"".html_safe %>
     <% end if component.attributes&.is_a?(Hash) %>
     <%= component.generated_html_attributes.html_safe %>
   >
-    <%= component.label %>
+    <%= label %>
   </a>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_transaction_card.html.erb
@@ -14,11 +14,12 @@
     <div class="sage-transaction-card__body-group">
       <<%= html_tag %> class="sage-transaction-card__name">
         <% if component.name_href.present? %>
-          <a class="sage-link sage-transaction-card__name-link" href="<%= component.name_href %>">
-            <span class="t-sage--truncate">
-            <%= component.name %>
-            </span>
-          </a>
+          <%= sage_component SageLink, {
+            label: component.name,
+            truncate: true,
+            url: component.name_href,
+            css_classes: "sage-transaction-card__name-link",
+          } %>
         <% else %>
           <%= component.name %>
         <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
@@ -6,6 +6,7 @@
 $-transaction-card-item-gap: sage-spacing(xs);
 $-transaction-card-time-max-width: rem(96px);
 $-transaction-card-state-max-width: rem(80px);
+$-transaction-card-price-max-width: rem(100px);
 
 .sage-transaction-card {
   @include sage-card;
@@ -21,7 +22,6 @@ $-transaction-card-state-max-width: rem(80px);
 
 .sage-transaction-card__body {
   @include sage-grid-stack;
-
 }
 
 .sage-transaction-card__body-group {
@@ -50,6 +50,7 @@ $-transaction-card-state-max-width: rem(80px);
 .sage-transaction-card__amount {
   @extend %t-sage-heading-6;
 
+  max-width: $-transaction-card-price-max-width;
   white-space: nowrap;
 }
 
@@ -68,7 +69,7 @@ $-transaction-card-state-max-width: rem(80px);
 .sage-transaction-card__name {
   @extend %t-sage-heading-6;
 
-  max-width: 100%;
+  max-width: calc(100% - #{$-transaction-card-price-max-width + $-transaction-card-item-gap});
 }
 
 .sage-transaction-card__name-link {

--- a/packages/sage-react/lib/Link/Link.jsx
+++ b/packages/sage-react/lib/Link/Link.jsx
@@ -12,6 +12,7 @@ export const Link = ({
   children,
   tag,
   tooltip,
+  truncate,
   ...rest
 }) => {
   const SelfTag = tag || 'a';
@@ -21,16 +22,20 @@ export const Link = ({
       {tooltip ? (
         <Tooltip {...tooltip}>
           <SelfTag {...rest}>
-            <span className="t-sage--truncate">
-              {children}
-            </span>
+            {truncate ? (
+              <span className="t-sage--truncate">
+                {children}
+              </span>
+            ) : children}
           </SelfTag>
         </Tooltip>
       ) : (
         <SelfTag {...rest}>
-          <span className="t-sage--truncate">
-            {children}
-          </span>
+          {truncate ? (
+            <span className="t-sage--truncate">
+              {children}
+            </span>
+          ) : children}
         </SelfTag>
       )}
     </>
@@ -41,6 +46,7 @@ Link.defaultProps = {
   children: null,
   tag: null,
   tooltip: null,
+  truncate: false,
 };
 
 Link.CLASSNAMES = { ...SageClassnames.LINK };
@@ -55,4 +61,5 @@ Link.propTypes = {
     size: PropTypes.oneOf(Object.values(Tooltip.SIZES)),
     theme: PropTypes.oneOf(Object.values(Tooltip.THEMES)),
   }),
+  truncate: PropTypes.bool,
 };

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -50,6 +50,7 @@ export const TransactionCard = ({
               <Link
                 href={nameHref}
                 className="sage-link sage-transaction-card__name-link"
+                truncate={true}
               >
                 {name}
               </Link>


### PR DESCRIPTION
## Description

This PR patches some potential issues with recent additions of truncation classes to SageLink component.


## Testing in `sage-lib`

The following pages use SageLink and should continue to function as expected:

- Link
- Transaction Card
- Catalog Item
- Preview for Sortable 

## Testing in `kajabi-products`
1. (LOW) Ensures truncation in Links can be set when desired. Affected areas include Transaction Card (not public), and the following:
   - [ ] Catalog Items on Products index page
   - [ ] Catalog Items on Coaching index page
   - [ ] Per prior bug reported, Forms index page links in table should now wrap again as expected
