### PR TITLE
[Sage-494] Sage 3 - Dropdowns and Menus

### DIFF
--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -104,6 +104,7 @@
   <%= sage_component SageDropdown, {
     align: "right",
     panel_size: "small",
+    panel_type: "status",
     items: [{
       value: sage_component(SageLabel, { color: "published", value: "Publish" }),
       attributes: {},
@@ -136,6 +137,7 @@
 <p>Note: This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.</p>
 <%= sage_component SageDropdown, {
   search: true,
+  panel_type: "searchable",
   trigger_type: "select",
   items: [{
     value: "-- None --"
@@ -176,6 +178,7 @@
 <p>Note: This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.</p>
 <%= sage_component SageDropdown, {
   search: true,
+  panel_type: "searchable",
   trigger_type: "select-labeled",
   align: "right",
   items: [{
@@ -203,6 +206,7 @@
 
 <h3 class="t-sage-heading-6">Dropdown Field with full-width Custom Content and Footer</h3>
 <%= sage_component SageDropdown, {
+  panel_type: "searchable",
   search: true,
   trigger_type: "select",
   contained: true,

--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -9,6 +9,7 @@ class SageDropdown < SageComponent
     id: [:optional, String],
     items: [:optional, [[SageSchemas::DROPDOWN_ITEM]]],
     panel_size: [:optional, Set.new(["small"])],
+    panel_type: [:optional, Set.new(["dropdown", "choice", "checkbox", "status", "searchable"])],
     search: [:optional, TrueClass],
     trigger_type: [:optional, Set.new(["select", "select-labeled"])],
     wrap_footer: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -9,7 +9,7 @@ class SageDropdown < SageComponent
     id: [:optional, String],
     items: [:optional, [[SageSchemas::DROPDOWN_ITEM]]],
     panel_size: [:optional, Set.new(["small"])],
-    panel_type: [:optional, Set.new(["dropdown", "choice", "checkbox", "status", "searchable"])],
+    panel_type: [:optional, Set.new(["custom", "dropdown", "choice", "checkbox", "status", "searchable"])],
     search: [:optional, TrueClass],
     trigger_type: [:optional, Set.new(["select", "select-labeled"])],
     wrap_footer: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -1,11 +1,12 @@
 <div
-  class="sage-dropdown 
+  class="sage-dropdown
     <%= "sage-dropdown--anchor-right" if component.align == "right" %>
     <%= "sage-dropdown--contained" if component.contained %>
     <%= "sage-dropdown--customized" if component.customized %>
     <%= "sage-dropdown--full-width" if component.full_width_panel %>
     <%= "sage-dropdown--small" if component.panel_size == "small" %>
     <%= "sage-dropdown--#{component.custom_modifier}" if component.custom_modifier.present? %>
+    <%= "sage-dropdown--#{component.panel_type}" if component.panel_type.present? %>
     <%= component.generated_css_classes %>
   "
   data-js-dropdown="<%= component.id %>"

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -12,7 +12,7 @@ $-checkbox-color-checked: sage-color(primary);
 $-checkbox-color-disabled: sage-color(grey, 200);
 $-checkbox-color-disabled-checked: sage-color(primary, 200);
 
-$-checkbox-size: rem(20px);
+$-checkbox-size: rem(16px);
 $-checkbox-label-spacing: rem(12px);
 $-checkbox-border-radius-inner: sage-border(radius-small);
 $-checkbox-border-radius-outer: sage-border(radius-large);
@@ -288,11 +288,11 @@ $-checkbox-focus-outline-color: sage-color(primary);
 
   .sage-checkbox & {
     @media (max-width: sage-breakpoint(md-max)) {
-      margin-top: sage-spacing(2xs);
+      margin-top: rem(6px);
     }
 
     @media (min-width: sage-breakpoint(lg-min)) {
-      margin-top: sage-spacing(3xs);
+      margin-top: sage-spacing(2xs);
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -193,8 +193,7 @@ $-checkbox-focus-outline-color: sage-color(primary);
     pointer-events: none;
     opacity: 0;
 
-    .sage-panel-controls__bulk-actions--checked &,
-    .sage-dropdown__item-control:focus-within & {
+    .sage-panel-controls__bulk-actions--checked & {
       display: none;
     }
   }

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -176,8 +176,24 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
     @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
     @include sage-focus-outline--update-color(sage-color(primary, 300));
 
+    // .sage-dropdown:not(.sage-dropdown--checkbox) &,
+    // .sage-dropdown:not(.sage-dropdown--choice) &,
+    // .sage-dropdown:not(.sage-dropdown--searchable) & {
+    //   &::after {
+    //     opacity: 1;
+    //   }
+    // }
+
     &::after {
       opacity: 1;
+    }
+
+    .sage-dropdown.sage-dropdown--checkbox &,
+    .sage-dropdown.sage-dropdown--choice &,
+    .sage-dropdown.sage-dropdown--searchable & {
+      &::after {
+        opacity: 0;
+      }
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -188,6 +188,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
       opacity: 1;
     }
 
+    /* stylelint-disable max-nesting-depth */
     .sage-dropdown.sage-dropdown--checkbox &,
     .sage-dropdown.sage-dropdown--choice &,
     .sage-dropdown.sage-dropdown--searchable & {
@@ -195,6 +196,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
         opacity: 0;
       }
     }
+    /* stylelint-enable max-nesting-depth */
   }
 
   .sage-dropdown__item--with-options > & {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -176,14 +176,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
     @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
     @include sage-focus-outline--update-color(sage-color(primary, 300));
 
-    // .sage-dropdown:not(.sage-dropdown--checkbox) &,
-    // .sage-dropdown:not(.sage-dropdown--choice) &,
-    // .sage-dropdown:not(.sage-dropdown--searchable) & {
-    //   &::after {
-    //     opacity: 1;
-    //   }
-    // }
-
     &::after {
       opacity: 1;
     }

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -148,13 +148,25 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
   @include sage-focus-outline--update-color(sage-color(primary, 300));
 
+  @extend %t-sage-body-med;
+
   display: flex;
   position: relative;
   align-items: center;
   width: 100%;
-  padding: rem(9px) sage-spacing(sm);
+  padding: rem(9px) sage-spacing();
   text-align: left;
   user-select: none;
+
+  .sage-dropdown--checkbox &,
+  .sage-dropdown--choice &,
+  .sage-dropdown--searchable & {
+    padding: rem(6px) sage-spacing();
+  }
+
+  .sage-dropdown--status & {
+    padding: rem(7px) sage-spacing();
+  }
 
   .sage-dropdown .sage-dropdown__menu &::after {
     border-radius: 0;

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -170,6 +170,7 @@ Dropdown.Trigger = DropdownTrigger;
 
 Dropdown.ITEM_COLORS = DROPDOWN_ITEM_COLORS;
 Dropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
+Dropdown.PANEL_TYPES = DROPDOWN_PANEL_TYPES;
 
 Dropdown.defaultProps = {
   align: null,
@@ -190,7 +191,7 @@ Dropdown.defaultProps = {
   panelModifier: 'default',
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   panelStateToken: null,
-  panelType: 'dropdown',
+  panelType: null,
   triggerButtonSubtle: false,
   triggerModifier: 'default',
   label: null
@@ -216,8 +217,8 @@ Dropdown.propTypes = {
   onEscapeHook: PropTypes.func,
   panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
-  panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
-  panelType: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_TYPES)),
+  panelSize: PropTypes.oneOf(Object.values(Dropdown.PANEL_SIZES)),
+  panelType: PropTypes.oneOf(Object.values(Dropdown.PANEL_TYPES)),
   panelStateToken: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -8,7 +8,7 @@ import { DropdownItemList } from './DropdownItemList';
 import { DropdownItemSearch } from './DropdownItemSearch';
 import { DropdownPanel } from './DropdownPanel';
 import { DropdownTrigger } from './DropdownTrigger';
-import { DROPDOWN_ITEM_COLORS, DROPDOWN_PANEL_SIZES } from './configs';
+import { DROPDOWN_ITEM_COLORS, DROPDOWN_PANEL_SIZES, DROPDOWN_PANEL_TYPES } from './configs';
 
 export const Dropdown = ({
   align,
@@ -30,6 +30,7 @@ export const Dropdown = ({
   panelMaxWidth,
   panelSize,
   panelStateToken,
+  panelType,
   triggerButtonSubtle,
   triggerModifier,
 }) => {
@@ -126,6 +127,7 @@ export const Dropdown = ({
       'sage-dropdown--disabled': disabled,
       'sage-dropdown--pinned': isPinned,
       [`sage-dropdown--${panelSize}`]: panelSize,
+      [`sage-dropdown--${panelType}`]: panelType,
     }
   );
 
@@ -188,6 +190,7 @@ Dropdown.defaultProps = {
   panelModifier: 'default',
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   panelStateToken: null,
+  panelType: 'dropdown',
   triggerButtonSubtle: false,
   triggerModifier: 'default',
   label: null
@@ -214,6 +217,7 @@ Dropdown.propTypes = {
   panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
   panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
+  panelType: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_TYPES)),
   panelStateToken: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,

--- a/packages/sage-react/lib/Dropdown/configs.js
+++ b/packages/sage-react/lib/Dropdown/configs.js
@@ -9,3 +9,11 @@ export const DROPDOWN_PANEL_SIZES = {
   DEFAULT: false,
   SMALL: 'small',
 };
+
+export const DROPDOWN_PANEL_TYPES = {
+  CHECKBOX: 'checkbox',
+  CHOICE: 'choice',
+  DROPDOWN: 'dropdown',
+  SEARCHABLE: 'searchable',
+  STATUS: 'status',
+};


### PR DESCRIPTION
closes #494 
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] align dropdowns to spec
- [x] align menus to spec
- [x] adjust the size of the checkboxes to match the spec

## Spec
[Sage 3 - dropdowns and menus](https://www.figma.com/file/9Km09NjlZHYWsMP7EGT8tI/%5BWIP%5D-Sage-3-%E2%80%94-Admin-Components?node-id=3435%3A17)


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
##### Menu Button
|  Before  |  After  |
|--------|--------|
|<img width="306" alt="Screen Shot 2021-09-13 at 9 46 06 AM" src="https://user-images.githubusercontent.com/1241836/133106064-bcb56ce7-bd8a-45de-9d0d-029cbcf4093c.png">|<img width="310" alt="Screen Shot 2021-09-13 at 9 47 37 AM" src="https://user-images.githubusercontent.com/1241836/133106256-04892c8f-53cf-410f-a1f1-77334e7470f5.png">|

##### Dropdown menu with headings
|  Before  |  After  |
|--------|--------|
|<img width="319" alt="Screen Shot 2021-09-13 at 9 46 16 AM" src="https://user-images.githubusercontent.com/1241836/133106102-98d2fcea-e100-4bd2-ac2c-535367e0af1b.png">|<img width="305" alt="Screen Shot 2021-09-13 at 9 47 44 AM" src="https://user-images.githubusercontent.com/1241836/133106321-7815a04e-99da-485f-99b7-8fbd84c3bd74.png">|

##### SageLabel button
|  Before  |  After  |
|--------|--------|
|<img width="229" alt="Screen Shot 2021-09-13 at 9 46 29 AM" src="https://user-images.githubusercontent.com/1241836/133106122-84d95e8c-d23c-4550-9abb-7afd381f5414.png">|<img width="232" alt="Screen Shot 2021-09-13 at 9 47 52 AM" src="https://user-images.githubusercontent.com/1241836/133106355-8d85ec9f-2040-45ab-9e8d-eab8f4c08def.png">|

##### Select
|  Before  |  After  |
|--------|--------|
|<img width="296" alt="Screen Shot 2021-09-13 at 9 46 51 AM" src="https://user-images.githubusercontent.com/1241836/133106172-2d4a96c7-2538-4cb3-8d17-c21839d0a9cb.png">|<img width="301" alt="Screen Shot 2021-09-13 at 9 47 59 AM" src="https://user-images.githubusercontent.com/1241836/133106423-012540b7-89ed-4ed5-ba49-6202cc74aed2.png">|

##### Form field
|  Before  |  After  |
|--------|--------|
|<img width="320" alt="Screen Shot 2021-09-13 at 9 47 02 AM" src="https://user-images.githubusercontent.com/1241836/133106193-fbc6ca6a-1063-4f2e-9952-cec858647f71.png">|<img width="299" alt="Screen Shot 2021-09-13 at 9 48 05 AM" src="https://user-images.githubusercontent.com/1241836/133106505-1f52572e-63e4-424e-a88e-d6179cb926d1.png">|

##### Dropdown with custom content
|  Before  |  After  |
|--------|--------|
|<img width="472" alt="Screen Shot 2021-09-13 at 9 47 10 AM" src="https://user-images.githubusercontent.com/1241836/133106214-56136a5b-7f44-4142-9b95-7262a312bbd6.png">|<img width="487" alt="Screen Shot 2021-09-13 at 9 48 15 AM" src="https://user-images.githubusercontent.com/1241836/133106617-d0f1255f-bff0-448f-962e-3c41e581192b.png">|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the form elements pages for interact with the elements to verify their states and spec matc

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (LOW) Dropdown component adjusted to latest specs. Label changes will occur as a result in kajabi-products but no adverse effects expected.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
