### PR TITLE
fix(workflow): update token to unique value to fix workflow

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -15,6 +15,8 @@ jobs:
       # Checkout the repository
       - name: "Checkout this repo to find Sage version"
         uses: "actions/checkout@v2"
+        with:
+          fetch-depth: "0"
 
       # Find Sage version from package.json in docs/
       - name: "Find Sage version from docs -> package.json version"
@@ -27,7 +29,7 @@ jobs:
       - name: "Update Release based on Tag"
         uses: "ncipollo/release-action@v1"
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.UPDATE_RELEASE_WORKFLOW_TOKEN }}"
           tag: "v${{ steps.extract_version.outputs.version }}"
           body: "See [changelog](https://github.com/Kajabi/sage-lib/blob/main/docs/CHANGELOG.md) for more information."
 


### PR DESCRIPTION
## Description

Following the creation of a unique workflow token, `UPDATE_RELEASE_WORKFLOW_TOKEN`, in this repo, this PR handles updating the `release-update.yml` file to allow the workflow to run. 

Previous to this issue, we believe that the use of `GITHUB_TOKEN` was causing GitHub Actions to stop this workflow from running.


## Testing in `sage-lib`
N/A this workflow will run once merged into `main` - nothing to test here


## Testing in `kajabi-products`
1. (**LOW**) N/A - nothing to test. The update is a GitHub Actions workflow change in `sage-lib` only
