### PR TITLE
Gracefully check for a trigger

### DIFF
--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -64,7 +64,7 @@ Sage.modal = (function() {
 
     dispatchOpenEvents(modal);
 
-    if(trigger.hasAttribute(SELECTOR_MODAL_REMOTE_URL)) {
+    if(trigger && trigger.hasAttribute(SELECTOR_MODAL_REMOTE_URL)) {
       fetchModalContent(modal, trigger.dataset.jsRemoteUrl);
     } else if (modal.hasAttribute(SELECTOR_MODAL_REMOTE_URL)) {
       fetchModalContent(modal);


### PR DESCRIPTION
## Description

This PR patches the recent modal changes to ensure `openModal` gracefully ignores if no `trigger` is provided for the second parameter (since this function is currently called within `kp` in some places).


## Testing in `kajabi-products`

1. (LOW) Fixes error occurring from prior modal update where `openModal` is called directly; no errors should remain.
