### PR TITLE
[SAGE-918] add SortableItemCustom to react

### DIFF
--- a/packages/sage-react/lib/Sortable/Sortable.story.jsx
+++ b/packages/sage-react/lib/Sortable/Sortable.story.jsx
@@ -4,12 +4,14 @@ import { Button } from '../Button';
 import { Grid } from '../Grid';
 import { SageTokens } from '../configs';
 import { Sortable } from './Sortable';
+import { SortableItemCustom } from './SortableItemCustom';
 
 export default {
   title: 'Sage/Sortable',
   component: Sortable,
   subcomponents: {
-    'Sortable.Item': Sortable.Item
+    'Sortable.Item': Sortable.Item,
+    'Sortable.ItemCustom': SortableItemCustom
   }
 };
 
@@ -93,4 +95,19 @@ Default.argTypes = {
   ...selectArgs({
     type: Sortable.Item.TYPES
   }),
+};
+
+const Template = (args) => <SortableItemCustom {...args} />;
+
+export const CustomItem = Template.bind({});
+
+CustomItem.args = {
+  gridTemplate: "te",
+  children: (
+    <>
+      <p>oh1</p>
+      <p>oh2</p>
+      <p>oh3</p>
+    </>
+  )
 };

--- a/packages/sage-react/lib/Sortable/Sortable.story.jsx
+++ b/packages/sage-react/lib/Sortable/Sortable.story.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Button } from '../Button';
 import { Grid } from '../Grid';
+import { OptionsDropdown } from '../Dropdown/OptionsDropdown';
+import { defaultOptionsItems } from '../Dropdown/stories/story-helper'
 import { SageTokens } from '../configs';
 import { Sortable } from './Sortable';
 import { SortableItemCustom } from './SortableItemCustom';
@@ -97,17 +99,40 @@ Default.argTypes = {
   }),
 };
 
-const Template = (args) => <SortableItemCustom {...args} />;
-
-export const CustomItem = Template.bind({});
-
-CustomItem.args = {
-  gridTemplate: "te",
-  children: (
+export const SortableCustomItem = (args) => {
+  const renderChild = () => (
     <>
-      <p>oh1</p>
-      <p>oh2</p>
-      <p>oh3</p>
+      <p>Title</p>
+      <OptionsDropdown options={defaultOptionsItems} isPinned={false} />
     </>
   )
+
+  const [state, setState] = useState([
+    {
+      id: '1',
+      children: renderChild(),
+      gridTemplate: "te"
+    },
+    {
+      id: '2',
+      children: renderChild(),
+      gridTemplate: "te"
+    },
+    {
+      id: '3',
+      children: renderChild(),
+      gridTemplate: "te"
+    },
+  ]);
+
+  return (
+    <Grid container={Grid.CONTAINER_SIZES.MD}>
+      <Sortable
+        list={state}
+        renderItem={SortableItemCustom}
+        setList={setState}
+      />
+    </Grid>
+  )
 };
+

--- a/packages/sage-react/lib/Sortable/Sortable.story.jsx
+++ b/packages/sage-react/lib/Sortable/Sortable.story.jsx
@@ -3,7 +3,7 @@ import { selectArgs } from '../story-support/helpers';
 import { Button } from '../Button';
 import { Grid } from '../Grid';
 import { OptionsDropdown } from '../Dropdown/OptionsDropdown';
-import { defaultOptionsItems } from '../Dropdown/stories/story-helper'
+import { defaultOptionsItems } from '../Dropdown/stories/story-helper';
 import { SageTokens } from '../configs';
 import { Sortable } from './Sortable';
 import { SortableItemCustom } from './SortableItemCustom';
@@ -99,29 +99,29 @@ Default.argTypes = {
   }),
 };
 
-export const SortableCustomItem = (args) => {
+export const SortableCustomItem = () => {
   const renderChild = () => (
     <>
       <p>Title</p>
       <OptionsDropdown options={defaultOptionsItems} isPinned={false} />
     </>
-  )
+  );
 
   const [state, setState] = useState([
     {
       id: '1',
       children: renderChild(),
-      gridTemplate: "te"
+      gridTemplate: 'te'
     },
     {
       id: '2',
       children: renderChild(),
-      gridTemplate: "te"
+      gridTemplate: 'te'
     },
     {
       id: '3',
       children: renderChild(),
-      gridTemplate: "te"
+      gridTemplate: 'te'
     },
   ]);
 
@@ -133,6 +133,5 @@ export const SortableCustomItem = (args) => {
         setList={setState}
       />
     </Grid>
-  )
+  );
 };
-

--- a/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
+++ b/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { SORTABLE_ITEM_TYPES } from './configs';
+import { SORTABLE_ROW_GAP_OPTIONS, SORTABLE_ITEM_TYPES } from './configs';
 
 import { CardRow } from '../Card/CardRow';
 import { SageTokens } from '..';
