### PR TITLE
Update Toast

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_toast.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_toast.scss
@@ -73,7 +73,7 @@ $-toast-bottom-spacing: sage-spacing(xs);
   color: sage-color(white);
   border-radius: sage-border(radius);
   box-shadow: sage-shadow(lg);
-  background-color: sage-color(charcoal);
+  background-color: sage-color(charcoal, 400);
   animation: 0.5s ease;
 
   @media #{$-toast-breakpoint-default} {
@@ -161,7 +161,7 @@ $-toast-bottom-spacing: sage-spacing(xs);
 }
 
 .sage-toast__button--close::before {
-  @include sage-icon-base(remove, lg);
+  @include sage-icon-base(remove);
 }
 
 .sage-toast__button--underline {


### PR DESCRIPTION
## Description
Updates the toast close icon sizing and the default background color in order to bring up to design spec.
Fixes #519

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-07-30 at 9 45 14 AM](https://user-images.githubusercontent.com/1175111/127686010-74ba204f-771b-4a21-a996-7b98b88dce9c.png)|![Screen Shot 2021-07-30 at 9 44 41 AM](https://user-images.githubusercontent.com/1175111/127686042-284582b4-4d86-401e-b0f0-04bf3e440e86.png)|
|![Screen Shot 2021-07-30 at 9 49 59 AM](https://user-images.githubusercontent.com/1175111/127686084-6746e484-6871-41c4-87e6-37588a3640ee.png)|![Screen Shot 2021-07-30 at 9 49 24 AM](https://user-images.githubusercontent.com/1175111/127686111-0c4edbf0-4fc3-4231-85d0-bd377bae9603.png)|

## Testing in `sage-lib`
Visit http://localhost:4000/pages/component/toast
Verify default background color matches the updated design
Verify close icon sizing matches the updated design

## Testing in `kajabi-products`
1. (**LOW**) Should have no impact but a quick sanity check should be performed anywhere a toast is used.
   - [ ] Any page w/ a save verification message or a copy text button.

## Related
#519
