### PR TITLE
[Sage-520] Sage 3 - Tooltip Update

### DIFF
--- a/docs/app/views/examples/components/tooltip/_preview.html.erb
+++ b/docs/app/views/examples/components/tooltip/_preview.html.erb
@@ -1,13 +1,8 @@
 <h3 class="t-sage-heading-6">Tooltips</h3>
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTooltip, {
-    position: "top",
+    position: "center",
     text: "Nascetur ridiculus mus",
-  } %>
-  <%= sage_component SageTooltip, {
-    position: "bottom",
-    text: "80%",
-    size: "small"
   } %>
   <%= sage_component SageTooltip, {
     position: "left",

--- a/docs/app/views/examples/components/tooltip/_preview.html.erb
+++ b/docs/app/views/examples/components/tooltip/_preview.html.erb
@@ -1,4 +1,4 @@
-<h3 class="t-sage-heading-6">Dark Tooltips</h3>
+<h3 class="t-sage-heading-6">Tooltips</h3>
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTooltip, {
     position: "top",
@@ -16,31 +16,5 @@
   <%= sage_component SageTooltip, {
     position: "right",
     text: "Bibendum Condimentum",
-  } %>
-<% end %>
-
-<h3 class="t-sage-heading-6">Light Tooltips</h3>
-<%= sage_component SagePanelBlock, {} do %>
-  <%= sage_component SageTooltip, {
-    position: "top",
-    text: "Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.",
-    theme: "light",
-    size: "large"
-  } %>
-  <%= sage_component SageTooltip, {
-    position: "bottom",
-    text: "Magnis dis parturient montes",
-    theme: "light",
-  } %>
-  <%= sage_component SageTooltip, {
-    position: "left",
-    text: "$12.99",
-    theme: "light",
-    size: "small"
-  } %>
-  <%= sage_component SageTooltip, {
-    position: "right",
-    text: "Sociis natoque et",
-    theme: "light",
   } %>
 <% end %>

--- a/docs/app/views/examples/components/tooltip/_props.html.erb
+++ b/docs/app/views/examples/components/tooltip/_props.html.erb
@@ -16,9 +16,3 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
-<tr>
-  <td><%= md('`theme`') %></td>
-  <td><%= md('Sets a light theme on tooltip. If empty, defaults to `dark`.') %></td>
-  <td><%= md('String: ["dark", "light"]') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_tooltip.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tooltip.rb
@@ -1,6 +1,6 @@
 class SageTooltip < SageComponent
   set_attribute_schema({
-    position: [:optional, Set.new(["top", "right", "bottom", "left"])],
+    position: [:optional, Set.new(["center", "right", "left"])],
     size: [:optional, Set.new(["small", "large"])],
     text: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_tooltip.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tooltip.rb
@@ -3,6 +3,5 @@ class SageTooltip < SageComponent
     position: [:optional, Set.new(["top", "right", "bottom", "left"])],
     size: [:optional, Set.new(["small", "large"])],
     text: [:optional, String],
-    theme: [:optional, Set.new(["light"])],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tooltip.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tooltip.html.erb
@@ -2,7 +2,6 @@
   class="sage-btn sage-btn--primary <%= component.generated_css_classes %>" 
   data-js-tooltip="<%= component.text %>" 
   data-js-tooltip-position="<%= component.position %>" 
-  <%= "data-js-tooltip-theme=#{component.theme}" if component.theme.present? -%>
   <%= "data-js-tooltip-size=#{component.size}" if component.size.present? -%>
   <%= component.generated_html_attributes.html_safe %>
 >

--- a/packages/sage-assets/lib/stylesheets/components/_tooltip.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tooltip.scss
@@ -42,6 +42,7 @@ $-tooltip-large-maxwidth: rem(320px);
   &::after {
     content: "";
     position: absolute;
+    
   }
 }
 
@@ -49,7 +50,7 @@ $-tooltip-large-maxwidth: rem(320px);
   position: relative;
 }
 
-.sage-tooltip--top {
+.sage-tooltip--center {
   &::after {
     left: 50%;
     top: 100%;
@@ -60,36 +61,25 @@ $-tooltip-large-maxwidth: rem(320px);
   }
 }
 
-.sage-tooltip--bottom {
-  &::after {
-    left: 50%;
-    bottom: 100%;
-    transform: translate3d(-50%, 0, 0);
-    border-left: $-tooltip-arrow-inactive;
-    border-right: $-tooltip-arrow-inactive;
-    border-bottom: $-tooltip-arrow-active;
-  }
-}
-
 .sage-tooltip--left {
   &::after {
-    left: 100%;
-    bottom: 50%;
-    transform: translate3d(0, 50%, 0);
-    border-top: $-tooltip-arrow-inactive;
-    border-bottom: $-tooltip-arrow-inactive;
-    border-left: $-tooltip-arrow-active;
+    left: 50%;
+    top: 100%;
+    transform: translate3d(var(--pointer-left), 0, 0);
+    border-left: $-tooltip-arrow-inactive;
+    border-right: $-tooltip-arrow-inactive;
+    border-top: $-tooltip-arrow-active;
   }
 }
 
 .sage-tooltip--right {
   &::after {
-    left: 0;
-    bottom: 50%;
-    transform: translate3d(-100%, 50%, 0);
-    border-top: $-tooltip-arrow-inactive;
-    border-bottom: $-tooltip-arrow-inactive;
-    border-right: $-tooltip-arrow-active;
+    right: 50%;
+    top: 100%;
+    transform: translate3d(var(--pointer-right), 0, 0);
+    border-left: $-tooltip-arrow-inactive;
+    border-right: $-tooltip-arrow-inactive;
+    border-top: $-tooltip-arrow-active;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_tooltip.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tooltip.scss
@@ -7,9 +7,7 @@
 
 // Colors
 $-tooltip-bg-color: sage-color(charcoal, 400);
-$-tooltip-light-bg-color: sage-color(white);
 $-tooltip-font-color: sage-color(white);
-$-tooltip-light-font-color: sage-color(charcoal, 400);
 
 // Indicator arrow
 $-tooltip-arrow-size: rem(6px);
@@ -92,24 +90,6 @@ $-tooltip-large-maxwidth: rem(320px);
     border-top: $-tooltip-arrow-inactive;
     border-bottom: $-tooltip-arrow-inactive;
     border-right: $-tooltip-arrow-active;
-  }
-}
-
-.sage-tooltip--light {
-  color: $-tooltip-light-font-color;
-  background: $-tooltip-light-bg-color;
-
-  &.sage-tooltip--top::after {
-    border-top-color: sage-color(white);
-  }
-  &.sage-tooltip--bottom::after {
-    border-bottom-color: sage-color(white);
-  }
-  &.sage-tooltip--left::after {
-    border-left-color: sage-color(white);
-  }
-  &.sage-tooltip--right::after {
-    border-right-color: sage-color(white);
   }
 }
 

--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -5,7 +5,6 @@ import { TooltipElement } from './TooltipElement';
 import {
   TOOLTIP_SIZES,
   TOOLTIP_POSITIONS,
-  TOOLTIP_THEMES,
 } from './configs';
 
 export const Tooltip = ({
@@ -43,7 +42,6 @@ export const Tooltip = ({
 Tooltip.Element = TooltipElement;
 Tooltip.POSITIONS = TOOLTIP_POSITIONS;
 Tooltip.SIZES = TOOLTIP_SIZES;
-Tooltip.THEMES = TOOLTIP_THEMES;
 
 Tooltip.defaultProps = {
 };

--- a/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
@@ -11,7 +11,6 @@ export default {
     ...selectArgs({
       position: Tooltip.POSITIONS,
       size: Tooltip.SIZES,
-      theme: Tooltip.THEMES
     }),
   },
   args: {
@@ -23,7 +22,6 @@ export default {
     content: 'Hi, I provide more context for this element!',
     position: Tooltip.POSITIONS.DEFAULT,
     size: Tooltip.SIZES.DEFAULT,
-    theme: Tooltip.THEMES.DEFAULT,
   }
 };
 const Template = (args) => <Tooltip {...args} />;

--- a/packages/sage-react/lib/Tooltip/TooltipElement.jsx
+++ b/packages/sage-react/lib/Tooltip/TooltipElement.jsx
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import {
   TOOLTIP_SIZES,
   TOOLTIP_POSITIONS,
-  TOOLTIP_THEMES,
 } from './configs';
 
 const TOOLTIP_DISTANCE = 8;
@@ -14,7 +13,6 @@ export const TooltipElement = ({
   parentDomRect,
   position,
   size,
-  theme,
 }) => {
   const tooltipRef = useRef(null);
   const [coordinates, setCoordinates] = useState({ top: null, left: null });
@@ -25,7 +23,6 @@ export const TooltipElement = ({
       'sage-tooltip--static': !parentDomRect,
       [`sage-tooltip--${position}`]: position,
       [`sage-tooltip--${size}`]: size,
-      [`sage-tooltip--${theme}`]: theme,
     }
   );
 
@@ -87,13 +84,11 @@ export const TooltipElement = ({
 
 TooltipElement.POSITIONS = TOOLTIP_POSITIONS;
 TooltipElement.SIZES = TOOLTIP_SIZES;
-TooltipElement.THEMES = TOOLTIP_THEMES;
 
 TooltipElement.defaultProps = {
   parentDomRect: null,
   position: TOOLTIP_POSITIONS.DEFAULT,
   size: TOOLTIP_SIZES.DEFAULT,
-  theme: TOOLTIP_THEMES.DEFAULT,
 };
 
 TooltipElement.propTypes = {
@@ -107,5 +102,4 @@ TooltipElement.propTypes = {
   }),
   position: PropTypes.oneOf(Object.values(TOOLTIP_POSITIONS)),
   size: PropTypes.oneOf(Object.values(TOOLTIP_SIZES)),
-  theme: PropTypes.oneOf(Object.values(TOOLTIP_THEMES)),
 };

--- a/packages/sage-react/lib/Tooltip/configs.js
+++ b/packages/sage-react/lib/Tooltip/configs.js
@@ -11,8 +11,3 @@ export const TOOLTIP_POSITIONS = {
   BOTTOM: 'bottom',
   LEFT: 'left',
 };
-
-export const TOOLTIP_THEMES = {
-  DEFAULT: null,
-  LIGHT: 'light',
-};

--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -16,8 +16,8 @@ Sage.tooltip = (function() {
   // can resolve it lingering when it shouldn't.
 
   function init(el) {
-    // el.addEventListener("mouseenter", buildToolTip);
-    el.addEventListener("focus", buildToolTip);
+    el.addEventListener("mouseenter", buildToolTip);
+    // el.addEventListener("focus", buildToolTip);
     el.addEventListener("mouseleave", removeTooltip);
     // el.addEventListener("blur", removeTooltip);
   }

--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -16,8 +16,8 @@ Sage.tooltip = (function() {
   // can resolve it lingering when it shouldn't.
 
   function init(el) {
-    el.addEventListener("mouseenter", buildToolTip);
-    // el.addEventListener("focus", buildToolTip);
+    // el.addEventListener("mouseenter", buildToolTip);
+    el.addEventListener("focus", buildToolTip);
     el.addEventListener("mouseleave", removeTooltip);
     // el.addEventListener("blur", removeTooltip);
   }
@@ -33,12 +33,12 @@ Sage.tooltip = (function() {
   function buildToolTip(evt) {
     if (!evt.target.hasAttribute(DATA_ATTR)) return;
 
-    var pos = evt.target.getAttribute(`${DATA_ATTR}-position`) || "top";
+    var pos = evt.target.getAttribute(`${DATA_ATTR}-position`) || "center";
     var tooltip = document.createElement("div");
     tooltip.className = TOOLTIP_CLASS;
     tooltip.innerHTML = evt.target.getAttribute(DATA_ATTR);
     tooltip.position = evt.target.getAttribute(`${DATA_ATTR}-position`);
-    tooltip.dataItems = [`${DATA_ATTR}-theme`, `${DATA_ATTR}-size`];
+    tooltip.dataItems = [`${DATA_ATTR}-size`];
 
     if (!tooltip.innerHTML.length > 0) return;
     generateClasses(tooltip, evt);
@@ -73,36 +73,31 @@ Sage.tooltip = (function() {
     var parentCoords = parent.getBoundingClientRect(),
       dist = 8,
       left,
-      top;
+      top,
+      minWidth = 60,
+      pointerLeft,
+      pointerRight;
 
-    switch (position) {
-      case "left":
-        top = (parseInt(parentCoords.top) + parseInt(parentCoords.bottom)) / 2 - tooltip.offsetHeight / 2;
-        left = parseInt(parentCoords.left) - dist - tooltip.offsetWidth;
-        if (parseInt(parentCoords.left) - tooltip.offsetWidth < 0) {
-          left = dist;
-        }
-        break;
-      case "right":
-        top = (parseInt(parentCoords.top) + parseInt(parentCoords.bottom)) / 2 - tooltip.offsetHeight / 2;
-        left = parentCoords.right + dist;
-        if (parseInt(parentCoords.right) + tooltip.offsetWidth > document.documentElement.clientWidth) {
-          left =  document.documentElement.clientWidth - tooltip.offsetWidth - dist;
-        }
-        break;
-      case "bottom":
-        top = parseInt(parentCoords.bottom) + dist;
-        left = parseInt(parentCoords.left) + (parent.offsetWidth - tooltip.offsetWidth) / 2;
-        break;
-      default:
-      case "top":
-        top = parseInt(parentCoords.top) - tooltip.offsetHeight - dist;
-        left = parseInt(parentCoords.left) + (parent.offsetWidth - tooltip.offsetWidth) / 2;
+    console.log(parentCoords);
+
+    top = parseInt(parentCoords.top) - tooltip.offsetHeight - dist;
+    left = parseInt(parentCoords.left) + (parent.offsetWidth - tooltip.offsetWidth) / 2;
+
+    pointerLeft = (parent.offsetWidth - tooltip.offsetWidth) / 2 + "px";
+    pointerRight = ((tooltip.offsetWidth / 2) - (parent.offsetWidth / 2)) + "px";
+
+    if (tooltip.offsetWidth < minWidth) {
+      pointerLeft = "-50%";
+      pointerRight = "50%";
     }
+
+    console.log("pointer position: ", pointerLeft);
 
     tooltip.style.left = left + "px";
     tooltip.style.top = top + pageYOffset + "px";
     tooltip.classList.add(`${TOOLTIP_CLASS}--${position}`);
+    tooltip.style.setProperty("--pointer-left", pointerLeft);
+    tooltip.style.setProperty("--pointer-right", pointerRight);
   }
 
   return {


### PR DESCRIPTION
## Description
Updates Tooltip component to Sage 3:
- Removes `theme` prop
- Updates `position` prop (WIP)




## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="294" alt="Screen Shot 2021-08-26 at 1 33 14 PM" src="https://user-images.githubusercontent.com/14791307/131017285-cb9ef6db-83b9-4f40-b80f-3984767d992a.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.

WIP

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #520 