### PR TITLE
Adjust spacer logic for `md` to check both string and symbol values

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -47,7 +47,7 @@ class SageComponent
   def spacer=(spacer_hash)
     @spacer = spacer_hash
     spacer_hash.each do |key, value|
-      generated_css_classes << " sage-spacer-#{key}#{value != :md ? "-#{value}" : ""}"
+      generated_css_classes << " sage-spacer-#{key}#{(value != :md and value != "md") ? "-#{value}" : ""}"
     end
   end
 


### PR DESCRIPTION
## Description

This PR patches the logic in SageComponent to ensure that both `"md"` and `:md` correctly apply the desired spacer on elements.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| <img width="381" alt="Screen Shot 2021-07-22 at 11 39 30 AM" src="https://user-images.githubusercontent.com/17955295/126667674-12764094-5dd4-42aa-aaf0-76c38ff9cb7b.png"> | <img width="404" alt="Screen Shot 2021-07-22 at 11 37 39 AM" src="https://user-images.githubusercontent.com/17955295/126667706-2337f2c7-5b63-49cb-ab16-088def4e352a.png"> |

## Testing in `sage-lib`

Try this out in the the Sandbox to test:

```erb
<%= sage_component SagePanelBlock, {} do %>
  <%= sage_component SageButton, {
    value: "I should have space to the right",
    spacer: {
      right: "md",
    },
    style: "secondary",
    raised: true,
  } %>

  <%= sage_component SageButton, {
    value: "Did it work?",
    style: "primary",
    raised: true,
  } %>
<% end %>
```

## Testing in `kajabi-products`

1. (LOW) Fix a bug related to use of `md` spacers on components. No adverse effects expected.
## Related

Closes #645 
