### PR TITLE
[SAGE-791] Copy Button Submit Bug

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,6 +1,7 @@
 <button
   class="sage-copy-btn <%= "sage-copy-btn--fill-container" if component.fill_container %> <%= component.generated_css_classes %>"
   data-js-copy-button="<%= component.value.html_safe %>"
+  type="button"
   <%= component.generated_html_attributes.html_safe %>
 >
   <%= sage_component SageCopyText, { value: component.value, semibold: component.semibold.present? && component.semibold } %>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes a bug where the Copy Button component submits a form when clicked.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
No screenshots. Added attribute `type="button"` to `<button>` tag in Rails component.


## Testing in `sage-lib`
- Check that Rails component now has `type` attribute.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Fixes a bug where the Copy Button component submits a form when clicked.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #791 
Related to [COMM-1108](https://github.com/Kajabi/kajabi-products/pull/20626)