### PR TITLE
refactor(rails sagecomponent class): Trims the HTML whitespace rendered by SageComponent class

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -31,7 +31,10 @@ class SageComponent
     context.render(
       partial: "sage_components/#{template_path}",
       locals: { component: self }
-    ).tap { cleanup_section_vars }
+    )
+    .tap { cleanup_section_vars }
+    .squish
+    .html_safe
   end
 
   # SageComponent Universal Spacer Attribute


### PR DESCRIPTION
## Description
This improvement trims the additional html whitespace that is rendered in ERB views. Allows us to format our SageRails html partials however we like, to maximize maintainability/readability, while not introducing janky hard-to-read source code in the web inspector.

When first standing up the SageComponent class we weren't sure the best way to accomplish this. IIRC has been on the improvements wishlist for a while, happy open up this fix!


## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/565743/129056330-cab8cddb-c1ed-4102-8055-a9375c59a031.png)|![image](https://user-images.githubusercontent.com/565743/129055069-22e4f52c-3bed-43c4-aabd-27121cbefaf3.png)|


## Testing in `sage-lib`
Ensure nothing is blowing up


## Testing in `kajabi-products`
1. (**LOW**) SageComponent-rendered html white-space changes
   - [ ] If the specs are green this should be fine


## Related
none
