### PR TITLE
Stat Box Enhancements

### DIFF
--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -7,11 +7,37 @@
   },
   data: "1,342",
   has_data: true,
+  
   link: {
     href: "#",
     value: "View More",
   },
   timeframe: "in last 30 days",
+  title: "Completed",
+} %>
+
+<h3 class="t-sage-heading-6">Default with Data - Raised</h3>
+<%= sage_component SageStatBox, {
+  change: { 
+    type: "positive", 
+    value: "30%", 
+  },
+  data: "1,342",
+  has_data: true,
+  link: {
+    href: "#",
+    value: "View More",
+  },
+  raised: true,
+  timeframe: "in last 30 days",
+  title: "Completed",
+} %>
+
+<h3 class="t-sage-heading-6">Simple with Image</h3>
+<%= sage_component SageStatBox, {
+  data: "No insights to show",
+  has_data: false,
+  image: image_tag("https://via.placeholder.com/150", alt: "Example"),
   title: "Completed",
 } %>
 

--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -16,7 +16,24 @@
   title: "Completed",
 } %>
 
-<h3 class="t-sage-heading-6">Default with Data - Legend Dot</h3>
+<h3 class="t-sage-heading-6">Default with Legend Dot - Sage Color</h3>
+<%= sage_component SageStatBox, {
+  change: { 
+    type: "positive", 
+    value: "30%", 
+  },
+  data: "1,342",
+  has_data: true,
+  legend_dot_color: "purple",
+  link: {
+    href: "#",
+    value: "View More",
+  },
+  timeframe: "in last 30 days",
+  title: "Completed",
+} %>
+
+<h3 class="t-sage-heading-6">Default with Legend Dot - Custom Color</h3>
 <%= sage_component SageStatBox, {
   change: { 
     type: "positive", 
@@ -54,7 +71,9 @@
 <%= sage_component SageStatBox, {
   data: "No insights to show",
   has_data: false,
-  image: image_tag("https://via.placeholder.com/150", alt: "Example"),
+  image: {
+    src: "card-placeholder-sm.png"
+  },
   title: "Completed",
 } %>
 

--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -16,6 +16,23 @@
   title: "Completed",
 } %>
 
+<h3 class="t-sage-heading-6">Default with Data - Legend Dot</h3>
+<%= sage_component SageStatBox, {
+  change: { 
+    type: "positive", 
+    value: "30%", 
+  },
+  data: "1,342",
+  has_data: true,
+  legend_dot_custom_color: "#4fc9c5",
+  link: {
+    href: "#",
+    value: "View More",
+  },
+  timeframe: "in last 30 days",
+  title: "Completed",
+} %>
+
 <h3 class="t-sage-heading-6">Default with Data - Raised</h3>
 <%= sage_component SageStatBox, {
   change: { 

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= md('`change`') %></td>
-  <td><%= md('Sets the `type` and `value` properties for the label.') %></td>
+  <td><%= md('Optional. Sets the `type` and `value` properties for the label.') %></td>
   <td><%= md('```
   {
     type: "positive, negative, neutral",
@@ -11,25 +11,25 @@
 </tr>
 <tr>
   <td><%= md('`custom_label`') %></td>
-  <td><%= md('Optional custom label or content.') %></td>
+  <td><%= md('Optional. Custom label or content.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`data`') %></td>
-  <td><%= md('Numeric data displayed.') %></td>
+  <td><%= md('Required. Numeric data displayed.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`has_data`') %></td>
-  <td><%= md('Boolean that determines styling for `data`.') %></td>
+  <td><%= md('Optional. Boolean that determines styling for `data`.') %></td>
   <td><%= md('Bool') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`link`') %></td>
-  <td><%= md('Sets the `href` and `value` properties for the link.') %></td>
+  <td><%= md('Optional. Sets the `href` and `value` properties for a given link.') %></td>
   <td><%= md('```
   {
     href: String,
@@ -39,20 +39,26 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`raised`') %></td>
+  <td><%= md('Optional. Sets "raised panel" styling.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`popover`') %></td>
+  <td><%= md('Optional. Slot for popover or custom content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`timeframe`') %></td>
-  <td><%= md('Optional timeframe for data.') %></td>
+  <td><%= md('Optional. Timeframe for data.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`title`') %></td>
-  <td><%= md('Text displayed as the title.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
-  <td><%= md('`popover`') %></td>
-  <td><%= md('Optional slot for popover or custom content.') %></td>
+  <td><%= md('Required. Text displayed as the title.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -17,7 +17,7 @@
 </tr>
 <tr>
   <td><%= md('`data`') %></td>
-  <td><%= md('Required. Numeric data displayed.') %></td>
+  <td><%= md('**Required.** Numeric data displayed.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -25,6 +25,18 @@
   <td><%= md('`has_data`') %></td>
   <td><%= md('Optional. Boolean that determines styling for `data`.') %></td>
   <td><%= md('Bool') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`legend_dot_color`') %></td>
+  <td><%= md('Optional. Show Legend dot with preset Sage system colors.') %></td>
+  <td><%= md('Sage system colors') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`legend_dot_custom_color`') %></td>
+  <td><%= md('Optional. Show Legend dot with any custom color.') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -58,7 +70,7 @@
 </tr>
 <tr>
   <td><%= md('`title`') %></td>
-  <td><%= md('Required. Text displayed as the title.') %></td>
+  <td><%= md('**Required**. Text displayed as the title.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -28,6 +28,17 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`image`') %></td>
+  <td><%= md('Optional. Shows image to the left of data.') %></td>
+  <td><%= md('```
+  {
+    alt: String (optional)
+    value: String
+  }
+  ```') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`legend_dot_color`') %></td>
   <td><%= md('Optional. Show Legend dot with preset Sage system colors.') %></td>
   <td><%= md('Sage system colors') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -7,7 +7,10 @@ class SageStatBox < SageComponent
     }],
     data: String,
     has_data: [:optional, TrueClass],
-    image: [:optional, String],
+    image: [:optional, {
+      alt: [:optional, String],
+      src: String
+    }],
     legend_dot_color: [:optional, SageSchemas::COLORS],
     legend_dot_custom_color: [:optional, String],
     link: [:optional, {

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -3,18 +3,20 @@ class SageStatBox < SageComponent
     custom_label: [:optional, NilClass, String],
     change: [:optional, {
       type: Set.new(["positive", "negative", "neutral"]),
-      value: String,
+      value: String
     }],
     data: String,
     has_data: [:optional, TrueClass],
     image: [:optional, String],
+    legend_dot_color: [:optional, SageSchemas::COLORS],
+    legend_dot_custom_color: [:optional, String],
     link: [:optional, {
       href: String,
-      value: String,
+      value: String
     }],
     raised: [:optional, TrueClass],
     timeframe: [:optional, String],
     title: String,
-    popover: [:optional, String],
+    popover: [:optional, String]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -7,10 +7,12 @@ class SageStatBox < SageComponent
     }],
     data: String,
     has_data: [:optional, TrueClass],
+    image: [:optional, String],
     link: [:optional, {
       href: String,
       value: String,
     }],
+    raised: [:optional, TrueClass],
     timeframe: [:optional, String],
     title: String,
     popover: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -21,12 +21,13 @@ color = false
 <article
   class="sage-stat-box
   <%= "sage-stat-box--raised" if component.raised %>
+  <%= "sage-stat-box--with-img" if component.image %>
   <%= component.generated_css_classes %>"
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.image.present? %>
-    <div class="sage-stat-box__image">
-      <%= component.image.html_safe %>
+    <div class="sage-stat-box__img">
+      <%= image_tag component.image[:src], alt: component.image[:alt] %>
     </div>
   <% end %>
   <header class="sage-stat-box__header">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -12,10 +12,6 @@ elsif change_type == "neutral"
   label_configs = { color: "draft", value: change_value, }
 end
 
-# Set up default color
-color = false
-
-
 %>
 
 <article

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -11,7 +11,13 @@ elsif change_type == "negative"
 elsif change_type == "neutral"
   label_configs = { color: "draft", value: change_value, }
 end
+
+# Set up default color
+color = false
+
+
 %>
+
 <article
   class="sage-stat-box
   <%= "sage-stat-box--raised" if component.raised %>
@@ -24,7 +30,18 @@ end
     </div>
   <% end %>
   <header class="sage-stat-box__header">
-    <h2 class="sage-stat-box__title"><%= component.title %></h2>
+    <h2 
+      class="
+        sage-stat-box__title
+        <%= "sage-stat-box__title--legend-#{component.legend_dot_color}" if component.legend_dot_color %>
+        <%= "sage-stat-box__title--legend-custom" if component.legend_dot_custom_color %>
+      "
+      <% if component.legend_dot_custom_color.present? %>
+        style="--legend-color: <%= component.legend_dot_custom_color %>"
+      <% end %>
+    >
+      <%= component.title %>
+    </h2>
     <% if component.popover.present? %>
       <%= component.popover.html_safe %>
     <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -23,7 +23,7 @@ end
 >
   <% if component.image.present? %>
     <div class="sage-stat-box__img">
-      <%= image_tag component.image[:src], alt: component.image[:alt] %>
+      <%= image_tag component.image[:src], alt: component.image[:alt] or '' %>
     </div>
   <% end %>
   <header class="sage-stat-box__header">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -23,7 +23,7 @@ end
 >
   <% if component.image.present? %>
     <div class="sage-stat-box__img">
-      <%= image_tag component.image[:src], alt: component.image[:alt] or '' %>
+      <%= image_tag component.image[:src], alt: component.image[:alt].present? ? component.image[:alt] : '' %>
     </div>
   <% end %>
   <header class="sage-stat-box__header">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -13,9 +13,16 @@ elsif change_type == "neutral"
 end
 %>
 <article
-  class="sage-stat-box <%= component.generated_css_classes %>"
+  class="sage-stat-box
+  <%= "sage-stat-box--raised" if component.raised %>
+  <%= component.generated_css_classes %>"
   <%= component.generated_html_attributes.html_safe %>
 >
+  <% if component.image.present? %>
+    <div class="sage-stat-box__image">
+      <%= component.image.html_safe %>
+    </div>
+  <% end %>
   <header class="sage-stat-box__header">
     <h2 class="sage-stat-box__title"><%= component.title %></h2>
     <% if component.popover.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -23,7 +23,8 @@
 }
 
 .sage-stat-box__header,
-.sage-stat-box__link {
+.sage-stat-box__link,
+.sage-stat-box__title {
   display: flex;
   align-items: center;
 }
@@ -36,6 +37,34 @@
 .sage-stat-box__title {
   @extend %t-sage-body-small-med;
   margin-right: sage-spacing(xs);
+}
+
+.sage-stat-box__title--legend-custom {
+  &::before {
+    content: "";
+    display: block;
+    width: rem(8px);
+    height: rem(8px);
+    margin-right: sage-spacing(xs);
+    border-radius: sage-border(radius);
+    background-color: var(--legend-color);
+  }
+}
+
+@each $-color-name, $-color-sliders in $sage-colors {
+  .sage-stat-box__title--legend-#{"" + $-color-name} {
+    --legend-color: #{sage-color($-color-name)};
+
+    &::before {
+      content: "";
+      display: block;
+      width: rem(8px);
+      height: rem(8px);
+      margin-right: sage-spacing(xs);
+      border-radius: sage-border(radius);
+      background-color: var(--legend-color);
+    }
+  }
 }
 
 .sage-stat-box__data {
@@ -55,3 +84,5 @@
   @extend %t-sage-body-med;
   margin-top: sage-spacing(xs);
 }
+
+

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -9,6 +9,11 @@
   @include sage-card($grid: false);
 }
 
+.sage-stat-box--raised {
+  box-shadow: sage-shadow(sm);
+  border: 0;
+}
+
 .sage-stat-box__body,
 .sage-stat-box__footer {
   @include sage-grid-card-row;

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -37,6 +37,7 @@ $-stat-box-image-max-width: rem(48px);
     transform: translateY(-50%);
     top: 50%;
     width: 100%;
+    border-radius: sage-border(radius);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -4,14 +4,52 @@
 /// @group sage
 ////
 
+$-stat-box-image-max-width: rem(48px);
+
 .sage-stat-box {
   // Styles here
   @include sage-card($grid: false);
+
+  &.sage-stat-box--raised {
+    box-shadow: sage-shadow(sm);
+    border: 0;
+  }
+
+  &.sage-stat-box--with-img {
+    display: grid;
+
+    grid-template-areas: 
+      "image header header"
+      "image body body";
+    grid-template-columns: $-stat-box-image-max-width 1fr;
+  }
 }
 
-.sage-stat-box--raised {
-  box-shadow: sage-shadow(sm);
-  border: 0;
+.sage-stat-box__img {
+  position: relative;
+  grid-area: image;
+  overflow: hidden;
+  min-height: $-stat-box-image-max-width;
+  margin-right: sage-spacing(xs);
+
+  img {
+    position: absolute;
+    transform: translateY(-50%);
+    top: 50%;
+    width: 100%;
+  }
+}
+
+.sage-stat-box__header {
+  grid-area: header;
+}
+
+.sage-stat-box__body {
+  grid-area: body;
+}
+
+.sage-stat-box__footer {
+  grid-area: footer;
 }
 
 .sage-stat-box__body,
@@ -39,7 +77,7 @@
   margin-right: sage-spacing(xs);
 }
 
-.sage-stat-box__title--legend-custom {
+[class*="sage-stat-box__title--legend"] {
   &::before {
     content: "";
     display: block;
@@ -54,16 +92,6 @@
 @each $-color-name, $-color-sliders in $sage-colors {
   .sage-stat-box__title--legend-#{"" + $-color-name} {
     --legend-color: #{sage-color($-color-name)};
-
-    &::before {
-      content: "";
-      display: block;
-      width: rem(8px);
-      height: rem(8px);
-      margin-right: sage-spacing(xs);
-      border-radius: sage-border(radius);
-      background-color: var(--legend-color);
-    }
   }
 }
 
@@ -84,5 +112,3 @@
   @extend %t-sage-body-med;
   margin-top: sage-spacing(xs);
 }
-
-

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -1,21 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { SageTokens } from '../configs';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { Label } from '../Label';
-import { LABEL_COLORS, TYPE } from './configs'; // component configurations as needed
+import { LABEL_COLORS, LEGEND_COLORS, TYPE } from './configs'; // component configurations as needed
 
 export const StatBox = ({
   customLabel,
   change,
   data,
   hasData,
+  image,
+  legendDotColor,
+  legendDotCustomColor,
   link,
   popover,
+  raised,
   timeframe,
   title,
 }) => {
+  const statBoxContainer = classnames(
+    'sage-stat-box',
+    {
+      'sage-stat-box--raised': raised,
+      'sage-stat-box--with-img': image,
+    }
+  );
+  const statBoxTitle = classnames(
+    'sage-stat-box__title',
+    {
+      [`sage-stat-box__title--legend-${legendDotColor}`]: legendDotColor,
+      'sage-stat-box__title--legend-custom': legendDotCustomColor,
+    }
+  );
   const renderLabelStatus = () => {
     let icon = null;
     let color;
@@ -40,9 +59,23 @@ export const StatBox = ({
   };
 
   return (
-    <article className="sage-stat-box">
+    <article
+      className={statBoxContainer}
+    >
+      {image && (
+        <div className="sage-stat-box__img">
+          <img src={image.src} alt={image.alt} />
+        </div>
+      )}
       <header className="sage-stat-box__header">
-        <h2 className="sage-stat-box__title">{title}</h2>
+        <h2
+          className={statBoxTitle}
+          style={(legendDotCustomColor && legendDotCustomColor !== '') && ({
+            '--legend-color': legendDotCustomColor
+          })}
+        >
+          {title}
+        </h2>
         {popover}
       </header>
       <div className="sage-stat-box__body sage-grid-template-te">
@@ -73,6 +106,7 @@ export const StatBox = ({
 };
 
 StatBox.LABEL_COLORS = LABEL_COLORS;
+StatBox.LEGEND_COLORS = LEGEND_COLORS;
 StatBox.TYPE = TYPE;
 
 StatBox.defaultProps = {
@@ -82,11 +116,18 @@ StatBox.defaultProps = {
   },
   customLabel: null,
   hasData: true,
+  image: {
+    alt: null,
+    src: null
+  },
+  legendDotColor: null,
+  legendDotCustomColor: null,
   link: {
     href: null,
     value: null,
   },
   popover: null,
+  raised: false,
   timeframe: null,
 };
 
@@ -98,11 +139,18 @@ StatBox.propTypes = {
   customLabel: PropTypes.node,
   data: PropTypes.string.isRequired,
   hasData: PropTypes.bool,
+  image: PropTypes.shape({
+    alt: PropTypes.string,
+    src: PropTypes.string
+  }),
+  legendDotColor: PropTypes.oneOf(['charcoal', 'grey', 'orange', 'primary', 'purple', 'red', 'sage', 'yellow']),
+  legendDotCustomColor: PropTypes.string,
   link: PropTypes.shape({
     href: PropTypes.string,
     value: PropTypes.string,
   }),
   popover: PropTypes.node,
+  raised: PropTypes.bool,
   timeframe: PropTypes.string,
   title: PropTypes.string.isRequired,
 };

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -64,7 +64,7 @@ export const StatBox = ({
     >
       {image && (
         <div className="sage-stat-box__img">
-          <img src={image.src} alt={image.alt} />
+          <img src={image.src} alt={image.alt || ''} />
         </div>
       )}
       <header className="sage-stat-box__header">
@@ -143,7 +143,7 @@ StatBox.propTypes = {
     alt: PropTypes.string,
     src: PropTypes.string
   }),
-  legendDotColor: PropTypes.oneOf(['charcoal', 'grey', 'orange', 'primary', 'purple', 'red', 'sage', 'yellow']),
+  legendDotColor: PropTypes.oneOf(Object.values(StatBox.LEGEND_COLORS)),
   legendDotCustomColor: PropTypes.string,
   link: PropTypes.shape({
     href: PropTypes.string,

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -15,6 +15,7 @@ Default.args = {
     value: '38%',
   },
   data: '4,010',
+  image: null,
   link: {
     value: 'View More',
     href: '#'
@@ -23,11 +24,75 @@ Default.args = {
   title: 'In Progress'
 };
 
+export const DefaultWithSageColorLegendDot = Template.bind({});
+DefaultWithSageColorLegendDot.args = {
+  change: {
+    type: StatBox.TYPE.POSITIVE,
+    value: '38%',
+  },
+  data: '4,010',
+  image: null,
+  legendDotColor: StatBox.LEGEND_COLORS.PRIMARY,
+  link: {
+    value: 'View More',
+    href: '#'
+  },
+  timeframe: 'in last 30 days',
+  title: 'In Progress'
+};
+
+export const DefaultWithSageCustomColorLegendDot = Template.bind({});
+DefaultWithSageCustomColorLegendDot.args = {
+  change: {
+    type: StatBox.TYPE.POSITIVE,
+    value: '42%',
+  },
+  data: '242',
+  image: null,
+  legendDotCustomColor: '#cf23a9',
+  link: {
+    value: 'View More',
+    href: '#'
+  },
+  timeframe: 'in last 30 days',
+  title: 'In Progress'
+};
+
+export const DefaultRaised = Template.bind({});
+DefaultRaised.args = {
+  change: {
+    type: StatBox.TYPE.POSITIVE,
+    value: '76%',
+  },
+  data: '309',
+  image: null,
+  link: {
+    value: 'View More',
+    href: '#'
+  },
+  raised: true,
+  timeframe: 'in last 30 days',
+  title: 'In Progress'
+};
+
+export const SimpleWithImage = Template.bind({});
+SimpleWithImage.args = {
+  change: null,
+  data: '1,000',
+  image: {
+    alt: 'Example',
+    src: 'https://via.placeholder.com/150'
+  },
+  link: null,
+  title: 'Title'
+};
+
 export const NullView = Template.bind({});
 NullView.args = {
   change: null,
   data: 'No insights to show',
   hasData: false,
+  image: null,
   link: null,
   title: 'In Progress'
 };

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import { selectArgs } from '../story-support/helpers';
 import { StatBox } from './StatBox';
 
 export default {
   title: 'Sage/StatBox',
   component: StatBox,
+  argTypes: {
+    ...selectArgs({
+      legendDotColor: StatBox.LEGEND_COLORS,
+    }),
+  }
 };
 const Template = (args) => <StatBox {...args} />;
 

--- a/packages/sage-react/lib/StatBox/configs.js
+++ b/packages/sage-react/lib/StatBox/configs.js
@@ -4,6 +4,17 @@ export const LABEL_COLORS = {
   DANGER: 'danger',
 };
 
+export const LEGEND_COLORS = {
+  CHARCOAL: 'charcoal',
+  GREY: 'grey',
+  ORANGE: 'orange',
+  PRIMARY: 'primary',
+  PURPLE: 'purple',
+  RED: 'red',
+  SAGE: 'sage',
+  YELLOW: 'yellow'
+};
+
 export const TYPE = {
   DEFAULT: 'neutral',
   NEGATIVE: 'negative',


### PR DESCRIPTION
## Description
Adds new features to Stat Box component including:
- Optional image
- Optional chart legend dot with Sage or custom colors
- Optional "raised" panel styling


## Screenshots
### Legend Dot, Sage Colors
<img width="400" alt="Screen Shot 2021-08-03 at 3 18 21 PM" src="https://user-images.githubusercontent.com/14791307/128080594-808c7091-dbab-4254-a1be-12029c48c451.png">

### Legend Dot, Custom Colors
<img width="405" alt="Screen Shot 2021-08-03 at 3 18 33 PM" src="https://user-images.githubusercontent.com/14791307/128080671-0bc57530-9e68-4b86-be51-bb11913c8112.png">

### Raised Panel style
<img width="400" alt="Screen Shot 2021-08-03 at 3 18 40 PM" src="https://user-images.githubusercontent.com/14791307/128080705-e897b881-dd5e-48e0-9c05-75d0fc6f1a66.png">

### Stat Box with Image
<img width="403" alt="Screen Shot 2021-08-03 at 3 18 46 PM" src="https://user-images.githubusercontent.com/14791307/128080739-9053e6b2-8afd-4d7b-8746-fdba7aeea5b7.png">


## Testing in `sage-lib`
### Rails
- View [Rails component](http://localhost:4000/pages/component/stat_box)
- Check that component UI exists and new attributes are not broken

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-statbox--default)
- Check that component UI exists and new attributes are not broken


## Testing in `kajabi-products`
(LOW) Introduces new stat box attributes for raised styling, images, and colored legend dot attributes. No breaking changes.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
#547
#526
[MAN-1798](https://kajabi.atlassian.net/browse/MAN-1798)