### PR TITLE
fix(lerna): revert lerna publish changes

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -73,7 +73,7 @@ jobs:
         run: npx lerna bootstrap --ci
 
       - name: Lerna Publish
-        run: sudo npx lerna publish --registry github --yes
+        run: npx lerna publish --registry github --yes
 
       # Deploy site
       - name: Documentation Site Deploy


### PR DESCRIPTION
`Lerna Publish` step is failing in the [workflow](https://github.com/Kajabi/sage-lib/runs/3792428391?check_suite_focus=true)

This PR reverts `Lerna Publish` change from #847 

This is a direct to `main` update