### PR TITLE
[SAGE-810] Create a yarn script to update main and develop branches for bump process

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "yarn lerna bootstrap",
+    "branches:update": "git checkout main && git pull && git checkout develop && git pull && git stash && git rebase main && git stash pop",
     "bridge:kajabi-products": "bin/bridge.sh true",
     "bridge:kajabi-products:status": "bin/bridge.sh status",
     "bridge:kajabi-products:destroy": "bin/bridge.sh false",
@@ -73,3 +74,4 @@
   },
   "dependencies": {}
 }
+


### PR DESCRIPTION
Closes #810 

## Description

In looking for ways to ease the burden of the manual steps during the bump process, this change will provide a quick command for bumpers to use to update the `main` and `develop` branches to ensure everything is up to date.

## Testing in `sage-lib`
N/A

## Testing in `kajabi-products`
1. (**LOW**) Update with `sage-lib`'s `package.json` file, no testing in `kajabi-products` is needed