### PR TITLE
SageLabel: remove duplicate quotes around `interactive_type` label

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -16,7 +16,7 @@
 >
   <<%= label_content_tag %>
     class="sage-label__value"
-    <%= 'type="button"' if component.interactive_type %>
+    <%= "type=button" if component.interactive_type %>
     <%= component.generated_html_attributes.html_safe %>
   />
     <span class="sage-label__value-text">


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->

Clicking a SageDropdown label button within a form will submit the form instead of displaying the dropdown. The `type` attribute is being rendered in two sets of quotes, causing it to be invalid or unrecognized by browsers. As a result, the base `button` type of `submit` takes over as the default.

This bug is limited to `SageLabel` when used as the button; other dropdown variants are not affected.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![dropdown-label-button-before](https://user-images.githubusercontent.com/816579/129104653-cc17b2d6-f399-49c7-a679-f8721f2315b8.png)|![dropdown-label-button-after](https://user-images.githubusercontent.com/816579/129104667-b2aefe9a-19ea-4011-b633-f4b1c973f6f3.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
1. Navigate to the [dropdown](http://localhost:4000/pages/component/dropdown) example in the Sage docs
2. Inspect the "SageLabel Button, with SageLabel Values, and aligned right" example
3. Confirm that the element has attribute `type="button"` as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Applies corrected button `type` attribute to `SageLabel` when used within a dropdown
   - [ ] Offer upsell (uses ajax and should not be affected; requires feature flag `comm_offer_detail`)
   - [ ] Offer edit - publish status (uses custom markup for dropdown and should not be affected; requires feature flag `comm_offer_detail`)


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
- closes #702
