### PR TITLE
Pagination Items Spacing on Smaller Screens

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_pagination.scss
@@ -45,6 +45,7 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   display: flex;
   flex-flow: row wrap;
   padding-left: 0;
+  margin-top: rem(-8px);
   list-style-type: none;
   border-radius: $-pagination-radius;
 
@@ -57,6 +58,11 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
   display: flex;
   align-items: center;
   margin-right: sage-spacing(xs);
+  margin-top: sage-spacing(xs);
+
+  @media screen and (min-width: sage-breakpoint(lg-max)) {
+    margin-top: 0;
+  }
 
   &:last-of-type {
     border: 0;

--- a/packages/sage-assets/lib/stylesheets/components/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_pagination.scss
@@ -44,10 +44,14 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 .sage-pagination__pages {
   display: flex;
   flex-flow: row wrap;
+  gap: sage-spacing(xs);
   padding-left: 0;
-  margin-top: rem(-8px);
   list-style-type: none;
   border-radius: $-pagination-radius;
+
+  @media screen and (min-width: sage-breakpoint(lg-max)) {
+    gap: 0 sage-spacing(xs);
+  }
 
   .sage-panel-controls & {
     margin-left: auto;
@@ -57,13 +61,6 @@ $-pagination-bg-color-dark: sage-color(grey, 300);
 .sage-pagination__item {
   display: flex;
   align-items: center;
-  margin-right: sage-spacing(xs);
-  margin-top: sage-spacing(xs);
-
-  @media screen and (min-width: sage-breakpoint(lg-max)) {
-    margin-top: 0;
-  }
-
   &:last-of-type {
     border: 0;
   }


### PR DESCRIPTION
## Description
Updates spacing of pagination items on smaller viewports.

Closes #697

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-08-17 at 12 26 12 PM](https://user-images.githubusercontent.com/1175111/129788678-f803d244-7ebb-4877-b5af-c591fc030554.png)|![Screen Shot 2021-08-17 at 12 26 32 PM](https://user-images.githubusercontent.com/1175111/129788713-67efd0a9-653f-4451-b6db-4a034856f9a8.png)|


## Testing in `sage-lib`
Visit http://localhost:4000/pages/component/pagination
Resize screen and verify pagination items no longer bump up against each other.


## Testing in `kajabi-products`
1. (**LOW**) Adjust pagination item spacing on smaller screen sizes. No impact is expected.
   - [ ] Sanity check of people or payments page. Any page with pagination.


## Related
https://github.com/Kajabi/sage-lib/issues/697
