### PR TITLE
Icon rounded variation

### DIFF
--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -24,9 +24,10 @@
 <h3>Background Colors</h3>
 <%= sage_component SageCardList, {} do %>
   <% SageTokens::STATUSES.each do | color | %>
-    <%= sage_component SageCardListItem, { grid_template: "et" } do %>
-      <%= sage_component SageIcon, { icon: "pen", card_color: color } %>
+    <%= sage_component SageCardListItem, { grid_template: "o" } do %>
       <%= color %>
+      <%= sage_component SageIcon, { icon: "pen", card_color: color } %>
+      <%= sage_component SageIcon, { icon: "pen", card_color: color, circular: true, } %>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -33,9 +33,10 @@
 <h3>Background Sizes</h3>
 <%= sage_component SageCardList, {} do %>
   <% SageTokens::ICON_SIZES.each do | size | %>
-    <%= sage_component SageCardListItem, { grid_template: "et" } do %>
-      <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft" } %>
+    <%= sage_component SageCardListItem, { grid_template: "o" } do %>
       <%= size == "md" ? "Default (#{size})" : size %>
+      <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft" } %>
+      <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft", circular: true, } %>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/icon/_props.html.erb
+++ b/docs/app/views/examples/components/icon/_props.html.erb
@@ -1,4 +1,16 @@
 <tr>
+  <td><%= md('`card_color`') %></td>
+  <td><%= md('Rather than just changing the icon color with the `color` property, this option adds a padded background behind the icon in one of the brand status color options.') %></td>
+  <td><%= md("`#{SageTokens::STATUSES.inspect()}`") %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`circular`') %></td>
+  <td><%= md('Optionally, when an icon has a background color, present the shape inside a circle (as opposed to default square with rounded corners.') %></td>
+  <td><%= md('`Boolean`') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`color`') %></td>
   <td><%= md('Which color to use to render the icon. See Sage Colors under "Design."') %></td>
   <td><%= md('Color slider values such as "primary", "prmary-100".') %></td>
@@ -19,7 +31,6 @@
 <tr>
   <td><%= md('`size`') %></td>
   <td><%= md('Adjusts the size of the icon.') %></td>
-  <td><%= md("`#{SageTokens::ICON_SIZES.inspect()}`") %>
-  </td>
+  <td><%= md("`#{SageTokens::ICON_SIZES.inspect()}`") %></td>
   <td><%= md('`nil` (Default is "md" size)') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon.rb
