### PR TITLE
[BUG] Set grid-template to optional for SageSortableItemCustom

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_sortable_item_custom.rb
@@ -1,7 +1,7 @@
 class SageSortableItemCustom < SageComponent
   set_attribute_schema({
     card: [:optional, TrueClass],
-    grid_template: String,
+    grid_template: [:optional, String],
     gap: [:optional, String],
     id: [:optional, Integer, String],
     url_update: [:optional, String],


### PR DESCRIPTION
## Description
Sets grid_template to optional on SageSortableItemCustom component.
This was missed in the previous https://github.com/Kajabi/sage-lib/pull/974


## Screenshots
No visual changes


## Testing in `sage-lib`
Verify grid_template attribute is now optional


## Testing in `kajabi-products`
1. (**LOW**) Sets sortable custom grid-template attribute to optional.


## Related
#974 
