### PR TITLE
Panel Controles button patch

### DIFF
--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -306,16 +306,40 @@ demo_configs_subtle = [
 <%= md("
   The primary, secondary, and danger buttons all have a small shadow treatment by default. In addition, these buttons allow for a 'no-shadow' treatment. Enable the treatment by adding the attribute: `raised: false`.
 ", use_sage_type: true) %>
-<%= sage_component SageButtonGroup, { gap: :md, spacer: { bottom: :md } } do %>
-  <%= sage_component SageButton, {
-    value: "Raised (default)",
-    style: "primary",
-  } %>
-  <%= sage_component SageButton, {
-    value: "No shadow",
-    style: "primary",
-    raised: false,
-  } %>
+<%= sage_component SageCardStack, {} do %>
+  <%= sage_component SageButtonGroup, { gap: :md } do %>
+    <%= sage_component SageButton, {
+      value: "Raised (default)",
+      style: "primary",
+    } %>
+    <%= sage_component SageButton, {
+      value: "No shadow",
+      style: "primary",
+      raised: false,
+    } %>
+  <% end %>
+  <%= sage_component SageButtonGroup, { gap: :md } do %>
+    <%= sage_component SageButton, {
+      value: "Raised (default)",
+      style: "secondary",
+    } %>
+    <%= sage_component SageButton, {
+      value: "No shadow",
+      style: "secondary",
+      raised: false,
+    } %>
+  <% end %>
+  <%= sage_component SageButtonGroup, { gap: :md } do %>
+    <%= sage_component SageButton, {
+      value: "Raised (default)",
+      style: "danger",
+    } %>
+    <%= sage_component SageButton, {
+      value: "No shadow",
+      style: "danger",
+      raised: false,
+    } %>
+  <% end %>
 <% end %>
 
 <h3>Full Width</h3>

--- a/docs/app/views/examples/components/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_preview.html.erb
@@ -39,7 +39,8 @@ dropdown = sage_component(SageDropdown, {
       style: "secondary",
       value: "",
       css_classes: "sage-dropdown__trigger-selected-value",
-      icon: { style: "right", name: "caret-down" }
+      icon: { style: "right", name: "caret-down" },
+      raised: false,
     })}
   <label class="sage-dropdown__trigger-label">Select an option...</label>
   ).html_safe
@@ -52,21 +53,24 @@ search_filter_toolbar = %(
       sage_component(SageButton, {
         value: "Saved filters",
         style: "secondary",
-        icon: { name: "favorite", style: "left" }
+        icon: { name: "favorite", style: "left" },
+        raised: false,
       })
     }
     #{
       sage_component(SageButton, {
         value: "Filters",
         style: "secondary",
-        icon: { name: "filters", style: "left" }
+        icon: { name: "filters", style: "left" },
+        raised: false,
       })
     }
     #{
       sage_component(SageButton, {
         value: "Clear filters",
         style: "secondary",
-        icon: { name: "remove", style: "left" }
+        icon: { name: "remove", style: "left" },
+        raised: false,
       })
     }
   </div>
@@ -152,7 +156,8 @@ actions_items = [
           style: "secondary",
           value: "",
           css_classes: "sage-dropdown__trigger-selected-value",
-          icon: { style: "right", name: "caret-down" }
+          icon: { style: "right", name: "caret-down" },
+          raised: false,
         } %>
         <label class="sage-dropdown__trigger-label">Sort</label>
       <% end %>
@@ -212,7 +217,8 @@ actions_items = [
           style: "secondary",
           value: "",
           css_classes: "sage-dropdown__trigger-selected-value",
-          icon: { style: "right", name: "caret-down" }
+          icon: { style: "right", name: "caret-down" },
+          raised: false,
         } %>
         <label class="sage-dropdown__trigger-label">Sort</label>
       <% end %>
@@ -268,7 +274,8 @@ actions_items = [
           style: "secondary",
           value: "",
           css_classes: "sage-dropdown__trigger-selected-value",
-          icon: { style: "right", name: "caret-down" }
+          icon: { style: "right", name: "caret-down" },
+          raised: false,
         } %>
         <label class="sage-dropdown__trigger-label">Sort</label>
       <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_controls.html.erb
@@ -55,7 +55,8 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
               style: "secondary",
               value: "",
               css_classes: "sage-dropdown__trigger-selected-value",
-              icon: { style: "right", name: "caret-down" }
+              icon: { style: "right", name: "caret-down" },
+              raised: false,
             } %>
             <label class="sage-dropdown__trigger-label">Actions</label>
           <% end %>
