### PR TITLE
[Sage-940] Icon - Background Size Updates

### DIFF
--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -62,6 +62,7 @@ and also be used with a vareity of layout techniques or components such as CSS f
       <%= size == "md" ? "Default (#{size})" : size %>
       <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft" } %>
       <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft", circular: true, } %>
+      <%= sage_component SageIcon, { icon: "pen", background_height: "40px", background_width: "40px", card_color: "draft", circular: true, } %>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -69,7 +69,7 @@ and also be used with a vareity of layout techniques or components such as CSS f
 <h3>Custom Background Sizes</h3>
 <%= sage_component SageCardList, {} do %>
   <%= sage_component SageCardListItem, { grid_template: "o" } do %>
-    <%= sage_component SageIcon, { icon: "pen", background_width: "64px", background_height: "20px", card_color: "draft" } %>
-    <%= sage_component SageIcon, { icon: "pen", size: "4xl", background_height: "64px", background_width: "10px", card_color: "draft", circular: true, } %>
+    <%= sage_component SageIcon, { icon: "pen", size: "2xl", background_width: "128px", background_height: "64px", card_color: "draft" } %>
+    <%= sage_component SageIcon, { icon: "pen", size: "xl", background_height: "64px", card_color: "draft", circular: true, } %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -62,7 +62,14 @@ and also be used with a vareity of layout techniques or components such as CSS f
       <%= size == "md" ? "Default (#{size})" : size %>
       <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft" } %>
       <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft", circular: true, } %>
-      <%= sage_component SageIcon, { icon: "pen", background_height: "40px", background_width: "40px", card_color: "draft", circular: true, } %>
     <% end %>
+  <% end %>
+<% end %>
+
+<h3>Custom Background Sizes</h3>
+<%= sage_component SageCardList, {} do %>
+  <%= sage_component SageCardListItem, { grid_template: "o" } do %>
+    <%= sage_component SageIcon, { icon: "pen", background_width: "64px", background_height: "20px", card_color: "draft" } %>
+    <%= sage_component SageIcon, { icon: "pen", size: "4xl", background_height: "64px", background_width: "10px", card_color: "draft", circular: true, } %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/icon/_props.html.erb
+++ b/docs/app/views/examples/components/icon/_props.html.erb
@@ -6,13 +6,13 @@
 </tr>
 <tr>
   <td><%= md('`background_height`') %></td>
-  <td><%= md('Allows a custom height for the icon background. **Note: if no width is set, width will be equal to height. Additionally, height and width for circular icons will be equal.**') %></td>
+  <td><%= md('Allows a custom height for the icon background. **Note: if no height is set, height will be equal to width. Additionally, height and width for circular icons will be equal.**') %></td>
   <td><%= md("`String`") %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`background_width`') %></td>
-  <td><%= md('Allows a custom width for the icon background. **Note: if no height is set, height will be equal to width. Additionally, height and width for circular icons will be equal.**') %></td>
+  <td><%= md('Allows a custom width for the icon background. **Note: if no width is set, width will be equal to height. Additionally, height and width for circular icons will be equal.**') %></td>
   <td><%= md("`String`") %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/icon/_props.html.erb
+++ b/docs/app/views/examples/components/icon/_props.html.erb
@@ -5,6 +5,18 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`background_height`') %></td>
+  <td><%= md('Allows a custom height for the icon background. **Note: if no width is set, width will be equal to height. Additionally, height and width for circular icons will be equal.**') %></td>
+  <td><%= md("`String`") %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`background_width`') %></td>
+  <td><%= md('Allows a custom width for the icon background. **Note: if no height is set, height will be equal to width. Additionally, height and width for circular icons will be equal.**') %></td>
+  <td><%= md("`String`") %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`card_color`') %></td>
   <td><%= md('Rather than just changing the icon color with the `color` property, this option adds a padded background behind the icon in one of the brand status color options.') %></td>
   <td><%= md("`#{SageTokens::STATUSES.inspect()}`") %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon.rb
