### PR TITLE
fix(link): adjust template logic for sagelink to correct spec failure

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -1,4 +1,5 @@
 <%
+  label = ""
   if component.label.present?
     label = if component.truncate.present?
       %(

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -1,12 +1,15 @@
 <%
-label = component.label.html_safe
-if component.truncate
-  label = %(
-    <span class="t-sage--truncate">
-      #{component.label}
-    </span>
-  ).html_safe
-end
+  if component.label.present?
+    label = if component.truncate.present?
+      %(
+        <span class="t-sage--truncate">
+          #{component.label}
+        </span>
+      ).html_safe
+    else
+      component.label.html_safe
+    end
+  end
 %>
 <% if component.help_link && component.show_label %>
   <a


### PR DESCRIPTION
## Description
Hotfix to address spec failures on `kajabi-products` ([full list here](https://app.circleci.com/pipelines/github/Kajabi/kajabi-products/53001/workflows/ef5f60e4-4356-4530-a22b-2964d4f341c1/jobs/201874/parallel-runs/0?filterBy=FAILED)) from sage version bump. Modifies conditional to check for presence of optional `label` property before rendering.

Example:
```
1) Form submission offer grants existing user with offer
     # The example failed, but another attempt will be done to rule out flakiness

     Failure/Error: <%= sage_component SageLink, { help_link: true, url: ZendeskHelpLink[:double_optin].to_s, attributes: { rel: "noreferrer noopener", target: "_blank" } } %>

     ActionView::Template::Error:
       undefined method `html_safe' for nil:NilClass
```


### Related
- #627 