### PR TITLE
Fix panel classes

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -24,7 +24,7 @@ class SageComponent
 
   def css_classes=(classes_string)
     @css_classes = classes_string
-    generated_css_classes << classes_string
+    generated_css_classes << " #{classes_string}"
   end
 
   def render

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,6 +1,6 @@
 class SagePanelRow < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE,
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
     vertical_align: [:optional, Set.new(["start"])],
   })
 end


### PR DESCRIPTION
## Description

This PR patches a bug with custom css classes in sage components where, depending on ordering, the class is appended without a space separating it from other generated classes.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| <img width="1139" alt="Screen Shot 2021-07-22 at 12 09 58 PM" src="https://user-images.githubusercontent.com/17955295/126672610-d806b4e4-e83b-4517-9104-93fcc2ba58d4.png"> | <img width="944" alt="Screen Shot 2021-07-22 at 12 06 48 PM" src="https://user-images.githubusercontent.com/17955295/126672635-b93c76be-8a9f-4fa4-a1d4-7d29223ebcb0.png"> |

## Testing in `sage-lib`

Drop this in sandbox to test:

```
<%= sage_component SagePanelRow, { grid_template: "o" } do %>
  <%= sage_component SageContainer, { size: "sm" } do %>
    <h3>Grid template > Spacer > Classes</h3>
    <%= sage_component SagePanelRow, { grid_template: "te", spacer: { bottom: :sm }, css_classes: "my-class" } do %>
      <%= sage_component SageButton, { value: "First row", style: "primary" } %>
    <% end %>
    <%= sage_component SagePanelRow, { grid_template: "te" } do %>
      <%= sage_component SageButton, { value: "Second row", style: "primary" } %>
    <% end %>
  <% end %>

  <%= sage_component SageContainer, { size: "sm" } do %>
    <h3>Classes > Grid template > Spacer</h3>
    <%= sage_component SagePanelRow, { css_classes: "my-class", grid_template: "te", spacer: { bottom: :sm } } do %>
      <%= sage_component SageButton, { value: "First row", style: "primary" } %>
    <% end %>
    <%= sage_component SagePanelRow, { grid_template: "te"} do %>
      <%= sage_component SageButton, { value: "Second row", style: "primary" } %>
    <% end %>
  <% end %>

  <%= sage_component SageContainer, { size: "sm" } do %>
    <h3>Spacer > Classes > Grid template</h3>
    <%= sage_component SagePanelRow, { spacer: { bottom: :sm }, css_classes: "my-class", grid_template: "te" } do %>
      <%= sage_component SageButton, { value: "First row", style: "primary" } %>
    <% end %>
    <%= sage_component SagePanelRow, { grid_template: "te" } do %>
      <%= sage_component SageButton, { value: "Second row", style: "primary" } %>
    <% end %>
  <% end %>
<% end %>
```


## Testing in `kajabi-products`

1. (MEDIUM) Patch to use of `css_classes` fixes instances where the effect is not applied to due a missing space. May have small effects on spacings overlooked earlier. Nothing in particular to test.

## Related

Closes #646 