@@ -1,6 +1,8 @@
 class SageIcon < SageComponent
   set_attribute_schema({
     adjacent_type: [:optional, NilClass, Set.new(SageTokens::RESPONSIVE_TYPE_SPECS)],
+    background_height: [:optional, String],
+    background_width: [:optional, String],
     card_color: [:optional, SageSchemas::STATUSES],
     circular: [:optional, NilClass, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -1,5 +1,5 @@
 <%
-# Set the custom height to equal the width when the height isn't defined
+# Set an undefined custom height or width equal to the value that is defined
 bg_height = component.background_height ? component.background_height : component.background_width;
 bg_width = component.background_width ? component.background_width : component.background_height;
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -2,11 +2,12 @@
   <div class="sage-icon-background 
     <%= "sage-icon-background--#{component.card_color}" %>
     <%= "sage-icon-background--#{component.size}" if component.size.present? %>
+    <%= "sage-icon-background--custom" if component.background_height || component.background_width %>
     <%= "sage-icon-background--circular" if component.circular %>
   "
   style="
-    <%= "--background-height: #{component.background_height}" if component.background_height %>
-    <%= "--background-width: #{component.background_width}" if component.background_width %>
+    <%= "--background-height: #{component.background_height};" if component.background_height %>
+    <%= "--background-width: #{component.background_width};" if component.background_width %>
   ">
 <% end %>
   <i class="

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -3,6 +3,10 @@
     <%= "sage-icon-background--#{component.card_color}" %>
     <%= "sage-icon-background--#{component.size}" if component.size.present? %>
     <%= "sage-icon-background--circular" if component.circular %>
+  "
+  style="
+    --background-height: <%= component.background_height if component.background_height %>
+    --background-width: <%= component.background_width if component.background_width %>
   ">
 <% end %>
   <i class="

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -5,8 +5,8 @@
     <%= "sage-icon-background--circular" if component.circular %>
   "
   style="
-    --background-height: <%= component.background_height if component.background_height %>
-    --background-width: <%= component.background_width if component.background_width %>
+    <%= "--background-height: #{component.background_height}" if component.background_height %>
+    <%= "--background-width: #{component.background_width}" if component.background_width %>
   ">
 <% end %>
   <i class="

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -15,16 +15,13 @@ end
     <%= "sage-icon-background--custom" if component.background_height || component.background_width %>
     <%= "sage-icon-background--circular" if component.circular %>
   "
-  <% if component.background_height || component.background_width %>
-    style="
-      --background-height: <%= bg_height %>;
-      --background-width: <%= bg_width %>;
-    "
-  <% end %>
-  style="
-    <%= "--background-height: #{bg_height};" if component.background_height || component.background_width %>
-    <%= "--background-width: #{bg_width};" if component.background_height || component.background_width %>
-  ">
+    <% if component.background_height || component.background_width %>
+      style="
+        --background-height: <%= bg_height %>;
+        --background-width: <%= bg_width %>;
+      "
+    <% end %>
+  >
 <% end %>
   <i class="
       <%= "sage-icon-#{component.icon}" %><%= "-#{component.size}" if component.size.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -1,3 +1,13 @@
+<%
+# Set the custom height to equal the width when the height isn't defined
+bg_height = component.background_height ? component.background_height : component.background_width;
+bg_width = component.background_width ? component.background_width : component.background_height;
+
+if component.circular
+  bg_width = bg_height
+end
+
+%>
 <% if component.card_color.present? %>
   <div class="sage-icon-background 
     <%= "sage-icon-background--#{component.card_color}" %>
@@ -5,9 +15,15 @@
     <%= "sage-icon-background--custom" if component.background_height || component.background_width %>
     <%= "sage-icon-background--circular" if component.circular %>
   "
+  <% if component.background_height || component.background_width %>
+    style="
+      --background-height: <%= bg_height %>;
+      --background-width: <%= bg_width %>;
+    "
+  <% end %>
   style="
-    <%= "--background-height: #{component.background_height};" if component.background_height %>
-    <%= "--background-width: #{component.background_width};" if component.background_width %>
+    <%= "--background-height: #{bg_height};" if component.background_height || component.background_width %>
+    <%= "--background-width: #{bg_width};" if component.background_height || component.background_width %>
   ">
 <% end %>
   <i class="

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -12,13 +12,13 @@ end
   <div class="sage-icon-background 
     <%= "sage-icon-background--#{component.card_color}" %>
     <%= "sage-icon-background--#{component.size}" if component.size.present? %>
-    <%= "sage-icon-background--custom" if component.background_height || component.background_width %>
+    <%= "sage-icon-background--custom-size" if component.background_height || component.background_width %>
     <%= "sage-icon-background--circular" if component.circular %>
   "
     <% if component.background_height || component.background_width %>
       style="
-        --background-height: <%= bg_height %>;
-        --background-width: <%= bg_width %>;
+        --sage-icon-background-height: <%= bg_height %>;
+        --sage-icon-background-width: <%= bg_width %>;
       "
     <% end %>
   >

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -125,12 +125,14 @@ $-icon-beside-type: (
 }
 
 .sage-icon-background {
+  --background-height: sage-spacing(xl);
+  --background-width: sage-spacing(xl);
   display: flex;
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  width: sage-spacing(xl);
-  height: sage-spacing(xl);
+  width: var(--background-width);
+  height: var(--background-height);
   background-color: var(--background-color, inherit);
 
   [class*="sage-icon-"] {

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -125,14 +125,12 @@ $-icon-beside-type: (
 }
 
 .sage-icon-background {
-  --background-height: sage-spacing(xl);
-  --background-width: sage-spacing(xl);
   display: flex;
   align-items: center;
   justify-content: center;
   align-self: stretch;
-  width: var(--background-width);
-  height: var(--background-height);
+  width: sage-spacing(xl);
+  height: sage-spacing(xl);
   background-color: var(--background-color, inherit);
 
   [class*="sage-icon-"] {
@@ -156,6 +154,14 @@ $-icon-beside-type: (
     width: $size;
     height: $size;
   }
+}
+
+.sage-icon-background--custom {
+  --background-height: sage-spacing(xl);
+  --background-width: sage-spacing(xl);
+
+  width: var(--background-width);
+  height: var(--background-height);
 }
 
 @each $-color, $-values in $sage-color-combos {

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -156,12 +156,12 @@ $-icon-beside-type: (
   }
 }
 
-.sage-icon-background--custom {
-  --background-height: sage-spacing(xl);
-  --background-width: sage-spacing(xl);
+.sage-icon-background--custom-size {
+  --sage-icon-background-height: sage-spacing(xl);
+  --sage-icon-background-width: sage-spacing(xl);
 
-  width: var(--background-width);
-  height: var(--background-height);
+  width: var(--sage-icon-background-width);
+  height: var(--sage-icon-background-height);
 }
 
 @each $-color, $-values in $sage-color-combos {

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -30,7 +30,7 @@ export const Icon = ({
   const wrapperClassNames = classnames(
     'sage-icon-background',
     {
-      'sage-icon-background--custom': backgroundHeight || backgroundWidth,
+      'sage-icon-background--custom-size': backgroundHeight || backgroundWidth,
       [`sage-icon-background--${cardColor}`]: cardColor,
       [`sage-icon-background--${size}`]: size,
       'sage-icon-background--circular': circular,
@@ -58,8 +58,8 @@ export const Icon = ({
       backgroundWidth = backgroundHeight;
     }
 
-    props['--background-height'] = backgroundHeight;
-    props['--background-width'] = backgroundWidth;
+    props['--sage-icon-background-height'] = backgroundHeight;
+    props['--sage-icon-background-width'] = backgroundWidth;
 
     return props;
   };

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -6,6 +6,8 @@ import { ICON_ADJACENT_TYPES, ICON_CARD_COLORS, ICON_SIZES } from './configs';
 
 export const Icon = ({
   adjacentType,
+  backgroundHeight,
+  backgroundWidth,
   cardColor,
   circular,
   className,
@@ -28,6 +30,7 @@ export const Icon = ({
   const wrapperClassNames = classnames(
     'sage-icon-background',
     {
+      'sage-icon-background--custom': backgroundHeight || backgroundWidth,
       [`sage-icon-background--${cardColor}`]: cardColor,
       [`sage-icon-background--${size}`]: size,
       'sage-icon-background--circular': circular,
@@ -45,8 +48,27 @@ export const Icon = ({
     <i className={classNames} {...attributes} {...rest} />
   );
 
+  const setBackgroundDimensions = () => {
+    const props = {};
+
+    backgroundHeight = backgroundHeight || backgroundWidth;
+    backgroundWidth = backgroundWidth || backgroundHeight;
+
+    if (circular) {
+      backgroundWidth = backgroundHeight;
+    }
+
+    props['--background-height'] = backgroundHeight;
+    props['--background-width'] = backgroundWidth;
+
+    return props;
+  };
+
   return cardColor ? (
-    <div className={wrapperClassNames}>
+    <div
+      style={setBackgroundDimensions()}
+      className={wrapperClassNames}
+    >
       {renderIcon()}
     </div>
   ) : renderIcon();
@@ -60,6 +82,8 @@ Icon.SIZES = ICON_SIZES;
 
 Icon.defaultProps = {
   adjacentType: null,
+  backgroundHeight: null,
+  backgroundWidth: null,
   cardColor: null,
   circular: false,
   className: '',
@@ -70,6 +94,8 @@ Icon.defaultProps = {
 
 Icon.propTypes = {
   adjacentType: PropTypes.oneOf(Object.values(Icon.ADJACENT_TYPES)),
+  backgroundHeight: PropTypes.string,
+  backgroundWidth: PropTypes.string,
   cardColor: PropTypes.oneOf(Object.values(Icon.CARD_COLORS)),
   circular: PropTypes.bool,
   className: PropTypes.string,

--- a/packages/sage-react/lib/Icon/Icon.story.jsx
+++ b/packages/sage-react/lib/Icon/Icon.story.jsx
@@ -45,3 +45,17 @@ AdjacentType.decorators = [
     </>
   )
 ];
+export const CustomBackgroundSize = Template.bind({});
+CustomBackgroundSize.args = {
+  cardColor: 'draft',
+  backgroundWidth: '96px',
+  backgroundHeight: '48px',
+  size: Icon.SIZES.LG
+};
+export const CustomBackgroundSizeCircular = Template.bind({});
+CustomBackgroundSizeCircular.args = {
+  cardColor: 'draft',
+  circular: true,
+  backgroundHeight: '48px',
+  size: Icon.SIZES.LG
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds new props to the Icon component to allow custom height and width.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="561" alt="Screen Shot 2021-11-04 at 3 05 37 PM" src="https://user-images.githubusercontent.com/14791307/140412019-c1bc493d-cff9-4216-82da-0f61fbafd6b0.png">

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/icon)
- Check that new props work as expected

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-icon--default)
- Check that new props work as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds new props to the Icon component to allow custom height and width.
## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #940 