### PR TITLE
Feature Toggle Optional Label

### DIFF
--- a/docs/app/views/examples/components/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/components/feature_toggle/_preview.html.erb
@@ -49,6 +49,10 @@
         text: "Feedback",
       },
     ],
+    label: {
+      color: "locked",
+      value: "Label Value",
+    },
     title: "New Sales Tab",
   } do %>
     <%= sage_component_section :feature_toggle_input do %>
@@ -78,6 +82,10 @@
         text: "Learn more",
       },
     ],
+    label: {
+      color: "locked",
+      value: "Label Value",
+    },
     title: "New People list view",
   } do %>
     <%= sage_component_section :feature_toggle_input do %>

--- a/docs/app/views/examples/components/feature_toggle/_props.html.erb
+++ b/docs/app/views/examples/components/feature_toggle/_props.html.erb
@@ -26,6 +26,18 @@ Hash<{
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`label`') %></td>
+  <td><%= md('Sets an optional [Label](/pages/component/label) component.') %></td>
+  <td>
+      <%= md('```
+Hash<{
+  color: String,
+  value: String,
+}>
+    ') %>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`image`') %></td>
   <td><%= md('Sets the `src` for the component\'s image.') %></td>
   <td><%= md('`nil`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_feature_toggle.rb
@@ -10,6 +10,10 @@ class SageFeatureToggle < SageComponent
       target: [:optional, String],
       text: [:optional, String],
     }]]],
+    label: [:optional, {
+      color: [:optional, SageSchemas::STATUSES],
+      value: [:optional, String],
+    }],
     title: [:optional, String],
     title_tag: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -1,10 +1,10 @@
 <% feature_toggle_title_tag = component.title_tag ? component.title_tag : "h3" %>
 
 <li class="
-    sage-feature-toggle 
+    sage-feature-toggle
     <%= "sage-feature-toggle--no-image" if component.image.blank? && component.icon.blank? %>
     <%= component.generated_css_classes %>
-  " 
+  "
   <%= component.generated_html_attributes.html_safe %>>
   <<%= feature_toggle_title_tag %> class="sage-feature-toggle__title"><%= component.title %></<%= feature_toggle_title_tag %>>
   <div class="sage-feature-toggle__content">
@@ -27,6 +27,14 @@
             } %>
           <% end %>
         <% end %>
+      <% end %>
+      <% if component.label.present? %>
+        <div class="sage-feature-toggle__label">
+          <%= sage_component SageLabel, {
+            color: component.label[:color],
+            value: component.label[:value]
+          } %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/packages/sage-assets/lib/stylesheets/components/_feature_toggle.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_feature_toggle.scss
@@ -90,6 +90,8 @@ $-feature-toggle-image-height-mobile: rem(120px);
 .sage-feature-toggle__links {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
+  margin-top: sage-spacing(xs);
 }
 
 .sage-feature-toggle__aside {
@@ -101,8 +103,15 @@ $-feature-toggle-image-height-mobile: rem(120px);
   }
 }
 
+.sage-feature-toggle__label {
+  align-self: center;
+  margin-left: auto;
+  @media (max-width: sage-breakpoint(md-min)) {
+    margin-left: 0;
+  }
+}
+
 .sage-feature-toggle__link-item {
-  margin-top: sage-spacing(xs);
   margin-right: sage-spacing(sm);
 }
 


### PR DESCRIPTION
## Description
Adds an optional label to the feature toggle component in preparation for upcoming work by the AOPS team related to the labs page.

More info: https://kajabi.atlassian.net/browse/AOPS-41

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-07-23 at 1 42 49 PM](https://user-images.githubusercontent.com/1175111/126839622-ca99d79c-d82f-43b1-a459-7a10c1f9bc19.png)|![Screen Shot 2021-07-23 at 1 42 22 PM](https://user-images.githubusercontent.com/1175111/126839672-f3b26a49-1d34-435e-9eab-571255b0b7b4.png)|


## Testing in `sage-lib`

- Navigate to Feature Toggle http://localhost:4000/pages/component/feature_toggle
- Verify new label appears. Feel free to adjust link and label setting to test use cases.
- Verify props documentation updates.


## Testing in `kajabi-products`
1. (**LOW) Adds an optional label to feature toggle component.
   - [ ] Sanity check of labs page to verify feature toggle components function as expected.


## Related
N/A
