### PR TITLE
[SAGE-886] Button update to spec

### DIFF
--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -5,3 +5,28 @@
 Use this scratchpad to test out elements and components in context. Just be sure not to commit your changes. ❤️
 ") %>
 <% end %>
+
+<button type="button" class="
+    sage-btn
+
+    sage-btn--subtle
+
+
+
+    sage-btn--primary
+
+    sage-btn--icon-only-gear
+
+  ">
+    <span class="visually-hidden">
+      Icon only
+    </span>
+</button>
+
+<a class="sage-btn sage-btn--subtle sage-btn--small sage-btn--primary" href="#" onclick="Forethought('widget', 'open'); Forethought('widget', 'show');">
+  Live Chat
+</a>
+
+<a class="sage-btn sage-btn--subtle sage-btn--small sage-btn--primary" href="#" onclick='zE("webWidget", "show"); zE("webWidget", "toggle");'>
+  Live Chat
+</a>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -5,28 +5,3 @@
 Use this scratchpad to test out elements and components in context. Just be sure not to commit your changes. ❤️
 ") %>
 <% end %>
-
-<button type="button" class="
-    sage-btn
-
-    sage-btn--subtle
-
-
-
-    sage-btn--primary
-
-    sage-btn--icon-only-gear
-
-  ">
-    <span class="visually-hidden">
-      Icon only
-    </span>
-</button>
-
-<a class="sage-btn sage-btn--subtle sage-btn--small sage-btn--primary" href="#" onclick="Forethought('widget', 'open'); Forethought('widget', 'show');">
-  Live Chat
-</a>
-
-<a class="sage-btn sage-btn--subtle sage-btn--small sage-btn--primary" href="#" onclick='zE("webWidget", "show"); zE("webWidget", "toggle");'>
-  Live Chat
-</a>

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -439,8 +439,6 @@ $-btn-loading-min-height: rem(36px);
       color: map-get($-styles, default);
       background-color: transparent;
 
-      // @include sage-focus-outline--update-color(map-get($-styles, focus-outline));
-
       // TODO: refactor the subtle button hover state, after Sage 3.0 conversion
       &::after {
         border-color: transparent;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -484,14 +484,14 @@ $-btn-loading-min-height: rem(36px);
         }
 
         &:hover::after {
-          opacity: 1;
           border-color: transparent;
+          opacity: 1;
         }
 
         &:focus::after {
-          border-color: map-get($-styles, focus-outline);
           width: $-btn-icon-only-focus-size;
           height: $-btn-icon-only-focus-size;
+          border-color: map-get($-styles, focus-outline);
 
         }
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -11,6 +11,8 @@
 $-btn-transition: map-get($sage-transitions, default);
 $-btn-border-radius: sage-border(radius);
 $-btn-shadow-base: sage-shadow(sm);
+$-btn-icon-only-hover-size: rem(26px);
+$-btn-icon-only-focus-size: rem(28px);
 
 $-btn-base-styles: (
   primary: (
@@ -425,10 +427,12 @@ $-btn-loading-min-height: rem(36px);
         background-color: sage-color(grey);
         border: 1px solid sage-color(grey, 400);
 
-        @include sage-focus-outline--update-color(transparent);
+        // @include sage-focus-outline--update-color(transparent);
 
         &::after {
           transform: translate3d(-50%, -50%, 0) scale(0.94);
+          border-color: transparent;
+          opacity: 0;
         }
       }
     }
@@ -463,10 +467,9 @@ $-btn-loading-min-height: rem(36px);
         color: map-get($-styles, hover);
 
         &::after {
-          z-index: 0 !important; /* stylelint-disable-line declaration-no-important */
-          border-color: transparent !important; /* stylelint-disable-line declaration-no-important */
+          z-index: 0;
           background-color: map-get($-styles, hover-background);
-          opacity: 1 !important; /* stylelint-disable-line declaration-no-important */
+          opacity: 1;
         }
 
         &::before,
