### PR TITLE
[Sage-508] Sage 3 - TinyMCE Icon Updates

### DIFF
--- a/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
@@ -60,6 +60,10 @@
     @include sage-icon-base(strikethrough, md);
   }
 
+  .mce-ico.mce-i-hr::before {
+    @include sage-icon-base(horizontal-line, md);
+  }
+
   .mce-ico.mce-i-underline::before {
     @include sage-icon-base(underline, md);
   }

--- a/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
@@ -89,6 +89,10 @@
     @include sage-icon-base(margin-right, md);
   }
 
+  .mce-ico.mce-i-link::before {
+    @include sage-icon-base(url, md);
+  }
+
   .mce-ico.mce-i-image::before {
     @include sage-icon-base(image, md);
   }

--- a/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
+++ b/packages/sage-assets/lib/stylesheets/vendor/_tinymcev4.scss
@@ -64,6 +64,10 @@
     @include sage-icon-base(horizontal-line, md);
   }
 
+  .mce-ico.mce-i-blockquote::before {
+    @include sage-icon-base(quote, md);
+  }
+
   .mce-ico.mce-i-underline::before {
     @include sage-icon-base(underline, md);
   }


### PR DESCRIPTION
## Description
This updates our TinyMCE shim stylesheet with the Sage icon equivalent of the following outstanding icons:
1. Horizontal Line
2. Link (URL)
3. Blockquote

It looks like changing the word "Formats" to "Styles" needs a task in `kajabi-products`. This branch can be deployed without that.

## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/5650617/133859459-a43a442a-4d2e-4418-bfe7-c4f2b55d63a1.png)|![image](https://user-images.githubusercontent.com/5650617/133859293-a623d628-ad5b-4bf5-a489-57a450722b5d.png)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->

## Testing in `kajabi-products`
1. (**LOW**) Updates outstanding TinyMCE icons to Sage icon equivalent.

## Related
Close #508