### PR TITLE
Image tag conversion and image path updates

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -16,7 +16,7 @@
   <%= sage_component SageAvatar, {
     image: {
       alt: "Court's profile image",
-      src: "/assets/avatar/court.png"
+      src: "avatar/court.png"
     }
   } %>
 </div>

--- a/docs/app/views/examples/components/billboard/_preview.html.erb
+++ b/docs/app/views/examples/components/billboard/_preview.html.erb
@@ -1,7 +1,7 @@
 <div class="sage-row" style="height:500px">
   <div class="sage-col--md-6">
     <%= sage_component SageBillboard, {
-      img: "/assets/billboard/background_1.jpg",
+      img: "billboard/background_1.jpg",
       message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
       title: "Title 1",
       title_tag: "h2"
@@ -9,7 +9,7 @@
   </div>
   <div class="sage-col--md-6">
     <%= sage_component SageBillboard, {
-      img: "/assets/billboard/background_2.jpg",
+      img: "billboard/background_2.jpg",
       message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
       title: "Title 2"
     } %>
@@ -18,14 +18,14 @@
 <div class="sage-row" style="height:500px">
   <div class="sage-col--md-6">
     <%= sage_component SageBillboard, {
-      img: "/assets/billboard/background_3.jpg",
+      img: "billboard/background_3.jpg",
       message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
       title: "Title 3"
     } %>
   </div>
   <div class="sage-col--md-6">
     <%= sage_component SageBillboard, {
-      img: "/assets/billboard/background_4.jpg",
+      img: "billboard/background_4.jpg",
       message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
       title: "Title 4"
     } %>

--- a/docs/app/views/examples/components/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/components/catalog_item/_preview.html.erb
@@ -2,7 +2,7 @@
   <% 2.times do %>
     <%= sage_component SageCatalogItem, {
       title: "Fun For All – The Children Call: Their Favorite Time Of Year",
-      image: "/assets/card-placeholder-sm.png",
+      image: "card-placeholder-sm.png",
       href: "#"
     } do %>
       <%= sage_component SageButton, {

--- a/docs/app/views/examples/components/description/_preview.html.erb
+++ b/docs/app/views/examples/components/description/_preview.html.erb
@@ -50,7 +50,7 @@
     },
     {
       title: "Name",
-      data: %(<img src="/assets/card-placeholder-sm.png" width="24" height="16" /> John Doe).html_safe,
+      data: "#{image_tag("card-placeholder-sm.png", height: 16, width: 24)} John Doe".html_safe,
     }
   ],
   inline_spread: true,

--- a/docs/app/views/examples/components/feature_toggle/_preview.html.erb
+++ b/docs/app/views/examples/components/feature_toggle/_preview.html.erb
@@ -73,7 +73,7 @@
 <%= sage_component SagePanel, {} do %>
   <%= sage_component SageFeatureToggle, {
     description: "Quickly see Segments & filter contacts with a consistent People list view.",
-    image: "/assets/card-placeholder-sm.png",
+    image: "card-placeholder-sm.png",
     links: [
       {
         icon: "launch",

--- a/docs/app/views/examples/components/hero/_preview.html.erb
+++ b/docs/app/views/examples/components/hero/_preview.html.erb
@@ -6,7 +6,7 @@
       href: "#",
     },
     description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-    image: "/assets/card-placeholder-sm.png", 
+    image: "card-placeholder-sm.png",
     title: "Be the first to try what Kajabi is building 1",
   } %>
 <% end %>
@@ -20,7 +20,7 @@
       href: "#",
     },
     description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-    image: "/assets/card-placeholder-sm.png", 
+    image: "card-placeholder-sm.png",
     title: "Be the first to try what Kajabi is building 2",
     title_tag: "h3",
     button: sage_component(SageButton, {

--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -89,7 +89,7 @@
   <%# Standard Modal with Header Image %>
   <%= sage_component SageModal, { id: "cool-modal-header-image" } do %>
     <%= sage_component SageModalContent, {
-      header_image: "/assets/card-placeholder-sm.png",
+      header_image: "card-placeholder-sm.png",
       title: "Example Modal"
     } do %>
       <% content_for :sage_header_aside do %>

--- a/docs/app/views/examples/components/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/components/page_heading/_preview.html.erb
@@ -78,7 +78,7 @@
 } do %>
 
     <% content_for :sage_page_heading_image do %>
-      <img src="/assets/card-placeholder-sm.png" alt=""/>
+      <%= image_tag "card-placeholder-sm.png" %>
     <% end %>
     <% content_for :sage_page_heading_toolbar do %>
       <%= sage_component SageButton, {
@@ -177,7 +177,7 @@
       }%>
     <% end %>
     <% content_for :sage_page_heading_image do %>
-      <img src="/assets/card-placeholder-sm.png" alt=""/>
+      <%= image_tag "card-placeholder-sm.png" %>
     <% end %>
     <% content_for :sage_page_heading_intro do %>
       <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nemo dolorum esse modi ut ipsa corporis.</p>

--- a/docs/app/views/examples/components/page_heading/_props.html.erb
+++ b/docs/app/views/examples/components/page_heading/_props.html.erb
@@ -55,5 +55,5 @@
 <tr>
   <td><%= md('`sage_page_heading_image`') %></td>
   <td><%= md('This area holds the page heading image') %></td>
-  <td colspan="2"><%= md('`<img>`, `image_tag()`') %></td>
+  <td colspan="2"><%= md('`image_tag()`') %></td>
 </tr>

--- a/docs/app/views/examples/components/popover/_preview.html.erb
+++ b/docs/app/views/examples/components/popover/_preview.html.erb
@@ -90,7 +90,7 @@ positions = [
   }
 } do %>
   <%= content_for :sage_popover_media do %>
