### PR TITLE
Choice content custom class

### DIFF
--- a/docs/app/views/examples/components/choice/_preview.html.erb
+++ b/docs/app/views/examples/components/choice/_preview.html.erb
@@ -70,11 +70,22 @@ long_description = "Description with longer text to cause wrapping and make the 
 
 <h3 class="t-sage-heading-6">Rich text/Customized</h3>
 <p>Choice cards can also be opened up for custom content to be composed within.</p>
+<style>
+.custom-choice {
+  max-width: 352px;
+}
+.custom-choice__content {
+  text-align: center;
+  justify-items: center;
+}
+</style>
 <%= sage_component SageChoice, {
-  target: "example",
   attributes: {
     href: "http://example.com",
   },
+  css_classes: "custom-choice",
+  custom_content_class: "custom-choice__content",
+  target: "example",
 } do %>
   <%= sage_component SageAvatar, { initials: 'PS' } %>
   <%= sage_component SageCardBlock, {} do %>

--- a/docs/app/views/examples/components/choice/_props.html.erb
+++ b/docs/app/views/examples/components/choice/_props.html.erb
@@ -29,6 +29,15 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`custom_content_class`') %></td>
+  <td>
+  <%= md('Sets a custom class on the `__content` element within this component.
+  This can be added when custom content is passed into the component block for additional local styling on that block.') %>
+  </td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`graphic`') %></td>
   <td><%= md('Sets the image path to for asset for this component.') %></td>
   <td><%= md('String') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -29,6 +29,7 @@ module SageSchemas
     active: [:optional, NilClass, TrueClass],
     align_center: [:optional, TrueClass],
     attributes: [:optional, NilClass, Hash],
+    custom_content_class: [:optional, NilClass, String],
     disabled: [:optional, NilClass, TrueClass],
     graphic: [:optional, NilClass, String],
     icon: [:optional, NilClass, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -58,7 +58,11 @@ end
       <%= component.graphic.html_safe %>
     </div>
   <% end %>
-  <div class="sage-choice__content <%= "sage-choice__content--custom" if component.content.present? %>">
+  <div class="
+    sage-choice__content
+    <%= "sage-choice__content--custom" if component.content.present? %>
+    <%= component.custom_content_class if component.custom_content_class.present? %>
+  ">
     <% if component.text.present? %>
       <em class="sage-choice__text"><%= component.text.html_safe %></em>
     <% end %>


### PR DESCRIPTION
## Description

This PR adds ability to add a custom CSS class on the `__content` element that wraps any content passed into a `Choice` through its content block.

## Screenshots

![Screen Shot 2021-07-22 at 5 14 17 PM](https://user-images.githubusercontent.com/17955295/126710687-549a822a-b169-406f-9acf-e3b908f4c607.png)

## Testing in `sage-lib`

See Choice and the "Rich text/Customized" section.

## Testing in `kajabi-products`

1. (LOW) New feature on Choice Card has no impact on existing uses.

