### PR TITLE
fix(gemfile version): manually update version so further automations will be correct

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (4.12.0)
+    sage_rails (4.18.3)
       classy_hash
       rails
 

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "4.12.0"
+  VERSION = "4.18.3"
 end


### PR DESCRIPTION
Resolves #862

## Description

Manually modifying the `Gemfile.lock` and the `version.rb` files to align the versioning to the current version of 4.18.3. 

Note: when the next bump goes out and runs the `Release-Deploy` workflow in GitHub Actions, these files should automatically update going forward.

## Testing in `sage-lib`
N/A - verification will happen following the version bump process. [See GitHub Actions step, within Lerna Publish line 4813](https://github.com/Kajabi/sage-lib/runs/3815939915?check_suite_focus=true#step:15:4813) where this automation happened in the prior bump


## Testing in `kajabi-products`
(**LOW**) - `sage-lib` versioning files updated; no `kajabi-products` testing necessary


## Related
https://github.com/Kajabi/sage-lib/issues/822