@@ -492,17 +495,26 @@ $-btn-loading-min-height: rem(36px);
       }
 
       &[class*="icon-only"] {
-        // @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 0);
-        // @include sage-focus-outline--update-color(map-get($-styles, default));
+        &::before,
+        &::after {
+          border-radius: sage-border(radius);
+        }
+
+        &::after {
+          width: $-btn-icon-only-hover-size;
+          height: $-btn-icon-only-hover-size;
+        }
 
         &:hover::after {
-          opacity: 0;
+          opacity: 1;
           border-color: transparent;
-          transform: translate3d(-50%, -50%, 0) scale(0.94);
         }
 
         &:focus::after {
           border-color: map-get($-styles, focus-outline);
+          width: $-btn-icon-only-focus-size;
+          height: $-btn-icon-only-focus-size;
+
         }
 
         .sage-label & {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -411,10 +411,6 @@ $-btn-loading-min-height: rem(36px);
       color: sage-color(charcoal);
       background-color: sage-color(white);
       border: 1px solid sage-color(grey, 500);
-
-      &[class*="icon-only"] {
-        border: 1px solid sage-color(grey, 400);
-      }
     }
 
     &:focus,
@@ -422,19 +418,6 @@ $-btn-loading-min-height: rem(36px);
       color: sage-color(charcoal);
       background-color: sage-color(white);
       border: 1px solid sage-color(grey);
-
-      &[class*="icon-only"] {
-        background-color: sage-color(grey);
-        border: 1px solid sage-color(grey, 400);
-
-        // @include sage-focus-outline--update-color(transparent);
-
-        &::after {
-          transform: translate3d(-50%, -50%, 0) scale(0.94);
-          border-color: transparent;
-          opacity: 0;
-        }
-      }
     }
 
     &[aria-disabled="true"] {
@@ -495,11 +478,6 @@ $-btn-loading-min-height: rem(36px);
       }
 
       &[class*="icon-only"] {
-        &::before,
-        &::after {
-          border-radius: sage-border(radius);
-        }
-
         &::after {
           width: $-btn-icon-only-hover-size;
           height: $-btn-icon-only-hover-size;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -409,6 +409,10 @@ $-btn-loading-min-height: rem(36px);
       color: sage-color(charcoal);
       background-color: sage-color(white);
       border: 1px solid sage-color(grey, 500);
+
+      &[class*="icon-only"] {
+        border: 1px solid sage-color(grey, 400);
+      }
     }
 
     &:focus,
@@ -416,6 +420,17 @@ $-btn-loading-min-height: rem(36px);
       color: sage-color(charcoal);
       background-color: sage-color(white);
       border: 1px solid sage-color(grey);
+
+      &[class*="icon-only"] {
+        background-color: sage-color(grey);
+        border: 1px solid sage-color(grey, 400);
+
+        @include sage-focus-outline--update-color(transparent);
+
+        &::after {
+          transform: translate3d(-50%, -50%, 0) scale(0.94);
+        }
+      }
     }
 
     &[aria-disabled="true"] {
@@ -437,7 +452,7 @@ $-btn-loading-min-height: rem(36px);
       color: map-get($-styles, default);
       background-color: transparent;
 
-      @include sage-focus-outline--update-color(map-get($-styles, focus-outline));
+      // @include sage-focus-outline--update-color(map-get($-styles, focus-outline));
 
       // TODO: refactor the subtle button hover state, after Sage 3.0 conversion
       &::after {
@@ -477,8 +492,18 @@ $-btn-loading-min-height: rem(36px);
       }
 
       &[class*="icon-only"] {
-        @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 0);
-        @include sage-focus-outline--update-color(map-get($-styles, default));
+        // @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 0);
+        // @include sage-focus-outline--update-color(map-get($-styles, default));
+
+        &:hover::after {
+          opacity: 0;
+          border-color: transparent;
+          transform: translate3d(-50%, -50%, 0) scale(0.94);
+        }
+
+        &:focus::after {
+          border-color: map-get($-styles, focus-outline);
+        }
 
         .sage-label & {
           @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -112,6 +112,10 @@
         padding: rem(6px) rem(10px);
       }
 
+      &.sage-btn--subtle::after {
+        // transform: translate3d(-50%, -50%, 0) scale(0.7857);
+      }
+
       &::before {
         @include sage-icon-base($icon-name);
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -112,10 +112,6 @@
         padding: rem(6px) rem(10px);
       }
 
-      &.sage-btn--subtle::after {
-        // transform: translate3d(-50%, -50%, 0) scale(0.7857);
-      }
-
       &::before {
         @include sage-icon-base($icon-name);
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -108,6 +108,10 @@
       justify-content: center;
       text-align: center;
 
+      &:not(.sage-btn--subtle) {
+        padding: rem(6px) rem(10px);
+      }
+
       &::before {
         @include sage-icon-base($icon-name);
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update sage 3 button to spec, namely padding between icon only subtle vs non-subtle variations
- [x] resolve hover interaction outline flash

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
#### Standard button
|  Before  |  After  |
|--------|--------|
|![standardbefore](https://user-images.githubusercontent.com/1241836/140438070-cc50f2df-fef8-4859-866e-cafe3db7bdd6.gif)|![standardafter](https://user-images.githubusercontent.com/1241836/140438096-8a5cd63e-81eb-497e-87c7-85cad71b5b21.gif)|

#### Subtle Button
|  Before  |  After  |
|--------|--------|
|![subtlebefore](https://user-images.githubusercontent.com/1241836/140438111-883e23cb-6a1e-4041-85cf-1f7fd7f6770d.gif)|![subtleafter](https://user-images.githubusercontent.com/1241836/140438182-f4d5cdd4-d3e2-4234-b789-9a0578200bde.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit Rails and React button pages and interact with the `icon-only` variants and verify they match the spec

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Updates spacing in standard and subtle icon only buttons throughout.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #886 