### PR TITLE
Media tiles in React

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -226,9 +226,11 @@ module ComponentsHelper
         title: "media_tile",
         description: "Easily display a tile or set of tiles that showcase products, templates, or other media-based content.", 
         scss: "done",
+        docs: "done",
         rails: "done",
-        react: "yes",
+        react: "done",
         a11y: "done",
+        react_component_slug: "sage-media-tile--default"
       },
       {
         title: "meter",

--- a/packages/sage-react/lib/MediaTile/MediaTile.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTile.jsx
@@ -36,7 +36,7 @@ export const MediaTile = ({
         <Panel.Figure
           bleed={Panel.Figure.BLEED_OPTIONS.TOP}
           {...mediaConfigs}
-          className={`sage-media-tile__media ${mediaConfigs && mediaConfigs.className || ''}`}
+          className={`sage-media-tile__media ${(mediaConfigs && mediaConfigs.className) || ''}`}
         >
           {media}
         </Panel.Figure>

--- a/packages/sage-react/lib/MediaTile/MediaTile.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTile.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { Button } from '../Button';
+import { Link } from '../Link';
+import { OptionsDropdown } from '../Dropdown';
+import { Panel } from '../Panel';
+
+export const MediaTile = ({
+  actionsDropdownItems,
+  actionsCustom,
+  caption,
+  children,
+  className,
+  footer,
+  media,
+  mediaConfigs,
+  tileLink,
+  title,
+  titleTag,
+  ...rest
+}) => {
+  const classNames = classnames(
+    'sage-media-tile',
+    className,
+    {
+      'sage-media-tile--interactive': tileLink,
+    }
+  );
+
+  const TitleTag = titleTag;
+
+  return (
+    <Panel className={classNames} {...rest}>
+      {media && (
+        <Panel.Figure
+          bleed={Panel.Figure.BLEED_OPTIONS.TOP}
+          {...mediaConfigs}
+          className={`sage-media-tile__media ${mediaConfigs && mediaConfigs.className || ''}`}
+        >
+          {media}
+        </Panel.Figure>
+      )}
+      <Panel.Stack className="sage-media-tile__content">
+        {title && (
+          <Panel.Row className="sage-media-tile__header">
+            <TitleTag className="sage-media-tile__title">
+              {tileLink ? (
+                <Link
+                  {...tileLink}
+                  className={`sage-media-tile__link ${tileLink.classname || ''}`}
+                >
+                  {title}
+                </Link>
+              ) : title}
+            </TitleTag>
+            {(actionsCustom || actionsDropdownItems) && (
+              <Button.Group gap={Button.Group.GAP_OPTIONS.SM}>
+                {actionsCustom}
+                {actionsDropdownItems && (
+                  <OptionsDropdown align="right" options={actionsDropdownItems} />
+                )}
+              </Button.Group>
+            )}
+          </Panel.Row>
+        )}
+        {children && (
+          <Panel.Block className="sage-media-tile__body">
+            {children}
+          </Panel.Block>
+        )}
+        {caption && (
+          <Panel.Block className="sage-media-tile__caption">
+            {caption}
+          </Panel.Block>
+        )}
+      </Panel.Stack>
+      {footer && (
+        <Panel.Footer className="sage-media-tile__footer" alignSpread={true}>
+          {footer}
+        </Panel.Footer>
+      )}
+    </Panel>
+  );
+};
+
+MediaTile.defaultProps = {
+  actionsDropdownItems: null,
+  actionsCustom: null,
+  caption: null,
+  children: null,
+  className: '',
+  footer: null,
+  media: null,
+  mediaConfigs: null,
+  tileLink: null,
+  title: null,
+  titleTag: 'h3',
+};
+
+MediaTile.propTypes = {
+  actionsDropdownItems: PropTypes.arrayOf(PropTypes.shape({})), // TODO: dropdown itme schema here
+  actionsCustom: PropTypes.node,
+  caption: PropTypes.node,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  footer: PropTypes.node,
+  media: PropTypes.node,
+  mediaConfigs: PropTypes.shape(Panel.Figure.propTypes), // TODO: panel figure configs
+  tileLink: PropTypes.shape(Link.propTypes),
+  title: PropTypes.string,
+  titleTag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
+};

--- a/packages/sage-react/lib/MediaTile/MediaTile.spec.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTile.spec.jsx
@@ -1,0 +1,24 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Hint } from './Hint';
+
+describe('Sage Hint', () => {
+  let component,
+    defaultProps;
+
+  beforeEach(() => {
+    defaultProps = {};
+
+    component = shallow(
+      <Hint {...defaultProps} />
+    );
+  });
+
+  describe('construction', () => {
+    it('renders the component', () => {
+      expect(component).toHaveLength(1);
+    });
+  });
+});

--- a/packages/sage-react/lib/MediaTile/MediaTile.story.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTile.story.jsx
@@ -4,6 +4,7 @@ import { selectArgs } from '../story-support/helpers';
 import { Button } from '../Button';
 import { Label } from '../Label';
 import { MediaTile } from './MediaTile';
+import { MediaTiles } from './MediaTiles';
 
 export default {
   title: 'Sage/Media Tile',

--- a/packages/sage-react/lib/MediaTile/MediaTile.story.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTile.story.jsx
@@ -4,7 +4,6 @@ import { selectArgs } from '../story-support/helpers';
 import { Button } from '../Button';
 import { Label } from '../Label';
 import { MediaTile } from './MediaTile';
-import { MediaTiles } from './MediaTiles';
 
 export default {
   title: 'Sage/Media Tile',
@@ -13,7 +12,7 @@ export default {
     ...selectArgs({}),
   },
   args: {
-    title: "Lorem Ipsum Dolor Sit",
+    title: 'Lorem Ipsum Dolor Sit',
     actionsCustom: null,
     actionsDropdownItems: [
       {
@@ -61,7 +60,7 @@ export const Default = Template.bind({});
 
 export const KitchenSink = Template.bind({});
 KitchenSink.args = {
-  title: "Lorem Ipsum Dolor Sit",
+  title: 'Lorem Ipsum Dolor Sit',
   actionsCustom: (
     <Label value="Published" color={Label.COLORS.PUBLISHED} />
   ),

--- a/packages/sage-react/lib/MediaTile/MediaTile.story.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTile.story.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { SageTokens } from '../configs';
+import { selectArgs } from '../story-support/helpers';
+import { Button } from '../Button';
+import { Label } from '../Label';
+import { MediaTile } from './MediaTile';
+
+export default {
+  title: 'Sage/Media Tile',
+  component: MediaTile,
+  argTypes: {
+    ...selectArgs({}),
+  },
+  args: {
+    title: "Lorem Ipsum Dolor Sit",
+    actionsCustom: null,
+    actionsDropdownItems: [
+      {
+        id: '1',
+        label: 'One item',
+      },
+      {
+        id: '2',
+        label: 'Two item',
+      },
+      {
+        id: '3',
+        label: 'Three item',
+      }
+    ],
+    children: (
+      <p>
+        Amet, consectetur adipiscing elit.
+        In quis ante tristique, posuere arcu id, lobortis ex.
+        Quisque mattis sapien et augue elementum.
+        Vitae euismod justo tristique.
+      </p>
+    ),
+    caption: (
+      <p>
+        Suspendisse euismod elit fringilla urna pulvinar ullamcorper.
+        Nam in risus velit.
+        Maecenas bibendum quis metus id placerat.
+      </p>
+    ),
+    footer: null,
+    media: (
+      <img src="//source.unsplash.com/random/800x600" alt="" />
+    ),
+    tileLink: {
+      href: '//example.com',
+      rel: 'noopener noreferrer',
+      target: '_blank',
+    },
+  }
+};
+
+const Template = (args) => <MediaTile {...args} />;
+export const Default = Template.bind({});
+
+export const KitchenSink = Template.bind({});
+KitchenSink.args = {
+  title: "Lorem Ipsum Dolor Sit",
+  actionsCustom: (
+    <Label value="Published" color={Label.COLORS.PUBLISHED} />
+  ),
+  footer: (
+    <Button
+      color={Button.COLORS.PRIMARY}
+      icon={SageTokens.ICONS.ARROW_RIGHT}
+      iconPosition={Button.ICON_POSITIONS.RIGHT}
+      subtle={true}
+    >
+      Learn more
+    </Button>
+  ),
+  mediaConfigs: {
+    aspectRatio: 1.8,
+    backgroundColor: SageTokens.COLOR_PALETTE.SAGE_100,
+    padded: true,
+  },
+  tileLink: null,
+};

--- a/packages/sage-react/lib/MediaTile/MediaTiles.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTiles.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import uuid from 'react-uuid';
 import classnames from 'classnames';
 import { Grid } from '../Grid';
+import { MediaTile } from './MediaTile';
 
 export const MediaTiles = ({
+  children,
   className,
+  items,
   ...rest
 }) => {
   const classNames = classnames(
@@ -14,15 +18,22 @@ export const MediaTiles = ({
 
   return (
     <Grid className={classNames} {...rest}>
+      {items.map((item) => (
+        <MediaTile key={uuid()} {...item} />
+      ))}
       {children}
     </Grid>
   );
 };
 
 MediaTiles.defaultProps = {
+  children: null,
   className: '',
+  items: [],
 };
 
 MediaTiles.propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.shape(MediaTile.propTypes)),
 };

--- a/packages/sage-react/lib/MediaTile/MediaTiles.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTiles.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { Grid } from '../Grid';
+
+export const MediaTiles = ({
+  className,
+  ...rest
+}) => {
+  const classNames = classnames(
+    'sage-media-tile-container',
+    className,
+  );
+
+  return (
+    <Grid className={classNames} {...rest}>
+      {children}
+    </Grid>
+  );
+};
+
+MediaTiles.defaultProps = {
+  className: '',
+};
+
+MediaTiles.propTypes = {
+  className: PropTypes.string,
+};

--- a/packages/sage-react/lib/MediaTile/MediaTiles.spec.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTiles.spec.jsx
@@ -2,9 +2,9 @@ require('../test/testHelper');
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { MediaTile } from './MediaTile';
+import { MediaTiles } from './MediaTiles';
 
-describe('Sage MediaTile', () => {
+describe('Sage MediaTiles', () => {
   let component,
     defaultProps;
 
@@ -12,7 +12,7 @@ describe('Sage MediaTile', () => {
     defaultProps = {};
 
     component = shallow(
-      <MediaTile {...defaultProps} />
+      <MediaTiles {...defaultProps} />
     );
   });
 

--- a/packages/sage-react/lib/MediaTile/MediaTiles.story.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTiles.story.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { MediaTiles } from './MediaTiles';
+
+const actionsDropdownItems = [
+  {
+    id: '1',
+    label: 'One item',
+  },
+  {
+    id: '2',
+    label: 'Two item',
+  },
+  {
+    id: '3',
+    label: 'Three item',
+  }
+];
+
+const commonChildren = (
+  <p>
+    Amet, consectetur adipiscing elit.
+    In quis ante tristique, posuere arcu id, lobortis ex.
+    Quisque mattis sapien et augue elementum.
+    Vitae euismod justo tristique.
+  </p>
+);
+
+const commonTileLink = {
+  href: '//example.com',
+  rel: 'noopener noreferrer',
+  target: '_blank',
+};
+
+export default {
+  title: 'Sage/Media Tiles',
+  component: MediaTiles,
+  argTypes: {
+    ...selectArgs({}),
+  },
+  args: {
+    items: [
+      {
+        title: "Lorem Ipsum Dolor Sit",
+        actionsCustom: null,
+        actionsDropdownItems,
+        children: commonChildren,
+        footer: null,
+        media: (
+          <img src="//source.unsplash.com/random/800x600?1" alt="" />
+        ),
+        tileLink: commonTileLink,
+      },
+      {
+        title: "Lorem Ipsum Dolor Sit",
+        actionsCustom: null,
+        actionsDropdownItems,
+        children: commonChildren,
+        footer: null,
+        media: (
+          <img src="//source.unsplash.com/random/800x600?2" alt="" />
+        ),
+        tileLink: commonTileLink,
+      },
+      {
+        title: "Lorem Ipsum Dolor Sit",
+        actionsCustom: null,
+        actionsDropdownItems,
+        children: commonChildren,
+        footer: null,
+        media: (
+          <img src="//source.unsplash.com/random/800x600?3" alt="" />
+        ),
+        tileLink: commonTileLink,
+      },
+      {
+        title: "Lorem Ipsum Dolor Sit",
+        actionsCustom: null,
+        actionsDropdownItems,
+        children: commonChildren,
+        footer: null,
+        media: (
+          <img src="//source.unsplash.com/random/800x600?4" alt="" />
+        ),
+        tileLink: commonTileLink,
+      },
+    ],
+  },
+};
+
+const Template = (args) => <MediaTiles {...args} />;
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/MediaTile/MediaTiles.story.jsx
+++ b/packages/sage-react/lib/MediaTile/MediaTiles.story.jsx
@@ -41,7 +41,7 @@ export default {
   args: {
     items: [
       {
-        title: "Lorem Ipsum Dolor Sit",
+        title: 'Lorem Ipsum Dolor Sit',
         actionsCustom: null,
         actionsDropdownItems,
         children: commonChildren,
@@ -52,7 +52,7 @@ export default {
         tileLink: commonTileLink,
       },
       {
-        title: "Lorem Ipsum Dolor Sit",
+        title: 'Lorem Ipsum Dolor Sit',
         actionsCustom: null,
         actionsDropdownItems,
         children: commonChildren,
@@ -63,7 +63,7 @@ export default {
         tileLink: commonTileLink,
       },
       {
-        title: "Lorem Ipsum Dolor Sit",
+        title: 'Lorem Ipsum Dolor Sit',
         actionsCustom: null,
         actionsDropdownItems,
         children: commonChildren,
@@ -74,7 +74,7 @@ export default {
         tileLink: commonTileLink,
       },
       {
-        title: "Lorem Ipsum Dolor Sit",
+        title: 'Lorem Ipsum Dolor Sit',
         actionsCustom: null,
         actionsDropdownItems,
         children: commonChildren,

--- a/packages/sage-react/lib/MediaTile/index.js
+++ b/packages/sage-react/lib/MediaTile/index.js
@@ -1,0 +1,1 @@
+export { MediaTile } from './MediaTile';

--- a/packages/sage-react/lib/MediaTile/index.js
+++ b/packages/sage-react/lib/MediaTile/index.js
@@ -1,1 +1,2 @@
 export { MediaTile } from './MediaTile';
+export { MediaTiles } from './MediaTiles';

--- a/packages/sage-react/lib/Panel/Panel.story.jsx
+++ b/packages/sage-react/lib/Panel/Panel.story.jsx
@@ -373,35 +373,49 @@ export const PanelRow = (args) => (
   </Grid>
 );
 
-export const PanelFigure = ({ bleedDirection, ...args }) => (
+export const PanelFigure = ({ aspectRatio, backgroundColor, bleed, padded }) => (
   <Grid container={Grid.CONTAINER_SIZES.LG}>
     <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.SPACERS.MD_BOTTOM}`}>
       <strong>Note:</strong> Normally there would be other content along with the figure.
       Content was ommitted here in order to demonstrate the bleed options through Knobs.
       Observe the space that remains inside the panel outside the figure with each setting.
     </p>
-    <Panel {...args}>
-      <Panel.Figure bleed={bleedDirection}>
+    <Panel>
+      <Panel.Figure
+        aspectRatio={aspectRatio}
+        backgroundColor={backgroundColor}
+        bleed={bleed}
+        padded={padded}
+      >
         <img src="//source.unsplash.com/800x500" alt="" />
       </Panel.Figure>
     </Panel>
   </Grid>
 );
 PanelFigure.args = {
-  bleedDirection: 3,
+  aspectRatio: null,
+  backgroundColor: null,
+  bleed: null,
+  padded: false,
 };
 // fully custom ArgsTable
 PanelFigure.argTypes = {
-  bleedDirection: {
+  bleed: {
     control: {
       type: 'radio',
       options: Panel.Figure.BLEED_OPTIONS
     }
-  }
+  },
 };
 PanelFigure.defaultProps = {
-  bleedDirection: null
+  aspectRatio: null,
+  backgroundColor: null,
+  bleed: null,
+  padded: false,
 };
 PanelFigure.propTypes = {
-  bleedDirection: PropTypes.oneOf(Object.values(Panel.Figure.BLEED_OPTIONS))
+  aspectRatio: PropTypes.number,
+  backgroundColor: PropTypes.string,
+  bleed: PropTypes.oneOf(Object.values(Panel.Figure.BLEED_OPTIONS)),
+  padded: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Panel/PanelFigure.jsx
+++ b/packages/sage-react/lib/Panel/PanelFigure.jsx
@@ -4,25 +4,40 @@ import classnames from 'classnames';
 import { PANEL_FIGURE_BLEED_OPTIONS } from './configs';
 
 export const PanelFigure = ({
+  aspectRatio,
+  backgroundColor,
+  bleed,
   children,
   className,
-  bleed,
   isWistia,
+  padded,
   ...rest
 }) => {
   const classNames = classnames(
     'sage-panel__figure',
     className,
     {
-      'sage-panel__figure--wistia': isWistia,
+      'sage-panel__figure--aspect-ratio': aspectRatio,
       [`sage-panel__figure--${bleed}`]: bleed,
+      'sage-panel__figure--padded': padded,
+      'sage-panel__figure--wistia': isWistia,
     }
   );
+
+  const customStyles = {};
+  if (aspectRatio) {
+    customStyles[`--sage-figure-aspect-ratio`] = aspectRatio;
+  }
+
+  if (backgroundColor) {
+    customStyles[`--sage-figure-background-color`] = backgroundColor;
+  }
 
   return (
     <div
       className={classNames}
       {...rest}
+      style={{ ...customStyles, ...rest.styles }}
     >
       {children}
     </div>
@@ -32,15 +47,21 @@ export const PanelFigure = ({
 PanelFigure.BLEED_OPTIONS = PANEL_FIGURE_BLEED_OPTIONS;
 
 PanelFigure.defaultProps = {
+  aspectRatio: null,
+  backgroundColor: null,
   bleed: PANEL_FIGURE_BLEED_OPTIONS.NONE,
   children: null,
   className: null,
   isWistia: false,
+  padded: false,
 };
 
 PanelFigure.propTypes = {
+  aspectRatio: PropTypes.number,
+  backgroundColor: PropTypes.string,
   bleed: PropTypes.oneOf(Object.values(PANEL_FIGURE_BLEED_OPTIONS)),
   children: PropTypes.node,
   className: PropTypes.string,
   isWistia: PropTypes.bool,
+  padded: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Panel/PanelFigure.jsx
+++ b/packages/sage-react/lib/Panel/PanelFigure.jsx
@@ -26,11 +26,11 @@ export const PanelFigure = ({
 
   const customStyles = {};
   if (aspectRatio) {
-    customStyles[`--sage-figure-aspect-ratio`] = aspectRatio;
+    customStyles['--sage-figure-aspect-ratio'] = aspectRatio;
   }
 
   if (backgroundColor) {
-    customStyles[`--sage-figure-background-color`] = backgroundColor;
+    customStyles['--sage-figure-background-color'] = backgroundColor;
   }
 
   return (

--- a/packages/sage-react/lib/Panel/PanelFigureNotes.story.mdx
+++ b/packages/sage-react/lib/Panel/PanelFigureNotes.story.mdx
@@ -7,3 +7,9 @@ Figues in Panels sit inside the panel's padding by default, but the `bleed` prop
 - `top` is meant for a figure as the very first child of a Panel and will bleed into the top and sides of the panel.
 - `sides` is meant for a figure in the middle of a panel and will bleed just to the edges.
 - `bottom` opposite of `top`, this is meant for a figure as the very last child of a panel and will bleed into the sides and bottom of the panel.
+
+Figures also allow for some particular configurations for the being shown:
+
+- `aspectRatio` allows you to specify an aspect ratio that will be used for rendering and resizing the media.
+- `backgroundColor` allows you to specify the background color that is used. A light grey will appear by default.
+- `padded` allows you to set whether or not the media has a standardized padding around it that allows a background color to show through. Note that this is designed currently to work best with the `bleed: "top"` setting.

--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -32,6 +32,7 @@ export { Link } from './Link';
 export { Loader } from './Loader';
 export {
   MediaTile,
+  MediaTiles,
 } from './MediaTile';
 export { Modal } from './Modal';
 export { PageHeading } from './PageHeading';

--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -30,6 +30,9 @@ export { Input } from './Input';
 export { Label } from './Label';
 export { Link } from './Link';
 export { Loader } from './Loader';
+export {
+  MediaTile,
+} from './MediaTile';
 export { Modal } from './Modal';
 export { PageHeading } from './PageHeading';
 export { Pagination } from './Pagination';


### PR DESCRIPTION
## Description

This PR adds a React component for the recent Rails component added for Media Tiles.

## Testing in `sage-lib`

See [Storybook](http://localhost:4100/?path=/story/sage-media-tile--default) for stories that demonstrate this component parallels the current Rails version. 

## Testing in `kajabi-products`

1. (LOW) Add React version of the Media Tiles component. No impact on current implementations.
