### PR TITLE
[SAGE-806] Fix folder icon unicode

### DIFF
--- a/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
@@ -113,7 +113,7 @@ $sage-icons: (
   file-money: unicode(e94b),
   filters: unicode(e94c),
   flag: unicode(e94d),
-  folder: unicode(e94d),
+  folder: unicode(e94e),
   folder-group: unicode(e94f),
   form: unicode(e950),
   fullscreen: unicode(e951),


### PR DESCRIPTION
Closes #806

## Description

Corrected unicode for folder icon

## Screenshots

|  Before  |  After  |
|--------|--------|
| ![before](https://user-images.githubusercontent.com/24237393/134064797-beecab7d-2ef4-4e32-bdb2-780ffb2a6128.png) | ![after](https://user-images.githubusercontent.com/24237393/134064830-717cd5dd-c576-4890-b0b6-04edeff427aa.png)|

## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/foundations/icon
2. Verify the folder icon is rendering a folder and not a flag


## Testing in `kajabi-products`
1. (**MEDIUM**) Anywhere there is a folder icon, verify it's rendering as a folder and not as a flag
    - [ ] View http://www.kajabi.test:3000/admin/products/1 for folder usage