### PR TITLE
Remove `stash` and `stash pop` from `branches:update` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "yarn lerna bootstrap",
-    "branches:update": "git checkout main && git pull && git checkout develop && git pull && git stash && git rebase main && git stash pop",
+    "branches:update": "git checkout main && git pull && git checkout develop && git pull && git rebase main",
     "bridge:kajabi-products": "bin/bridge.sh true",
     "bridge:kajabi-products:status": "bin/bridge.sh status",
     "bridge:kajabi-products:destroy": "bin/bridge.sh false",


### PR DESCRIPTION
## Description

`stash` and `stash pop` could cause unintended side effects for local dev environments like popping stashed changes. This PR is to remove those commands so that the script only updates branches and begins the rebase.

## Testing in `sage-lib`
N/A - package.json script update 

## Testing in `kajabi-products`
1. (**LOW**) Nothing for `kajabi-products`; `package.json` update