### PR TITLE
[Sage-802] Expandable Card Alignment Prop

### DIFF
--- a/docs/app/views/examples/components/expandable_card/_preview.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_preview.html.erb
@@ -81,7 +81,7 @@
 <h3 class="t-sage-heading-6">Arrow Aligned Right</h3>
 <%= sage_component SageExpandableCard, {
   trigger_label: "Expand",
-  align_right: true,
+  align_arrow_right: true,
 } do %>
   <%= sage_component SageCheckbox, {
     id:"c4",

--- a/docs/app/views/examples/components/expandable_card/_preview.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_preview.html.erb
@@ -78,3 +78,30 @@
     has_error: false
   } %>
 <% end %>
+<h3 class="t-sage-heading-6">Arrow Aligned Right</h3>
+<%= sage_component SageExpandableCard, {
+  trigger_label: "Expand",
+  align_right: true,
+} do %>
+  <%= sage_component SageCheckbox, {
+    id:"c4",
+    label_text: "Grant offers",
+    checked: false,
+    disabled: false,
+    has_error: false
+  } %>
+  <%= sage_component SageCheckbox, {
+    id:"c5",
+    label_text: "Add tags",
+    checked: false,
+    disabled: false,
+    has_error: false
+  } %>
+  <%= sage_component SageCheckbox, {
+    id:"c6",
+    label_text: "Subscribe to emails",
+    checked: false,
+    disabled: false,
+    has_error: false
+  } %>
+<% end %>

--- a/docs/app/views/examples/components/expandable_card/_props.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_props.html.erb
@@ -1,4 +1,10 @@
 <tr>
+  <td><%= md('`align_right`') %></td>
+  <td><%= md("Adds the `sage-expandable-card--align-right` class to the block level `sage-expandable-card`. Aligns the arrow to the far right of the container.") %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`expanded`') %></td>
   <td><%= md("Adds the `sage-expandable-card--expanded` class to the block level `sage-expandable-card` and allows you to load the expandable card body expanded") %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/components/expandable_card/_props.html.erb
