### PR TITLE
sage_table_for cleanup

### DIFF
--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -86,7 +86,7 @@ module SageTableHelper
     def initialize(template, collection, opts={})
       @template = template
       @caption = opts[:caption]
-      @class_name = opts[:class]
+      @class_name = opts[:class_name]
       @condensed = opts[:condensed]
       @collection = collection
       @reset_above = opts[:reset_above]
@@ -131,7 +131,7 @@ module SageTableHelper
       table_classes << " sage-table--condensed" if condensed
       table_classes << " sage-table--sortable" if sortable
       table_classes << " sage-table--striped" if striped
-      table_classes << " #{class_name}" if striped
+      table_classes << " #{class_name}" if class_name
 
       content_tag "table", id: id, class: table_classes do
         (caption << head << body).html_safe

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -134,13 +134,17 @@ module SageTableHelper
       table_classes << " #{class_name}" if striped
 
       content_tag "table", id: id, class: table_classes do
-        caption + head + body
+        (caption << head << body).html_safe
       end
     end
 
     def caption
-      content_tag "caption" do
-        @caption
+      if @caption
+        content_tag "caption" do
+          @caption
+        end
+      else
+        ""
       end
     end
 


### PR DESCRIPTION
## Description

This PR make a few tidying updates to `sage_table_for`:

- Ensures `caption` is not output by default
- Ensures `class_name` on table is output as expected


## Testing in `sage-lib`

Verify table page loads. Test by adding `class_name` and removing `caption` on final example on `table/_preview`

## Testing in `kajabi-products`
1. (LOW) Small adjustments internally to `sage_table_for`. UXD verified no regressions in the following uses:
   - [x] Assessments
   - [x] Marketing > Events
   - [x] Marketing > Forms
   - [x] Settings > Account Users

