### PR TITLE
Next version bump ~4.18.0

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -136,7 +136,7 @@ module ComponentsHelper
         rails: "done",
         react: "todo",
         a11y: "todo",
-        react_component_slug: "sage-tabs--default",
+        react_component_slug: "sage-choice--default",
         figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F9Km09NjlZHYWsMP7EGT8tI%2F%255BWIP%255D-Sage-3-%25E2%2580%2594-Admin-Components%3Fnode-id%3D6999%253A21795",
       },
       {

--- a/docs/app/views/examples/components/banner/_preview.html.erb
+++ b/docs/app/views/examples/components/banner/_preview.html.erb
@@ -1,4 +1,4 @@
-<h3 class="t-sage-heading-6">Announcement (with link)</h3>
+<h3 class="t-sage-heading-6">Default (with link)</h3>
 <%= sage_component SageBanner, {
   banner_context: "sage-demo",
   active: true,
@@ -36,7 +36,6 @@
   dismissable: true,
   type: "warning",
   text: "Execute Order 66.",
-  icon: "sage-icon-warning",
   link: {
     name: "Link here",
     attributes: {
@@ -55,8 +54,8 @@
   text: "It's over, Anakin. I have the high ground.",
 } %>
 
-<h3 class="t-sage-heading-6">Primary fixed (Ladera top context)</h3>
-<p>See active example at top of page</p>
+<h3 class="t-sage-heading-6">Default fixed (Ladera top context)</h3>
+<p>Select "Toggle banner" to trigger banner at top of page</p>
 <%= sage_component SageButton, {
   style: "primary",
   value: "Toggle banner",

--- a/docs/app/views/examples/components/banner/_props.html.erb
+++ b/docs/app/views/examples/components/banner/_props.html.erb
@@ -17,12 +17,6 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`icon`') %></td>
-  <td><%= md('Icon to be displayed.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('See Sage Icons.') %></td>
-</tr>
-<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('Unique identifier for this component.') %></td>
   <td><%= md('String') %></td>
@@ -42,7 +36,7 @@
 </tr>
 <tr>
   <td><%= md('`type`') %></td>
-  <td><%= md('Modifier that sets the color scheme for the component.') %></td>
+  <td><%= md('Modifier that sets the color scheme and icon type for the component.') %></td>
   <td><%= md('`"default"`, `"secondary"`, `"warning"`, `"danger"`') %></td>
   <td><%= md('`default`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_banner.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_banner.rb
@@ -3,7 +3,6 @@ class SageBanner < SageComponent
     active: [:optional, TrueClass],
     banner_context: [:optional, Set.new(["ladera-top", "sage-demo"])],
     dismissable: [:optional, TrueClass],
-    icon: [:optional, String],
     id: [:optional, String],
     link: [:optional, {name: String, attributes: Hash}],
     text: String,

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
@@ -7,11 +7,12 @@
   data-js-select="true"
   <%= component.generated_html_attributes.html_safe %>
 >
-  <select 
-    class="sage-select__field" 
-    name="<%= selectID %>" 
-    id="<%= selectID %>" 
+  <select
+    class="sage-select__field"
+    name="<%= selectID %>"
+    id="<%= selectID %>"
     <%= "disabled" if component.disabled %>
+  >
     <% component.select_options.each do |option| %>
       <option value="<%= option[:value] %>"><%= option[:text] %></option>
     <% end %>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "yarn lerna bootstrap",
-    "branches:update": "git checkout main && git pull && git checkout develop && git pull && git stash && git rebase main && git stash pop",
+    "branches:update": "git checkout main && git pull && git checkout develop && git pull && git rebase main",
     "bridge:kajabi-products": "bin/bridge.sh true",
     "bridge:kajabi-products:status": "bin/bridge.sh status",
     "bridge:kajabi-products:destroy": "bin/bridge.sh false",

--- a/packages/sage-assets/lib/stylesheets/components/_banner.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_banner.scss
@@ -11,7 +11,7 @@ $-banner-colors: (
     background: sage-color(primary),
     text: sage-color(white),
     text-hover: sage-color(primary, 100),
-    icon: "megaphone",
+    icon: "flag",
   ),
   secondary: (
     background: sage-color(grey, 400),

--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -17,12 +17,12 @@ $-choice-radio-color-checked: map-get($sage-radio-colors, checked);
 $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
 
 :root {
-  --icon-top-offset: #{rem(7px)};
+  --icon-top-offset: #{rem(6px)};
 }
 
 @media (max-width: sage-breakpoint(md-min)) {
   :root {
-    --icon-top-offset: #{rem(6px)};
+    --icon-top-offset: #{rem(5px)};
   }
 }
 
@@ -123,7 +123,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     @include sage-icon-base(caret-right, lg);
 
     margin: 0 0 0 sage-spacing(sm);
-    color: sage-color(grey, 300);
+    color: sage-color(charcoal, 100);
     transition: color map-get($sage-transitions, default);
   }
 
@@ -138,7 +138,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
 [class*="sage-choice--icon-"] {
   &::#{$-choice-el-icon} {
     /* See icon generator */
-    margin: 0 sage-spacing(sm) 0 0;
+    margin: 0 sage-spacing(xs) 0 0;
     color: currentColor;
     transition: color map-get($sage-transitions, default);
   }
@@ -157,7 +157,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     height: $-choice-radio-size;
     min-width: $-choice-radio-size;
     width: $-choice-radio-size;
-    margin: 0 sage-spacing(sm) 0 0;
+    margin: 0 sage-spacing(xs) 0 0;
     background-color: $-choice-radio-color-checked-inner;
     border-radius: sage-border(radius-round);
     border: sage-border();
@@ -233,7 +233,8 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
 }
 
 .sage-choice__subtext {
-  @extend %t-sage-body-small;
+  @extend %t-sage-body-xsmall;
 
+  margin-top: sage-spacing(2xs);
   color: sage-color(charcoal, 100);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -8,9 +8,6 @@
 $-input-border-width: rem(1px);
 $-input-height: rem(40px);
 $-input-label-offset: rem(12px);
-$-input-padding: sage-spacing(sm);
-$-input-padding-filled: sage-spacing(2xs);
-$-input-padding-label: sage-spacing(2xs);
 $-input-padding-offset: sage-spacing(sm) - $-input-border-width;
 $-input-popover-size: rem(40px);
 $-input-text-height: sage-font-size(body);
@@ -31,9 +28,11 @@ $-input-text-height: sage-font-size(body);
 }
 
 .sage-input__affix {
+  display: flex;
+  align-items: center;
   position: absolute;
-  top: sage-spacing(xs);
   z-index: sage-z-index(default, 1);
+  height: $-input-height;
 
   .sage-input--suffixed &,
   .sage-input--prefixed & {
@@ -45,12 +44,18 @@ $-input-text-height: sage-font-size(body);
   }
 }
 
+.sage-input__affix-value {
+  color: sage-color(charcoal, 100);
+}
+
 .sage-input__affix--prefix {
-  left: sage-spacing(xs);
+  left: sage-spacing(sm);
+  padding-right: sage-spacing(2xs);
 }
 
 .sage-input__affix--suffix {
-  right: sage-spacing(xs);
+  right: sage-spacing(sm);
+  padding-left: sage-spacing(2xs);
 }
 
 .sage-input__label {

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -452,7 +452,7 @@
 ///
 @mixin sage-form-field-floating-label(
   $textarea: false,
-  $input-text-height: sage-font-size(body),
+  $input-text-height: sage-spacing(sm),
   $input-padding: sage-spacing(2xs),
   $textarea-label-padding: rem(3px),
   $textarea-padding: sage-spacing(sm)
@@ -461,7 +461,6 @@
     transform: translateY($textarea-label-padding - $textarea-padding);
   }
   @else {
-    transform: translateY(-($input-text-height + $input-padding * 2)); // IE doesn't support calc in transforms so we provide a fallback
     transform: translateY(calc(-50% - (#{$input-text-height} + #{$input-padding}))); // we calculate the centered position minus the offset of the text height plus the spacing height
   }
   transition: opacity 0.1s ease-in, transform 0.15s ease-in-out, color 0.15s ease-out;

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Icon } from '../Icon';
-import { Label } from '../Label';
 import { SageTokens } from '../configs';
 
 export const Input = ({
@@ -89,22 +88,22 @@ export const Input = ({
         </label>
       )}
       {prefix && (
-        <Label
-          aria-label={`Prefixed with ${prefix}`}
+        <span
+          aria-label={`prefixed with ${prefix}`}
           className="sage-input__affix sage-input__affix--prefix"
-          color={Label.COLORS.DRAFT}
           ref={prefixRef}
-          value={prefix}
-        />
+        >
+          <span className="sage-input__affix-value">{prefix}</span>
+        </span>
       )}
       {suffix && (
-        <Label
-          aria-label={`Suffixed with ${suffix}`}
+        <span
+          aria-label={`suffixed with ${suffix}`}
           className="sage-input__affix sage-input__affix--suffix"
-          color={Label.COLORS.DRAFT}
           ref={suffixRef}
-          value={suffix}
-        />
+        >
+          <span className="sage-input__affix-value">{suffix}</span>
+        </span>
       )}
       {icon && (
         <div className="sage-input__icon">

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -33,10 +33,10 @@ export const Default = (args) => {
       label={args.label}
       message={null}
       onChange={onChange}
-      prefix={null}
+      prefix={args.prefix}
       required={false}
       standalone={args.standalone}
-      suffix={null}
+      suffix={args.suffix}
       value={value}
     />
   );

--- a/packages/sage-system/lib/inputaffixes.js
+++ b/packages/sage-system/lib/inputaffixes.js
@@ -8,10 +8,8 @@ Sage.inputaffixes = (() => {
   const prefixRootClass = "sage-input--prefixed";
   const suffixRootClass = "sage-input--suffixed";
   const fieldClass = "sage-input__field";
-  const labelClass = "sage-label";
-  const labelValueClass = "sage-label__value";
-  const labelColorModifier = "draft";
-  const labelElement = "span";
+  const valueClass = "sage-input__affix-value";
+  const valueElement = "span";
   const inputPaddingOffset = 16;
 
 
@@ -44,26 +42,24 @@ Sage.inputaffixes = (() => {
 
   // Make the sage-label that will display the affix content
   const makeLabel = (content, type) => {
-    const elLabel = document.createElement(labelElement);
-    const elLabelValue = document.createElement(labelElement);
+    const elLabel = document.createElement(valueElement);
+    const elLabelValue = document.createElement(valueElement);
     elLabel.appendChild(elLabelValue);
     elLabelValue.appendChild(document.createTextNode(content));
     elLabel.setAttribute("aria-label", `${type}ed with ${content}`);
     elLabel.classList.add(
-      labelClass,
       affixClass,
-      `${labelClass}--${labelColorModifier}`,
       `${affixClass}--${type}`
     );
     elLabelValue.classList.add(
-      labelValueClass
+      valueClass
     );
 
     return elLabel;
   };
 
   const handleAffixClick = (ev) => {
-    if (ev.target.classList.contains(labelValueClass)) {
+    if (ev.target.classList.contains(valueClass)) {
       // Find neighboring input and focus on it
       ev.target.parentNode.parentNode.querySelector(`.${fieldClass}`).focus();
     }


### PR DESCRIPTION
1. #812 (**MEDIUM**) Affects styling of form input affixes. JS that renders the affixes has been simplified, as we're no longer using a label.
2. #815 (**LOW**) - These Banner icon updates are visual and doc changes
    - Removal of incorrect Banner icon usage is in `kajabi-products` within PR [#20761](https://github.com/Kajabi/kajabi-products/pull/20761)
3. #816 (**LOW**) - `package.json` change, no impact on `kajabi-products`
4. #813 (**LOW**) Updates Choice component styling to Sage 3 specs.
5. #829 (**LOW**) Fixes select markup bug in `SageFormSelect` component. Should have no effect on `kajabi-products` at this time due to no instances existing.
6. #824 (**LOW**) Minor UI fix for floating input labels.