### PR TITLE
Chart: Stabilizes React component 

### DIFF
--- a/packages/sage-react/lib/Chart/Chart.jsx
+++ b/packages/sage-react/lib/Chart/Chart.jsx
@@ -8,6 +8,7 @@ import { SageTokens } from '../configs';
 
 export const Chart = ({
   configs,
+  framework,
   data,
   noDataText,
   loading,
@@ -24,10 +25,10 @@ export const Chart = ({
     let chart = null;
     switch (type) {
       case CHART_TYPES.BAR:
-        chart = <Bar data={data} {...configs} />;
+        chart = <Bar data={data} chartingFramework={framework} {...configs} />;
         break;
       case CHART_TYPES.DONUT:
-        chart = <Donut data={data} {...configs} />;
+        chart = <Donut data={data} chartingFramework={framework} {...configs} />;
         break;
       default:
         break;
@@ -59,6 +60,7 @@ Chart.propTypes = {
   configs: PropTypes.shape({}),
   containerStyles: PropTypes.shape({}),
   data: PropTypes.arrayOf(PropTypes.shape(dataPropTypes)),
+  framework: PropTypes.shape({}).isRequired,
   loading: PropTypes.bool,
   noDataText: PropTypes.string,
   type: PropTypes.oneOf(Object.values(Chart.TYPES)).isRequired,

--- a/packages/sage-react/lib/Chart/Chart.story.jsx
+++ b/packages/sage-react/lib/Chart/Chart.story.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Recharts from 'recharts';
 import { selectArgs } from '../story-support/helpers';
 import { SageTokens } from '../configs';
 import { Chart } from './Chart';
@@ -8,6 +9,7 @@ export default {
   component: Chart,
   args: {
     type: Chart.TYPES.BAR,
+    framework: Recharts,
   },
   argTypes: {
     ...selectArgs({

--- a/packages/sage-react/lib/Chart/types/Bar.jsx
+++ b/packages/sage-react/lib/Chart/types/Bar.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Recharts from 'recharts';
 import { Legend, Tooltip as SageTooltip } from '../parts';
 import {
   defaultTooltipContentFormatterFn,
@@ -11,6 +10,7 @@ import { SageTokens } from '../../configs';
 export const Bar = ({
   aspect,
   bars,
+  chartingFramework,
   data,
   showLegend,
   tooltipContentFormatterFn,
@@ -19,6 +19,8 @@ export const Bar = ({
   ...rest
 }) => {
   const { BarChart, CartesianGrid, Tooltip, XAxis, YAxis } = { ...rest };
+
+  const Recharts = chartingFramework;
 
   return (
     <>
@@ -86,6 +88,7 @@ Bar.propTypes = {
     fill: PropTypes.string,
     name: PropTypes.string,
   })),
+  chartingFramework: PropTypes.shape({}).isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,
     value: PropTypes.number,

--- a/packages/sage-react/lib/Chart/types/Donut.jsx
+++ b/packages/sage-react/lib/Chart/types/Donut.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import * as Recharts from 'recharts';
 import { SageTokens } from '../../configs';
 import { Summary, Tooltip as SageTooltip } from '../parts';
 import {
@@ -15,6 +14,7 @@ import {
 
 export const Donut = ({
   centered,
+  chartingFramework,
   combineDataAfterItem,
   donutDiameter,
   donutWidth,
@@ -37,6 +37,8 @@ export const Donut = ({
   const { Tooltip, PieChart, Pie } = { ...rest };
 
   const [selfData] = useState(getDataEntries(data, combineDataAfterItem));
+
+  const Recharts = chartingFramework;
 
   return (
     <>
@@ -81,6 +83,7 @@ Donut.defaultProps = {
 
 Donut.propTypes = {
   centered: PropTypes.bool,
+  chartingFramework: PropTypes.shape({}).isRequired,
   combineDataAfterItem: PropTypes.number,
   donutDiameter: PropTypes.number,
   donutWidth: PropTypes.number,

--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -4,7 +4,7 @@ export { AvatarGroup } from './AvatarGroup';
 export { Breadcrumbs } from './Breadcrumbs';
 export { Button } from './Button';
 export { Card } from './Card';
-// export { Chart } from './Chart';
+export { Chart } from './Chart';
 export { Choice } from './Choice';
 export {
   Dropdown,


### PR DESCRIPTION
## Description

Prior to this PR the Chart component was developed using Recharts. However, this library presented conflicts with the version used in `kajabi-products` that lead to the js failing to compile. It was commented out here for further investigation.

This PR adds a temporary fix that removes the library from direct use in the component allowing instead for it to be passed in when used in the desired context. 

Future consideration should investigate syncing Recharts versions with `kp` and using peer dependencies. However, this may also be helpful as a start towards allowing multiple charting frameworks to be used depending on a product team's preferences. In that case different configurations would need to be integrated and forked from the existing Recharts assumptions.

## Testing in `sage-lib`

See Storybook > Charts for demonstration of these features.


## Testing in `kajabi-products`

1. (LOW) Recharts-based Chart component is re-integrated. No expected changes as this is a new feature. However, earlier attempts to implement this component caused JS to fail to compile in app, so load a page such as People and confirm all loads and behaves as expected.