@@ -87,7 +88,8 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
                 style: "secondary",
                 value: "",
                 css_classes: "sage-dropdown__trigger-selected-value",
-                icon: { style: "right", name: "caret-down" }
+                icon: { style: "right", name: "caret-down" },
+                raised: false,
               } %>
               <label class="sage-dropdown__trigger-label">Sort</label>
             <% end %>
@@ -106,13 +108,15 @@ item_count_text = component.item_count_label.present? ? component.item_count_lab
                 value: "Expand",
                 style: "secondary",
                 icon: { name: "list-details", style: "only" },
-                css_classes: "sage-panel-controls__expand-btn"
+                css_classes: "sage-panel-controls__expand-btn",
+                raised: false,
               } %>
               <%= sage_component SageButton, {
                 value: "Collapse",
                 style: "secondary",
                 icon: { name: "list-stack", style: "only" },
-                css_classes: "sage-panel-controls__collapse-btn"
+                css_classes: "sage-panel-controls__collapse-btn",
+                raised: false,
               } %>
             </div>
           <% end %>

--- a/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
@@ -11,6 +11,7 @@ export const DropdownTrigger = ({
   label,
   modifier,
   onClickTrigger,
+  raisedButton,
   subtleButton,
 }) => {
   const onClick = () => {
@@ -35,6 +36,7 @@ export const DropdownTrigger = ({
             isLabelVisible={isLabelVisible}
             label={label}
             onClick={onClickTrigger}
+            raised={raisedButton}
             subtle={subtleButton}
           />
         )}
@@ -49,6 +51,7 @@ DropdownTrigger.defaultProps = {
   isLabelVisible: true,
   modifier: null,
   label: null,
+  raisedButton: false,
   subtleButton: false,
 };
 
@@ -60,5 +63,6 @@ DropdownTrigger.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   modifier: PropTypes.string,
   onClickTrigger: PropTypes.func.isRequired,
+  raisedButton: PropTypes.bool,
   subtleButton: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTriggerDefault.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerDefault.jsx
@@ -9,6 +9,7 @@ export const DropdownTriggerDefault = ({
   isLabelVisible,
   label,
   onClick,
+  raised,
   subtle,
 }) => (
   <Button
@@ -18,6 +19,7 @@ export const DropdownTriggerDefault = ({
     iconOnly={!isLabelVisible}
     onClick={onClick}
     type="button"
+    raised={raised}
     subtle={subtle}
   >
     {label}
@@ -28,6 +30,7 @@ DropdownTriggerDefault.defaultProps = {
   disabled: false,
   isLabelVisible: true,
   icon: null,
+  raised: false,
   subtle: false,
 };
 
@@ -37,5 +40,6 @@ DropdownTriggerDefault.propTypes = {
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   isLabelVisible: PropTypes.bool,
+  raised: PropTypes.bool,
   subtle: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
@@ -19,6 +19,7 @@ export const DropdownTriggerSelect = ({
       disabled={disabled}
       icon={SageTokens.ICONS.CARET_DOWN}
       iconPosition={Button.ICON_POSITIONS.RIGHT}
+      raised={false}
       type="button"
       onClick={onClick}
     >

--- a/packages/sage-react/lib/PanelControls/PanelControlsPagination.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControlsPagination.jsx
@@ -16,6 +16,7 @@ export const PanelControlsPagination = ({
       icon={SageTokens.ICONS.ARROW_LEFT}
       iconOnly={true}
       onClick={() => onClickPagination(currentPage - 1)}
+      raised={false}
     >
       Previous Page
     </Button>
@@ -26,6 +27,7 @@ export const PanelControlsPagination = ({
       icon={SageTokens.ICONS.ARROW_RIGHT}
       iconOnly={true}
       onClick={() => onClickPagination(currentPage + 1)}
+      raised={false}
     >
       Next Page
     </Button>


### PR DESCRIPTION
## Description

Patches raised style appearing in panel controls sub-elements.

## Screenshots

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2021-10-05 at 11 12 21 AM](https://user-images.githubusercontent.com/17955295/136051369-6d46f266-16a8-4d1d-8823-0a3440221f0f.png) | ![Screen Shot 2021-10-05 at 11 10 27 AM](https://user-images.githubusercontent.com/17955295/136051435-fb8a27f4-edbf-4fa4-99f3-0492d8f45adc.png) |

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`

1. (MEDIUM) Fixes a bug in panel controls for a high-traffic area of `kp`
   - [ ] Verify that buttons in panel controls on People page appear as they did before recent button changes.


## Related

Closes #854 
