### PR TITLE
Sage docs homepage cleanup

### DIFF
--- a/docs/app/views/application/_footer.html.erb
+++ b/docs/app/views/application/_footer.html.erb
@@ -1,4 +1,10 @@
+<% footerContainer ||= false %>
+
 <div class="docs-footer">
+  <% if footerContainer %>
+    <div class="sage-container sage-container--xl">
+  <% end %>
+
   <%= sage_component SageButtonGroup, { gap: :md } do %>
     <%= sage_component SageButton, {
       value: "Version #{$SAGE_VERSION_GEM}",
@@ -33,5 +39,9 @@
       subtle: true,
       style: "secondary",
     } %>
+  <% end %>
+
+  <% if footerContainer %>
+    </div>
   <% end %>
 </div>

--- a/docs/app/views/application/_home_code.html.erb
+++ b/docs/app/views/application/_home_code.html.erb
@@ -1,65 +1,67 @@
 <div class="docs-section">
-  <h2 class="docs-section__title t-sage-heading-1">How It Works</h2>
-  <%= sage_component SageGridRow, {} do %> 
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "3" } do %> 
-      <%= sage_component SagePanel, { spacer: { bottom: :lg } } do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__platform-icon devicon devicon-sass-original colored"></i>
-          <h3 class="t-sage-heading-3">SCSS System</h3>
-          <p class="t-sage-body">The language-agnostic style system that allows us to service any app code choice.</p>
-          <%= sage_component SageButton, {
-            value: "View Sassdocs site",
-            attributes: {
-              href: Rails.application.config.sassdocs_root_url,
-              title: "View Sassdocs site"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+  <%= sage_component SageContainer, { size: "xl" } do %>
+    <h2 class="docs-section__title t-sage-heading-1">How It Works</h2>
+    <%= sage_component SageGridRow, {} do %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "3", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__platform-icon devicon devicon-sass-original colored"></i>
+            <h3 class="t-sage-heading-3">SCSS System</h3>
+            <p class="t-sage-body">The language-agnostic style system that allows us to service any app code choice.</p>
+            <%= sage_component SageButton, {
+              value: "View Sassdocs site",
+              attributes: {
+                href: Rails.application.config.sassdocs_root_url,
+                title: "View Sassdocs site"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "3" } do %> 
-      <%= sage_component SagePanel, { spacer: { bottom: :lg } } do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__platform-icon devicon devicon-rails-plain-wordmark colored"></i>
-          <h3 class="t-sage-heading-3">Rails Components</h3>
-          <p class="t-sage-body">Our default approach, custom Rails View Components to serve our system to the app.</p>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "3", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__platform-icon devicon devicon-rails-plain-wordmark colored"></i>
+            <h3 class="t-sage-heading-3">Rails Components</h3>
+            <p class="t-sage-body">Our default approach, custom Rails View Components to serve our system to the app.</p>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "3" } do %> 
-      <%= sage_component SagePanel, { spacer: { bottom: :lg } } do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__platform-icon devicon devicon-javascript-plain colored"></i>
-          <h3 class="t-sage-heading-3">Vanilla Javascript</h3>
-          <p class="t-sage-body">Clean, minimal JavaScript to ensure the necessary interactions and accessibility features.</p>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "3", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__platform-icon devicon devicon-javascript-plain colored"></i>
+            <h3 class="t-sage-heading-3">Vanilla Javascript</h3>
+            <p class="t-sage-body">Clean, minimal JavaScript to ensure the necessary interactions and accessibility features.</p>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "3" } do %> 
-      <%= sage_component SagePanel, { spacer: { bottom: :lg } } do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__platform-icon devicon devicon-react-original colored"></i>
-          <h3 class="t-sage-heading-3">React Components</h3>
-          <p class="t-sage-body">Versions of our components for when heavy state and interaction management is needed.</p>
-          <%= sage_component SageButton, {
-            value: "Storybook",
-            attributes: {
-              href: Rails.application.config.storybook_root_url,
-              title: "Storybook"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "3", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, { } do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__platform-icon devicon devicon-react-original colored"></i>
+            <h3 class="t-sage-heading-3">React Components</h3>
+            <p class="t-sage-body">Versions of our components for when heavy state and interaction management is needed.</p>
+            <%= sage_component SageButton, {
+              value: "Storybook",
+              attributes: {
+                href: Rails.application.config.storybook_root_url,
+                title: "Storybook"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/docs/app/views/application/_home_developer.html.erb
+++ b/docs/app/views/application/_home_developer.html.erb
@@ -1,47 +1,49 @@
 <div class="docs-section">
-  <h2 class="docs-section__title t-sage-heading-1">Developer Guides</h2>
-  <%= sage_component SageGridRow, {} do %> 
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "6" } do %> 
-      <%= sage_component SagePanel, { spacer: { bottom: :lg } } do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-check-circle-3xl t-sage--color-purple"></i>
-          <h3 class="t-sage-heading-3">Get up and running</h3>
-          <p class="t-sage-body">Getting started with Sage is meant to be easy and approachable. Check out these practical developer guides to understand how to get up and running with the Sage Design System quickly.</p>
-          <%= sage_component SageButton, {
-            value: "Readme",
-            attributes: {
-              href: "https://github.com/Kajabi/sage-lib",
-              title: "Readme"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+  <%= sage_component SageContainer, { size: "xl" } do %>
+    <h2 class="docs-section__title t-sage-heading-1">Developer Guides</h2>
+    <%= sage_component SageGridRow, {} do %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "6", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-check-circle-3xl t-sage--color-purple"></i>
+            <h3 class="t-sage-heading-3">Get up and running</h3>
+            <p class="t-sage-body">Getting started with Sage is meant to be easy and approachable. Check out these practical developer guides to understand how to get up and running with the Sage Design System quickly.</p>
+            <%= sage_component SageButton, {
+              value: "Readme",
+              attributes: {
+                href: "https://github.com/Kajabi/sage-lib",
+                title: "Readme"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "6" } do %> 
-      <%= sage_component SagePanel, { spacer: { bottom: :lg } } do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-automations-3xl t-sage--color-purple"></i>
-          <h3 class="t-sage-heading-3">Contributing</h3>
-          <p class="t-sage-body">we encourage any member of the Kajabi team to feel empowered to participate. Understanding and contributing to the system are the keys to the system's longevity.</p>
-          <%= sage_component SageButton, {
-            value: "Guidelines",
-            attributes: {
-              href: "https://github.com/Kajabi/sage-lib/wiki",
-              title: "Guidelines"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "6", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-automations-3xl t-sage--color-purple"></i>
+            <h3 class="t-sage-heading-3">Contributing</h3>
+            <p class="t-sage-body">we encourage any member of the Kajabi team to feel empowered to participate. Understanding and contributing to the system are the keys to the system's longevity.</p>
+            <%= sage_component SageButton, {
+              value: "Guidelines",
+              attributes: {
+                href: "https://github.com/Kajabi/sage-lib/wiki",
+                title: "Guidelines"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/docs/app/views/application/_home_developer.html.erb
+++ b/docs/app/views/application/_home_developer.html.erb
@@ -5,7 +5,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "6", spacer: { bottom: :lg } } do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-check-circle-3xl t-sage--color-purple"></i>
+            <%= sage_component SageIcon, {
+              icon: "check-circle",
+              size: "3xl",
+              color: "purple",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Get up and running</h3>
             <p class="t-sage-body">Getting started with Sage is meant to be easy and approachable. Check out these practical developer guides to understand how to get up and running with the Sage Design System quickly.</p>
             <%= sage_component SageButton, {
@@ -27,7 +34,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "6", spacer: { bottom: :lg } } do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-automations-3xl t-sage--color-purple"></i>
+            <%= sage_component SageIcon, {
+              icon: "automations",
+              size: "3xl",
+              color: "purple",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Contributing</h3>
             <p class="t-sage-body">we encourage any member of the Kajabi team to feel empowered to participate. Understanding and contributing to the system are the keys to the system's longevity.</p>
             <%= sage_component SageButton, {

--- a/docs/app/views/application/_home_sections.html.erb
+++ b/docs/app/views/application/_home_sections.html.erb
@@ -5,7 +5,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-form-3xl t-sage--color-sage"></i>
+            <%= sage_component SageIcon, {
+              icon: "form",
+              size: "3xl",
+              color: "sage",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Foundations</h3>
             <p class="t-sage-body">Principles that reflect our design philosophy and inspire our team to shape great experiences for Knowledge Commerce businesses of any scale.</p>
             <%= sage_component SageButton, {
@@ -27,7 +34,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-pen-3xl t-sage--color-sage"></i>
+            <%= sage_component SageIcon, {
+              icon: "pen",
+              size: "3xl",
+              color: "sage",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Content</h3>
             <p class="t-sage-body">Our content standards will help you understand how to think strategically about the language in your products and apps.</p>
             <%= sage_component SageButton, {
@@ -49,7 +63,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-customize-3xl t-sage--color-sage"></i>
+            <%= sage_component SageIcon, {
+              icon: "customize",
+              size: "3xl",
+              color: "sage",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Design</h3>
             <p class="t-sage-body">
               Our system starts with some core visual elements: Type, Color, and Icons.
@@ -74,7 +95,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg }} do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-stack-3xl t-sage--color-sage"></i>
+            <%= sage_component SageIcon, {
+              icon: "stack",
+              size: "3xl",
+              color: "sage",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Layout</h3>
             <p class="t-sage-body">Patterns that allow us to position our content in various formats and locations without needing to change the content.</p>
             <%= sage_component SageButton, {
@@ -96,7 +124,14 @@
       <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
         <%= sage_component SagePanel, {} do %>
           <%= sage_component SagePanelStack, {} do %>
-            <i class="docs-section__icon sage-icon-product-3xl t-sage--color-sage"></i>
+            <%= sage_component SageIcon, {
+              icon: "product",
+              size: "3xl",
+              color: "sage",
+              spacer: {
+                "bottom": "md"
+              }
+            } %>
             <h3 class="t-sage-heading-3">Components</h3>
             <p class="t-sage-body">Find a full reference for our library or Rails UI components. Links to corresponding React components are provided as well.</p>
             <%= sage_component SageButton, {

--- a/docs/app/views/application/_home_sections.html.erb
+++ b/docs/app/views/application/_home_sections.html.erb
@@ -1,116 +1,118 @@
 <div class="docs-section">
-  <h2 class="docs-section__title t-sage-heading-1">Our Design System</h2>
-  <%= sage_component SageGridRow, {} do %> 
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %> 
-      <%= sage_component SagePanel, {} do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-form-3xl t-sage--color-sage"></i>
-          <h3 class="t-sage-heading-3">Foundations</h3>
-          <p class="t-sage-body">Principles that reflect our design philosophy and inspire our team to shape great experiences for Knowledge Commerce businesses of any scale.</p>
-          <%= sage_component SageButton, {
-            value: "Explore Foundations",
-            attributes: {
-              href: pages_foundation_path(:design_principles),
-              title: "Explore Foundations"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+  <%= sage_component SageContainer, { size: "xl" } do %>
+    <h2 class="docs-section__title t-sage-heading-1">Our Design System</h2>
+    <%= sage_component SageGridRow, {} do %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-form-3xl t-sage--color-sage"></i>
+            <h3 class="t-sage-heading-3">Foundations</h3>
+            <p class="t-sage-body">Principles that reflect our design philosophy and inspire our team to shape great experiences for Knowledge Commerce businesses of any scale.</p>
+            <%= sage_component SageButton, {
+              value: "Explore Foundations",
+              attributes: {
+                href: pages_foundation_path(:design_principles),
+                title: "Explore Foundations"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %> 
-      <%= sage_component SagePanel, {} do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-pen-3xl t-sage--color-sage"></i>
-          <h3 class="t-sage-heading-3">Content</h3>
-          <p class="t-sage-body">Our content standards will help you understand how to think strategically about the language in your products and apps.</p>
-          <%= sage_component SageButton, {
-            value: "Content Guides",
-            attributes: {
-              href: pages_content_path(:voice_tone),
-              title: "Content Guides"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-pen-3xl t-sage--color-sage"></i>
+            <h3 class="t-sage-heading-3">Content</h3>
+            <p class="t-sage-body">Our content standards will help you understand how to think strategically about the language in your products and apps.</p>
+            <%= sage_component SageButton, {
+              value: "Content Guides",
+              attributes: {
+                href: pages_content_path(:voice_tone),
+                title: "Content Guides"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %> 
-      <%= sage_component SagePanel, {} do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-customize-3xl t-sage--color-sage"></i>
-          <h3 class="t-sage-heading-3">Design</h3>
-          <p class="t-sage-body">
-            Our system starts with some core visual elements: Type, Color, and Icons.
-            We also prescribe common practices for aspects such as motion.
-          </p>
-          <%= sage_component SageButton, {
-            value: "Style Tokens",
-            attributes: {
-              href: pages_design_path(:color),
-              title: "Browse Design"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-customize-3xl t-sage--color-sage"></i>
+            <h3 class="t-sage-heading-3">Design</h3>
+            <p class="t-sage-body">
+              Our system starts with some core visual elements: Type, Color, and Icons.
+              We also prescribe common practices for aspects such as motion.
+            </p>
+            <%= sage_component SageButton, {
+              value: "Style Tokens",
+              attributes: {
+                href: pages_design_path(:color),
+                title: "Browse Design"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg }} do %> 
-      <%= sage_component SagePanel, {} do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-stack-3xl t-sage--color-sage"></i>
-          <h3 class="t-sage-heading-3">Layout</h3>
-          <p class="t-sage-body">Patterns that allow us to position our content in various formats and locations without needing to change the content.</p>
-          <%= sage_component SageButton, {
-            value: "Layout Patterns",
-            attributes: {
-              href: pages_layout_path(:container),
-              title: "Layout Patterns"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg }} do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-stack-3xl t-sage--color-sage"></i>
+            <h3 class="t-sage-heading-3">Layout</h3>
+            <p class="t-sage-body">Patterns that allow us to position our content in various formats and locations without needing to change the content.</p>
+            <%= sage_component SageButton, {
+              value: "Layout Patterns",
+              attributes: {
+                href: pages_layout_path(:container),
+                title: "Layout Patterns"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %> 
-      <%= sage_component SagePanel, {} do %>
-        <%= sage_component SagePanelStack, {} do %>
-          <i class="docs-section__icon sage-icon-product-3xl t-sage--color-sage"></i>
-          <h3 class="t-sage-heading-3">Components</h3>
-          <p class="t-sage-body">Find a full reference for our library or Rails UI components. Links to corresponding React components are provided as well.</p>
-          <%= sage_component SageButton, {
-            value: "Browse Components",
-            attributes: {
-              href: pages_component_path(sorted_sage_components.first[:title]),
-              title: "Browse Components"
-            },
-            subtle: true,
-            icon: {
-              style: "right",
-              name: "arrow-right"
-            },
-            style: "primary",
-          } %>
+      <%= sage_component SageGridCol, { breakpoint: "md", size: "4", spacer: { bottom: :lg } } do %>
+        <%= sage_component SagePanel, {} do %>
+          <%= sage_component SagePanelStack, {} do %>
+            <i class="docs-section__icon sage-icon-product-3xl t-sage--color-sage"></i>
+            <h3 class="t-sage-heading-3">Components</h3>
+            <p class="t-sage-body">Find a full reference for our library or Rails UI components. Links to corresponding React components are provided as well.</p>
+            <%= sage_component SageButton, {
+              value: "Browse Components",
+              attributes: {
+                href: pages_component_path(sorted_sage_components.first[:title]),
+                title: "Browse Components"
+              },
+              subtle: true,
+              icon: {
+                style: "right",
+                name: "arrow-right"
+              },
+              style: "primary",
+            } %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/docs/app/views/layouts/home.html.erb
+++ b/docs/app/views/layouts/home.html.erb
@@ -10,9 +10,7 @@
       link_id: "main-content"
     -%>
     <%= yield %>
-    <%= sage_component SageContainer, { size: "xl" } do %>
-      <%= render "application/footer" %>
-    <% end %>
+    <%= render "application/footer", footerContainer: true %>
     <%= render "scripts" %>
   </body>
 </html>

--- a/docs/app/views/pages/index.html.erb
+++ b/docs/app/views/pages/index.html.erb
@@ -1,7 +1,5 @@
 <%= render "application/home_hero" %>
 
-<%= sage_component SageContainer, { size: "xl" } do %>
-  <%= render "application/home_sections" %>
-  <%= render "application/home_developer" %>
-  <%= render "application/home_code" %>
-<% end %>
+<%= render "application/home_sections" %>
+<%= render "application/home_developer" %>
+<%= render "application/home_code" %>

--- a/docs/lib/sage-frontend/stylesheets/docs/_home.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_home.scss
@@ -45,7 +45,7 @@
 }
 
 .docs-section {
-  padding: sage-spacing(2xl) 0;
+  padding: sage-spacing(2xl) sage-spacing();
 
   .sage-panel {
     height: 100%;


### PR DESCRIPTION
## Description
A few small edits to the docs homepage and footer after noticing misalignment and inconsistent padding in between breakpoints.

- spacing adjustments for tablet and mobile breakpoints
- replaced markup with components


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
| |Before  |  After  |
|-----|---|--------|
|Tablet|![before-tablet-home1](https://user-images.githubusercontent.com/816579/129462507-864c1c9b-3dc2-4b0b-bf8d-1fb5d5ce4179.png)|![after-tablet-home1](https://user-images.githubusercontent.com/816579/129462508-536cdbf9-5da4-43d9-9ad5-363f300614ef.png)|
|Tablet|![before-tablet-home2](https://user-images.githubusercontent.com/816579/129462512-16253956-9ed5-487b-9f88-8b400d0e215f.png)|![after-tablet-home2](https://user-images.githubusercontent.com/816579/129462514-b9338246-3906-4ea0-b1c8-8a809259529f.png)|
|Mobile|![before-mobile-home1](https://user-images.githubusercontent.com/816579/129462517-cfebfc04-c0f2-40f4-96ce-cc6d458c547a.png)|![after-mobile-home1](https://user-images.githubusercontent.com/816579/129462522-cddb4838-5a9b-48d9-b070-0c62cd951b83.png)|
|Mobile|![before-mobile-home2](https://user-images.githubusercontent.com/816579/129462532-7f35dd35-504a-44b8-9d21-f50212fb58c8.png)|![after-mobile-home2](https://user-images.githubusercontent.com/816579/129462534-89fc89e9-0bac-4f0b-868f-d74373fe62f2.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
1. (**N/A**) Sage docs only


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
