### PR TITLE
Input Group Message Bug

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -234,7 +234,7 @@ $-btn-loading-min-height: rem(36px);
   .sage-input-group & {
     position: absolute;
     top: rem(2px);
-    right: calc(0.125rem / 2);
+    right: rem(1px);
     background-color: sage-color(white);
     box-shadow: rem(-1px) 0 0 0 sage-color(grey, 300);
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -233,10 +233,8 @@ $-btn-loading-min-height: rem(36px);
 
   .sage-input-group & {
     position: absolute;
-    transform: translateY(-50%);
-    top: 50%;
-    right: calc(#{rem(2px)} / 2);
-    height: calc(100% - #{rem(2px)});
+    top: rem(2px);
+    right: calc(0.125rem / 2);
     background-color: sage-color(white);
     box-shadow: rem(-1px) 0 0 0 sage-color(grey, 300);
 


### PR DESCRIPTION
## Description
Closes #672

Adjusts styling to prevent button stretching when input within an input group includes message/helper text.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-08-20 at 4 28 00 PM](https://user-images.githubusercontent.com/1175111/130303208-4fddad3f-a897-43e7-aa07-e374a96e6c94.png)|![Screen Shot 2021-08-20 at 4 28 38 PM](https://user-images.githubusercontent.com/1175111/130303214-7bf2c5fa-0b1f-4883-92d1-a701161f4d67.png)|


## Testing in `sage-lib`

- Add `message_text:` attribute to a `SageFormInput` within `docs/app/views/examples/components/input_group/_preview.html.erb`
- Visit http://localhost:4000/pages/component/input_group
- Verify InputGroup button no longer stretches and the `message_text` appears as expected.


## Testing in `kajabi-products`
1. (**LOW**) Styling adjustment to prevent the button from stretching when input group has message/helper text. No impact is expected but a quick sanity check should be performed.
   - [ ] Settings/Account Details


## Related
#672