### PR TITLE
Centralize Tab and Choice schemas for more efficient use

### DIFF
--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -266,7 +266,7 @@ document.addEventListener("sage.tabs.change", function(evt) {
             ).html_safe})}
             <i class="sage-icon-check-circle-lg t-sage--color-primary u-rich-choice-card__option-checkmark" aria-label="Selected"></i>
             <input type="hidden" id="item1" name="item1" value="User A" />
-          )
+          ).html_safe,
         },
         {
           target: "item2",
@@ -278,7 +278,7 @@ document.addEventListener("sage.tabs.change", function(evt) {
             ).html_safe})}
             <i class="sage-icon-check-circle-lg t-sage--color-primary u-rich-choice-card__option-checkmark" aria-label="Selected"></i>
             <input type="hidden" id="item2" name="item2" value="User B" />
-          )
+          ).html_safe,
         },
       ],
       style: "choice",

--- a/docs/lib/sage_rails/app/sage_components/sage_choice.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_choice.rb
@@ -1,21 +1,3 @@
 class SageChoice < SageComponent
-  set_attribute_schema({
-    active: [:optional, NilClass, TrueClass],
-    align_center: [:optional, TrueClass],
-    attributes: [:optional, NilClass, Hash],
-    disabled: [:optional, NilClass, TrueClass],
-    graphic: [:optional, NilClass, String],
-    icon: [:optional, NilClass, String],
-    link_text: [:optional, NilClass, String],
-    subtext: [:optional, NilClass, String],
-    target: [:optional, NilClass, String],
-    text: [:optional, NilClass, String],
-    type: [:optional, NilClass, Set.new(["arrow", "graphic", "icon", "radio"])],
-    vertical_align_icon: [:optional, NilClass, Set.new(["start"])],
-    radio_configs: [:optional, NilClass, {
-      value: String,
-      name: String,
-      id: String,
-    }]
-  })
+  set_attribute_schema(SageSchemas::CHOICE)
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -1,4 +1,7 @@
 module SageSchemas
+
+  # Miscellaneous
+
   ICON = Set.new(SageTokens::ICONS)
   
   ICON_SIZE = Set.new(SageTokens::ICON_SIZES)
@@ -18,6 +21,28 @@ module SageSchemas
     right: [:optional, Set.new(SageTokens::SPACER_SIZES)],
     bottom: [:optional, Set.new(SageTokens::SPACER_SIZES)],
     left: [:optional, Set.new(SageTokens::SPACER_SIZES)],
+  }
+
+  # Components
+
+  CHOICE = {
+    active: [:optional, NilClass, TrueClass],
+    align_center: [:optional, TrueClass],
+    attributes: [:optional, NilClass, Hash],
+    disabled: [:optional, NilClass, TrueClass],
+    graphic: [:optional, NilClass, String],
+    icon: [:optional, NilClass, String],
+    link_text: [:optional, NilClass, String],
+    subtext: [:optional, NilClass, String],
+    target: [:optional, NilClass, String],
+    text: [:optional, NilClass, String],
+    type: [:optional, NilClass, Set.new(["arrow", "graphic", "icon", "radio"])],
+    vertical_align_icon: [:optional, NilClass, Set.new(["start"])],
+    radio_configs: [:optional, NilClass, {
+      value: String,
+      name: String,
+      id: String,
+    }]
   }
 
   DROPDOWN_ITEM = {
@@ -48,6 +73,14 @@ module SageSchemas
     media: [:optional, NilClass, String],
     media_configs: [:optional, NilClass, SageSchemas::PANEL_FIGURE],
     title: [:optional, NilClass, String],
+  }
+
+  TAB = {
+    active: [:optional, NilClass, TrueClass],
+    attributes: [:optional, NilClass, Hash],
+    disabled: [:optional, NilClass, TrueClass],
+    target: [:optional, NilClass, String],
+    text: String,
   }
 
   # Accepts any Collection that can be paginated

--- a/docs/lib/sage_rails/app/sage_components/sage_tab.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tab.rb
@@ -1,9 +1,3 @@
 class SageTab < SageComponent
-  set_attribute_schema({
-    active: [:optional, NilClass, TrueClass],
-    attributes: [:optional, NilClass, Hash],
-    disabled: [:optional, NilClass, TrueClass],
-    target: [:optional, NilClass, String],
-    text: String,
-  })
+  set_attribute_schema(SageSchemas::TAB)
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -2,26 +2,7 @@ class SageTabs < SageComponent
   set_attribute_schema({
     align_items_center: [:optional, TrueClass],
     id: [:optional, String],
-    items: [:optional, [[
-      active: [:optional, NilClass, TrueClass],
-      align_center: [:optional, TrueClass],
-      attributes: [:optional, NilClass, Hash],
-      data: [:optional, Hash],
-      disabled: [:optional, NilClass, TrueClass],
-      graphic: [:optional, NilClass, String],
-      icon: [:optional,NilClass, String],
-      link_text: [:optional, NilClass, String],
-      subtext: [:optional, NilClass, String],
-      target: [:optional, NilClass, String],
-      text: [:optional, NilClass, String],
-      type: [:optional, Set.new(["arrow", "graphic", "icon", "radio"])],
-      vertical_align_icon: [:optional, NilClass, Set.new(["start"])],
-      radio_configs: [:optional, NilClass, {
-        value: String,
-        name: String,
-        id: String,
-      }]
-    ]]],
+    items: [:optional, [[SageSchemas::CHOICE]], [[SageSchemas::TAB]]],
     navigational: [:optional, TrueClass],
     progressbar: [:optional, TrueClass],
     stacked: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -12,28 +12,9 @@
 >
   <% component.items.each do |item| %>
     <% if component.style.present? && component.style === "choice" %>
-      <%= sage_component SageChoice, {
-        target: item[:target],
-        text: item[:text],
-        subtext: item[:subtext],
-        active: item[:active],
-        type: item[:type],
-        icon: item[:icon],
-        attributes: item[:attributes],
-        disabled: item[:disabled],
-        radio_configs: item[:radio_configs],
-        vertical_align_icon: item[:vertical_align_icon],
-      } do %>
-        <%= item[:content].html_safe if defined?(item[:content]) and item[:content] %>
-      <% end %>
+      <%= sage_component SageChoice, item %>
     <% else %>
-      <%= sage_component SageTab,
-        target: item[:target],
-        text: item[:text],
-        active: item[:active],
-        attributes: item[:attributes],
-        disabled: item[:disabled]
-      %>
+      <%= sage_component SageTab, item %>
     <% end %>
   <% end  if component.items.present? %>
   <%= component.content if component.content.present? %>


### PR DESCRIPTION
## Description

This PR centralizes complex schemas for `Tab` and `Choice` to help streamline changes to these components and how they're referenced in the `Tabs.items` property.

## Testing in `sage-lib`

Verify no errors on Tab, Choice, and Tabs pages. 👍 


## Testing in `kajabi-products`
1. (LOW) Internal changes to Tab, Choice, and Tabs have no impact on existing uses. UXD verified in the following:
   - [ ] Podcats > New Podcast modal with choice cards.
   - [ ] Events > Tabs at the top
