### PR TITLE
[Button] loading state focus ring alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -323,7 +323,7 @@ $-btn-loading-min-height: rem(36px);
   pointer-events: none;
 
   &.sage-btn--icon-only-check::before {
-    content: '';
+    content: "";
   }
 
   svg {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -320,8 +320,11 @@ $-btn-loading-min-height: rem(36px);
 }
 
 .sage-btn--is-loading {
-  min-height: $-btn-loading-min-height;
   pointer-events: none;
+
+  &.sage-btn--icon-only-check::before {
+    content: '';
+  }
 
   svg {
     position: absolute;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -322,7 +322,7 @@ $-btn-loading-min-height: rem(36px);
 .sage-btn--is-loading {
   pointer-events: none;
 
-  &.sage-btn--icon-only-check::before {
+  &[class*="sage-btn--icon"]::before {
     content: "";
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] updated the focus ring alignment for agenda items

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![loadingbuttonagendaitemsbefore](https://user-images.githubusercontent.com/1241836/129588332-a9382d2a-10dd-42d8-af37-d859210f99bd.gif)|![loadingbuttonagendaitems](https://user-images.githubusercontent.com/1241836/129588364-43772aa6-0426-4680-9c14-0ed953989218.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
It is unseeable when the component is used in isolation.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update alignment of the focus ring when an agenda items is saved.
   - [ ] Coaching programs client view -> edit agenda item


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