@@ -9,6 +9,7 @@ import { SageTokens } from '..';
 export const SortableItemCustom = ({
   children,
   gridTemplate,
+  gap,
   type,
   ...rest
 }) => {
@@ -26,7 +27,7 @@ export const SortableItemCustom = ({
       className={className}
 
     >
-      <CardRow gridTemplate={gridTemplate}>
+      <CardRow gridTemplate={gridTemplate} gap={gap}>
         {children}
       </CardRow>
     </section>
@@ -34,15 +35,18 @@ export const SortableItemCustom = ({
 };
 
 SortableItemCustom.TYPES = SORTABLE_ITEM_TYPES;
+SortableItemCustom.GAP_OPTIONS = SORTABLE_ROW_GAP_OPTIONS;
 
 SortableItemCustom.defaultProps = {
   children: null,
+  gap: SORTABLE_ROW_GAP_OPTIONS.DEFAULT,
   gridTemplate: null,
   type: SORTABLE_ITEM_TYPES.DEFAULT,
 };
 
 SortableItemCustom.propTypes = {
   children: PropTypes.node,
+  grid: PropTypes.oneOf(Object.values(SORTABLE_ROW_GAP_OPTIONS)),
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   type: PropTypes.oneOf(Object.values(SORTABLE_ITEM_TYPES)),
 };

--- a/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
+++ b/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
@@ -46,7 +46,7 @@ SortableItemCustom.defaultProps = {
 
 SortableItemCustom.propTypes = {
   children: PropTypes.node,
-  grid: PropTypes.oneOf(Object.values(SORTABLE_ROW_GAP_OPTIONS)),
+  gap: PropTypes.oneOf(Object.values(SortableItemCustom.GAP_OPTIONS)),
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   type: PropTypes.oneOf(Object.values(SORTABLE_ITEM_TYPES)),
 };

--- a/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
+++ b/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { SORTABLE_ITEM_TYPES } from './configs';
+
+import { CardRow } from './CardRow';
+import { SageTokens } from '..';
+
+export const SortableItemCustom = ({
+  gridTemplate,
+  type,
+  ...rest
+}) => {
+  const className = classnames(
+    'sage-sortable__item',
+    'sage-sortable__item--custom',
+    {
+      'sage-sortable__item--card': type === SORTABLE_ITEM_TYPES.CARD,
+    }
+  );
+
+  return (
+    <section
+      {...rest}
+      className={className}
+
+    >
+      <CardRow gridTemplate={gridTemplate}>
+        {children}
+      </CardRow>
+    </section>
+  );
+};
+
+SortableItemCustom.TYPES = SORTABLE_ITEM_TYPES;
+
+SortableItemCustom.defaultProps = {
+  gridTemplate: null,
+  type: SORTABLE_ITEM_TYPES.DEFAULT,
+};
+
+SortableItemCustom.propTypes = {
+  gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
+  type: PropTypes.oneOf(Object.values(SORTABLE_ITEM_TYPES)),
+};

--- a/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
+++ b/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
@@ -27,9 +27,11 @@ export const SortableItemCustom = ({
       className={className}
 
     >
-      <CardRow gridTemplate={gridTemplate} gap={gap}>
-        {children}
-      </CardRow>
+      {gridTemplate ? (
+        <CardRow gridTemplate={gridTemplate} gap={gap}>
+          {children}
+        </CardRow>
+      ) : children}
     </section>
   );
 };

--- a/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
+++ b/packages/sage-react/lib/Sortable/SortableItemCustom.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SORTABLE_ITEM_TYPES } from './configs';
 
-import { CardRow } from './CardRow';
+import { CardRow } from '../Card/CardRow';
 import { SageTokens } from '..';
 
 export const SortableItemCustom = ({
+  children,
   gridTemplate,
   type,
   ...rest
@@ -35,11 +36,13 @@ export const SortableItemCustom = ({
 SortableItemCustom.TYPES = SORTABLE_ITEM_TYPES;
 
 SortableItemCustom.defaultProps = {
+  children: null,
   gridTemplate: null,
   type: SORTABLE_ITEM_TYPES.DEFAULT,
 };
 
 SortableItemCustom.propTypes = {
+  children: PropTypes.node,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   type: PropTypes.oneOf(Object.values(SORTABLE_ITEM_TYPES)),
 };

--- a/packages/sage-react/lib/Sortable/configs.js
+++ b/packages/sage-react/lib/Sortable/configs.js
@@ -2,3 +2,13 @@ export const SORTABLE_ITEM_TYPES = {
   DEFAULT: null,
   CARD: 'card',
 };
+
+export const SORTABLE_ROW_GAP_OPTIONS = {
+  DEFAULT: null,
+  XS: 'xs',
+  SM: 'sm',
+  MD: 'md',
+  LG: 'lg',
+};
+
+

--- a/packages/sage-react/lib/Sortable/configs.js
+++ b/packages/sage-react/lib/Sortable/configs.js
@@ -10,5 +10,3 @@ export const SORTABLE_ROW_GAP_OPTIONS = {
   MD: 'md',
   LG: 'lg',
 };
-
-


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add SortableItemCustom to react to align with the rails side

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|does not exist|![Screen Shot 2021-10-28 at 2 56 24 PM](https://user-images.githubusercontent.com/1241836/139326949-bf0f4472-1085-490b-a0d7-ca8d9702e6b1.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Sortable Custom Item storybook page and verify that the example aligns with the Rails example, SageSortableItemCustom using a custom grid template : "te" as a Panel List

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adding a new property. No affect on the app.
  


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #918 