### PR TITLE
fix(avatar): remove margin top and bottom 

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -121,7 +121,8 @@ $-avatar-group-item-sizes: (
 }
 
 .sage-avatar--centered {
-  margin: 0 auto;
+  margin-right: auto;
+  margin-left: auto;
 }
 
 // Documentation-specific styles


### PR DESCRIPTION
Fixes #889 

## Description

With the use of `centered: true` on SageAvatar, the `margin: 0 auto` overrides spacer CSS. This PR removes forcing top and bottom margin to `0`.

## Screenshots

### In `sage-lib`
|  Before  |  After  |
|--------|--------|
| ![avatar-centered_before](https://user-images.githubusercontent.com/24237393/137764725-b14a212b-3b38-43c1-82ba-7d6d8f63ed61.png) | ![avatar-centered_after](https://user-images.githubusercontent.com/24237393/137764760-f959676d-7158-4104-ac7a-f6a30984f9a8.png) |

### In `kajabi-products` usecase

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2021-10-18 at 10 55 27 AM](https://user-images.githubusercontent.com/24237393/137766602-1f4cb561-2509-4fc7-b226-0f03587875c5.png) | ![Screen Shot 2021-10-18 at 10 55 08 AM](https://user-images.githubusercontent.com/24237393/137766650-c5da8f6e-9099-4959-8c1a-a1e4c1e87ae2.png) |

## Testing in `sage-lib`
1. Verify centering in `sage-lib` has not changed: http://localhost:4000/pages/component/avatar

## Testing in `kajabi-products`
1. (**MEDIUM**) Verify that any use of `centered: true` in SageAvatars is spaced appropriately.
   - [ ] Contact Bulk Action / Forms / Merge Contact 
   - [ ] Stories / Mocks / Contacts / Single Contact Modal, in Modal Body

## FYI Verification in `kajabi-products`

To ensure no `SageAvatar` or `<Avatar />` went unchecked by running the following commands:
```ssh
$ cd kajabi-products
$ # brew install rg # (if you haven't already)
$ rg 'SageAvatar' -A 5
$ rg `<Avatar' -A 5
```

The results of the two `rg` commands will output all existing uses of the `SageAlert` and the `<Avatar />` components showing the context of which it's used and any properties used within.  