### PR TITLE
[Sage-667] Popover - Long Link Bug Fix

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -38,6 +38,7 @@ $-popover-panel-offset: sage-spacing(sm);
 
   visibility: hidden;
   z-index: sage-z-index(modal);
+  grid-template-columns: minmax(auto, $-popover-panel-max-size);
   position: absolute;
   width: auto;
   min-width: $-popover-panel-min-size;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes an issue where long links stretch the popover panel container wider than expected.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1236" alt="Screen Shot 2021-10-14 at 4 54 47 PM" src="https://user-images.githubusercontent.com/14791307/137400926-dcf1b2c8-99fa-492f-baac-3567a14b8c09.png">|<img width="465" alt="Screen Shot 2021-10-14 at 3 59 22 PM" src="https://user-images.githubusercontent.com/14791307/137400941-f7f65e6d-2338-477a-8dd1-c638e36101cb.png">

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Rails component](http://localhost:4000/pages/component/popover)
- Check that component styling updates are there

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Fixes an issue where long links stretch the Popover panel container wider than expected.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #667