### PR TITLE
[SAGE-935] Panel, Card, Sortable Optional Grid Template & Gap

### DIFF
--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -25,3 +25,33 @@
   <td><%= md('Optionally: `"sm"`') %></td>
   <td><%= md('`--`') %></td>
 </tr>
+<tr>
+  <td colspan="4"><%= md('**Card List Item**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a list item.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td colspan="4"><%= md('**Card Row**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a card row.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -30,7 +30,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -45,7 +45,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/panel/_props.html.erb
+++ b/docs/app/views/examples/components/panel/_props.html.erb
@@ -24,7 +24,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -39,7 +39,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/panel/_props.html.erb
+++ b/docs/app/views/examples/components/panel/_props.html.erb
@@ -19,3 +19,33 @@
   <td><%= md('Optionally: `md`') %></td>
   <td><%= md('`--`') %></td>
 </tr>
+<tr>
+  <td colspan="4"><%= md('**Panel ListItem**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a list item.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td colspan="4"><%= md('**Panel Row**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a panel row.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -117,7 +117,7 @@
 
 
 <%= md('
-`SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the [Sage Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.
+`SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the [Sage Grid Templates](../patterns/grid_templates) docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.
 ', use_sage_type: true) %>
 
 <h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "te"</code> as a Panel List</h3>

--- a/docs/app/views/examples/components/sortable/_props.html.erb
+++ b/docs/app/views/examples/components/sortable/_props.html.erb
@@ -20,6 +20,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in the row.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('The unique identifier for this component.') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/components/sortable/_props.html.erb
+++ b/docs/app/views/examples/components/sortable/_props.html.erb
@@ -15,7 +15,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_card_list_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_list_item.rb
@@ -1,5 +1,6 @@
 class SageCardListItem < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
@@ -1,6 +1,7 @@
 class SageCardRow < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE,
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
     vertical_align: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
@@ -1,7 +1,7 @@
 class SageCardRow < SageComponent
   set_attribute_schema({
-    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
-    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
+    grid_template: [:optional, NilClass, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, NilClass, Set.new([:xs, :sm, :md, :lg])],
     vertical_align: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_list_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_list_item.rb
@@ -1,5 +1,6 @@
 class SagePanelListItem < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE,
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,6 +1,7 @@
 class SagePanelRow < SageComponent
   set_attribute_schema({
     grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
     vertical_align: [:optional, Set.new(["start"])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
@@ -2,6 +2,7 @@ class SageSortableItemCustom < SageComponent
   set_attribute_schema({
     card: [:optional, TrueClass],
     grid_template: String,
+    gap: [:optional, String],
     id: [:optional, Integer, String],
     url_update: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card_list_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card_list_item.html.erb
@@ -2,6 +2,7 @@
   class="
     sage-card__list-item
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
+    <%= "sage-card__list-item--gap-#{component.gap}" if component.gap %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card_row.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card_row.html.erb
@@ -1,7 +1,8 @@
 <div
   class="sage-card__row
-    <%= "sage-panel__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
-    <%= "sage-grid-template-#{component.grid_template}" %>
+    <%= "sage-card__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
+    <%= "sage-card__row--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_list_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_list_item.html.erb
@@ -1,6 +1,7 @@
 <li
   class="sage-panel__list-item
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
+    <%= "sage-panel__list-item--gap-#{component.gap}" if component.gap %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_row.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_row.html.erb
@@ -1,7 +1,8 @@
 <div
   class="sage-panel__row
     <%= "sage-panel__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
-    <%= "sage-grid-template-#{component.grid_template}" %>
+    <%= "sage-panel__row--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
@@ -9,7 +9,10 @@
   <%= "id=#{component.id}" if component.id %>
   <%= component.generated_html_attributes.html_safe %>
 >
-  <%= sage_component SageCardRow, { grid_template: component.grid_template } do %>
+  <%= sage_component SageCardRow, {
+    grid_template: component.grid_template,
+    gap: component.gap,
+  } do %>
     <%= component.content %>
   <% end %>
 </li>

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -157,7 +157,8 @@
 }
 
 @each $-key, $-value in $sage-spacings {
-  .sage-card__row--gap-#{$-key} {
+  .sage-card__row--gap-#{$-key},
+  .sage-card__list-item--gap-#{$-key} {
     gap: sage-spacing($-key);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -156,6 +156,12 @@
   }
 }
 
+@each $-key, $-value in $sage-spacings {
+  .sage-card__row--gap-#{$-key} {
+    gap: sage-spacing($-key);
+  }
+}
+
 .sage-card__row--vertical-align-start {
   align-items: start;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -113,6 +113,12 @@
   @include sage-grid-panel-row();
 }
 
+@each $-key, $-value in $sage-spacings {
+  .sage-panel__row--gap-#{$-key} {
+    gap: sage-spacing($-key);
+  }
+}
+
 .sage-panel__row--media {
   grid-template-columns: 160px 1fr;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -114,7 +114,8 @@
 }
 
 @each $-key, $-value in $sage-spacings {
-  .sage-panel__row--gap-#{$-key} {
+  .sage-panel__row--gap-#{$-key}
+  .sage-panel__list-item--gap-#{$-key} {
     gap: sage-spacing($-key);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -258,7 +258,7 @@
 /// Adjusts to a wrapping flex layout below the `min` breakpoint.
 ///
 @mixin sage-grid-card-row() {
-  justify-content: space-between;
+  justify-content: start;
   align-items: center;
   gap: sage-spacing(card);
 
@@ -280,7 +280,7 @@
 /// Adjusts to a wrapping flex layout below the `min` breakpoint.
 ///
 @mixin sage-grid-panel-row() {
-  justify-content: space-between;
+  justify-content: start;
   align-items: center;
   gap: sage-spacing();
 

--- a/packages/sage-react/lib/Card/CardListItem.jsx
+++ b/packages/sage-react/lib/Card/CardListItem.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
+import { CARD_LIST_GAP_OPTIONS } from './configs';
 
 export const CardListItem = ({
   children,
   className,
   gridTemplate,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -14,6 +16,7 @@ export const CardListItem = ({
     className,
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
+      [`sage-card__list-item--gap-${gap}`]: gap
     }
   );
 
@@ -31,10 +34,12 @@ CardListItem.defaultProps = {
   children: null,
   className: '',
   gridTemplate: null,
+  gap: CARD_LIST_GAP_OPTIONS.DEFAULT
 };
 
 CardListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
+  gap: PropTypes.oneOf(Object.values(CARD_LIST_GAP_OPTIONS)),
 };

--- a/packages/sage-react/lib/Card/CardRow.jsx
+++ b/packages/sage-react/lib/Card/CardRow.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
-import { CARD_ROW_ALIGNMENT_OPTIONS } from './configs';
+import { CARD_ROW_ALIGNMENT_OPTIONS, CARD_ROW_GAP_OPTIONS } from './configs';
 
 export const CardRow = ({
   children,
   className,
   gridTemplate,
   verticalAlign,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -17,6 +18,7 @@ export const CardRow = ({
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
       [`sage-card__row--vertical-align-${verticalAlign}`]: verticalAlign,
+      [`sage-card__row--gap-${gap}`]: gap,
     }
   );
 
@@ -35,6 +37,7 @@ CardRow.defaultProps = {
   className: '',
   gridTemplate: null,
   verticalAlign: CARD_ROW_ALIGNMENT_OPTIONS.DEFAULT,
+  gap: CARD_ROW_GAP_OPTIONS.DEFAULT,
 };
 
 CardRow.propTypes = {
@@ -42,4 +45,5 @@ CardRow.propTypes = {
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   verticalAlign: PropTypes.oneOf(Object.values(CARD_ROW_ALIGNMENT_OPTIONS)),
+  gap: CARD_ROW_GAP_OPTIONS.DEFAULT
 };

--- a/packages/sage-react/lib/Card/configs.js
+++ b/packages/sage-react/lib/Card/configs.js
@@ -18,6 +18,14 @@ export const CARD_ROW_ALIGNMENT_OPTIONS = {
   TOP: 'start',
 };
 
+export const CARD_ROW_GAP_OPTIONS = {
+  DEFAULT: null,
+  XS: 'xs',
+  SM: 'sm',
+  MD: 'md',
+  LG: 'lg',
+};
+
 export const CARD_HIGHLIGHT_COLORS = {
   CHARCOAL: SageTokens.COLORS.CHARCOAL,
   GREY: SageTokens.COLORS.GREY,

--- a/packages/sage-react/lib/Card/configs.js
+++ b/packages/sage-react/lib/Card/configs.js
@@ -26,6 +26,8 @@ export const CARD_ROW_GAP_OPTIONS = {
   LG: 'lg',
 };
 
+export const CARD_LIST_GAP_OPTIONS = CARD_ROW_GAP_OPTIONS;
+
 export const CARD_HIGHLIGHT_COLORS = {
   CHARCOAL: SageTokens.COLORS.CHARCOAL,
   GREY: SageTokens.COLORS.GREY,

--- a/packages/sage-react/lib/Panel/PanelListItem.jsx
+++ b/packages/sage-react/lib/Panel/PanelListItem.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
+import { PANEL_LIST_GAP_OPTIONS } from './configs';
 
 export const PanelListItem = ({
   children,
   className,
   gridTemplate,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -14,6 +16,7 @@ export const PanelListItem = ({
     className,
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
+      [`sage-panel__list-item--gap-${gap}`]: gap
     }
   );
 
@@ -31,10 +34,12 @@ PanelListItem.defaultProps = {
   children: null,
   className: '',
   gridTemplate: null,
+  gap: PANEL_LIST_GAP_OPTIONS.DEFAULT
 };
 
 PanelListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
+  gap: PropTypes.oneOf(Object.values(PANEL_LIST_GAP_OPTIONS)),
 };

--- a/packages/sage-react/lib/Panel/PanelRow.jsx
+++ b/packages/sage-react/lib/Panel/PanelRow.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
-import { PANEL_ROW_ALIGNMENT_OPTIONS } from './configs';
+import { PANEL_ROW_ALIGNMENT_OPTIONS, PANEL_ROW_GAP_OPTIONS } from './configs';
 
 export const PanelRow = ({
   children,
   className,
   gridTemplate,
   verticalAlign,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -17,6 +18,7 @@ export const PanelRow = ({
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
       [`sage-panel__row--vertical-align-${verticalAlign}`]: verticalAlign,
+      [`sage-panel__row--gap-${gap}`]: gap,
     }
   );
 
@@ -31,12 +33,14 @@ export const PanelRow = ({
 };
 
 PanelRow.VERTICAL_ALIGNMENTS = PANEL_ROW_ALIGNMENT_OPTIONS;
+PanelRow.GAP_OPTIONS = PANEL_ROW_GAP_OPTIONS;
 
 PanelRow.defaultProps = {
   children: null,
   className: '',
   gridTemplate: null,
   verticalAlign: PANEL_ROW_ALIGNMENT_OPTIONS.DEFAULT,
+  gap: PANEL_ROW_GAP_OPTIONS.DEFAULT
 };
 
 PanelRow.propTypes = {
@@ -44,4 +48,5 @@ PanelRow.propTypes = {
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   verticalAlign: PropTypes.oneOf(Object.values(PANEL_ROW_ALIGNMENT_OPTIONS)),
+  gap: PropTypes.oneOf(Object.values(PANEL_ROW_GAP_OPTIONS)),
 };

--- a/packages/sage-react/lib/Panel/configs.js
+++ b/packages/sage-react/lib/Panel/configs.js
@@ -11,6 +11,14 @@ export const PANEL_ROW_ALIGNMENT_OPTIONS = {
   TOP: 'start',
 };
 
+export const PANEL_ROW_GAP_OPTIONS = {
+  DEFAULT: null,
+  XS: 'xs',
+  SM: 'sm',
+  MD: 'md',
+  LG: 'lg',
+};
+
 export const PANEL_TILE_OPTIONS_ARRAY = [2, 3, 4];
 
 export const PANEL_LIST_BLOCK_SPACING = {

--- a/packages/sage-react/lib/Panel/configs.js
+++ b/packages/sage-react/lib/Panel/configs.js
@@ -19,6 +19,8 @@ export const PANEL_ROW_GAP_OPTIONS = {
   LG: 'lg',
 };
 
+export const PANEL_LIST_GAP_OPTIONS = PANEL_ROW_GAP_OPTIONS;
+
 export const PANEL_TILE_OPTIONS_ARRAY = [2, 3, 4];
 
 export const PANEL_LIST_BLOCK_SPACING = {


### PR DESCRIPTION
## Description
Makes `grid-template` optional and adds optional `gap` attribute to the following components:

-  PanelRow
-  PanelListItem
-  CardRow
-  CardListItem
-  SortableItemCustom

Note: the current default gaps will not change but additional sizes can now be passed in as needed.

## Screenshots
There are no visual changes related to these adjustments.


## Testing in `sage-lib`

PANEL:

- Navigate to [Panel](http://localhost:4000/pages/component/panel) ([Storybook](http://localhost:4100/?path=/docs/sage-panel--default))
- Verify no layout has changed.
- Try removing grid template or adding gap attribute to `panelRow` or `panelListItem`

CARD:

- Navigate to [Card](http://localhost:4000/pages/component/card) ([Storybook](http://localhost:4100/?path=/docs/sage-card--default))
- Verify no layout has changed.
- Try removing grid template or adding gap attribute to `cardlRow` or `cardListItem`

SORTABLE:

- Navigate to [Sortable](http://localhost:4000/pages/component/sortable)
- Verify no layout has changed.
- Try removing grid template or adding gap attribute to `SortableItemCustom`


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Make grid-template optional and adds an optional gap attribute to components.
   - [ ] A sanity check in KP should be performed to verify no layout issues appear.


## Related
#935
