### PR TITLE
[SAGE-759] expandable card active

### DIFF
--- a/docs/app/views/examples/components/expandable_card/_preview.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_preview.html.erb
@@ -1,3 +1,30 @@
+<h3 class="t-sage-heading-6">Expanded (Open state)</h3>
+<%= sage_component SageExpandableCard, {
+  trigger_label: "Expand",
+  expanded: true,
+} do %>
+  <%= sage_component SageCheckbox, {
+    id:"c1",
+    label_text: "Grant offers",
+    checked: false,
+    disabled: false,
+    has_error: false
+  } %>
+  <%= sage_component SageCheckbox, {
+    id:"c2",
+    label_text: "Add tags",
+    checked: false,
+    disabled: false,
+    has_error: false
+  } %>
+  <%= sage_component SageCheckbox, {
+    id:"c3",
+    label_text: "Subscribe to emails",
+    checked: false,
+    disabled: false,
+    has_error: false
+  } %>
+<% end %>
 <h3 class="t-sage-heading-6">Bordered</h3>
 <%= sage_component SageExpandableCard, {
   trigger_label: "Expand",

--- a/docs/app/views/examples/components/expandable_card/_preview.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_preview.html.erb
@@ -1,7 +1,7 @@
 <h3 class="t-sage-heading-6">Expanded (Open state)</h3>
 <%= sage_component SageExpandableCard, {
   trigger_label: "Expand",
-  expanded: true,
+  expanded: true
 } do %>
   <%= sage_component SageCheckbox, {
     id:"c1",

--- a/docs/app/views/examples/components/expandable_card/_props.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_props.html.erb
@@ -1,4 +1,10 @@
 <tr>
+  <td><%= md('`expanded`') %></td>
+  <td><%= md("Adds the `sage-expandable-card--expanded` class to the block level `sage-expandable-card` and allows you to load the expandable card body expanded") %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`body_bordered`') %></td>
   <td><%= md('Adds border and background to body.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/shared/_code.html.erb
+++ b/docs/app/views/examples/shared/_code.html.erb
@@ -6,7 +6,7 @@
         <code><%= klass %></code>
       <% end %>
       <div class="example__code">
-        <button class="example__expand-btn" ="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+        <button class="example__expand-btn" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
         <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
           <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
         </div>
@@ -17,7 +17,7 @@
         <code><%= klass %>::ATTRIBUTE_SCHEMA</code>
       <% end %>
       <div class="example__code">
-        <button class="example__expand-btn" ="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+        <button class="example__expand-btn" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
         <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
           <pre class="prettyprint"><code><%= klass::ATTRIBUTE_SCHEMA.pretty_inspect %></code></pre>
         </div>
@@ -33,7 +33,7 @@
   <%= sage_component SageCard, { spacer: { bottom: :md } } do %>
     <%= sage_component SageCardHeader, { title: "Generated HTML Code"} %>
     <div class="example__code">
-      <button class="example__expand-btn" ="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
+      <button class="example__expand-btn" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
       <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
         <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
       </div>

--- a/docs/app/views/examples/shared/_code.html.erb
+++ b/docs/app/views/examples/shared/_code.html.erb
@@ -6,7 +6,7 @@
         <code><%= klass %></code>
       <% end %>
       <div class="example__code">
-        <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+        <button class="example__expand-btn" ="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
         <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
           <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
         </div>
@@ -17,7 +17,7 @@
         <code><%= klass %>::ATTRIBUTE_SCHEMA</code>
       <% end %>
       <div class="example__code">
-        <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+        <button class="example__expand-btn" ="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
         <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
           <pre class="prettyprint"><code><%= klass::ATTRIBUTE_SCHEMA.pretty_inspect %></code></pre>
         </div>
@@ -33,7 +33,7 @@
   <%= sage_component SageCard, { spacer: { bottom: :md } } do %>
     <%= sage_component SageCardHeader, { title: "Generated HTML Code"} %>
     <div class="example__code">
-      <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
+      <button class="example__expand-btn" ="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
       <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
         <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
       </div>

--- a/docs/app/views/examples/shared/_code.html.erb
+++ b/docs/app/views/examples/shared/_code.html.erb
@@ -6,7 +6,7 @@
         <code><%= klass %></code>
       <% end %>
       <div class="example__code">
-        <button class="example__expand-btn" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+        <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
         <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
           <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/", type.pluralize, title, "_preview.html.erb")) %></code></pre>
         </div>
@@ -17,7 +17,7 @@
         <code><%= klass %>::ATTRIBUTE_SCHEMA</code>
       <% end %>
       <div class="example__code">
-        <button class="example__expand-btn" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
+        <button class="example__expand-btn" aria-expanded="false" aria-controls="example-rails-code-<%= title %>">Expand this code snippet</button>
         <div id="example-rails-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
           <pre class="prettyprint"><code><%= klass::ATTRIBUTE_SCHEMA.pretty_inspect %></code></pre>
         </div>
@@ -33,7 +33,7 @@
   <%= sage_component SageCard, { spacer: { bottom: :md } } do %>
     <%= sage_component SageCardHeader, { title: "Generated HTML Code"} %>
     <div class="example__code">
-      <button class="example__expand-btn" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
+      <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
       <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
         <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
       </div>

--- a/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
@@ -2,6 +2,7 @@ class SageExpandableCard < SageComponent
   set_attribute_schema({
     body_bordered: [:optional, TrueClass],
     sage_type: [:optional, TrueClass],
+    expanded: [:optional, TrueClass],
     trigger_label: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -12,6 +12,7 @@
     css_classes: "sage-expandable-card__trigger",
     attributes: {
       "data-js-accordion": "header",
+      "aria-expanded": (component.expanded.present? ? true : false)
     },
   } %>
   <div class="

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -1,4 +1,9 @@
-<div class="sage-expandable-card <%= component.generated_css_classes %>" <%= component.generated_html_attributes.html_safe %>>
+<div 
+  class="sage-expandable-card 
+    <%= component.generated_css_classes %>
+    <% if component.expanded.present? %>sage-expandable-card--expanded<% end %>"
+    <%= component.generated_html_attributes.html_safe %>
+>
   <%= sage_component SageButton, {
     style: "primary",
     value: component.trigger_label,
@@ -7,7 +12,6 @@
     css_classes: "sage-expandable-card__trigger",
     attributes: {
       "data-js-accordion": "header",
-      "aria-expanded": "false",
     },
   } %>
   <div class="

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -19,7 +19,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
   margin: 0;
   padding: 0;
   
-  [aria-expanded="true"] + & {
+  .sage-expandable-card--expanded & {
     overflow: initial;
     height: auto;
     margin-top: sage-spacing(xs);
@@ -34,7 +34,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
   padding-left: $-expandable-card-padding;
   padding-right: $-expandable-card-padding;
 
-  [aria-expanded="true"] + & {
+  .sage-expandable-card--expanded & {
     padding-top: $-expandable-card-padding;
     padding-bottom: $-expandable-card-padding;
     border-radius: $-expandable-card-border-radius;
@@ -52,8 +52,10 @@ $-expandable-card-padding-xs: sage-spacing(xs);
     font-size: rem(8px);
     transition: transform 0.2s linear;
   }
+}
 
-  &[aria-expanded="true"]::before {
+.sage-expandable-card--expanded {
+  .sage-expandable-card__trigger::before {
     transform: rotateZ(90deg);
   }
 }

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -31,6 +31,7 @@ export const ExpandableCard = ({
   const containerClassnames = classnames({
     'sage-expandable-card sage-expandable-card--expanded': expanded,
     'sage-expandable-card': !expanded,
+    'sage-expandable-card--expanded': selfActive
   });
 
   const bodyClassnames = classnames({
@@ -53,11 +54,9 @@ export const ExpandableCard = ({
       >
         {triggerLabel}
       </Button>
-      {selfActive && (
-        <div id={id} className={bodyClassnames}>
-          {children}
-        </div>
-      )}
+      <div id={id} className={bodyClassnames}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -5,7 +5,14 @@ import uuid from 'react-uuid';
 import { Button } from '../Button';
 import { SageClassnames, SageTokens } from '../configs';
 
-export const ExpandableCard = ({ bodyBordered, children, className, sageType, triggerLabel, }) => {
+export const ExpandableCard = ({
+  bodyBordered,
+  expanded,
+  children,
+  className,
+  sageType,
+  triggerLabel,
+}) => {
   const [selfActive, setSelfActive] = useState(false);
 
   const handleBodyToggle = () => {
@@ -21,6 +28,11 @@ export const ExpandableCard = ({ bodyBordered, children, className, sageType, tr
 
   const id = uuid();
 
+  const containerClassnames = classnames({
+    'sage-expandable-card sage-expandable-card--expanded': expanded,
+    'sage-expandable-card': !expanded,
+  });
+
   const bodyClassnames = classnames({
     'sage-expandable-card__body-bordered': bodyBordered,
     'sage-expandable-card__body': !bodyBordered,
@@ -28,7 +40,7 @@ export const ExpandableCard = ({ bodyBordered, children, className, sageType, tr
   });
 
   return (
-    <div className={`sage-expandable-card ${className || ''}`}>
+    <div className={`${containerClassnames} ${className || ''}`}>
       <Button
         aria-controls={id}
         aria-expanded={selfActive}
@@ -52,6 +64,7 @@ export const ExpandableCard = ({ bodyBordered, children, className, sageType, tr
 
 ExpandableCard.defaultProps = {
   bodyBordered: false,
+  expanded: false,
   children: null,
   className: null,
   sageType: false,
@@ -60,6 +73,7 @@ ExpandableCard.defaultProps = {
 
 ExpandableCard.propTypes = {
   bodyBordered: PropTypes.bool,
+  expanded: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
   sageType: PropTypes.bool,

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx
@@ -7,6 +7,7 @@ export default {
   component: ExpandableCard,
   args: {
     bodyBordered: false,
+    expanded: true,
     children: (
       <>
         <Checkbox

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx
@@ -7,7 +7,7 @@ export default {
   component: ExpandableCard,
   args: {
     bodyBordered: false,
-    expanded: true,
+    expanded: false,
     children: (
       <>
         <Checkbox

--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -61,7 +61,6 @@ Sage.accordion = (function () {
     }
 
     // Add a11y attributes
-    // header.setAttribute('aria-expanded', false);
     header.setAttribute('aria-controls', bodyId);
     header.setAttribute('role', 'button');
     header.setAttribute('tabindex', 0);

--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -34,7 +34,7 @@ Sage.accordion = (function () {
     // Toggle target
     const toggle = el.getAttribute('aria-expanded') === 'true';
     el.setAttribute('aria-expanded', !toggle);
-    el.nextElementSibling.hidden = toggle;
+    el.parentNode.classList.toggle('sage-expandable-card--expanded');
   }
 
   function init(el) {
@@ -58,11 +58,10 @@ Sage.accordion = (function () {
     if (!bodyId) {
       bodyId = generateId(JS_ACCORDION_ID_BODY_PREFIX);
       body.setAttribute('id', bodyId);
-      body.hidden = true;
     }
 
     // Add a11y attributes
-    header.setAttribute('aria-expanded', false);
+    // header.setAttribute('aria-expanded', false);
     header.setAttribute('aria-controls', bodyId);
     header.setAttribute('role', 'button');
     header.setAttribute('tabindex', 0);


### PR DESCRIPTION
Resolves #759 

## Description

Provides an option for the expandable card component to allow for devs to load the expandable card expanded, rather than closed.


## Screenshots

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-09-16 at 2 30 54 PM](https://user-images.githubusercontent.com/24237393/133673991-67cb7c48-a7cd-4c4f-b41a-49b8693ea69e.png) |![Screen Shot 2021-09-16 at 2 15 45 PM](https://user-images.githubusercontent.com/24237393/133673855-d209b7e9-5608-4f40-a3d3-2dc1bbcc0218.png)|


## Testing in `sage-lib`

1. Navigate to the [Expandable Card component](http://localhost:4000/pages/component/expandable_card)
2. Note that the first card is loaded "expanded" or "open"
3. Confirm the card closes and reopens
4. Confirm that the other cards open and close

## Testing in `kajabi-products`

1. (**MEDIUM**) Expanded card update is a new option within the expandable cards and instances of expandable cards should be verified to confirm no regressions, for example:
    -  [ ] Fowarding Page Rule: Step 5 in Settings -> Domain -> Cloudflare account setup under "Setup Forwarding Page Rules"
