### PR TITLE
[Workflow] Release/Deploy workflow is not running

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Set NPM Config
         run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.ACCESS_TOKEN }}'
 
+      - name: Unsafe Perm set
+      run: npm set unsafe-perm true
+
       - name: Clone Sage-Lib Repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.ACCESS_TOKEN }}'
 
       - name: Unsafe Perm set
-        run: npm set unsafe-perm true
+        run: npm config set unsafe-perm true
 
       - name: Clone Sage-Lib Repo
         uses: actions/checkout@v2

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.ACCESS_TOKEN }}'
 
       - name: Unsafe Perm set
-      run: npm set unsafe-perm true
+        run: npm set unsafe-perm true
 
       - name: Clone Sage-Lib Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Within the `Lerna Publish` step of the Release-Deploy workflow, the following is appearing in GitHub Actions.

```
lerna WARN lifecycle @kajabi/sage-assets@0.50.1~preversion: cannot run in wd @kajabi/sage-assets@0.50.1 yarn run build (wd=/__w/sage-lib/sage-lib/packages/sage-assets)
lerna info lifecycle @kajabi/sage-react@0.59.4~preversion: @kajabi/sage-react@0.59.4
lerna WARN lifecycle @kajabi/sage-react@0.59.4~preversion: cannot run in wd @kajabi/sage-react@0.59.4 yarn install && yarn run build (wd=/__w/sage-lib/sage-lib/packages/sage-react)
lerna info lifecycle @kajabi/sage@4.18.2~version: @kajabi/sage@4.18.2
lerna WARN lifecycle @kajabi/sage@4.18.2~version: cannot run in wd @kajabi/sage@4.18.2 ../bin/bump-gem.sh (wd=/__w/sage-lib/sage-lib/docs)
```

This PR is an attempt to resolve this working directory issue.

## Testing in `sage-lib`
N/A - can only be verified once merged into `main`


## Testing in `kajabi-products`
**N/A** - `sage-lib` only update