### PR TITLE
[Sage-504] Sage 3 - Form Input Icon

### DIFF
--- a/docs/app/views/examples/components/form_input/_preview.html.erb
+++ b/docs/app/views/examples/components/form_input/_preview.html.erb
@@ -2,6 +2,7 @@
 
   <h3 class="t-sage-heading-6">Text (default)</h3>
   <%= sage_component SageFormInput, {
+    icon: "info-circle",
     id: "form__fname1",
     input_type: "text",
     label_text: "First name",

--- a/docs/app/views/examples/components/form_input/_preview.html.erb
+++ b/docs/app/views/examples/components/form_input/_preview.html.erb
@@ -200,6 +200,10 @@
   } do %>
     <%= sage_component SagePopover, {
       icon: "info-circle",
+      link: {
+        href: "#",
+        name: "Learn more about a thing",
+      },
       popover_position: "left",
       trigger_value: "Open Menu",
       trigger_icon_only: true,

--- a/docs/app/views/examples/components/form_input/_preview.html.erb
+++ b/docs/app/views/examples/components/form_input/_preview.html.erb
@@ -198,17 +198,19 @@
     name: "custom_input_name",
     has_placeholder: false
   } do %>
-    <%= sage_component SagePopover, {
-      icon: "info-circle",
-      link: {
-        href: "#",
-        name: "Learn more about a thing",
-      },
-      popover_position: "left",
-      trigger_value: "Open Menu",
-      trigger_icon_only: true,
-    } do %>
-      <p>I can put whatever content I want in here and use the custom class as a hook to style it like a good 'ol BEM mixin!</p>
+    <%= content_for :sage_form_input_popover do %>
+      <%= sage_component SagePopover, {
+        icon: "info-circle",
+        link: {
+          href: "#",
+          name: "Learn more about a thing",
+        },
+        popover_position: "left",
+        trigger_value: "Open Menu",
+        trigger_icon_only: true,
+      } do %>
+        <p>I can put whatever content I want in here and use the custom class as a hook to style it like a good 'ol BEM mixin!</p>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/docs/app/views/examples/components/form_input/_preview.html.erb
+++ b/docs/app/views/examples/components/form_input/_preview.html.erb
@@ -2,7 +2,6 @@
 
   <h3 class="t-sage-heading-6">Text (default)</h3>
   <%= sage_component SageFormInput, {
-    icon: "info-circle",
     id: "form__fname1",
     input_type: "text",
     label_text: "First name",
@@ -13,7 +12,15 @@
     name: "custom_input_name",
     message_text: "This is a message",
     has_placeholder: false
-  } %>
+  } do %>
+  <%= sage_component SagePopover, {
+    icon: "info-circle",
+    trigger_value: "Open Menu",
+    trigger_icon_only: true,
+  } do %>
+    <p>I can put whatever content I want in here and use the custom class as a hook to style it like a good 'ol BEM mixin!</p>
+  <% end %>
+<% end %>
 
   <h3 class="t-sage-heading-6">Text (with error)</h3>
   <%= sage_component SageFormInput, {

--- a/docs/app/views/examples/components/form_input/_preview.html.erb
+++ b/docs/app/views/examples/components/form_input/_preview.html.erb
@@ -12,15 +12,7 @@
     name: "custom_input_name",
     message_text: "This is a message",
     has_placeholder: false
-  } do %>
-  <%= sage_component SagePopover, {
-    icon: "info-circle",
-    trigger_value: "Open Menu",
-    trigger_icon_only: true,
-  } do %>
-    <p>I can put whatever content I want in here and use the custom class as a hook to style it like a good 'ol BEM mixin!</p>
-  <% end %>
-<% end %>
+  } %>
 
   <h3 class="t-sage-heading-6">Text (with error)</h3>
   <%= sage_component SageFormInput, {
@@ -179,5 +171,41 @@
     has_error: false,
     has_placeholder: true
   } %>
