### PR TITLE
[Sage-511] Sage 3 - Loader Update

### DIFF
--- a/docs/app/views/examples/components/loader/_preview.html.erb
+++ b/docs/app/views/examples/components/loader/_preview.html.erb
@@ -1,12 +1,17 @@
 <div class="sage-row">
-  <div class="sage-col--md-6 example__block--lg">
+  <div class="sage-col--md-4 example__block--lg">
     <%= sage_component SageLoader, {
       type: "bar"
     } %>
   </div>
-  <div class="sage-col--md-6 example__block--lg">
+  <div class="sage-col--md-4 example__block--lg">
     <%= sage_component SageLoader, {
       type: "spinner"
+    } %>
+  </div>
+  <div class="sage-col--md-4 example__block--lg">
+    <%= sage_component SageLoader, {
+      type: "success"
     } %>
   </div>
 </div>

--- a/docs/app/views/examples/components/loader/_props.html.erb
+++ b/docs/app/views/examples/components/loader/_props.html.erb
@@ -6,7 +6,7 @@
 </tr>
 <tr>
   <td><%= md('`type`') %></td>
-  <td><%= md('Determines which loader will be used. We currently support a type of `bar` and `spinner`') %></td>
+  <td><%= md('Determines which loader will be used. We currently support a type of `bar`, `spinner`, and `success`') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_loader.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_loader.rb
@@ -1,6 +1,6 @@
 class SageLoader < SageComponent
   set_attribute_schema({
     fill: [:optional, TrueClass],
-    type: Set.new(["bar", "spinner"]),
+    type: Set.new(["bar", "spinner", "success"]),
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
@@ -1,3 +1,7 @@
+<%
+  isSuccessful = component.type === "success" ? "Success" : "Loading"
+%>
+
 <div class="
     sage-loader
     sage-loader--<%= component.type %>
@@ -15,7 +19,15 @@
       <circle class="sage-loader__spinner-path" cx="50" cy="50" r="20" fill="none" stroke="0072EF" stroke-width="4" />
     </svg>
   <% end %>
-  <span class="visually-hidden">Loading...</span>
+
+  <%# Success/Complete SVG %>
+  <% if component.type === "success" %>
+    <svg class="sage-loader__success" viewBox="25 25 50 50" >
+      <circle class="sage-loader__success-path" cx="50" cy="50" r="20" fill="none" stroke="0072EF" stroke-width="4" />
+      <path class="sage-loader__success-check" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" d="M22.7071 1.29291C23.0976 1.68344 23.0976 2.3166 22.7071 2.70713L9.7071 15.7071C9.31658 16.0977 8.68341 16.0977 8.29289 15.7071L1.29289 8.70713C0.902365 8.3166 0.902365 7.68344 1.29289 7.29291C1.68341 6.90239 2.31658 6.90239 2.7071 7.29291L9 13.5858L21.2929 1.29291C21.6834 0.902388 22.3166 0.902388 22.7071 1.29291Z" stroke-width="2" />
+    </svg>
+  <% end %>
+  <span class="visually-hidden"><%= isSuccessful %></span>
 </div>
 
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
@@ -1,5 +1,5 @@
 <%
-  isSuccessful = component.type === "success" ? "Success" : "Loading"
+  component_description = component.type === "success" ? "Success" : "Loading"
 %>
 
 <div class="
@@ -27,7 +27,7 @@
       <path class="sage-loader__success-check" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" d="M22.7071 1.29291C23.0976 1.68344 23.0976 2.3166 22.7071 2.70713L9.7071 15.7071C9.31658 16.0977 8.68341 16.0977 8.29289 15.7071L1.29289 8.70713C0.902365 8.3166 0.902365 7.68344 1.29289 7.29291C1.68341 6.90239 2.31658 6.90239 2.7071 7.29291L9 13.5858L21.2929 1.29291C21.6834 0.902388 22.3166 0.902388 22.7071 1.29291Z" stroke-width="2" />
     </svg>
   <% end %>
-  <span class="visually-hidden"><%= isSuccessful %></span>
+  <span class="visually-hidden"><%= component_description %></span>
 </div>
 
 

--- a/packages/sage-assets/lib/stylesheets/components/_loader.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_loader.scss
@@ -84,6 +84,24 @@ $-loader-spinner-path-speed: 1.5s;
   animation: dash $-loader-spinner-path-speed ease-in-out infinite;
 }
 
+.sage-loader__success {
+  width: sage-spacing(xl);
+  height: sage-spacing(xl);
+}
+
+.sage-loader__success-path {
+  stroke-dasharray: 150,200;
+  stroke-linecap: round;
+  stroke: sage-color(sage, 300);
+}
+
+.sage-loader__success-check {
+  transform: translate(76%, 84%);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-miterlimit: 10;
+  stroke: sage-color(sage, 300)
+}
 
 @keyframes loader-bar {
   0% {

--- a/packages/sage-assets/lib/stylesheets/components/_loader.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_loader.scss
@@ -100,7 +100,7 @@ $-loader-spinner-path-speed: 1.5s;
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-miterlimit: 10;
-  stroke: sage-color(sage, 300)
+  stroke: sage-color(sage, 300);
 }
 
 @keyframes loader-bar {

--- a/packages/sage-assets/lib/stylesheets/components/_loader.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_loader.scss
@@ -6,7 +6,7 @@
 
 
 $-loader-bar-bg-color: sage-color(grey);
-$-loader-bar-height: rem(10px);
+$-loader-bar-height: rem(6px);
 $-loader-bar-speed: 1.2s;
 $-loader-bar-speed-delay: 0.5s;
 $-loader-bar-width: rem(300px);

--- a/packages/sage-react/lib/Loader/Loader.jsx
+++ b/packages/sage-react/lib/Loader/Loader.jsx
@@ -41,6 +41,12 @@ export const Loader = ({
           <circle className="sage-loader__spinner-path" cx="50" cy="50" r="20" fill="none" stroke="url(#linear)" strokeWidth="4" />
         </svg>
       )}
+      {(type === LOADER_TYPES.SUCCESS) && (
+        <svg className="sage-loader__success" viewBox="25 25 50 50">
+          <circle className="sage-loader__success-path" cx="50" cy="50" r="20" fill="none" stroke="0072EF" strokeWidth="4" />
+          <path className="sage-loader__success-check" xmlns="http://www.w3.org/2000/svg" fillRule="evenodd" clipRule="evenodd" d="M22.7071 1.29291C23.0976 1.68344 23.0976 2.3166 22.7071 2.70713L9.7071 15.7071C9.31658 16.0977 8.68341 16.0977 8.29289 15.7071L1.29289 8.70713C0.902365 8.3166 0.902365 7.68344 1.29289 7.29291C1.68341 6.90239 2.31658 6.90239 2.7071 7.29291L9 13.5858L21.2929 1.29291C21.6834 0.902388 22.3166 0.902388 22.7071 1.29291Z" strokeWidth="2" />
+        </svg>
+      )}
       <span className="visually-hidden">{label}</span>
     </div>
   );

--- a/packages/sage-react/lib/Loader/configs.js
+++ b/packages/sage-react/lib/Loader/configs.js
@@ -1,4 +1,5 @@
 export const LOADER_TYPES = {
   BAR: 'bar',
   SPINNER: 'spinner',
+  SUCCESS: 'success',
 };


### PR DESCRIPTION
## Description
- Updates the height of the loader bar from 10px to 6px.
- Add new "success" variant.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="324" alt="Screen Shot 2021-08-20 at 1 46 29 PM" src="https://user-images.githubusercontent.com/14791307/130279820-81ecf15f-0dd5-4173-b2c8-0dff26ede447.png">|<img width="344" alt="Screen Shot 2021-08-20 at 1 43 40 PM" src="https://user-images.githubusercontent.com/14791307/130279841-cc998805-9daa-4859-a3a2-4de5fb84bc1b.png">

<img width="187" alt="Screen Shot 2021-08-23 at 10 12 50 AM" src="https://user-images.githubusercontent.com/14791307/130472672-c38fc62e-b424-4788-bcf8-790d6fdfe7f9.png">

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Loader](http://localhost:4000/pages/component/loader) component
- Check that bar loader height has been updated
- Check that "success" variant exists and isn't broken

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->

LOW. Updates progress bar height and add new "success" variant.

## Related
#511 


