### PR TITLE
Dropdown border top and schema cleanup

### DIFF
--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -54,7 +54,7 @@
   <td><%= md('```
 Array<{
   attributes: String,
-  css_class: String,
+  css_classes: String,
   icon: String,
   is_heading: Boolean,
   modifiers: [

--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -54,12 +54,14 @@
   <td><%= md('```
 Array<{
   attributes: String,
-  border_before: String,
+  css_class: String,
   icon: String,
   is_heading: Boolean,
-  modifiers: Array,
+  modifiers: [
+    "disabled" | "border-before" | "border-after" | nil,
+  ],
   selected: Boolean,
-  style: String,
+  style: "primary" | "danger" | "muted",
   value: String,
 }>
 ```

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -48,12 +48,12 @@ module SageSchemas
 
   DROPDOWN_ITEM = {
     attributes: [:optional, Hash],
-    border_before: [:optional, TrueClass],
     icon: [:optional, NilClass, String],
+    css_classes: [:optional, NilClass, String],
     is_heading: [:optional, TrueClass],
-    modifiers: [:optional, Array],
+    modifiers: [:optional, [[Set.new(["disabled", "border-before", "border-after", nil])]]],
     selected: [:optional, TrueClass],
-    style: [:optional, String],
+    style: [:optional, Set.new(["primary", "danger", "muted"])],
     value: String,
   }
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -48,8 +48,9 @@
             <li class="
                 sage-dropdown__item
                 <% item[:modifiers]&.each do |item_modifier| %>
-                  <%= "sage-dropdown__item--#{item_modifier}" %>
+                  <%= "sage-dropdown__item--#{item_modifier}" if item_modifier %>
                 <% end %>
+                <%= item[:css_classes] if item[:css_classes].present? %>
               "
               role="none"
               <%= "aria-selected=true" if item[:selected] %>


### PR DESCRIPTION
## Description

Closes #669 

The PR removes the `border_top` property from the `items` in `SageDropdown` as it was not being applied to the items as expected. instead, the `modifiers` allowed for `border-top` to be provided. Took the opportunity to tighten the Schema for `modifiers` to explicitly list the possible string values that can be passed in this array. Also added `css_classes` to the options and tightened the `style` options on items.

Checked this work in the bridge to ensure no regressions since technically nothing changed in the actual affordances other than adding `css_classes` to items.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`

1. (LOW) Internal updates to schemas in DropdownItems. [This PR](https://github.com/Kajabi/kajabi-products/pull/20137) removed unnecessary properties in use related to this update.

