### PR TITLE
fix(input error class): deprecate and remove `sage-input--error` class

### DIFF
--- a/docs/app/views/examples/components/dynamic_select/_props.html.erb
+++ b/docs/app/views/examples/components/dynamic_select/_props.html.erb
@@ -24,7 +24,7 @@
 </tr>
 <tr>
   <td><%= md('`has_error`') %></td>
-  <td><%= md('Enabling this property adds the `.sage-input--error` class to the component.') %></td>
+  <td><%= md('Enabling this property adds the `.sage-select--error` class to the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -21,7 +21,15 @@ $-input-text-height: sage-font-size(body);
   }
 }
 
+// TODO: deprecated in favor of sage-form-field--error
 .sage-input--error {
+  .sage-upload-card & {
+    margin-top: sage-spacing(sm);
+  }
+}
+
+// Note: this will be the block of code remaining after above is removed
+.sage-form-field--error {
   .sage-upload-card & {
     margin-top: sage-spacing(sm);
   }


### PR DESCRIPTION
Resolves #953 

## Description

Remove `sage-input--error` class in favor of `sage-form-field--error`


## Screenshots
NA


## Testing in `sage-lib`
NA

## Testing in `kajabi-products`
1. (**LOW**) Sage documentation and deprecation changes only; nothing to test in `kajabi-products`