### PR TITLE
Panel tile spacing

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -115,8 +115,6 @@
 .sage-panel__tiles {
   display: grid;
   grid-gap: sage-spacing();
-  margin: 0;
-  padding: 0;
   list-style: none;
 }
 


### PR DESCRIPTION
## Description

Removes unnecessary margin and padding resets from this component.

Found that spacers could not apply due to conflicts these extra settings caused.

## Testing in `sage-lib`

See no change in Components > Panel > Tiles area.

## Testing in `kajabi-products`

1. (LOW) Removes excess styling from Panel Tiles. No impact on existing uses.
