### PR TITLE
Progress Bar min-width fix

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -23,7 +23,6 @@
 
 .sage-progress-bar__value {
   transform-origin: center left;
-  min-width: 5%;
   height: 100%;
   background-color: sage-color(sage, 300);
   border-radius: sage-border(radius-large);


### PR DESCRIPTION
## Description
This PR removes the `min-width` CSS property from the Progress Bar value element as it is displaying small percentage values incorrectly. For example, if the percentage passed in is `0` the bar will always display 5%.

## Screenshots
|  Before  |  After  |
|--------|--------|
|<img width="913" alt="Before" src="https://user-images.githubusercontent.com/7331038/128924559-cf823231-e9af-4f9c-85b9-1e8da738dd10.png">|<img width="915" alt="After" src="https://user-images.githubusercontent.com/7331038/128924579-684839c3-0bdb-4797-9433-997c11e67f08.png">|

## Testing in `sage-lib`
1. Visit http://0.0.0.0:4000/pages/component/progress_bar and ensure that the percentage is still displaying correctly.

## Testing in `kajabi-products`
1. (**LOW**) Ensure that percentages are displaying correctly in:
   - [ ] Podcasts Importing
   - [ ] Products - Cloning a product