### PR TITLE
Patch dropdown trigger leading

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -164,7 +164,7 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-dropdown__trigger > & {
-    line-height: sage-line-height(md);
+    line-height: sage-line-height(body);
   }
 
   .sage-dropdown__trigger--select & {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -163,6 +163,14 @@ $-btn-loading-min-height: rem(36px);
     border-radius: 0;
   }
 
+  .sage-dropdown__trigger > & {
+    line-height: sage-line-height(md);
+  }
+
+  .sage-dropdown__trigger--select & {
+    font-weight: sage-font-weight(regular);
+  }
+
   .sage-input-group & {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -336,16 +336,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   &.sage-dropdown__trigger--options {
     min-width: auto;
   }
-
-  > .sage-btn {
-    line-height: sage-line-height(md);
-  }
-}
-
-.sage-dropdown__trigger--select {
-  .sage-btn {
-    font-weight: sage-font-weight(regular);
-  }
 }
 
 .sage-dropdown__trigger--select,

--- a/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
@@ -53,6 +53,26 @@ $sage-line-heights: (
 ///    If the next parameter is `false` then this should be a line height token.
 /// @param {bool} $responsive [true] Whether or not retrieve a responsive css custom property (based on type specs) or a flat value (based on line-height tokens).
 ///
+/// @example scss - Responsive setting
+///   .sage-box {
+///     line-height: sage-line-height(body-sm);
+///   }
+///
+///   // Output
+///   .sage-box {
+///     line-height: var(--sage-line-height-body-sm);
+///   }
+///
+/// @example scss - Flat setting
+///   .sage-box {
+///     @include sage-line-height(md, false);
+///   }
+///
+///   // Output
+///   .sage-box {
+///     line-height: 1.75rem;
+///   }
+///
 /// @return {length} The value retrieved
 ///
 @function sage-line-height($key: body, $responsive: true) {

--- a/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
@@ -48,8 +48,10 @@ $sage-line-heights: (
 ///
 /// Sage line height token utility
 ///
-/// @param {string} $key [body] The token to retrieve
-/// @param {bool} $responsive [true] Whether or not retrieve a responsive css custom property or a flat value
+/// @param {string} $key [body] The token to retrieve.
+///    By default, this should be a type spec token.
+///    If the next parameter is `false` then this should be a line height token.
+/// @param {bool} $responsive [true] Whether or not retrieve a responsive css custom property (based on type specs) or a flat value (based on line-height tokens).
 ///
 /// @return {length} The value retrieved
 ///


### PR DESCRIPTION
## Description

This PR makes a quick patch to dropdown trigger styles that ensure consistent size and alignment for the button trigger.

## Testing in `sage-lib`

See no changes in Components > Dropdown

## Testing in `kajabi-products`

1. (LOW) Fix to line height in dropdown button trigger fixes tiny alignment issue.

## Related

#489 