### PR TITLE
Expandable Card: React state patch

### DIFF
--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -14,7 +14,7 @@ export const ExpandableCard = ({
   sageType,
   triggerLabel,
 }) => {
-  const [selfActive, setSelfActive] = useState(false);
+  const [selfActive, setSelfActive] = useState(expanded);
 
   const handleBodyToggle = () => {
     if (selfActive) {
@@ -31,8 +31,7 @@ export const ExpandableCard = ({
 
   const containerClassnames = classnames({
     'sage-expandable-card--align-arrow-right': alignArrowRight,
-    'sage-expandable-card sage-expandable-card--expanded': expanded,
-    'sage-expandable-card': !expanded,
+    'sage-expandable-card': !selfActive,
     'sage-expandable-card--expanded': selfActive
   });
 


### PR DESCRIPTION
## Description

This PR patches how the `expanded` state prop is instantiated to ensure the `expanded` prop passed in influences but does not conflict with internal state control.

## Testing in `sage-lib`

See Storybook > Expandable Card and that prop coming in initially impacts the panel state while interaction afterwards still works.


## Testing in `kajabi-products`

1. (LOW) React version of Expandable Card is patched to ensure its initial state can be set yet toggled internall afterwards. No impact on Rails uses and no current React uses to affect.
