### PR TITLE
[SAGE-952] Upload card dropdown position fix

### DIFF
--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td><%= md('`align`') %></td>
-  <td><%= md('Aligns a button to the "right" rather than its default position.') %></td>
-  <td><%= md('String: [ nil | "right" ]') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md('Specifies which side of the button the dropdown will be aligned to. By default, this is `nil`, positioning the dropdown to the left edge of the button. When used inside of an Upload Card, the default behavior will instead be set to "center".') %></td>
+  <td><%= md('String: [ nil | "left" | "right" | "center" ]') %></td>
+  <td><%= md('`nil` (left)') %></td>
 </tr>
 <tr>
   <td><%= md('`contained`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -1,6 +1,6 @@
 class SageDropdown < SageComponent
   set_attribute_schema({
-    align: [:optional, Set.new(["right"])],
+    align: [:optional, Set.new(["left", "center", "right"])],
     contained: [:optional, TrueClass],
     content: [:optional, String],
     customized: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -1,6 +1,8 @@
 <div
   class="sage-dropdown
+    <%= "sage-dropdown--anchor-left" if component.align == "left" %>
     <%= "sage-dropdown--anchor-right" if component.align == "right" %>
+    <%= "sage-dropdown--anchor-center" if component.align == "center" %>
     <%= "sage-dropdown--contained" if component.contained %>
     <%= "sage-dropdown--customized" if component.customized %>
     <%= "sage-dropdown--full-width" if component.full_width_panel %>

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -325,9 +325,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   [aria-expanded="true"] > & {
     display: block;
     z-index: sage-z-index(default, 100);
-    // Temporarily removing animation as it causes
-    // a positioning issue with nested flex positioned elements
-    // transform: rotate3d(0, 0, 0, 0);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -291,8 +291,17 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   // to prevent it from touching the bottom of the viewport/page when it expands
   margin-bottom: sage-spacing(); /* stylelint-disable-line order/properties-order */
 
+  .sage-dropdown--anchor-left & {
+    left: 0;
+  }
+
   .sage-dropdown--anchor-right & {
     right: 0;
+  }
+
+  .sage-dropdown--anchor-center & {
+    left: 50%;
+    transform: translateX(-50%);
   }
 
   .sage-dropdown--pinned & {
@@ -319,11 +328,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
     // Temporarily removing animation as it causes
     // a positioning issue with nested flex positioned elements
     // transform: rotate3d(0, 0, 0, 0);
-  }
-
-  .sage-upload-card .sage-dropdown & {
-    left: 50%;
-    transform: translateX(-50%);
   }
 }
 

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -8,7 +8,7 @@ import { DropdownItemList } from './DropdownItemList';
 import { DropdownItemSearch } from './DropdownItemSearch';
 import { DropdownPanel } from './DropdownPanel';
 import { DropdownTrigger } from './DropdownTrigger';
-import { DROPDOWN_ITEM_COLORS, DROPDOWN_PANEL_SIZES, DROPDOWN_PANEL_TYPES } from './configs';
+import { DROPDOWN_ITEM_COLORS, DROPDOWN_PANEL_SIZES, DROPDOWN_PANEL_TYPES, DROPDOWN_POSITIONS } from './configs';
 
 export const Dropdown = ({
   align,
@@ -171,9 +171,10 @@ Dropdown.Trigger = DropdownTrigger;
 Dropdown.ITEM_COLORS = DROPDOWN_ITEM_COLORS;
 Dropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
 Dropdown.PANEL_TYPES = DROPDOWN_PANEL_TYPES;
+Dropdown.POSITIONS = DROPDOWN_POSITIONS;
 
 Dropdown.defaultProps = {
-  align: null,
+  align: DROPDOWN_POSITIONS.DEFAULT,
   children: null,
   className: null,
   clickTriggerHandler: null,
@@ -198,9 +199,7 @@ Dropdown.defaultProps = {
 };
 
 Dropdown.propTypes = {
-  align: PropTypes.oneOf([
-    'right',
-  ]),
+  align: PropTypes.oneOf(Object.values(Dropdown.POSITIONS)),
   children: PropTypes.node,
   className: PropTypes.string,
   clickTriggerHandler: PropTypes.func,

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -19,11 +19,12 @@ export default {
   argTypes: {
     ...selectArgs({
       icon: SageTokens.ICONS,
+      align: Dropdown.POSITIONS,
       panelSize: Dropdown.PANEL_SIZES
     }),
   },
   args: {
-    align: null,
+    align: Dropdown.POSITIONS.DEFAULT,
     className: null,
     closePanelOnExit: true,
     contained: false,

--- a/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
 import { DropdownItemList } from './DropdownItemList';
-import { DROPDOWN_PANEL_SIZES } from './configs';
+import { DROPDOWN_PANEL_SIZES, DROPDOWN_POSITIONS } from './configs';
 
 export const OptionsDropdown = ({
   align,
@@ -34,9 +34,10 @@ export const OptionsDropdown = ({
 );
 
 OptionsDropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
+OptionsDropdown.POSITIONS = DROPDOWN_POSITIONS;
 
 OptionsDropdown.defaultProps = {
-  align: null,
+  align: DROPDOWN_POSITIONS.DEFAULT,
   className: null,
   exitPanelHandler: (evt) => evt,
   isPinned: true,
@@ -47,9 +48,7 @@ OptionsDropdown.defaultProps = {
 };
 
 OptionsDropdown.propTypes = {
-  align: PropTypes.oneOf([
-    'right',
-  ]),
+  align: PropTypes.oneOf(Object.values(DROPDOWN_POSITIONS)),
   className: PropTypes.string,
   exitPanelHandler: PropTypes.func,
   isPinned: PropTypes.bool,

--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -7,7 +7,7 @@ import { SageTokens } from '../configs';
 import { Label } from '../Label';
 import { Dropdown } from './Dropdown';
 import { DropdownTriggerSelect } from './DropdownTriggerSelect';
-import { DROPDOWN_PANEL_SIZES } from './configs';
+import { DROPDOWN_PANEL_SIZES, DROPDOWN_POSITIONS } from './configs';
 
 export const SelectDropdown = ({
   align,
@@ -245,9 +245,10 @@ export const SelectDropdown = ({
 };
 
 SelectDropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
+SelectDropdown.POSITIONS = DROPDOWN_POSITIONS;
 
 SelectDropdown.defaultProps = {
-  align: null,
+  align: DROPDOWN_POSITIONS.DEFAULT,
   allowDeselect: false,
   allowMultiselect: false,
   className: null,
@@ -276,9 +277,7 @@ SelectDropdown.defaultProps = {
 };
 
 SelectDropdown.propTypes = {
-  align: PropTypes.oneOf([
-    'right',
-  ]),
+  align: PropTypes.oneOf(Object.values(DROPDOWN_POSITIONS)),
   allowDeselect: PropTypes.bool,
   allowMultiselect: PropTypes.bool,
   className: PropTypes.string,

--- a/packages/sage-react/lib/Dropdown/configs.js
+++ b/packages/sage-react/lib/Dropdown/configs.js
@@ -17,3 +17,10 @@ export const DROPDOWN_PANEL_TYPES = {
   SEARCHABLE: 'searchable',
   STATUS: 'status',
 };
+
+export const DROPDOWN_POSITIONS = {
+  DEFAULT: null,
+  LEFT: 'left',
+  RIGHT: 'right',
+  CENTER: 'center'
+};


### PR DESCRIPTION
## Description
Removes forced dropdown center position when used in an upload card and adds new options to component for positioning. This will allow component-level overrides to position a dropdown independently.


## Screenshots
No visual changes


## Testing in `sage-lib`
### Rails
- Verify [Dropdown](http://localhost:4000/pages/component/dropdown) positioning continues to behave as expected.

### React
- Verify [Dropdown](http://localhost:4100/?path=/docs/sage-dropdown--default) positioning continues to behave as expected. Test new positioning options available in the default story


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MED**) Removes forced center positioning from dropdowns when used in upload cards. No visual change expected in normal use, confirm that dropdown position appears as expected:
   - [ ] Affiliates -> Settings -> Logo upload - "Select a file" dropdown
   - [ ] Products -> Edit Product - publish status dropdown
   - [ ] Websites -> Pages -> "Filters" dropdown


## Related
closes #952
