### PR TITLE
Clickable media tiles

### DIFF
--- a/docs/app/views/examples/components/media_tile/_preview.html.erb
+++ b/docs/app/views/examples/components/media_tile/_preview.html.erb
@@ -44,7 +44,7 @@ panels = [
     caption: %(
       <p>Suspendisse eu tellus quis arcu sagittis semper</p>
     ),
-    media: %(<img src="//source.unsplash.com/gkJCCn1hZDk/600x400?2" />),
+    media: %(<img src="//source.unsplash.com/gkJCCn1hZDk/600x400?2" alt="Image of Product Cadabra" />),
     title: "Product Cadabra",
   },
   {
@@ -56,7 +56,7 @@ panels = [
     caption: %(
       <p>Maecenas vitae leo eu tellus efficitur viverra sit amet ut tortor vestibulum</p>
     ),
-    media: %(<img src="//source.unsplash.com/3lqEqS1s7mw/600x400?3" />),
+    media: %(<img src="//source.unsplash.com/3lqEqS1s7mw/600x400?3" alt="Image of Product Jimminycricket" />),
     title: "Product Jimminycricket",
   },
 ]

--- a/docs/app/views/examples/components/media_tile/_preview.html.erb
+++ b/docs/app/views/examples/components/media_tile/_preview.html.erb
@@ -108,17 +108,26 @@ While typically a part of this component, the `media` area is also optional.
 - Dropdown next to the title through `actions_dropdown_items`
 - Additional action buttons/links in the `footer`
 
