### PR TITLE
[Sage-758] Adds Preview Modal for Active Event

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -578,6 +578,41 @@ As shown elsewhere on this page default content (such as `SageLoader`) can also 
   <% end %>
 
   <%# Event-enabled Modals %>
+  <%= sage_component SageModal, { id: "cool-modal-event-active", disable_background_blur: true, animate: true } do %>
+    <%= sage_component SageModalContent, { title: "Example 'Active' Event Modal" } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <p class="t-sage-body">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <%= sage_component SageModal, { id: "cool-modal-event-open", disable_background_blur: true, animate: true, css_classes: "custom-class-name-here" } do %>
     <%= sage_component SageModalContent, { title: "Example 'Open' Event Modal" } do %>
       <% content_for :sage_header_aside do %>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a missing preview modal for the `sage.modal.active` event in docs.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->

https://user-images.githubusercontent.com/14791307/136097419-5f4b1a40-b2b8-448a-bc99-bfb671a33720.mov

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Modal](http://localhost:4000/pages/component/modal)
- Check that the `sage.modal.active` button opens the preview modal

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Sage docs update. No change within Kajabi Products.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #758