### PR TITLE
[Modal] add spacing between sibling buttons

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -93,6 +93,11 @@
           } %>
         <% end %>
         <%= sage_component SageButton, {
+          style: "secondary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+        <%= sage_component SageButton, {
           style: "primary",
           icon: { name: "check", style: "left" },
           value: "Take An Action",

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -169,6 +169,7 @@ $-modal-header-image-size: rem(28px);
   justify-content: flex-end;
   align-items: center;
   margin: $-modal-padding-y $-modal-padding-x;
+  gap: sage-spacing(sm);
 }
 
 .sage-modal__footer-aside {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -168,8 +168,8 @@ $-modal-header-image-size: rem(28px);
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  margin: $-modal-padding-y $-modal-padding-x;
   gap: sage-spacing(sm);
+  margin: $-modal-padding-y $-modal-padding-x;
 }
 
 .sage-modal__footer-aside {

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -48,6 +48,14 @@ const DefaultBody = ({ onExit }) => (
         </Button>
       </Modal.FooterAside>
       <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.CHECK}
+        iconPosition={Button.ICON_POSITIONS.LEFT}
+        onClick={onExit}
+      >
+        Take An Action
+      </Button>
+      <Button
         color={Button.COLORS.PRIMARY}
         icon={SageTokens.ICONS.CHECK}
         iconPosition={Button.ICON_POSITIONS.LEFT}


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add spacing between adjacent modal footer buttons

#### Spec
[Sage 3 Modal ](https://www.figma.com/file/9Km09NjlZHYWsMP7EGT8tI/Sage-3-for-Admin?node-id=6999%3A23107)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-10-07 at 6 50 59 PM](https://user-images.githubusercontent.com/1241836/136479078-e0c66a6b-284a-476f-a470-93af9012cb83.png)|![Screen Shot 2021-10-07 at 6 50 43 PM](https://user-images.githubusercontent.com/1241836/136479085-a08d7aed-b75b-4666-86e5-57b0e2e79f20.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Go to modal page and verify that the sibling button spacing are aligned with the spec

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds spacing to the sibling button in the modal footer.
   - [ ] Products -> New Post modal
   - [ ] Coaching Programs -> Session -> New Session modal.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
