### PR TITLE
[BUG] SageFormSelect Markup Fix

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
@@ -7,11 +7,12 @@
   data-js-select="true"
   <%= component.generated_html_attributes.html_safe %>
 >
-  <select 
-    class="sage-select__field" 
-    name="<%= selectID %>" 
-    id="<%= selectID %>" 
+  <select
+    class="sage-select__field"
+    name="<%= selectID %>"
+    id="<%= selectID %>"
     <%= "disabled" if component.disabled %>
+  >
     <% component.select_options.each do |option| %>
       <option value="<%= option[:value] %>"><%= option[:text] %></option>
     <% end %>


### PR DESCRIPTION
## Description
SageFormSelect element is missing the closing `>` on the `select` element. This causes options to not appear correctly.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-09-23 at 1 58 33 PM](https://user-images.githubusercontent.com/1175111/134583804-d3b17b71-af7d-4db4-b58d-54695eb59d2a.png)|![Screen Shot 2021-09-23 at 1 59 04 PM](https://user-images.githubusercontent.com/1175111/134583853-c3142fb3-0eaa-4fbe-a0ad-3d083f968548.png)|

## Testing in `sage-lib`
Navigate to http://localhost:4000/pages/component/form_select
Inspect a select dropdown via devtools
Verify markup is no longer broken


## Testing in `kajabi-products`
(LOW) Should have no effect on kajabi-products at this time. Usage of `SageFormSelect` does not exist in kajabi-products. I am currently working on what seems to be the first implementation.


## Related
N/A
