### PR TITLE
fix: add `content` as a possible default component property

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -8,6 +8,7 @@ class SageComponent
     html_attributes: [:optional, Hash],
     spacer: [:optional, SageSchemas::SPACER],
     css_classes: [:optional, NilClass, String],
+    content: [:optional, String],
   }
 
   def generated_css_classes


### PR DESCRIPTION
## Description

Adds `content` as a generic attribute available for components.


## Testing in `sage-lib`

N/A fallback attribute

## Testing in `kajabi-products`

1. (**LOW/MEDIUM/HIGH/BREAKING**) Adds a new default attribute for all sage components that also patches a recent issue where `content` was not outputting.