+NOTE: the examples below omit `media` but this can safely be used as well with these actions affordances.
+
 ', use_sage_type: true) %>
 
 <%= sage_component SageMediaTiles, {
   items: [
     {
       title: "Plain and simple",
+      title_tag: "h1",
       body: md("Tiles do not have to include an actions area if they're not needed."),
     },
     {
+      title: "Clickable Tile",
+      body: md('As tiles may often be desired as an entire clickable element, the `tile_link` can be provided with link configurations to enable this functionality.'),
+      tile_link: { href: "#" },
+    },
+    {
       title: "Actions dropdown",
-      body: md('Since an "options" dropdown is common, you can easily pass a list of items to this default slot.'),
+      body: md('Since an "options" dropdown is common, you can easily pass a list of items to this default slot.
+      This can be used in combinaton with `tile_link` or independently as desired.'),
       actions_dropdown_items: common_actions_dropdown_items,
       tile_link: { href: "#" },
     },

--- a/docs/app/views/examples/components/media_tile/_preview.html.erb
+++ b/docs/app/views/examples/components/media_tile/_preview.html.erb
@@ -63,7 +63,7 @@ panels = [
 %>
 <%= md('
 NOTE: While `MediaTile` (singular) can be used on its own, it will commonly be implemented in a set.
-Therefore, the `MediaTiles` (plural) component is used in examples here.
+Therefore, the `MediaTiles` (plural) component is used these initial examples.
 ', use_sage_type: true) %>
 
 <h3>Basic Tiles</h3>
@@ -138,6 +138,46 @@ NOTE: the examples below omit `media` but this can safely be used as well with t
     }
   ]
 } %>
+
+<h3>Standalone/Kitchen Sink Example</h3>
+<%= md('Previous examples have shown tiles in sets. Below is an example of a standalone tile that makes use of the compositional sections more explicitly.', use_sage_type: true) %>
+<%= sage_component SageMediaTile, {
+  media_configs: {
+    aspect_ratio: 0.89,
+    padded: true,
+    background_color: SageTokens::COLOR_PALETTE[:SAGE_100],
+  },
+  tile_link: {
+    href: "#",
+    "data-js-modaltoggle": "pretend-modal",
+  },
+  title: "TITLE Kitchen Sink Example",
+  title_tag: "h2",
+} do %>
+  <%= content_for :sage_media_tile_media do %>
+    <img src="//source.unsplash.com/Ssj4uWXcvS4/600x400?1" alt="MEDIA Image of Product Abra" />
+  <% end %>
+  <%= content_for :sage_media_tile_actions_custom do %>
+    <%= sage_component SageLabel, { value: "CUSTOM Draft", color: "draft" } %>
+  <% end %>
+  <%= content_for :sage_media_tile_body do %>
+    <p>
+      BODY Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Etiam rhoncus aliquam odio.
+    </p>
+  <% end %>
+  <%= content_for :sage_media_tile_caption do %>
+    <p>CAPTION Vivamus dictum rutrum dui, nec placerat ante</p>
+  <% end %>
+  <%= content_for :sage_media_tile_footer do %>
+    <%= sage_component SageButton, {
+      value: "FOOTER More",
+      icon: { name: "arrow-right", style: "right" },
+      subtle: true,
+      style: "primary",
+    } %>
+  <% end %>
+<% end %>
 
 <h3>Other Settings for Media</h3>
 <%= md("

--- a/docs/app/views/examples/components/media_tile/_preview.html.erb
+++ b/docs/app/views/examples/components/media_tile/_preview.html.erb
@@ -14,18 +14,6 @@ common_actions_dropdown_items = [
   }
 ]
 
-common_additional_actions_custom = sage_component(SageButton, {
-  value: "Preview",
-  icon: { name: "preview-on", style: "only" },
-  subtle: true,
-  style: "secondary",
-}) << sage_component(SageButton, {
-  value: "Edit",
-  icon: { name: "pen", style: "only" },
-  subtle: true,
-  style: "secondary",
-})
-
 common_footer = sage_component(SageButton, {
   value: "More",
   icon: { name: "arrow-right", style: "right" },
@@ -92,7 +80,7 @@ While typically a part of this component, the `media` area is also optional.
       caption: panels[0][:caption],
       media: panels[0][:media],
       actions_dropdown_items: common_actions_dropdown_items,
-      footer: common_footer,
+      tile_link: { href: "#tile-link" }
     },
     {
       title: panels[1][:title],
@@ -100,7 +88,7 @@ While typically a part of this component, the `media` area is also optional.
       caption: panels[1][:caption],
       media: panels[1][:media],
       actions_dropdown_items: common_actions_dropdown_items,
-      footer: common_footer,
+      tile_link: { href: "#tile-link" }
     },
     {
       title: panels[2][:title],
@@ -108,29 +96,35 @@ While typically a part of this component, the `media` area is also optional.
       caption: panels[2][:caption],
       media: panels[2][:media],
       actions_dropdown_items: common_actions_dropdown_items,
-      footer: common_footer,
+      tile_link: { href: "#tile-link" }
     }
   ]
 } %>
 
 <h3>Actions</h3>
+<%= md('Tiles can include the following actionable features:
+
+- A primary action that makes the whole tile clickable through `tile_link`
+- Dropdown next to the title through `actions_dropdown_items`
+- Additional action buttons/links in the `footer`
+
+', use_sage_type: true) %>
+
 <%= sage_component SageMediaTiles, {
   items: [
     {
       title: "Plain and simple",
-      body: md('Tiles do not have to include an actions area if its not needed.'),
-      footer: common_footer,
+      body: md("Tiles do not have to include an actions area if they're not needed."),
     },
     {
       title: "Actions dropdown",
       body: md('Since an "options" dropdown is common, you can easily pass a list of items to this default slot.'),
       actions_dropdown_items: common_actions_dropdown_items,
-      footer: common_footer,
+      tile_link: { href: "#" },
     },
     {
       title: "Custom actions",
-      body: md('Additional actions can be provided in lieu of or even in combination with the default dropdown.'),
-      actions_custom: common_additional_actions_custom,
+      body: md('In lieu of a whole clickable tile, additional actions can be provided as links in the footer area.'),
       footer: common_footer,
     }
   ]

--- a/docs/app/views/examples/components/media_tile/_props.html.erb
+++ b/docs/app/views/examples/components/media_tile/_props.html.erb
@@ -74,6 +74,38 @@
   <td><%= md('One of `h1` through `h6`') %></td>
   <td><%= md('`h3`') %></td>
 </tr>
+
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_media_tile_media`') %></td>
+  <td><%= md('Provides the HTML content for the media area at the top of the tile; same purpose as the `media` property.') %></td>
+  <td colspan="2"><%= md('Any; typically images or video embeds.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_media_tile_actions_custom`') %></td>
+  <td><%= md('Provides the HTML content for a custom set of actions or other content that is placed to the right of the title; same purpose as the `acttions_custom` property.') %></td>
+  <td colspan="2"><%= md('Any; typically `SageButton` or `SageLabel`.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_media_tile_body`') %></td>
+  <td><%= md('Provides HTML content for the main body copy area; same purpose as the `body` property.') %></td>
+  <td colspan="2"><%= md('Any; formatted as HTML.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_media_tile_caption`') %></td>
+  <td><%= md('Provides HTML content for the smaller "caption" copy area below the `body`; same purpose as the `caption` property.') %></td>
+  <td colspan="2"><%= md('Any; formatted as HTML.') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_media_tile_footer`') %></td>
+  <td><%= md('Provides HTML content for the very bottom portion of the tile that is also aligned to the bottom consistently when tiles are stretched; same purpose as the `caption` property.') %></td>
+  <td colspan="2"><%= md('Any; typically `SageButton` or `SageLink`.') %></td>
+</tr>
+
+
 <tr>
   <td colspan="4">
     <strong>MediaTiles</strong>

--- a/docs/app/views/examples/components/media_tile/_props.html.erb
+++ b/docs/app/views/examples/components/media_tile/_props.html.erb
@@ -58,7 +58,7 @@
 <tr>
   <td><%= md('`tile_link`') %></td>
   <td><%= md('Provide a primary action link configuration that makes the whole tile clickable.
-  Similar to `attributes` on `SageButton`, this is a Hash that can contain ant HTML attribute desired for this link.') %></td>
+  Similar to `attributes` on `SageButton`, this is a Hash that can contain any HTML attribute desired for this link.') %></td>
   <td><%= md('`Hash`') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/media_tile/_props.html.erb
+++ b/docs/app/views/examples/components/media_tile/_props.html.erb
@@ -69,6 +69,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`title_tag`') %></td>
+  <td><%= md('Sets which HTML heading tag to use on the title.') %></td>
+  <td><%= md('One of `h1` through `h6`') %></td>
+  <td><%= md('`h3`') %></td>
+</tr>
+<tr>
   <td colspan="4">
     <strong>MediaTiles</strong>
   </td>

--- a/docs/app/views/examples/components/media_tile/_props.html.erb
+++ b/docs/app/views/examples/components/media_tile/_props.html.erb
@@ -14,6 +14,7 @@
 <tr>
   <td><%= md('`actions_custom`') %></td>
   <td><%= md('Provide any items you want to appear to the right of the title in an actions_custom slot.
+  NOTE: It is preferrable to use the `actions_dropdown_items` to contain interactive features.
   Alternatively, compose this using a `content_for :sage_media_tile_actions_custom` block.') %></td>
   <td><%= md('String  | HTML Content') %></td>
   <td><%= md('`nil`') %></td>
@@ -52,6 +53,13 @@
   <td><%= md('`media_configs`') %></td>
   <td><%= md('Allows for a set of configurations for the media figure that plays a prominent role in this tiling component.') %></td>
   <td><%= md("See schema for [Panel Figure](#{pages_component_path(:panel_figure)})") %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`tile_link`') %></td>
+  <td><%= md('Provide a primary action link configuration that makes the whole tile clickable.
+  Similar to `attributes` on `SageButton`, this is a Hash that can contain ant HTML attribute desired for this link.') %></td>
+  <td><%= md('`Hash`') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/components/media_tile/_rules_do.html.erb
+++ b/docs/app/views/examples/components/media_tile/_rules_do.html.erb
@@ -1,5 +1,3 @@
-<!-- Uncomment when in use.
 <ul>
-  <li>Rules for what you should do with this component go here.</li>
+  <li>Keep interactive features simple.</li>
 </ul>
--->

--- a/docs/app/views/examples/components/media_tile/_rules_dont.html.erb
+++ b/docs/app/views/examples/components/media_tile/_rules_dont.html.erb
@@ -1,5 +1,3 @@
-<!-- Uncomment when in use.
 <ul>
-  <li>Rules for what you should not do with this component go here.</li>
+  <li><%= md('Use `tile_link` and actions in the `footer`; only use one or the other.') %></li>
 </ul>
--->

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -75,6 +75,7 @@ module SageSchemas
     media_configs: [:optional, NilClass, SageSchemas::PANEL_FIGURE],
     tile_link: [:optional, NilClass, Hash],
     title: [:optional, NilClass, String],
+    title_tag: [:optional, NilClass, Set.new(["h1", "h2", "h3", "h4", "h5", "h5", "h6"])],
   }
 
   TAB = {

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -73,6 +73,7 @@ module SageSchemas
     footer: [:optional, NilClass, String],
     media: [:optional, NilClass, String],
     media_configs: [:optional, NilClass, SageSchemas::PANEL_FIGURE],
+    tile_link: [:optional, NilClass, Hash],
     title: [:optional, NilClass, String],
   }
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_media_tile.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_media_tile.html.erb
@@ -16,7 +16,6 @@ end
   spacer: component.spacer,
   test_id: component.test_id,
 } do %>
-<%= @preset_aspect_ratio %>
   <%= sage_component SagePanelFigure, {
     aspect_ratio: media_aspect_ratio,
     bleed: "top",

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_media_tile.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_media_tile.html.erb
@@ -3,6 +3,7 @@ is_interactive = component.tile_link.present? ? true : false
 media_aspect_ratio = nil
 media_background_color = nil
 media_padded = false
+title_tag = component.title_tag.present? ? component.title_tag : 'h3'
 if component.media_configs.present?
   media_aspect_ratio = component.media_configs[:aspect_ratio].present? ? component.media_configs[:aspect_ratio] : media_aspect_ratio
   media_background_color = component.media_configs[:background_color].present? ? component.media_configs[:background_color] : media_background_color
@@ -31,7 +32,7 @@ end
     css_classes: "sage-media-tile__content",
   } do %>
     <%= sage_component SagePanelRow, { css_classes: "sage-media-tile__header" } do %>
-      <h3 class="sage-media-tile__title">
+      <<%= title_tag %> class="sage-media-tile__title">
         <% if component.tile_link.present? %>
           <a
             class="sage-media-tile__link <%= component.tile_link[:class] if component.tile_link[:class] %>"
@@ -44,7 +45,7 @@ end
         <% else %>
           <%= component.title %>
         <% end %>
-      </h3>
+      </<%= title_tag %>>
 
       <%= sage_component SageButtonGroup, { gap: :sm } do %>
         <%= content_for :sage_media_tile_actions_custom if content_for? :sage_media_tile_actions_custom %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_media_tile.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_media_tile.html.erb
@@ -1,4 +1,5 @@
 <%
+is_interactive = component.tile_link.present? ? true : false
 media_aspect_ratio = nil
 media_background_color = nil
 media_padded = false
@@ -9,7 +10,7 @@ if component.media_configs.present?
 end
 %>
 <%= sage_component SagePanel, {
-  css_classes: "sage-media-tile #{component.css_classes}",
+  css_classes: "sage-media-tile #{component.css_classes} #{is_interactive ? "sage-media-tile--interactive" : ""}",
   html_attributes: component.html_attributes,
   spacer: component.spacer,
   test_id: component.test_id,
@@ -29,10 +30,22 @@ end
   <%= sage_component SagePanelStack, {
     css_classes: "sage-media-tile__content",
   } do %>
-    <%= sage_component SagePanelHeader, {
-      css_classes: "sage-media-tile__header",
-      title: component.title,
-    } do %>
+    <%= sage_component SagePanelRow, { css_classes: "sage-media-tile__header" } do %>
+      <h3 class="sage-media-tile__title">
+        <% if component.tile_link.present? %>
+          <a
+            class="sage-media-tile__link <%= component.tile_link[:class] if component.tile_link[:class] %>"
+            <% component.tile_link.each do |key, value| %>
+              <%= "#{key}=\"#{value}\"".html_safe if key != "class" %>
+            <% end if component.tile_link&.is_a?(Hash) %>
+          >
+            <%= component.title %>
+          </a>
+        <% else %>
+          <%= component.title %>
+        <% end %>
+      </h3>
+
       <%= sage_component SageButtonGroup, { gap: :sm } do %>
         <%= content_for :sage_media_tile_actions_custom if content_for? :sage_media_tile_actions_custom %>
         <%= component.actions_custom.html_safe if component.actions_custom.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
@@ -85,6 +85,10 @@ $-media-tile-breakpoints: (
   }
 }
 
+.sage-media-tile__title {
+  @extend %t-sage-heading-5;
+}
+
 .sage-media-tile-container {
   @include sage-grid-panel;
 

--- a/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
@@ -14,10 +14,19 @@ $-media-tile-breakpoints: (
 );
 
 .sage-media-tile {
+  position: relative;
   max-width: $-media-tile-max-col-size;
 
   @media (min-width: map-get($-media-tile-breakpoints, 2-col-min)) {
     min-width: $-media-tile-min-col-size;
+  }
+}
+
+.sage-media-tile--interactive {
+  &:hover {
+    box-shadow: sage-shadow(md);
+    transition: map-get($sage-transitions, default);
+    transition-property: box-shadow;
   }
 }
 
@@ -47,6 +56,33 @@ $-media-tile-breakpoints: (
 
 .sage-media-tile__header {
   width: 100%;
+}
+
+.sage-media-tile__link {
+  color: inherit;
+
+  &::after {
+    @include position-full();
+
+    content: "";
+    position: absolute;
+    border: 2px solid transparent;
+    border-radius: sage-border(radius-large);
+    transition: map-get($sage-transitions, default);
+    transition-property: border-color;
+  }
+
+  &:hover {
+    color: inherit;
+  }
+
+  &:focus {
+    outline: 0;
+
+    &::after {
+      border-color: sage-color(primary);
+    }
+  }
 }
 
 .sage-media-tile-container {


### PR DESCRIPTION
## Description

This PR adds `tile_link` property to MediaTiles that allows for the whole tile to become clickable. 

## Testing in `sage-lib`

See Components > MediaTile for new feature preview, props, and rules.

Design Spec forthcoming, draft mode here:


## Testing in `kajabi-products`

1. (LOW) New tile link feature on Media Tiles. No expected change to current uses which include:
   - [ ] Analytics dashboard
   - [ ] Save Email as Template Template Manager
   - [ ] Coaching program list

## Related

Closes #666 
Closes #694 
Closes #692 
Closes #693 