### PR TITLE
Solve table paint flakiness in safari

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -113,6 +113,12 @@ $-table-avatar-width: rem(32px);
       color: $-table-cell-font-color-strong;
     }
   }
+
+  .sage-table-wrapper__overflow & {
+    // This pushes table to use GPU rendering
+    // in order to solve a painting bug in Safari
+    transform: rotateX(0);
+  }
 }
 
 // Decreased vertical padding


### PR DESCRIPTION
## Description

This PR fixes a bug where Safari painted tables with `responsive: true` unreliably with flaking blinking on hover and window resize.

Problem goes away when the `overflow` settings are turned off, which is not an option as this breaks the current approach to side-scrolling tables.

Solution was to use `transform: rotateX(0);` to push the table rendering to GPU making paint more reliable.

## Screenshots

**Before:**

<a href="https://www.loom.com/share/12797d37c6094a11926566d36b840157">
    <p>Safari - Table disappearing - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/12797d37c6094a11926566d36b840157-with-play.gif">
  </a>

**After:**

<a href="https://www.loom.com/share/dc0948b44da14eca8d81c7b941188b8d">
    <p>Safari - Table paint bug fixed - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/dc0948b44da14eca8d81c7b941188b8d-with-play.gif">
  </a>


## Testing in `sage-lib`

Error is not visible in Sage-lib


## Testing in `kajabi-products`

1. (LOW) Fixes flaky table rendering in Safari on Forms page (MAN-1805)
   - [ ] Validate Forms table renders reliably in Safari and no impact on other browsers.

## Related

Closes #662 