@@ -1,9 +1,10 @@
 class SageIcon < SageComponent
   set_attribute_schema({
-    color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
     card_color: [:optional, SageSchemas::STATUSES],
+    circular: [:optional, NilClass, TrueClass],
+    color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
     icon: SageSchemas::ICON,
     label: [:optional, NilClass, String],
-    size: [:optional, NilClass, SageSchemas::ICON_SIZE]
+    size: [:optional, NilClass, SageSchemas::ICON_SIZE],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -1,18 +1,22 @@
 <% if component.card_color.present? %>
   <div class="sage-icon-background 
-  <%= "sage-icon-background--#{component.card_color}" %>
-  <%= "sage-icon-background--#{component.size}" if component.size.present? %>">
+    <%= "sage-icon-background--#{component.card_color}" %>
+    <%= "sage-icon-background--#{component.size}" if component.size.present? %>
+    <%= "sage-icon-background--circular" if component.circular %>
+  ">
 <% end %>
-  <i class="sage-icon-<%= component.icon %><%= "-#{component.size}" if component.size.present? %>
-  <%= component.generated_css_classes %>
-  <%= "t-sage--color-#{component.color}" if component.color.present? %>"
+  <i class="
+      <%= "sage-icon-#{component.icon}" %><%= "-#{component.size}" if component.size.present? %>
+      <%= "t-sage--color-#{component.color}" if component.color.present? %>
+      <%= component.generated_css_classes %>
+    "
     <% if component.label.present? %>
       aria-label="<%= component.label %>"
     <% else %>
       aria-hidden=true
     <% end %>
-    <%= component.generated_html_attributes.html_safe %>>
-  </i>
+    <%= component.generated_html_attributes.html_safe %>
+  ></i>
 <% if component.card_color.present? %>
   </div>
 <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -98,13 +98,20 @@ $-icon-font-path: "../fonts/sage";
   align-self: stretch;
   width: sage-spacing(xl);
   height: sage-spacing(xl);
-  border-radius: sage-border(radius);
   background-color: var(--background-color, inherit);
 
   [class*="sage-icon-"] {
     display: flex;
     color: var(--color, currentColor);
   }
+
+  &:not(.sage-icon-background--circular) {
+    border-radius: sage-border(radius);
+  }
+}
+
+.sage-icon-background--circular {
+  border-radius: sage-border(radius-round);
 }
 
 @each $size-name, $size in $sage-icon-background-sizes {

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -27,7 +27,7 @@ export const Icon = ({
     'sage-icon-background',
     {
       [`sage-icon-background--${cardColor}`]: cardColor,
-      [`sage-icon-background--${size}`]: size.present,
+      [`sage-icon-background--${size}`]: size,
       'sage-icon-background--circular': circular,
     },
   );

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -27,7 +27,7 @@ export const Icon = ({
     'sage-icon-background',
     {
       [`sage-icon-background--${cardColor}`]: cardColor,
-      [`sage-icon-background--#{component.size}`]: size.present,
+      [`sage-icon-background--${size}`]: size.present,
       'sage-icon-background--circular': circular,
     },
   );

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageTokens } from '../configs';
-import { ICON_SIZES } from './configs';
+import { ICON_CARD_COLORS, ICON_SIZES } from './configs';
 
 export const Icon = ({
+  cardColor,
+  circular,
   className,
   color,
   icon,
@@ -21,6 +23,15 @@ export const Icon = ({
     }
   );
 
+  const wrapperClassNames = classnames(
+    'sage-icon-background',
+    {
+      [`sage-icon-background--${cardColor}`]: cardColor,
+      [`sage-icon-background--#{component.size}`]: size.present,
+      'sage-icon-background--circular': circular,
+    },
+  );
+
   const attributes = {};
   if (!label || label === '') {
     attributes['aria-hidden'] = true;
@@ -28,16 +39,25 @@ export const Icon = ({
     attributes['aria-label'] = label;
   }
 
-  return (
+  const renderIcon = () => (
     <i className={classNames} {...attributes} {...rest} />
   );
+
+  return cardColor ? (
+    <div className={wrapperClassNames}>
+      {renderIcon()}
+    </div>
+  ) : renderIcon();
 };
 
+Icon.CARD_COLORS = ICON_CARD_COLORS;
 Icon.COLORS = SageTokens.COLOR_SLIDERS;
 Icon.ICONS = SageTokens.ICONS;
 Icon.SIZES = ICON_SIZES;
 
 Icon.defaultProps = {
+  cardColor: null,
+  circular: false,
   className: '',
   color: SageTokens.COLOR_SLIDERS.INHERIT,
   label: '',
@@ -45,6 +65,8 @@ Icon.defaultProps = {
 };
 
 Icon.propTypes = {
+  cardColor: PropTypes.oneOf(Object.values(Icon.CARD_COLORS)),
+  circular: PropTypes.bool,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(Icon.COLORS)),
   icon: PropTypes.oneOf(Object.values(Icon.ICONS)).isRequired,

--- a/packages/sage-react/lib/Icon/Icon.spec.jsx
+++ b/packages/sage-react/lib/Icon/Icon.spec.jsx
@@ -32,7 +32,7 @@ describe('Rendering the Sage Icon Component', () => {
       expect(component.get(0).props).toHaveProperty('aria-hidden', true);
     });
   });
-  
+
   describe('variations', () => {
     it('label results in aria-label', () => {
       const label = 'New label';

--- a/packages/sage-react/lib/Icon/Icon.spec.jsx
+++ b/packages/sage-react/lib/Icon/Icon.spec.jsx
@@ -28,16 +28,16 @@ describe('Rendering the Sage Icon Component', () => {
       expect(component.get(0).props.className).toContain(`sage-icon-${defaultProps.icon}`);
     });
 
+    it('no label results in aria-hidden', () => {
+      expect(component.get(0).props).toHaveProperty('aria-hidden', true);
+    });
+  });
+  
+  describe('variations', () => {
     it('label results in aria-label', () => {
       const label = 'New label';
       component.setProps({ label });
       expect(component.get(0).props).toHaveProperty('aria-label', label);
-    });
-  });
-
-  describe('variations', () => {
-    it('no label results in aria-hidden', () => {
-      expect(component.get(0).props).toHaveProperty('aria-hidden', true);
     });
   });
 });

--- a/packages/sage-react/lib/Icon/Icon.story.jsx
+++ b/packages/sage-react/lib/Icon/Icon.story.jsx
@@ -8,12 +8,15 @@ export default {
   component: Icon,
   argTypes: {
     ...selectArgs({
+      cardColor: Icon.CARD_COLORS,
       color: Icon.COLORS,
       icon: SageTokens.ICONS,
       size: Icon.SIZES
     }),
   },
   args: {
+    cardColor: null,
+    circular: false,
     color: Icon.COLORS.CHARCOAL,
     icon: Icon.ICONS.CHECK_CIRCLE,
     label: 'Click me',

--- a/packages/sage-react/lib/Icon/configs.js
+++ b/packages/sage-react/lib/Icon/configs.js
@@ -11,3 +11,12 @@ export const ICON_SIZES = {
   '4XL': '4xl',
   XXXXL: '4xl',
 };
+
+export const ICON_CARD_COLORS = {
+  DANGER: "danger",
+  DRAFT: "draft",
+  INFO: "info",
+  LOCKED: "locked",
+  PUBLISHED: "published",
+  WARNING: "warning",
+};

--- a/packages/sage-react/lib/Icon/configs.js
+++ b/packages/sage-react/lib/Icon/configs.js
@@ -13,10 +13,10 @@ export const ICON_SIZES = {
 };
 
 export const ICON_CARD_COLORS = {
-  DANGER: "danger",
-  DRAFT: "draft",
-  INFO: "info",
-  LOCKED: "locked",
-  PUBLISHED: "published",
-  WARNING: "warning",
+  DANGER: 'danger',
+  DRAFT: 'draft',
+  INFO: 'info',
+  LOCKED: 'locked',
+  PUBLISHED: 'published',
+  WARNING: 'warning',
 };


### PR DESCRIPTION
## Description

This PR adds ability to make an Icon that has the `card_color` provided to display with a circular frame.

## Screenshots

![Screen Shot 2021-07-21 at 11 44 46 AM](https://user-images.githubusercontent.com/17955295/126518840-b19b6e35-3348-40fe-88b9-b087326d59d0.png)

## Testing in `sage-lib`

See Components > Icon and corresponding entry in Storybook.

## Testing in `kajabi-products`

1. (LOW) Add circular variation to icon with background. No impact on existing uses of SageIcon (Rails) or Icon (React).

