### PR TITLE
fix(modal-header): set display to `flex` to revert modal changes

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -101,7 +101,7 @@ $-modal-header-image-size: rem(28px);
 }
 
 .sage-modal__header {
-  display: grid;
+  display: flex;
   align-items: baseline;
   margin: $-modal-padding-y $-modal-padding-x;
 }


### PR DESCRIPTION
## Description

Follow-up to another PR that changed the [`display` property to `grid`](https://github.com/Kajabi/sage-lib/pull/756/files#diff-c4b0939ec4a98894934a99f808f070978ce3157e58a115db3aba25b23585b512R104). This PR reverts that change to `display: flex` to fix issues in QE review with version bump.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2021-09-02 at 11 48 45 AM](https://user-images.githubusercontent.com/24237393/131884684-7f2e3f0a-3d4a-4f1d-b0db-442f94e5570e.png) | ![Screen Shot 2021-09-02 at 11 48 53 AM](https://user-images.githubusercontent.com/24237393/131884725-dc52f274-a016-4aac-a621-2c1977a29fa2.png) |


## Testing in `sage-lib`
1. Navigate to [Modals](http://localhost:4000/pages/component/modal)
2. Observe modal close button is positioned correctly


## Testing in `kajabi-products`
1. (**MEDIUM**) Modal close button alignment must show on the top right and be inline with the heading

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
