### PR TITLE
fix(revert node version): move node to 12.x

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install node and yarn
         env:
           YARN_VERSION: 1.22.5
-          NODE_VERSION: 12.16.1
+          NODE_VERSION: 14.14.0
           ARCH: "x64"
         run: |
           curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \


### PR DESCRIPTION
## Description

Revert changes for `npm` and `yarn` packages. Update `node` to 12.x