### PR TITLE
[Sage-505] Sage 3 - Form Input Affixes

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -44,12 +44,18 @@ $-input-text-height: sage-font-size(body);
   }
 }
 
+.sage-input__affix-value {
+  color: sage-color(charcoal, 100);
+}
+
 .sage-input__affix--prefix {
   left: sage-spacing(sm);
+  padding-right: sage-spacing(2xs);
 }
 
 .sage-input__affix--suffix {
   right: sage-spacing(sm);
+  padding-left: sage-spacing(2xs);
 }
 
 .sage-input__label {

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -7,7 +7,7 @@
 
 $-input-border-width: rem(1px);
 $-input-height: rem(40px);
-$-input-label-offset: sage-spacing(xs);
+$-input-label-offset: rem(12px);
 $-input-padding-offset: sage-spacing(sm) - $-input-border-width;
 $-input-popover-size: rem(40px);
 $-input-text-height: sage-font-size(body);
@@ -45,15 +45,11 @@ $-input-text-height: sage-font-size(body);
 }
 
 .sage-input__affix--prefix {
-  left: rem(12px);
+  left: sage-spacing(sm);
 }
 
 .sage-input__affix--suffix {
-  right: rem(12px);
-}
-
-.sage-input__affix-value {
-  color: sage-color(charcoal, 100);
+  right: sage-spacing(sm);
 }
 
 .sage-input__label {
@@ -76,7 +72,7 @@ $-input-text-height: sage-font-size(body);
   @include sage-form-field;
 
   height: $-input-height;
-  padding: 0 rem(12px);
+  padding: $-input-padding-offset sage-spacing(sm);
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -7,10 +7,7 @@
 
 $-input-border-width: rem(1px);
 $-input-height: rem(40px);
-$-input-label-offset: rem(12px);
-$-input-padding: sage-spacing(sm);
-$-input-padding-filled: sage-spacing(2xs);
-$-input-padding-label: sage-spacing(2xs);
+$-input-label-offset: sage-spacing(xs);
 $-input-padding-offset: sage-spacing(sm) - $-input-border-width;
 $-input-popover-size: rem(40px);
 $-input-text-height: sage-font-size(body);
@@ -31,9 +28,11 @@ $-input-text-height: sage-font-size(body);
 }
 
 .sage-input__affix {
+  display: flex;
+  align-items: center;
   position: absolute;
-  top: sage-spacing(xs);
   z-index: sage-z-index(default, 1);
+  height: $-input-height;
 
   .sage-input--suffixed &,
   .sage-input--prefixed & {
@@ -46,11 +45,15 @@ $-input-text-height: sage-font-size(body);
 }
 
 .sage-input__affix--prefix {
-  left: sage-spacing(xs);
+  left: rem(12px);
 }
 
 .sage-input__affix--suffix {
-  right: sage-spacing(xs);
+  right: rem(12px);
+}
+
+.sage-input__affix-value {
+  color: sage-color(charcoal, 100);
 }
 
 .sage-input__label {
@@ -73,7 +76,7 @@ $-input-text-height: sage-font-size(body);
   @include sage-form-field;
 
   height: $-input-height;
-  padding: $-input-padding-offset sage-spacing(sm);
+  padding: 0 rem(12px);
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -475,9 +475,11 @@
   @extend %t-sage-body-xsmall;
 
   margin-top: sage-spacing(xs);
+  margin-left: rem(12px);
   color: sage-color(charcoal, 100);
 
   .sage-form-field--error & {
+    margin-left: 0;
     color: sage-color(red);
 
     &::before {

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -475,7 +475,6 @@
   @extend %t-sage-body-xsmall;
 
   margin-top: sage-spacing(xs);
-  margin-left: rem(12px);
   color: sage-color(charcoal, 100);
 
   .sage-form-field--error & {

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -478,7 +478,6 @@
   color: sage-color(charcoal, 100);
 
   .sage-form-field--error & {
-    margin-left: 0;
     color: sage-color(red);
 
     &::before {

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Icon } from '../Icon';
-import { Label } from '../Label';
 import { SageTokens } from '../configs';
 
 export const Input = ({
@@ -89,22 +88,22 @@ export const Input = ({
         </label>
       )}
       {prefix && (
-        <Label
-          aria-label={`Prefixed with ${prefix}`}
+        <span
+          aria-label={`prefixed with ${prefix}`}
           className="sage-input__affix sage-input__affix--prefix"
-          color={Label.COLORS.DRAFT}
           ref={prefixRef}
-          value={prefix}
-        />
+        >
+          <span className="sage-input__affix-value">{prefix}</span>
+        </span>
       )}
       {suffix && (
-        <Label
+        <span
           aria-label={`Suffixed with ${suffix}`}
           className="sage-input__affix sage-input__affix--suffix"
-          color={Label.COLORS.DRAFT}
           ref={suffixRef}
-          value={suffix}
-        />
+        >
+          <span className="sage-input__affix-value">{suffix}</span>
+        </span>
       )}
       {icon && (
         <div className="sage-input__icon">

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -98,7 +98,7 @@ export const Input = ({
       )}
       {suffix && (
         <span
-          aria-label={`Suffixed with ${suffix}`}
+          aria-label={`suffixed with ${suffix}`}
           className="sage-input__affix sage-input__affix--suffix"
           ref={suffixRef}
         >

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -33,10 +33,10 @@ export const Default = (args) => {
       label={args.label}
       message={null}
       onChange={onChange}
-      prefix={null}
+      prefix={args.prefix}
       required={false}
       standalone={args.standalone}
-      suffix={null}
+      suffix={args.suffix}
       value={value}
     />
   );

--- a/packages/sage-system/lib/inputaffixes.js
+++ b/packages/sage-system/lib/inputaffixes.js
@@ -8,10 +8,8 @@ Sage.inputaffixes = (() => {
   const prefixRootClass = "sage-input--prefixed";
   const suffixRootClass = "sage-input--suffixed";
   const fieldClass = "sage-input__field";
-  const labelClass = "sage-label";
-  const labelValueClass = "sage-label__value";
-  const labelColorModifier = "draft";
-  const labelElement = "span";
+  const valueClass = "sage-input__affix-value";
+  const valueElement = "span";
   const inputPaddingOffset = 16;
 
 
@@ -44,26 +42,24 @@ Sage.inputaffixes = (() => {
 
   // Make the sage-label that will display the affix content
   const makeLabel = (content, type) => {
-    const elLabel = document.createElement(labelElement);
-    const elLabelValue = document.createElement(labelElement);
+    const elLabel = document.createElement(valueElement);
+    const elLabelValue = document.createElement(valueElement);
     elLabel.appendChild(elLabelValue);
     elLabelValue.appendChild(document.createTextNode(content));
     elLabel.setAttribute("aria-label", `${type}ed with ${content}`);
     elLabel.classList.add(
-      labelClass,
       affixClass,
-      `${labelClass}--${labelColorModifier}`,
       `${affixClass}--${type}`
     );
     elLabelValue.classList.add(
-      labelValueClass
+      valueClass
     );
 
     return elLabel;
   };
 
   const handleAffixClick = (ev) => {
-    if (ev.target.classList.contains(labelValueClass)) {
+    if (ev.target.classList.contains(valueClass)) {
       // Find neighboring input and focus on it
       ev.target.parentNode.parentNode.querySelector(`.${fieldClass}`).focus();
     }


### PR DESCRIPTION
## Description
This branch updates Form Input Affixes per Figma specs. Essentially, we're using a text object as opposed to a label.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="955" alt="image" src="https://user-images.githubusercontent.com/5650617/134396317-4d97b1cd-5091-4d4e-9069-8335b2ad7e4d.png">|<img width="955" alt="image" src="https://user-images.githubusercontent.com/5650617/134396347-03d472c0-5baf-4b92-b396-69f642f441b4.png">|

## Testing in `sage-lib`
### Rails
- View [Rails component](http://localhost:4000/pages/component/form_input)
- Check that component styling updates are there

### React
- View [Storybook](http://localhost:4100/?path=/story/sage-input--default)
- Check that component styling updates are there

## Testing in `kajabi-products`
1. (**MEDIUM**) Affects styling of form input affixes. JS that renders the affixes has been simplified, as we're no longer using a label.

## Related
Closes #505