### PR TITLE
[SAGE-941] Button - center full_width button

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -520,6 +520,7 @@ $-btn-loading-min-height: rem(36px);
 
 .sage-btn--full-width {
   align-self: stretch;
+  justify-content: center;
   width: 100%;
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] center text in the `full_width` button

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="674" alt="Screen Shot 2021-10-28 at 8 15 55 PM" src="https://user-images.githubusercontent.com/1241836/139361386-9f2ea661-b444-4fa3-876e-c8092601f661.png">|<img width="672" alt="Screen Shot 2021-10-28 at 8 16 03 PM" src="https://user-images.githubusercontent.com/1241836/139361398-7c0835b0-9203-4a4a-8a6a-fb692c4f7bb2.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Check the `full_width` variant in Rails and React and verify that text is centered

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update text alignment in full-width buttons  Description of the change and its impact with QA as the audience.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #941 