### PR TITLE
MOCK: Plan usage alerts

### DIFF
--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -6,7 +6,15 @@
   title: "You’ve used [percentage] of available [feature_name]",
 } do %>
   <% content_for :sage_alert_actions do %>
-    <%= link_to "Upgrade plan", "#" %>
+    <%= sage_component SageButton, {
+      attributes: {
+        href: "#",
+      },
+      css_classes: SageClassnames::SPACERS::SM_RIGHT,
+      raised: false,
+      style: "secondary",
+      value: "Upgrade plan",
+    } %>
     <%= link_to "Check usage", "#" %>
   <% end %>
 <% end %>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -1,3 +1,42 @@
+<%= sage_component SageAlert, {
+  color: "warning",
+  desc: "Upgrade your plan to access more [feature_name].",
+  dismissable: true,
+  icon_name: "sage-icon-warning",
+  title: "You’ve used [percentage] of available [feature_name]",
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= link_to "Upgrade plan", "#" %>
+    <%= link_to "Check usage", "#" %>
+  <% end %>
+<% end %>
+
+<%= sage_component SageAlert, {
+  color: "warning",
+  desc: "Upgrade your plan to access more [feature_name].",
+  dismissable: true,
+  icon_name: "sage-icon-flag",
+  title: "You’ve reached your [feature_name] limit",
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= link_to "Upgrade plan", "#" %>
+    <%= link_to "Check usage", "#" %>
+  <% end %>
+<% end %>
+
+<%= sage_component SageAlert, {
+  color: "danger",
+  desc: "To avoid any issues with your experience, upgrade your plan now.",
+  dismissable: true,
+  icon_name: "sage-icon-danger",
+  title: "You’ve exceeded your [feature_name] limit",
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= link_to "Upgrade plan", "#" %>
+    <%= link_to "Check usage", "#" %>
+  <% end %>
+<% end %>
+
 <%= content_for :heading do %>
 <%= md("
 # Sandbox


### PR DESCRIPTION
## Description
This PR is a POC mock for the upcoming Plan Usage Alerts.

## Screenshots
|[Design Spec](https://www.figma.com/file/MXOtLcMOqSaRbbZkXPAscn/Plan-upgrade-framework?node-id=1612%3A12841)|Possible now (See sandbox page)|
|--------|--------|
|![image](https://user-images.githubusercontent.com/7331038/137806125-bf1edc6b-a7b0-423b-b230-6ee4b5f99916.png)|<img width="1743" alt="Possible" src="https://user-images.githubusercontent.com/7331038/137806213-f9007ed6-3f96-4727-a25b-84cda4f6cb97.png">|

## Items to discuss:
- [x] DESIGN: Final color choices need to be added to Sage 3
- [x] DESIGN: Are text and icon colors going to change to Charcoal within `SageAlert` or is this custom for this alert?
- [x] GENERAL: Secondary button style needs to be adapted to use with the Alert, probably as a prop that can be exposed.