### PR TITLE
build(lerna config): update release-deploy config to correct version numbering

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Clone Sage-Lib Repo
         uses: actions/checkout@v2
+        with:
+          # pulls all commits (needed for lerna / semantic release to correctly version)
+          fetch-depth: "0"
 
       # Setup Git Credentials to come from the Bot
       - name: Set Bot Email


### PR DESCRIPTION
## Description

~~🛑 ON HOLD until sage version bump has merged~~

Following a Sage version bump, the generated tag and package release version for Sage does not increment as expected:

Expected: `v4.11.5` -> `v4.12.0`
Actual: `v4.11.5` -> `v4.11.6`

This happens regardless of the size and scope of the changeset due to a bug with Lerna in Github Actions that @voodooGQ uncovered: lerna/lerna#2542

This PR adds a new setting in our build process which forces Lerna to inspect all commits. The tagging addition mentioned in the issue thread has been left off for this first pass at a fix.

⚠️  Note that this PR will need to merge directly to `main`; `develop` should be rebased afterwards.


## Screenshots
No visual changes

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Local testing is not possible. We'll need to generate a new release/package to verify the versioning has been corrected.


## Testing in `kajabi-products`
N/A. This branch will not affect existing components


## Related
- closes #726