-    <%= image_tag("card-placeholder-lg.png", alt: "") %>
+    <%= image_tag "card-placeholder-lg.png", alt: "" %>
   <% end %>
 
   <p>

--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -91,7 +91,7 @@
     <%= sage_component SageSortableItem, {
       title: "Fringilla Ullamcorper Dolor Adipiscing Ultricies",
       url_update: "update/endpoint",
-      image: "/assets/card-placeholder-sm.png",
+      image: "card-placeholder-sm.png",
       id: "id",
       card: true
     } do %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 >
   <% if component.image %>
-    <img alt="<%= component.image[:alt] || "" %>" class="sage-avatar__image" src="<%= component.image[:src] %>">
+    <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image" %>
   <% else %>
     <svg class="sage-avatar__initials" viewBox="0 0 32 32">
       <text x="16" y="20"><%= component.initials %></text>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_catalog_item.html.erb
@@ -36,7 +36,7 @@
   <% if component.image.present? %>
     <%# Uses tabindex="-1" because there are two links to the same location in this component (component.title also links to the href) %>
     <<%= link_tag %> class="sage-catalog-item__img" href="<%= component.href %>" tabindex="-1" title="Go to: <%= component.title %>">
-      <img src="<%= component.image %>" alt="Cover image for: <%= component.title %>">
+      <%= image_tag component.image, alt: "Cover image for: #{component.title}" %>
     </<%= link_tag %>>
   <% end %>
   <% if component.icon.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_feature_toggle.html.erb
@@ -56,7 +56,11 @@
           size: (component.icon[:size] if component.icon[:size].present?),
         }.compact %>
       <% elsif component.image.present? %>
-        <img class="sage-feature-toggle__image" src=<%= component.image %> alt="<%= component.alt_text %>" <%= "aria-hidden=true" if component.alt_text.blank? %> />
+        <% image_options = {
+          alt: component.alt_text,
+          class: "sage-feature-toggle__image"
+        }.merge((component.alt_text.blank? ? { "aria-hidden": true } : {})) %>
+        <%= image_tag component.image, image_options %>
       <% end %>
     </div>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
@@ -18,7 +18,11 @@
     class="sage-hero__artwork"
   >
     <span class="sage-hero__artwork-image-container">
-      <img class="sage-hero__artwork-image" <%= "aria-hidden=true" if component.alt_text.blank? %> src=<%= component.image%> alt="<%= component.alt_text %>" />
+      <% image_options = {
+        alt: component.alt_text,
+        class: "sage-hero__artwork-image"
+      }.merge((component.alt_text.blank? ? { "aria-hidden": true } : {})) %>
+      <%= image_tag component.image, image_options %>
     </span>
   </a>
 </article>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -1,7 +1,7 @@
 <% if component.title.present? %>
   <header class="sage-modal__header">
     <% if component.header_image.present? %>
-      <img class="sage-modal__header-image" src=<%= component.header_image %> alt="" aria-hidden="true"/>
+      <%= image_tag component.header_image, alt: "", "aria-hidden": true, class: "sage-modal__header-image" %>
     <% end %>
     <div class="sage-modal__header-text">
       <h1 class="t-sage-heading-4">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item.html.erb
@@ -10,10 +10,7 @@
 >
   <% if component.image.present? %>
     <div class="sage-sortable__item-image">
-      <img
-        src="<%= component.image %>"
-        alt="Cover for <%= component.title %>"
-      />
+      <%= image_tag component.image, alt: "Cover for #{component.title}" %>
     </div>
   <% end %>
   <div class="sage-sortable__item-content">


### PR DESCRIPTION
## Description
This PR does the following:
- Updates all instances of `<img>` to use `image_tag` for all Rails components
- Updates all image paths in the docs to NOT start with `/assets/`

Image references are currently broken in the production version of Sage docs. 

In order to correct this, we must use the `image_tag` helper which will correctly assign a hash to all images for caching purposes.

In addition, it should be noted that when referencing images in the docs folder, the path MUST NOT includes `/assets/` as the `image_tag` helper knows to look in that directory by default. While including this in the path will work locally, it does not work when deployed.

**Going forward, we should always use `image_tag` for creating inline images for Rails components.**

## Testing in `sage-lib`
Visit the following URLs and ensure that each image appears correctly, has a hash appended to it when inspecting it and that the `alt` attribute appears where appropriate. For some components, if no `alt` attribute is provided, the `aria-hidden: true` attribute appears (`Feature Toggle`, `Hero` and `Modal - Heading`).

- http://0.0.0.0:4000/pages/component/avatar
- http://0.0.0.0:4000/pages/component/billboard
- http://0.0.0.0:4000/pages/component/catalog_item
- http://0.0.0.0:4000/pages/component/choice
- http://0.0.0.0:4000/pages/component/description
- http://0.0.0.0:4000/pages/component/feature_toggle
- http://0.0.0.0:4000/pages/component/hero
- http://0.0.0.0:4000/pages/component/page_heading
- http://0.0.0.0:4000/pages/component/popover
- http://0.0.0.0:4000/pages/component/sortable

## Testing in `kajabi-products`
This PR touches a number of components and should be tested in the following areas (**there may be others that I am not aware of...**)
1. (**MEDIUM**) The way images are generated has changed, but the output should be the same.
   - [ ] Settings -> Labs
   - [ ] Products -> All Products

## Related
N/A
