### PR TITLE
[revert] render method stripping whitespace

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -31,16 +31,7 @@ class SageComponent
     context.render(
       partial: "sage_components/#{template_path}",
       locals: { component: self }
-    ).tap do |html|
-      cleanup_section_vars
-
-      # We strip additional whitespace out of the partial's html
-      # to allow for cleaner rendering in the browser.
-      # In cases where <pre></pre> html tags exist in the returned html,
-      # we do not strip any of the whitespace in the partial.
-      # In the future we may want more specific string matching as <pre></pre> tag usage grows.
-      return html.squish.html_safe unless html.include?("</pre>")
-    end
+    ).tap { cleanup_section_vars }
   end
 
   # SageComponent Universal Spacer Attribute


### PR DESCRIPTION
## Description
Patches version bump to correct [failing specs](https://app.circleci.com/pipelines/github/Kajabi/kajabi-products/55909/workflows/492f3302-48b2-423e-917e-f5219b8eb268/jobs/213966) in kajabi-products.

Reverts updates from #699 and #706.

Specs are failing due to a space being rendered in `textarea`s. Removing the adjustments to whitespace in the method resolve the issue.