+
+  <h3 class="t-sage-heading-6">With Static Icon</h3>
+  <%= sage_component SageFormInput, {
+    icon: "info-circle",
+    id: "form__fname1",
+    input_type: "text",
+    label_text: "First name",
+    placeholder: "First name",
+    required: true,
+    disabled: false,
+    has_error: false,
+    name: "custom_input_name",
+    has_placeholder: false
+  } %>
+
+  <h3 class="t-sage-heading-6">With Popover</h3>
+  <%= sage_component SageFormInput, {
+    id: "form__fname1",
+    input_type: "text",
+    label_text: "First name",
+    placeholder: "First name",
+    required: true,
+    disabled: false,
+    has_error: false,
+    name: "custom_input_name",
+    has_placeholder: false
+  } do %>
+    <%= sage_component SagePopover, {
+      icon: "info-circle",
+      popover_position: "left",
+      trigger_value: "Open Menu",
+      trigger_icon_only: true,
+    } do %>
+      <p>I can put whatever content I want in here and use the custom class as a hook to style it like a good 'ol BEM mixin!</p>
+    <% end %>
+  <% end %>
 
 </fieldset>

--- a/docs/app/views/examples/components/form_input/_props.html.erb
+++ b/docs/app/views/examples/components/form_input/_props.html.erb
@@ -23,6 +23,12 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Adds a static icon for visual context. See Sage Icons under "Design."') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('Unique identifier for this input field. Should match the `for` property on the corresponding label.') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/components/form_input/_props.html.erb
+++ b/docs/app/views/examples/components/form_input/_props.html.erb
@@ -143,3 +143,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 
+<tr>
+  <td colspan="2"><%= md('**Sections**') %></td>
+  <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_form_input_popover`') %></td>
+  <td><%= md('Provides the HTML content for the popover component, rendered at the right end of the form input.') %></td>
+  <td colspan="2"><%= md('Restricted to Popover `sage_component`.') %></td>
+</tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
@@ -4,6 +4,7 @@ class SageFormInput < SageComponent
     disabled: [:optional, TrueClass],
     has_error: [:optional, TrueClass],
     has_placeholder: [:optional, TrueClass],
+    icon: [:optional, NilClass, SageSchemas::ICON],
     id: String,
     input_mode: [:optional, String],
     input_type: [:optional, String],

--- a/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_input.rb
@@ -24,4 +24,8 @@ class SageFormInput < SageComponent
     suffix: [:optional, String],
     value: [:optional, String]
   })
+
+  def sections
+    %w(form_input_popover)
+  end
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -3,6 +3,8 @@
     <%= "sage-form-field--error" if component.has_error %>
     <%= "sage-input--affixed" if component.prefix.present? or component.suffix.present? %>
     <%= "sage-form-field--showplaceholder" if component.has_placeholder %>
+    <%= "sage-input--has-popover" if component.content.present? %>
+    <%= "sage-input--has-icon" if component.icon.present? %>
     <%= component.generated_css_classes %>"
   <%= "data-js-input-prefix=#{component.prefix}" if component.prefix.present? -%>
   <%= "data-js-input-suffix=#{component.suffix}" if component.suffix.present? -%>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -30,6 +30,11 @@
   <label for="<%= component.id %>" class="sage-input__label">
     <%= component.label_text %>
   </label>
+  <% if component.icon.present? %>
+    <div class="sage-input__icon">
+      <%= sage_component SageIcon, { icon: component.icon } %>
+    </div>
+  <% end %>
   <% if component.message_text.present? %>
     <div class="sage-input__message"><%= component.message_text %></div>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -38,4 +38,5 @@
   <% if component.message_text.present? %>
     <div class="sage-input__message"><%= component.message_text %></div>
   <% end %>
+  <%= component.content %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -3,7 +3,7 @@
     <%= "sage-form-field--error" if component.has_error %>
     <%= "sage-input--affixed" if component.prefix.present? or component.suffix.present? %>
     <%= "sage-form-field--showplaceholder" if component.has_placeholder %>
-    <%= "sage-input--has-popover" if component.content.present? %>
+    <%= "sage-input--has-popover" if content_for? :sage_form_input_popover %>
     <%= "sage-input--has-icon" if component.icon.present? %>
     <%= component.generated_css_classes %>"
   <%= "data-js-input-prefix=#{component.prefix}" if component.prefix.present? -%>
@@ -40,5 +40,7 @@
   <% if component.message_text.present? %>
     <div class="sage-input__message"><%= component.message_text %></div>
   <% end %>
-  <%= component.content %>
+  <% if content_for? :sage_form_input_popover %>
+    <%= content_for :sage_form_input_popover %>
+  <% end %>
 </div>

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -12,6 +12,7 @@ $-input-padding: sage-spacing(sm);
 $-input-padding-filled: sage-spacing(2xs);
 $-input-padding-label: sage-spacing(2xs);
 $-input-padding-offset: sage-spacing(sm) - $-input-border-width;
+$-input-popover-size: $-input-height;
 $-input-text-height: sage-font-size(body);
 
 
@@ -21,6 +22,21 @@ $-input-text-height: sage-font-size(body);
   .sage-input-group & {
     height: auto;
     margin-bottom: 0;
+  }
+
+  .sage-popover {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: $-input-popover-size;
+    width: $-input-popover-size;
+
+    .docs-panel & {
+      width: $-input-popover-size;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -15,6 +15,16 @@ $-input-padding-offset: sage-spacing(sm) - $-input-border-width;
 $-input-popover-size: $-input-height;
 $-input-text-height: sage-font-size(body);
 
+@mixin form-input-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: $-input-popover-size;
+  width: $-input-popover-size;
+}
 
 .sage-input {
   @include sage-form-field-group;
@@ -25,14 +35,7 @@ $-input-text-height: sage-font-size(body);
   }
 
   .sage-popover {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: absolute;
-    right: 0;
-    top: 0;
-    height: $-input-popover-size;
-    width: $-input-popover-size;
+    @include form-input-icon;
 
     .docs-panel & {
       width: $-input-popover-size;
@@ -123,14 +126,8 @@ $-input-text-height: sage-font-size(body);
 }
 
 .sage-input__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  right: 0;
-  top: 0;
-  height: $-input-popover-size;
-  width: $-input-popover-size;
+  @include form-input-icon;
+
   pointer-events: none;
 
   > i {

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -53,6 +53,7 @@ $-input-text-height: sage-font-size(body);
 
     > i {
       color: sage-color(charcoal, 200);
+      line-height: var(--sage-line-height-body-xs);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -106,6 +106,22 @@ $-input-text-height: sage-font-size(body);
   }
 }
 
+.sage-input__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: $-input-height;
+  width: $-input-height;
+  pointer-events: none;
+
+  > i {
+    color: sage-color(charcoal, 100);
+  }
+}
+
 .sage-input__message {
   @include sage-form-field-message;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -129,8 +129,8 @@ $-input-text-height: sage-font-size(body);
   position: absolute;
   right: 0;
   top: 0;
-  height: $-input-height;
-  width: $-input-height;
+  height: $-input-popover-size;
+  width: $-input-popover-size;
   pointer-events: none;
 
   > i {

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -12,19 +12,8 @@ $-input-padding: sage-spacing(sm);
 $-input-padding-filled: sage-spacing(2xs);
 $-input-padding-label: sage-spacing(2xs);
 $-input-padding-offset: sage-spacing(sm) - $-input-border-width;
-$-input-popover-size: $-input-height;
+$-input-popover-size: rem(40px);
 $-input-text-height: sage-font-size(body);
-
-@mixin form-input-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  right: 0;
-  top: 0;
-  height: $-input-popover-size;
-  width: $-input-popover-size;
-}
 
 .sage-input {
   @include sage-form-field-group;
@@ -38,37 +27,6 @@ $-input-text-height: sage-font-size(body);
 .sage-input--error {
   .sage-upload-card & {
     margin-top: sage-spacing(sm);
-  }
-}
-
-.sage-input--has-icon {
-  .sage-input__field {
-    padding-right: $-input-popover-size;
-  }
-
-  .sage-input__icon {
-    @include form-input-icon;
-
-    pointer-events: none;
-
-    > i {
-      color: sage-color(charcoal, 200);
-      line-height: var(--sage-line-height-body-xs);
-    }
-  }
-}
-
-.sage-input--has-popover {
-  .sage-input__field {
-    padding-right: $-input-popover-size;
-  }
-
-  .sage-popover {
-    @include form-input-icon;
-
-    .docs-panel & {
-      width: $-input-popover-size;
-    }
   }
 }
 
@@ -145,6 +103,22 @@ $-input-text-height: sage-font-size(body);
     ~ .sage-input__label {
       @include floating-label-active();
     }
+  }
+
+  .sage-input--has-icon & {
+    padding-right: $-input-popover-size;
+  }
+
+  .sage-input--has-popover & {
+    padding-right: $-input-popover-size;
+  }
+}
+
+.sage-input__icon {
+  .sage-input--has-icon & {
+    @include sage-form-field-icon;
+
+    pointer-events: none;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -134,7 +134,7 @@ $-input-text-height: sage-font-size(body);
   pointer-events: none;
 
   > i {
-    color: sage-color(charcoal, 100);
+    color: sage-color(charcoal, 200);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -33,6 +33,34 @@ $-input-text-height: sage-font-size(body);
     height: auto;
     margin-bottom: 0;
   }
+}
+
+.sage-input--error {
+  .sage-upload-card & {
+    margin-top: sage-spacing(sm);
+  }
+}
+
+.sage-input--has-icon {
+  .sage-input__field {
+    padding-right: $-input-popover-size;
+  }
+
+  .sage-input__icon {
+    @include form-input-icon;
+
+    pointer-events: none;
+
+    > i {
+      color: sage-color(charcoal, 200);
+    }
+  }
+}
+
+.sage-input--has-popover {
+  .sage-input__field {
+    padding-right: $-input-popover-size;
+  }
 
   .sage-popover {
     @include form-input-icon;
@@ -40,12 +68,6 @@ $-input-text-height: sage-font-size(body);
     .docs-panel & {
       width: $-input-popover-size;
     }
-  }
-}
-
-.sage-input--error {
-  .sage-upload-card & {
-    margin-top: sage-spacing(sm);
   }
 }
 
@@ -122,16 +144,6 @@ $-input-text-height: sage-font-size(body);
     ~ .sage-input__label {
       @include floating-label-active();
     }
-  }
-}
-
-.sage-input__icon {
-  @include form-input-icon;
-
-  pointer-events: none;
-
-  > i {
-    color: sage-color(charcoal, 200);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -66,6 +66,11 @@ $-icon-beside-type: (
     margin: 0 sage-spacing(xs) 0 0;
   }
 
+  .sage-input__icon .sage-icon-#{$icon-name} {
+    color: sage-color(charcoal, 200);
+    line-height: sage-line-height(body-xs);
+  }
+
   .sage-label--icon-#{$icon-name} .sage-label__value::before {
     @include sage-icon-base($icon-name, md);
     align-self: center;

--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -21,6 +21,10 @@ $-popover-panel-offset: sage-spacing(sm);
     justify-self: start;
     width: min-content;
   }
+
+  .sage-input--has-popover & {
+    @include sage-form-field-icon;
+  }
 }
 
 .sage-popover__actions {
@@ -51,27 +55,27 @@ $-popover-panel-offset: sage-spacing(sm);
     bottom: calc(100% + #{$-popover-panel-offset});
     left: 0;
   }
-  
+
   .sage-popover--top-right & {
     bottom: calc(100% + #{$-popover-panel-offset});
     right: 0;
   }
-  
+
   .sage-popover--right & {
     top: 0;
     left: calc(100% + #{$-popover-panel-offset});
   }
-  
+
   .sage-popover--bottom & {
     top: calc(100% + #{$-popover-panel-offset});
     left: 0;
   }
-  
+
   .sage-popover--bottom-right & {
     top: calc(100% + #{$-popover-panel-offset});
     right: 0;
   }
-  
+
   .sage-popover--left & {
     top: 0;
     right: calc(100% + #{$-popover-panel-offset});
@@ -83,7 +87,7 @@ $-popover-panel-offset: sage-spacing(sm);
 }
 
 .sage-popover__content {
-  @extend %t-sage-body-small;	
+  @extend %t-sage-body-small;
   @include sage-grid-stack();
 
   color: sage-color(charcoal, 200);

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -414,6 +414,21 @@
 }
 
 ///
+/// Adds layout styles for form input icon container. This is used for a
+/// static icon and popover icon placement.
+///
+@mixin sage-form-field-icon() {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: rem(40px);
+  width: rem(40px);
+}
+
+///
 /// Adds the basic default form label spacing, and border treatment
 ///
 @mixin sage-form-field-label() {

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -6,7 +6,6 @@ import { Label } from '../Label';
 import { SageTokens } from '../configs';
 
 export const Input = ({
-  children,
   className,
   hasError,
   icon,
@@ -14,6 +13,7 @@ export const Input = ({
   label,
   message,
   onChange,
+  popover,
   prefix,
   standalone,
   suffix,
@@ -24,11 +24,6 @@ export const Input = ({
   const [fieldValue, updateFieldValue] = useState(null);
   const [inputStyles, updateStyles] = useState(rest.style || {});
 
-  let hasPopoverChild = false;
-  React.Children.forEach(children, (child) => {
-    if (child.type.name === 'Popover') hasPopoverChild = true;
-  });
-
   const classNames = classnames(
     'sage-input',
     className,
@@ -38,7 +33,7 @@ export const Input = ({
       'sage-input--suffixed': suffix,
       'sage-input--standalone': standalone,
       'sage-input--has-icon': icon,
-      'sage-input--has-popover': hasPopoverChild,
+      'sage-input--has-popover': popover,
     }
   );
 
@@ -119,19 +114,19 @@ export const Input = ({
       {message && (
         <div className="sage-input__message">{message}</div>
       )}
-      {children}
+      {popover}
     </div>
   );
 };
 
 Input.defaultProps = {
-  children: null,
   className: null,
   hasError: false,
   icon: null,
   label: null,
   message: null,
   onChange: null,
+  popover: null,
   prefix: null,
   standalone: false,
   suffix: null,
@@ -139,7 +134,6 @@ Input.defaultProps = {
 };
 
 Input.propTypes = {
-  children: PropTypes.node,
   className: PropTypes.string,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,
@@ -147,6 +141,7 @@ Input.propTypes = {
   label: PropTypes.string,
   message: PropTypes.string,
   onChange: PropTypes.func,
+  popover: PropTypes.node,
   prefix: PropTypes.string,
   standalone: PropTypes.bool,
   suffix: PropTypes.string,

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -6,6 +6,7 @@ import { Label } from '../Label';
 import { SageTokens } from '../configs';
 
 export const Input = ({
+  children,
   className,
   hasError,
   icon,
@@ -22,6 +23,12 @@ export const Input = ({
   const inputPaddingOffset = 16;
   const [fieldValue, updateFieldValue] = useState(null);
   const [inputStyles, updateStyles] = useState(rest.style || {});
+
+  let hasPopoverChild = false;
+  React.Children.forEach(children, (child) => {
+    if (child.type.name === 'Popover') hasPopoverChild = true;
+  });
+
   const classNames = classnames(
     'sage-input',
     className,
@@ -31,6 +38,7 @@ export const Input = ({
       'sage-input--suffixed': suffix,
       'sage-input--standalone': standalone,
       'sage-input--has-icon': icon,
+      'sage-input--has-popover': hasPopoverChild,
     }
   );
 
@@ -111,11 +119,13 @@ export const Input = ({
       {message && (
         <div className="sage-input__message">{message}</div>
       )}
+      {children}
     </div>
   );
 };
 
 Input.defaultProps = {
+  children: null,
   className: null,
   hasError: false,
   icon: null,
@@ -129,6 +139,7 @@ Input.defaultProps = {
 };
 
 Input.propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Icon } from '../Icon';
 import { Label } from '../Label';
+import { SageTokens } from '../configs';
 
 export const Input = ({
   className,
   hasError,
+  icon,
   id,
   label,
   message,
@@ -27,6 +30,7 @@ export const Input = ({
       'sage-input--prefixed': prefix,
       'sage-input--suffixed': suffix,
       'sage-input--standalone': standalone,
+      'sage-input--has-icon': icon,
     }
   );
 
@@ -99,6 +103,11 @@ export const Input = ({
           value={suffix}
         />
       )}
+      {icon && (
+        <div className="sage-input__icon">
+          <Icon icon={icon} />
+        </div>
+      )}
       {message && (
         <div className="sage-input__message">{message}</div>
       )}
@@ -109,6 +118,7 @@ export const Input = ({
 Input.defaultProps = {
   className: null,
   hasError: false,
+  icon: null,
   label: null,
   message: null,
   onChange: null,
@@ -120,6 +130,7 @@ Input.defaultProps = {
 
 Input.propTypes = {
   className: PropTypes.string,
+  icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,
   hasError: PropTypes.bool,
   label: PropTypes.string,

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -24,23 +24,21 @@ export const Default = (args) => {
   };
 
   return (
-    <>
-      <Input
-        className={args.className}
-        disabled={args.disabled}
-        hasError={args.hasError}
-        icon={args.icon}
-        id={args.id}
-        label={args.label}
-        message={null}
-        onChange={onChange}
-        prefix={null}
-        required={false}
-        standalone={args.standalone}
-        suffix={null}
-        value={value}
-      />
-    </>
+    <Input
+      className={args.className}
+      disabled={args.disabled}
+      hasError={args.hasError}
+      icon={args.icon}
+      id={args.id}
+      label={args.label}
+      message={null}
+      onChange={onChange}
+      prefix={null}
+      required={false}
+      standalone={args.standalone}
+      suffix={null}
+      value={value}
+    />
   );
 };
 
@@ -51,23 +49,21 @@ export const InputWithStaticIcon = (args) => {
   };
 
   return (
-    <>
-      <Input
-        className={args.className}
-        disabled={args.disabled}
-        hasError={args.hasError}
-        icon={args.icon}
-        id={args.id}
-        label={args.label}
-        message={null}
-        onChange={onChange}
-        prefix={null}
-        required={false}
-        standalone={args.standalone}
-        suffix={null}
-        value={value}
-      />
-    </>
+    <Input
+      className={args.className}
+      disabled={args.disabled}
+      hasError={args.hasError}
+      icon={args.icon}
+      id={args.id}
+      label={args.label}
+      message={null}
+      onChange={onChange}
+      prefix={null}
+      required={false}
+      standalone={args.standalone}
+      suffix={null}
+      value={value}
+    />
   );
 };
 
@@ -78,24 +74,22 @@ export const InputWithPopover = (args) => {
   };
 
   return (
-    <>
-      <Input
-        className={args.className}
-        disabled={args.disabled}
-        hasError={args.hasError}
-        icon={args.icon}
-        id={args.id}
-        label={args.label}
-        message={null}
-        onChange={onChange}
-        popover={args.popover}
-        prefix={null}
-        required={false}
-        standalone={args.standalone}
-        suffix={null}
-        value={value}
-      />
-    </>
+    <Input
+      className={args.className}
+      disabled={args.disabled}
+      hasError={args.hasError}
+      icon={args.icon}
+      id={args.id}
+      label={args.label}
+      message={null}
+      onChange={onChange}
+      popover={args.popover}
+      prefix={null}
+      required={false}
+      standalone={args.standalone}
+      suffix={null}
+      value={value}
+    />
   );
 };
 

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -1,11 +1,19 @@
 import React, { useState } from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { SageTokens } from '../configs';
 import { Input } from './Input';
 
 export default {
   title: 'Sage/Input',
   component: Input,
+  argTypes: {
+    ...selectArgs({
+      icon: SageTokens.ICONS,
+    }),
+  },
   args: {
-    label: 'Label'
+    icon: SageTokens.ICONS.INFO_CIRCLE,
+    label: 'Label',
   }
 };
 
@@ -21,6 +29,7 @@ export const Default = (args) => {
         className={args.className}
         disabled={args.disabled}
         hasError={args.hasError}
+        icon={args.icon}
         id={args.id}
         label={args.label}
         message={null}

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { SageTokens } from '../configs';
 import { Input } from './Input';
+import { Popover } from '../Popover';
 
 export default {
   title: 'Sage/Input',
@@ -44,7 +45,50 @@ export const Default = (args) => {
   );
 };
 
+export const InputWithPopover = (args) => {
+  const [value, updateValue] = useState('Test');
+  const onChange = (e) => {
+    updateValue(e.target.value);
+  };
+
+  return (
+    <>
+      <Input
+        className={args.className}
+        disabled={args.disabled}
+        hasError={args.hasError}
+        id={args.id}
+        label={args.label}
+        message={null}
+        onChange={onChange}
+        prefix={null}
+        required={false}
+        standalone={args.standalone}
+        suffix={null}
+        value={value}
+      >
+        <Popover
+          icon={SageTokens.ICONS.INFO_CIRCLE}
+          moreLinkText="Link text"
+          moreLinkURL="https://example.com"
+          position="left"
+          title="Amazing popover"
+        >
+          <p>
+            I can put whatever content I want in here and use the custom class
+            as a hook to style it like a good &apos;ol BEM mixin!
+          </p>
+        </Popover>
+      </Input>
+    </>
+  );
+};
+
 Default.args = {
   id: 'field-1',
   label: 'First name'
+};
+
+InputWithPopover.args = {
+  label: 'First name',
 };

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -13,8 +13,7 @@ export default {
     }),
   },
   args: {
-    icon: SageTokens.ICONS.INFO_CIRCLE,
-    label: 'Label',
+    label: 'First name',
   }
 };
 
@@ -30,6 +29,7 @@ export const Default = (args) => {
         className={args.className}
         disabled={args.disabled}
         hasError={args.hasError}
+        icon={args.icon}
         id={args.id}
         label={args.label}
         message={null}
@@ -83,42 +83,43 @@ export const InputWithPopover = (args) => {
         className={args.className}
         disabled={args.disabled}
         hasError={args.hasError}
+        icon={args.icon}
         id={args.id}
         label={args.label}
         message={null}
         onChange={onChange}
+        popover={args.popover}
         prefix={null}
         required={false}
         standalone={args.standalone}
         suffix={null}
         value={value}
-      >
-        <Popover
-          icon={SageTokens.ICONS.INFO_CIRCLE}
-          moreLinkText="Link text"
-          moreLinkURL="https://example.com"
-          position="left"
-          title="Amazing popover"
-        >
-          <p>
-            I can put whatever content I want in here and use the custom class
-            as a hook to style it like a good &apos;ol BEM mixin!
-          </p>
-        </Popover>
-      </Input>
+      />
     </>
   );
 };
 
 Default.args = {
   id: 'field-1',
-  label: 'First name'
 };
 
 InputWithStaticIcon.args = {
-  label: 'First name',
+  icon: SageTokens.ICONS.INFO_CIRCLE,
 };
 
 InputWithPopover.args = {
-  label: 'First name',
+  popover: (
+    <Popover
+      icon={SageTokens.ICONS.INFO_CIRCLE}
+      moreLinkText="Link text"
+      moreLinkURL="https://example.com"
+      position="left"
+      title="Amazing popover"
+    >
+      <p>
+        I can put whatever content I want in here and use the custom class
+        as a hook to style it like a good &apos;ol BEM mixin!
+      </p>
+    </Popover>
+  )
 };

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -30,6 +30,32 @@ export const Default = (args) => {
         className={args.className}
         disabled={args.disabled}
         hasError={args.hasError}
+        id={args.id}
+        label={args.label}
+        message={null}
+        onChange={onChange}
+        prefix={null}
+        required={false}
+        standalone={args.standalone}
+        suffix={null}
+        value={value}
+      />
+    </>
+  );
+};
+
+export const InputWithStaticIcon = (args) => {
+  const [value, updateValue] = useState('Test');
+  const onChange = (e) => {
+    updateValue(e.target.value);
+  };
+
+  return (
+    <>
+      <Input
+        className={args.className}
+        disabled={args.disabled}
+        hasError={args.hasError}
         icon={args.icon}
         id={args.id}
         label={args.label}
@@ -87,6 +113,10 @@ export const InputWithPopover = (args) => {
 Default.args = {
   id: 'field-1',
   label: 'First name'
+};
+
+InputWithStaticIcon.args = {
+  label: 'First name',
 };
 
 InputWithPopover.args = {


### PR DESCRIPTION
## Description
Allows an affordance and positioning for icon within a form input. This allows for either a static icon or a popover. The static icon is chosen with the `icon` attribute. The popover is a child of the `SageFormInput` component.

## Screenshots
![image](https://user-images.githubusercontent.com/5650617/132924621-66b06d0f-f1c5-4ba5-a030-da4d952cc5ae.png)
![image](https://user-images.githubusercontent.com/5650617/132928519-10c437fd-b7b6-4577-b023-efce40814409.png)

## Testing in `sage-lib`
TBD

## Testing in `kajabi-products`
TBD
1. (**MEDIUM**) Adds icon affordance across all form inputs.

## Related
Closes #504 