### PR TITLE
[SAGE-832] expandable card rails js bug

### DIFF
--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -71,8 +71,8 @@ Sage.accordion = (function () {
   }
 
   function unbind(el) {
-    header.removeEventListener('click', handleAccordionClick);
-    header.removeEventListener('keydown', handleAccordionClick);
+    el.removeEventListener('click', handleAccordionClick);
+    el.removeEventListener('keydown', handleAccordionClick);
   }
 
   return {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] resolve issue when clicking button within ExpandableCard

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|same video in issue #832  https://user-images.githubusercontent.com/1241836/134976170-53012f93-e269-41bb-be64-f00dc7cfdde0.mp4|![coachingexpandablecard](https://user-images.githubusercontent.com/1241836/134976209-09f39712-7b92-4e65-93fd-072c48f7493c.gif)|
Closed #832 

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Resolve js error related to clicking child elements for the expandable card.
   - [ ] Coaching session view.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #832 