### PR TITLE
[SAGE-631] update interactive state of sidenav

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -70,6 +70,8 @@ $-nav-icon-size: rem(20px);
   padding: sage-spacing(2xs) sage-spacing(xs);
 
   &.sage-nav__link--active {
+    @include sage-focus-outline--update-color(transparent);
+
     background: $-nav-color-background;
   }
 }
@@ -90,6 +92,12 @@ $-nav-icon-size: rem(20px);
   margin: 0;
   padding: 0;
   list-style: none;
+
+  &:not(.sage-nav__list--sub) {
+    .sage-nav__link--active {
+      @include sage-focus-outline--update-color(transparent);
+    }
+  }
 }
 
 .sage-nav__list--sub-with-icon,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] - remove focus ring from nav items

[Sidebarnav Spec](https://www.figma.com/file/9Km09NjlZHYWsMP7EGT8tI/%5BWIP%5D-Sage-3-%E2%80%94-Admin-Components?node-id=6999%3A22305)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="269" alt="Sidebar" src="https://user-images.githubusercontent.com/1241836/125841522-9a17b182-9dce-4fb6-84bb-4c3429fb1635.png">|![navinteraction](https://user-images.githubusercontent.com/1241836/125841662-1623bc92-0fa8-478d-9fd0-b787b90ac222.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the alert page and verify that neither `Components` or `Alert` has the focus ring
Click on the `Banner` page and verify the process repeats when on the next page

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) No impact as this is purely docs site related

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-631](https://github.com/Kajabi/sage-lib/issues/631)