### PR TITLE
[SortableCustom] add panel styling similar to SortableItem

### DIFF
--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -120,7 +120,7 @@
 `SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the [Sage Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.
 ', use_sage_type: true) %>
 
-<h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "te"</code></h3>
+<h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "te"</code> as a Panel List</h3>
 <%= sage_component SageSortable, { resource_name: "link" } do %>
   <% 3.times do |i| %>
     <%= sage_component SageSortableItemCustom, {
@@ -178,11 +178,12 @@
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "me"</code></h3>
+<h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "me"</code>as cards</h3>
 <%= sage_component SageSortable, {
   resource_name: "link" } do %>
   <% 3.times do %>
     <%= sage_component SageSortableItemCustom, {
+      card: true,
       grid_template: "me",
       id: "id",
       url_update: "update/endpoint",

--- a/docs/app/views/examples/components/sortable/_props.html.erb
+++ b/docs/app/views/examples/components/sortable/_props.html.erb
@@ -8,6 +8,12 @@
   <td colspan="4"><%= md('**Sortable Row**') %></td>
 </tr>
 <tr>
+  <td><%= md('`card`') %></td>
+  <td><%= md('Determines styling associated with SortableItem.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`grid_template`') %></td>
   <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
@@ -1,5 +1,6 @@
 class SageSortableItemCustom < SageComponent
   set_attribute_schema({
+    card: [:optional, TrueClass],
     grid_template: String,
     id: [:optional, Integer, String],
     url_update: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
@@ -1,6 +1,7 @@
 <li
   class="
     sage-sortable__item
+    <%= "sage-sortable__item--card" if component.card %>
     sage-sortable__item--custom
     <%= component.generated_css_classes %>
   "

--- a/packages/sage-assets/lib/stylesheets/components/_sortable.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_sortable.scss
@@ -37,8 +37,7 @@ $-sortable-image-height: rem(48px);
     }
   }
 
-  &.sage-sortable__item--card,
-  &.sage-sortable__item--custom {
+  &.sage-sortable__item--card {
     padding: sage-spacing(xs) sage-spacing(card);
     border-bottom: sage-border();
     border-left: sage-border();


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update to align with the `card` option in `SortableItem`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-08-17 at 9 32 54 AM](https://user-images.githubusercontent.com/1241836/129745910-b1227d1d-dca9-4582-94ca-4c5d8c45f589.png)|![Screen Shot 2021-08-17 at 9 32 38 AM](https://user-images.githubusercontent.com/1241836/129746079-09304bfa-630e-4d6d-9ca6-b25eddd2a790.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the sortable rails preview page and verify the two options: card vs panel

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) aligns `SortableCustom` card and panel which currently exist in `SortableItem`
   - [ ] Coaching programs client view


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
