### PR TITLE
fix(rails sagecomponent class): avoid stripping whitespace if contains pre html tags (Fixes #699)

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -31,10 +31,16 @@ class SageComponent
     context.render(
       partial: "sage_components/#{template_path}",
       locals: { component: self }
-    )
-    .tap { cleanup_section_vars }
-    .squish
-    .html_safe
+    ).tap do |html|
+      cleanup_section_vars
+
+      # We strip additional whitespace out of the partial's html
+      # to allow for cleaner rendering in the browser.
+      # In cases where <pre></pre> html tags exist in the returned html,
+      # we do not strip any of the whitespace in the partial.
+      # In the future we may want more specific string matching as <pre></pre> tag usage grows.
+      return html.squish.html_safe unless html.include?("</pre>")
+    end
   end
 
   # SageComponent Universal Spacer Attribute


### PR DESCRIPTION
🙋 **Update:**
Updated this PR with a solution that I think can satisfy the bug that was introduced within #699.
This PR will strip whitespaces for all components that do not contain `"</pre>"` within their returned html. Rather than attempting to use a specific regex to parse this we're relying on Ruby's string method `include?`. See the description in diff for more info!

https://apidock.com/ruby/String/include%3f

Re-requesting review!

## Description
~This change caused whitespace to be clear within `<pre>` tags. I spent the better part of the afternoon testing out a regex solution with limited success. For the time being I'll go ahead and revert. :sadpanda:~

~Ultimately, I'm not sure parsing _every_ Sage components' output with a regex is the right solution. Regexes can be delicate because of the ambiguity of their syntax and the number of various HTML-output variations. Nokigiri may be a better tool to reach for to "post-process" the html coming out of the partial.~

Conversation ref: https://kajabi.slack.com/archives/C01A424HY8Y/p1628709560057600

## Screenshots
n/a


## Testing in `sage-lib`
None, reversion


## Testing in `kajabi-products`
None, reversion


## Related
#699 
