### PR TITLE
[SAGE-635] fix border-radius on dropdown items when interacted

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -156,7 +156,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   text-align: left;
   user-select: none;
 
-  .sage-dropdown &::after {
+  .sage-dropdown .sage-dropdown__menu &::after {
     border-radius: 0;
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] resolve incorrect border-radius for dropdown items

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![dropdownpanelinteraction](https://user-images.githubusercontent.com/1241836/125845076-ab9faf50-0a26-40b0-b131-25f7c33afdae.gif)|![dropdownpanelinteractionAfter](https://user-images.githubusercontent.com/1241836/125845087-5c43f4fa-d4c0-4ec2-b230-6b7bff215eec.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the dropdown page
- On the `Select` variation, click the dropdown and tab through the items
- Verify that the border-radius has a value of 0

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Description of the change and its impact with QA as the audience.
   - [ ] User profile dropdown in the top-right

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
#635 