### PR TITLE
Next Version Bump ~4.24.0

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -64,3 +64,23 @@ NOTE: This also allows for a fallback approach with image APIs such as Gravatar 
 In such cases a transparent PNG image can be provided as the default image so that when this default image is layered on top of the initials,
 the initials are seen rather than a generic "anonymous user" image.
 ') %>
+
+<p>Invalid Gravatar with blank fallback to initials:</p>
+<%= sage_component SageAvatar, {
+  initials: "PS",
+  image: { src: "https://s.gravatar.com/avatar/000?default=blank" }
+} %>
+
+<p>Valid Gravatar with lazy loading:</p>
+<%= sage_component SageAvatar, {
+  initials: "PS",
+  image: { src: "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?" }
+} %>
+
+<p>Valid Gravatar with NO lazy loading:</p>
+<%= sage_component SageAvatar, {
+  initials: "PS",
+  image: { src: "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?" },
+  lazy_load_initials: false
+} %>
+

--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -53,3 +53,14 @@
     ]
   } %>
 </div>
+
+<h3>Layering and lazy loading</h3>
+<%= md('
+By default, Avatars with both an `image` and `initials` provided will stack with the image on top of the initials.
+The result is a lazy loading effect where initials appear immediately and an image will appear later on slower or delayed connetions.
+If this effect is not desired when an `image` is used, then also set `lazy_load_initials: false`.
+
+NOTE: This also allows for a fallback approach with image APIs such as Gravatar that return a default image when no user image is available.
+In such cases a transparent PNG image can be provided as the default image so that when this default image is layered on top of the initials,
+the initials are seen rather than a generic "anonymous user" image.
+') %>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -6,7 +6,7 @@
     sets the initials color and background color to variants of the
     system\'s orange swatch.
   ') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md("`#{SageTokens::COLORS.inspect()}`") %></td>
   <td><%= md('`nil` (primary color)') %></td>
 </tr>
 <tr>
@@ -23,11 +23,11 @@
   </td>
   <td>
   <%= md('```
-image: {
+{
   alt: String (optional),
   src: String,
 }
-    ') %>
+```') %>
   </td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -38,6 +38,14 @@ image: {
   ') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`lazy_load_initials`') %></td>
+  <td><%= md('
+    Whether or not to layer initials behind an image as a lazy loading helper.
+  ') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`true`') %></td>
 </tr>
 <tr>
   <td><%= md('`size`') %></td>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -25,3 +25,33 @@
   <td><%= md('Optionally: `"sm"`') %></td>
   <td><%= md('`--`') %></td>
 </tr>
+<tr>
+  <td colspan="4"><%= md('**Card List Item**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a list item.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td colspan="4"><%= md('**Card Row**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a card row.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -30,7 +30,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -45,7 +45,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/panel/_props.html.erb
+++ b/docs/app/views/examples/components/panel/_props.html.erb
@@ -24,7 +24,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -39,7 +39,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/panel/_props.html.erb
+++ b/docs/app/views/examples/components/panel/_props.html.erb
@@ -19,3 +19,33 @@
   <td><%= md('Optionally: `md`') %></td>
   <td><%= md('`--`') %></td>
 </tr>
+<tr>
+  <td colspan="4"><%= md('**Panel ListItem**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a list item.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td colspan="4"><%= md('**Panel Row**') %></td>
+</tr>
+<tr>
+  <td><%= md('`grid_template`') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in a panel row.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/sortable/_preview.html.erb
+++ b/docs/app/views/examples/components/sortable/_preview.html.erb
@@ -117,7 +117,7 @@
 
 
 <%= md('
-`SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the [Sage Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.
+`SageSortableItemCustom` should be used when you want to create a layout within the Sortable Item that follows any pattern using specified dot and dash pattern denoted in the [Sage Grid Templates](../patterns/grid_templates) docs. At its simpliest form, `SageSortableItemCustom` is `SageSortableItem` as cards with no image or subtitles, but any combination Sage Grid Template.
 ', use_sage_type: true) %>
 
 <h3 class="t-sage-heading-6"><code>SageSortableItemCustom</code> using a custom <code>grid template : "te"</code> as a Panel List</h3>

--- a/docs/app/views/examples/components/sortable/_props.html.erb
+++ b/docs/app/views/examples/components/sortable/_props.html.erb
@@ -20,6 +20,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between items in the row.') %></td>
+  <td><%= md('Optionally: [`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('The unique identifier for this component.') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/components/sortable/_props.html.erb
+++ b/docs/app/views/examples/components/sortable/_props.html.erb
@@ -15,7 +15,7 @@
 </tr>
 <tr>
   <td><%= md('`grid_template`') %></td>
-  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](http://sage-design-system.kajabi.com/pages/layout/grid_templates) to decide which pattern.') %></td>
+  <td><%= md('Sets the grid template to be used in the row of the component. See the [Grid Templates](../patterns/grid_templates) to decide which pattern.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -1,9 +1,3 @@
 class SageAvatar < SageComponent
-  set_attribute_schema({
-    centered: [:optional, TrueClass],
-    color: [:optional, NilClass, SageSchemas::COLORS],
-    image: [:optional, {alt: [:optional, String], src: String}],
-    initials: [:optional, String],
-    size: [:optional, String],
-  })
+  set_attribute_schema(SageSchemas::AVATAR)
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar_group.rb
@@ -1,9 +1,5 @@
 class SageAvatarGroup < SageComponent
   set_attribute_schema({
-    items: [[
-      color: [:optional, NilClass, SageSchemas::COLORS],
-      css_classes: [:optional, String],
-      initials: String,
-    ]]
+    items: [[SageSchemas::AVATAR]]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_list_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_list_item.rb
@@ -1,5 +1,6 @@
 class SageCardListItem < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
@@ -1,6 +1,7 @@
 class SageCardRow < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE,
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
     vertical_align: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card_row.rb
@@ -1,7 +1,7 @@
 class SageCardRow < SageComponent
   set_attribute_schema({
-    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
-    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
+    grid_template: [:optional, NilClass, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, NilClass, Set.new([:xs, :sm, :md, :lg])],
     vertical_align: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_list_item.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_list_item.rb
@@ -1,5 +1,6 @@
 class SagePanelListItem < SageComponent
   set_attribute_schema({
-    grid_template: SageSchemas::GRID_TEMPLATE,
+    grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,6 +1,7 @@
 class SagePanelRow < SageComponent
   set_attribute_schema({
     grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
+    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
     vertical_align: [:optional, Set.new(["start"])],
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -27,6 +27,15 @@ module SageSchemas
 
   # Components
 
+  AVATAR = {
+    centered: [:optional, TrueClass],
+    color: [:optional, NilClass, SageSchemas::COLORS],
+    image: [:optional, {alt: [:optional, String], src: String}],
+    initials: [:optional, String],
+    lazy_load_initials: [:optional, NilClass, TrueClass],
+    size: [:optional, String],
+  }
+
   CHOICE = {
     active: [:optional, NilClass, TrueClass],
     align_center: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
@@ -2,6 +2,7 @@ class SageSortableItemCustom < SageComponent
   set_attribute_schema({
     card: [:optional, TrueClass],
     grid_template: String,
+    gap: [:optional, String],
     id: [:optional, Integer, String],
     url_update: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
@@ -1,7 +1,7 @@
 class SageSortableItemCustom < SageComponent
   set_attribute_schema({
     card: [:optional, TrueClass],
-    grid_template: String,
+    grid_template: [:optional, String],
     gap: [:optional, String],
     id: [:optional, Integer, String],
     url_update: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -1,3 +1,6 @@
+<%
+lazy_load_initials = component.lazy_load_initials.present? ? component.lazy_load_initials : true
+%>
 <div
   class="
     sage-avatar
@@ -12,7 +15,9 @@
 >
   <% if component.image %>
     <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image" %>
-  <% else %>
+  <% end %>
+
+  <% if lazy_load_initials %>
     <svg class="sage-avatar__initials" viewBox="0 0 32 32">
       <text x="16" y="20"><%= component.initials %></text>
     </svg>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -1,6 +1,12 @@
 <%
-lazy_load_initials = component.lazy_load_initials.present? ? component.lazy_load_initials : true
+lazy_load_initials = true
+
+if component.lazy_load_initials == false
+  lazy_load_initials = false
+end
 %>
+<%= component.lazy_load_initials.inspect() %>
+<%= lazy_load_initials.inspect() %>
 <div
   class="
     sage-avatar

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -5,8 +5,6 @@ if component.lazy_load_initials == false
   lazy_load_initials = false
 end
 %>
-<%= component.lazy_load_initials.inspect() %>
-<%= lazy_load_initials.inspect() %>
 <div
   class="
     sage-avatar

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card_list_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card_list_item.html.erb
@@ -2,6 +2,7 @@
   class="
     sage-card__list-item
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
+    <%= "sage-card__list-item--gap-#{component.gap}" if component.gap %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card_row.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card_row.html.erb
@@ -1,7 +1,8 @@
 <div
   class="sage-card__row
-    <%= "sage-panel__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
-    <%= "sage-grid-template-#{component.grid_template}" %>
+    <%= "sage-card__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
+    <%= "sage-card__row--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_list_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_list_item.html.erb
@@ -1,6 +1,7 @@
 <li
   class="sage-panel__list-item
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
+    <%= "sage-panel__list-item--gap-#{component.gap}" if component.gap %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_panel_row.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_panel_row.html.erb
@@ -1,7 +1,8 @@
 <div
   class="sage-panel__row
     <%= "sage-panel__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
-    <%= "sage-grid-template-#{component.grid_template}" %>
+    <%= "sage-panel__row--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
@@ -9,7 +9,10 @@
   <%= "id=#{component.id}" if component.id %>
   <%= component.generated_html_attributes.html_safe %>
 >
-  <%= sage_component SageCardRow, { grid_template: component.grid_template } do %>
+  <%= sage_component SageCardRow, {
+    grid_template: component.grid_template,
+    gap: component.gap,
+  } do %>
     <%= component.content %>
   <% end %>
 </li>

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -157,7 +157,8 @@
 }
 
 @each $-key, $-value in $sage-spacings {
-  .sage-card__row--gap-#{$-key} {
+  .sage-card__row--gap-#{$-key},
+  .sage-card__list-item--gap-#{$-key} {
     gap: sage-spacing($-key);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -156,6 +156,12 @@
   }
 }
 
+@each $-key, $-value in $sage-spacings {
+  .sage-card__row--gap-#{$-key} {
+    gap: sage-spacing($-key);
+  }
+}
+
 .sage-card__row--vertical-align-start {
   align-items: start;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -113,6 +113,12 @@
   @include sage-grid-panel-row();
 }
 
+@each $-key, $-value in $sage-spacings {
+  .sage-panel__row--gap-#{$-key} {
+    gap: sage-spacing($-key);
+  }
+}
+
 .sage-panel__row--media {
   grid-template-columns: 160px 1fr;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -114,7 +114,8 @@
 }
 
 @each $-key, $-value in $sage-spacings {
-  .sage-panel__row--gap-#{$-key} {
+  .sage-panel__row--gap-#{$-key}
+  .sage-panel__list-item--gap-#{$-key} {
     gap: sage-spacing($-key);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -258,7 +258,7 @@
 /// Adjusts to a wrapping flex layout below the `min` breakpoint.
 ///
 @mixin sage-grid-card-row() {
-  justify-content: space-between;
+  justify-content: start;
   align-items: center;
   gap: sage-spacing(card);
 
@@ -280,7 +280,7 @@
 /// Adjusts to a wrapping flex layout below the `min` breakpoint.
 ///
 @mixin sage-grid-panel-row() {
-  justify-content: space-between;
+  justify-content: start;
   align-items: center;
   gap: sage-spacing();
 

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -9,6 +9,7 @@ export const Avatar = ({
   color,
   image,
   initials,
+  lazyLoadInitials,
   size,
   ...rest
 }) => {
@@ -30,15 +31,14 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {image.src
-        ? (
-          <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
-        )
-        : (
-          <svg className="sage-avatar__initials" viewBox="0 0 32 32">
-            <text x="16" y="20">{initials}</text>
-          </svg>
-        )}
+      {image.src && (
+        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
+      )}
+      {lazyLoadInitials && (
+        <svg className="sage-avatar__initials" viewBox="0 0 32 32">
+          <text x="16" y="20">{initials}</text>
+        </svg>
+      )}
     </div>
   );
 };
@@ -50,7 +50,8 @@ Avatar.defaultProps = {
   className: '',
   color: AVATAR_COLORS.DEFAULT,
   image: {},
-  initials: null,
+  initials: '',
+  lazyLoadInitials: true,
   size: null,
 };
 
@@ -63,5 +64,6 @@ Avatar.propTypes = {
     src: PropTypes.string
   }),
   initials: PropTypes.string,
+  lazyLoadInitials: PropTypes.bool,
   size: PropTypes.string,
 };

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -6,14 +6,15 @@ export default {
   title: 'Sage/Avatar',
   component: Avatar,
   args: {
+    centered: true,
+    color: Avatar.COLORS.SAGE,
     image: {
       alt: null,
       src: null,
     },
     initials: 'QJ',
-    color: Avatar.COLORS.SAGE,
+    lazyLoadInitials: true,
     size: null,
-    centered: true,
   },
   argTypes: {
     ...selectArgs({

--- a/packages/sage-react/lib/Card/CardListItem.jsx
+++ b/packages/sage-react/lib/Card/CardListItem.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
+import { CARD_LIST_GAP_OPTIONS } from './configs';
 
 export const CardListItem = ({
   children,
   className,
   gridTemplate,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -14,6 +16,7 @@ export const CardListItem = ({
     className,
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
+      [`sage-card__list-item--gap-${gap}`]: gap
     }
   );
 
@@ -31,10 +34,12 @@ CardListItem.defaultProps = {
   children: null,
   className: '',
   gridTemplate: null,
+  gap: CARD_LIST_GAP_OPTIONS.DEFAULT
 };
 
 CardListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
+  gap: PropTypes.oneOf(Object.values(CARD_LIST_GAP_OPTIONS)),
 };

--- a/packages/sage-react/lib/Card/CardRow.jsx
+++ b/packages/sage-react/lib/Card/CardRow.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
-import { CARD_ROW_ALIGNMENT_OPTIONS } from './configs';
+import { CARD_ROW_ALIGNMENT_OPTIONS, CARD_ROW_GAP_OPTIONS } from './configs';
 
 export const CardRow = ({
   children,
   className,
   gridTemplate,
   verticalAlign,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -17,6 +18,7 @@ export const CardRow = ({
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
       [`sage-card__row--vertical-align-${verticalAlign}`]: verticalAlign,
+      [`sage-card__row--gap-${gap}`]: gap,
     }
   );
 
@@ -35,6 +37,7 @@ CardRow.defaultProps = {
   className: '',
   gridTemplate: null,
   verticalAlign: CARD_ROW_ALIGNMENT_OPTIONS.DEFAULT,
+  gap: CARD_ROW_GAP_OPTIONS.DEFAULT,
 };
 
 CardRow.propTypes = {
@@ -42,4 +45,5 @@ CardRow.propTypes = {
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   verticalAlign: PropTypes.oneOf(Object.values(CARD_ROW_ALIGNMENT_OPTIONS)),
+  gap: CARD_ROW_GAP_OPTIONS.DEFAULT
 };

--- a/packages/sage-react/lib/Card/configs.js
+++ b/packages/sage-react/lib/Card/configs.js
@@ -18,6 +18,14 @@ export const CARD_ROW_ALIGNMENT_OPTIONS = {
   TOP: 'start',
 };
 
+export const CARD_ROW_GAP_OPTIONS = {
+  DEFAULT: null,
+  XS: 'xs',
+  SM: 'sm',
+  MD: 'md',
+  LG: 'lg',
+};
+
 export const CARD_HIGHLIGHT_COLORS = {
   CHARCOAL: SageTokens.COLORS.CHARCOAL,
   GREY: SageTokens.COLORS.GREY,

--- a/packages/sage-react/lib/Card/configs.js
+++ b/packages/sage-react/lib/Card/configs.js
@@ -26,6 +26,8 @@ export const CARD_ROW_GAP_OPTIONS = {
   LG: 'lg',
 };
 
+export const CARD_LIST_GAP_OPTIONS = CARD_ROW_GAP_OPTIONS;
+
 export const CARD_HIGHLIGHT_COLORS = {
   CHARCOAL: SageTokens.COLORS.CHARCOAL,
   GREY: SageTokens.COLORS.GREY,

--- a/packages/sage-react/lib/Panel/PanelListItem.jsx
+++ b/packages/sage-react/lib/Panel/PanelListItem.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
+import { PANEL_LIST_GAP_OPTIONS } from './configs';
 
 export const PanelListItem = ({
   children,
   className,
   gridTemplate,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -14,6 +16,7 @@ export const PanelListItem = ({
     className,
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
+      [`sage-panel__list-item--gap-${gap}`]: gap
     }
   );
 
@@ -31,10 +34,12 @@ PanelListItem.defaultProps = {
   children: null,
   className: '',
   gridTemplate: null,
+  gap: PANEL_LIST_GAP_OPTIONS.DEFAULT
 };
 
 PanelListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
+  gap: PropTypes.oneOf(Object.values(PANEL_LIST_GAP_OPTIONS)),
 };

--- a/packages/sage-react/lib/Panel/PanelRow.jsx
+++ b/packages/sage-react/lib/Panel/PanelRow.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames, SageTokens } from '../configs';
-import { PANEL_ROW_ALIGNMENT_OPTIONS } from './configs';
+import { PANEL_ROW_ALIGNMENT_OPTIONS, PANEL_ROW_GAP_OPTIONS } from './configs';
 
 export const PanelRow = ({
   children,
   className,
   gridTemplate,
   verticalAlign,
+  gap,
   ...rest
 }) => {
   const classNames = classnames(
@@ -17,6 +18,7 @@ export const PanelRow = ({
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
       [`sage-panel__row--vertical-align-${verticalAlign}`]: verticalAlign,
+      [`sage-panel__row--gap-${gap}`]: gap,
     }
   );
 
@@ -31,12 +33,14 @@ export const PanelRow = ({
 };
 
 PanelRow.VERTICAL_ALIGNMENTS = PANEL_ROW_ALIGNMENT_OPTIONS;
+PanelRow.GAP_OPTIONS = PANEL_ROW_GAP_OPTIONS;
 
 PanelRow.defaultProps = {
   children: null,
   className: '',
   gridTemplate: null,
   verticalAlign: PANEL_ROW_ALIGNMENT_OPTIONS.DEFAULT,
+  gap: PANEL_ROW_GAP_OPTIONS.DEFAULT
 };
 
 PanelRow.propTypes = {
@@ -44,4 +48,5 @@ PanelRow.propTypes = {
   className: PropTypes.string,
   gridTemplate: PropTypes.oneOf(Object.values(SageTokens.GRID_TEMPLATES)),
   verticalAlign: PropTypes.oneOf(Object.values(PANEL_ROW_ALIGNMENT_OPTIONS)),
+  gap: PropTypes.oneOf(Object.values(PANEL_ROW_GAP_OPTIONS)),
 };

--- a/packages/sage-react/lib/Panel/configs.js
+++ b/packages/sage-react/lib/Panel/configs.js
@@ -11,6 +11,14 @@ export const PANEL_ROW_ALIGNMENT_OPTIONS = {
   TOP: 'start',
 };
 
+export const PANEL_ROW_GAP_OPTIONS = {
+  DEFAULT: null,
+  XS: 'xs',
+  SM: 'sm',
+  MD: 'md',
+  LG: 'lg',
+};
+
 export const PANEL_TILE_OPTIONS_ARRAY = [2, 3, 4];
 
 export const PANEL_LIST_BLOCK_SPACING = {

--- a/packages/sage-react/lib/Panel/configs.js
+++ b/packages/sage-react/lib/Panel/configs.js
@@ -19,6 +19,8 @@ export const PANEL_ROW_GAP_OPTIONS = {
   LG: 'lg',
 };
 
+export const PANEL_LIST_GAP_OPTIONS = PANEL_ROW_GAP_OPTIONS;
+
 export const PANEL_TILE_OPTIONS_ARRAY = [2, 3, 4];
 
 export const PANEL_LIST_BLOCK_SPACING = {


### PR DESCRIPTION
1. (**MEDIUM**) - kajabi/sage-lib#974 -  Make grid-template optional and adds an optional gap attribute to components.
   - [ ] A sanity check in KP should be performed to verify no layout issues appear.
 2. (**LOW**) - kajabi/sage-lib/#979 - Sets sortable custom grid-template attribute to optional.
 3. (**LOW**) Avatar updated to allow initials to layer behind an image for lazy loading and fallback. No adverse impact on existing uses expected. See the following:
    - [ ] People > table shows avatar initials as before
    - [ ] App header > shows avatar with initials or image as before