### PR TITLE
[Checkbox] strike-through text for checked sortable item value

### DIFF
--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -129,7 +129,13 @@
       url_update: "update/endpoint",
     } do %>
       <div>
-        <%= sage_component SageLink, { label: "Field 1", truncate: true, url: "#" } %>
+        <%= sage_component SageCheckbox, {
+          id: "c2",
+          label_text: "Checked",
+          checked: true,
+          disabled: false,
+          has_error: false
+        } %>
       </div>
       <%= sage_component SageDropdown, {
         align: "right",

--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -122,7 +122,7 @@
 
 <h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "te"</code></h3>
 <%= sage_component SageSortable, { resource_name: "link" } do %>
-  <% 3.times do %>
+  <% 3.times do |i| %>
     <%= sage_component SageSortableItemCustom, {
       grid_template: "te",
       id: "id",
@@ -130,7 +130,7 @@
     } do %>
       <div>
         <%= sage_component SageCheckbox, {
-          id: "c2",
+          id: "c#{i + 1}",
           label_text: "Checked",
           checked: true,
           disabled: false,

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -221,6 +221,10 @@ $-checkbox-focus-outline-color: sage-color(primary);
     &::after {
       opacity: 1;
     }
+
+    .sage-sortable__item & + .sage-checkbox__label {
+      text-decoration: line-through;
+    }
   }
 
   &:hover:not(:checked):not(:disabled) {

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -92,6 +92,10 @@ $-checkbox-focus-outline-color: sage-color(primary);
       box-shadow: map-get($sage-toolbar-button-borders, focus);
     }
   }
+
+  .sage-sortable__item & {
+    margin-bottom: 0;
+  }
 }
 
 .sage-checkbox--standalone {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] strike-through text for checked sortable item value

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-08-16 at 7 13 59 AM](https://user-images.githubusercontent.com/1241836/129565569-be4d246c-d57d-45ca-a92e-75d50c6cf4ff.png)|![Screen Shot 2021-08-16 at 7 13 44 AM](https://user-images.githubusercontent.com/1241836/129565580-4bab26ec-5a08-4ba8-95a1-c93acebc6e75.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the sortable item page and scroll to the section labeled `SageSortableItemCustom using a custom grid template : "te"`
Interact with the checkbox to see the strike-through

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) add strike-through to checked sortable item text
   - [ ] Coaching Program coaching portal


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
