### PR TITLE
[Sage-762] Fixes Icon page in Docs

### DIFF
--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -29,19 +29,19 @@ This can be used in combination with the different icon sizes.
 and also be used with a vareity of layout techniques or components such as CSS flexbox (used below) or grid templates within `SageCardRow` or `SagePanelRow`.
 ") %>
 <div style="display: flex;">
-  <%= sage_component SageIcon, { icon: "check-circle", beside_type: "h2", spacer: { right: "xs" } } %>
+  <%= sage_component SageIcon, { icon: "check-circle", adjacent_type: "h2", spacer: { right: "xs" } } %>
   <h2 class="<%= SageClassnames::TYPE::HEADING_2 %>">Heading 2 Lorem ipsum dolor sit</h2>
 </div>
 <div style="display: flex;">
-  <%= sage_component SageIcon, { icon: "check-circle", beside_type: "h4", spacer: { right: "xs" } } %>
+  <%= sage_component SageIcon, { icon: "check-circle", adjacent_type: "h4", spacer: { right: "xs" } } %>
   <h4 class="<%= SageClassnames::TYPE::HEADING_4 %>">Heading 4 Lorem ipsum dolor sit</h4>
 </div>
 <div style="display: flex;">
-  <%= sage_component SageIcon, { icon: "check-circle", beside_type: "body", spacer: { right: "xs" } } %>
+  <%= sage_component SageIcon, { icon: "check-circle", adjacent_type: "body", spacer: { right: "xs" } } %>
   <p class="<%= SageClassnames::TYPE::BODY %>">Body Lorem ipsum dolor sit</p>
 </div>
 <div style="display: flex;">
-  <%= sage_component SageIcon, { icon: "check-circle", beside_type: "body-sm", spacer: { right: "xs" } } %>
+  <%= sage_component SageIcon, { icon: "check-circle", adjacent_type: "body-sm", spacer: { right: "xs" } } %>
   <p class="<%= SageClassnames::TYPE::BODY_SMALL %>">Body Small Lorem ipsum dolor sit</p>
 </div>
 

--- a/docs/app/views/examples/components/icon/_props.html.erb
+++ b/docs/app/views/examples/components/icon/_props.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= md('`beside_type`') %></td>
+  <td><%= md('`adjacent_type`') %></td>
   <td><%= md('Improves alignment for icons that are placed beside type such as in `SagePanelRow` or with flexbox.') %></td>
   <td><%= md("`#{SageTokens::RESPONSIVE_TYPE_SPECS.inspect()}`") %></td>
   <td><%= md('`nil`') %></td>


### PR DESCRIPTION
## Description
Updates prop to fix Icon page in Sage Docs 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
N/A


## Testing in `sage-lib`
- Navigate to Icon page
- Ensure that page isn't broken

## Testing in `kajabi-products`
N/A. Sage Docs-related.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
#762 