### PR TITLE
Ensure expandable card is hidden by default

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -31,7 +31,10 @@ class SageComponent
     context.render(
       partial: "sage_components/#{template_path}",
       locals: { component: self }
-    ).tap { cleanup_section_vars }
+    )
+    .tap { cleanup_section_vars }
+    .squish
+    .html_safe
   end
 
   # SageComponent Universal Spacer Attribute

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -20,7 +20,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
   padding: 0;
   
   [aria-expanded="true"] + & {
-    overflow: auto;
+    overflow: initial;
     height: auto;
     margin-top: sage-spacing(xs);
   }

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -14,16 +14,15 @@ $-expandable-card-padding-xs: sage-spacing(xs);
 
 .sage-expandable-card__body,
 .sage-expandable-card__body-bordered {
-  margin-top: sage-spacing(xs);
-
-  [aria-expanded="false"] + & {
-    height: 0;
-    margin: 0;
-    padding: 0;
-  }
-
+  overflow: hidden;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  
   [aria-expanded="true"] + & {
+    overflow: auto;
     height: auto;
+    margin-top: sage-spacing(xs);
   }
 
   > :last-child {
@@ -34,6 +33,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
 .sage-expandable-card__body-bordered {
   padding-left: $-expandable-card-padding;
   padding-right: $-expandable-card-padding;
+
   [aria-expanded="true"] + & {
     padding-top: $-expandable-card-padding;
     padding-bottom: $-expandable-card-padding;
@@ -52,6 +52,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
     font-size: rem(8px);
     transition: transform 0.2s linear;
   }
+
   &[aria-expanded="true"]::before {
     transform: rotateZ(90deg);
   }


### PR DESCRIPTION
Closes #682 

## Description

Expandable card flashes content when page loads. This PR tightens how the card is hidden to ensure it stays securely hidden by default until `aria-expanded="true"` is toggled on via JS:

- remove `aria-expanded="false"` filter to aid default appearance
- add `overflow: hidden` to aid hiding when `aria-hidden="true"` is not activated.


## Testing in `sage-lib`

Validate that Components > ExpandableCard still appears hidden by default until actiavated.

## Testing in `kajabi-products`

1. (LOW) Fixes a bug in Expandable Card to ensure it does not flash on page load before hiding. Note: Undo this patch after this version bump: https://github.com/Kajabi/kajabi-products/pull/20205


