### PR TITLE
Add content to media tiles

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_media_tiles.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_media_tiles.html.erb
@@ -7,4 +7,6 @@
   <% component.items.each do | panel | %>
     <%= sage_component SageMediaTile, panel %>
   <% end if component.items %>
+
+  <%= component.content %>
 <% end %>


### PR DESCRIPTION
## Description

This quick patch for media tiles adds the ability to compose individual `MediaTile` items as you like inside a `MediaTiles` wrapper.


## Testing in `kajabi-products`

1. (Low) Quick patch for Media Tiles; no impact