+++ b/docs/app/views/examples/components/expandable_card/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td><%= md('`align_right`') %></td>
-  <td><%= md("Adds the `sage-expandable-card--align-right` class to the block level `sage-expandable-card`. Aligns the arrow to the far right of the container.") %></td>
+  <td><%= md('`align_arrow_right`') %></td>
+  <td><%= md("Adds the `sage-expandable-card--align-arrow-right` class to the block level `sage-expandable-card`. Aligns the arrow to the far right of the container.") %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
@@ -1,6 +1,6 @@
 class SageExpandableCard < SageComponent
   set_attribute_schema({
-    align_right: [:optional, TrueClass],
+    align_arrow_right: [:optional, TrueClass],
     body_bordered: [:optional, TrueClass],
     sage_type: [:optional, TrueClass],
     expanded: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_expandable_card.rb
@@ -1,5 +1,6 @@
 class SageExpandableCard < SageComponent
   set_attribute_schema({
+    align_right: [:optional, TrueClass],
     body_bordered: [:optional, TrueClass],
     sage_type: [:optional, TrueClass],
     expanded: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -2,7 +2,7 @@
   class="sage-expandable-card 
     <%= component.generated_css_classes %>
     <% if component.expanded.present? %>sage-expandable-card--expanded<% end %>
-    <% if component.align_right %>sage-expandable-card--align-right<% end %>"
+    <% if component.align_arrow_right %>sage-expandable-card--align-arrow-right<% end %>"
     <%= component.generated_html_attributes.html_safe %>
 >
   <%= sage_component SageButton, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_expandable_card.html.erb
@@ -1,7 +1,8 @@
 <div 
   class="sage-expandable-card 
     <%= component.generated_css_classes %>
-    <% if component.expanded.present? %>sage-expandable-card--expanded<% end %>"
+    <% if component.expanded.present? %>sage-expandable-card--expanded<% end %>
+    <% if component.align_right %>sage-expandable-card--align-right<% end %>"
     <%= component.generated_html_attributes.html_safe %>
 >
   <%= sage_component SageButton, {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -178,6 +178,16 @@ $-btn-loading-min-height: rem(36px);
     font-weight: sage-font-weight(regular);
   }
 
+  .sage-expandable-card--align-arrow-right & {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+
+    &::after {
+      transform: translate3D(-50%, -50%, 0);
+    }
+  }
+
   .sage-input-group & {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
@@ -516,6 +526,10 @@ $-btn-loading-min-height: rem(36px);
   .sage-dropdown__trigger & {
     display: inline-flex;
     align-items: center;
+  }
+
+  .sage-expandable-card--align-arrow-right & {
+    order: -1;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -183,6 +183,10 @@ $-btn-loading-min-height: rem(36px);
     justify-content: space-between;
     width: 100%;
 
+    &::before {
+      margin-right: 0;
+    }
+
     &::after {
       transform: translate3D(-50%, -50%, 0);
     }

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -70,6 +70,7 @@ $-expandable-card-padding-xs: sage-spacing(xs);
       transform: translate3d(-50%, -50%, 0);
     }
   }
+
   .sage-btn__truncate-text {
     order: -1;
   }

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -59,3 +59,14 @@ $-expandable-card-padding-xs: sage-spacing(xs);
     transform: rotateZ(90deg);
   }
 }
+
+.sage-expandable-card--align-right {
+  .sage-btn {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+  .sage-btn__truncate-text {
+    order: -1;
+  }
+}

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -59,19 +59,4 @@ $-expandable-card-padding-xs: sage-spacing(xs);
     transform: rotateZ(90deg);
   }
 }
-
-.sage-expandable-card--align-right {
-  .sage-btn {
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-
-    &::after {
-      transform: translate3d(-50%, -50%, 0);
-    }
-  }
-
-  .sage-btn__truncate-text {
-    order: -1;
-  }
-}
+// NOTE: Styles for align_arrow_right prop added in `_button`

--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -65,6 +65,10 @@ $-expandable-card-padding-xs: sage-spacing(xs);
     display: flex;
     justify-content: space-between;
     width: 100%;
+
+    &::after {
+      transform: translate3d(-50%, -50%, 0);
+    }
   }
   .sage-btn__truncate-text {
     order: -1;

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 import { SageClassnames, SageTokens } from '../configs';
 
 export const ExpandableCard = ({
+  alignRight,
   bodyBordered,
   expanded,
   children,
@@ -29,6 +30,7 @@ export const ExpandableCard = ({
   const id = uuid();
 
   const containerClassnames = classnames({
+    'sage-expandable-card--align-right': alignRight,
     'sage-expandable-card sage-expandable-card--expanded': expanded,
     'sage-expandable-card': !expanded,
     'sage-expandable-card--expanded': selfActive
@@ -62,6 +64,7 @@ export const ExpandableCard = ({
 };
 
 ExpandableCard.defaultProps = {
+  alignRight: false,
   bodyBordered: false,
   expanded: false,
   children: null,
@@ -71,6 +74,7 @@ ExpandableCard.defaultProps = {
 };
 
 ExpandableCard.propTypes = {
+  alignRight: PropTypes.bool,
   bodyBordered: PropTypes.bool,
   expanded: PropTypes.bool,
   className: PropTypes.string,

--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -6,7 +6,7 @@ import { Button } from '../Button';
 import { SageClassnames, SageTokens } from '../configs';
 
 export const ExpandableCard = ({
-  alignRight,
+  alignArrowRight,
   bodyBordered,
   expanded,
   children,
@@ -30,7 +30,7 @@ export const ExpandableCard = ({
   const id = uuid();
 
   const containerClassnames = classnames({
-    'sage-expandable-card--align-right': alignRight,
+    'sage-expandable-card--align-arrow-right': alignArrowRight,
     'sage-expandable-card sage-expandable-card--expanded': expanded,
     'sage-expandable-card': !expanded,
     'sage-expandable-card--expanded': selfActive
@@ -64,7 +64,7 @@ export const ExpandableCard = ({
 };
 
 ExpandableCard.defaultProps = {
-  alignRight: false,
+  alignArrowRight: false,
   bodyBordered: false,
   expanded: false,
   children: null,
@@ -74,7 +74,7 @@ ExpandableCard.defaultProps = {
 };
 
 ExpandableCard.propTypes = {
-  alignRight: PropTypes.bool,
+  alignArrowRight: PropTypes.bool,
   bodyBordered: PropTypes.bool,
   expanded: PropTypes.bool,
   className: PropTypes.string,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a new prop to the Expandable Card component to allow arrow alignment to the right.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="259" alt="Screen Shot 2021-10-11 at 2 17 54 PM" src="https://user-images.githubusercontent.com/14791307/136844953-c2312086-20db-48f1-b2da-54f555124bc6.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/expandable_card)
- Check that new component props works as expected.

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-expandablecard--default)
- Check that new component props works as expected.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) New prop added for Expandable Card. Does not affect existing functionality.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #802 