### PR TITLE
Avatar: Add image layering with initials

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -64,3 +64,23 @@ NOTE: This also allows for a fallback approach with image APIs such as Gravatar 
 In such cases a transparent PNG image can be provided as the default image so that when this default image is layered on top of the initials,
 the initials are seen rather than a generic "anonymous user" image.
 ') %>
+
+<p>Invalid Gravatar with blank fallback to initials:</p>
+<%= sage_component SageAvatar, {
+  initials: "PS",
+  image: { src: "https://s.gravatar.com/avatar/000?default=blank" }
+} %>
+
+<p>Valid Gravatar with lazy loading:</p>
+<%= sage_component SageAvatar, {
+  initials: "PS",
+  image: { src: "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?" }
+} %>
+
+<p>Valid Gravatar with NO lazy loading:</p>
+<%= sage_component SageAvatar, {
+  initials: "PS",
+  image: { src: "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?" },
+  lazy_load_initials: false
+} %>
+

--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -53,3 +53,14 @@
     ]
   } %>
 </div>
+
+<h3>Layering and lazy loading</h3>
+<%= md('
+By default, Avatars with both an `image` and `initials` provided will stack with the image on top of the initials.
+The result is a lazy loading effect where initials appear immediately and an image will appear later on slower or delayed connetions.
+If this effect is not desired when an `image` is used, then also set `lazy_load_initials: false`.
+
+NOTE: This also allows for a fallback approach with image APIs such as Gravatar that return a default image when no user image is available.
+In such cases a transparent PNG image can be provided as the default image so that when this default image is layered on top of the initials,
+the initials are seen rather than a generic "anonymous user" image.
+') %>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -6,7 +6,7 @@
     sets the initials color and background color to variants of the
     system\'s orange swatch.
   ') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md("`#{SageTokens::COLORS.inspect()}`") %></td>
   <td><%= md('`nil` (primary color)') %></td>
 </tr>
 <tr>
@@ -23,11 +23,11 @@
   </td>
   <td>
   <%= md('```
-image: {
+{
   alt: String (optional),
   src: String,
 }
-    ') %>
+```') %>
   </td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -38,6 +38,14 @@ image: {
   ') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`lazy_load_initials`') %></td>
+  <td><%= md('
+    Whether or not to layer initials behind an image as a lazy loading helper.
+  ') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`true`') %></td>
 </tr>
 <tr>
   <td><%= md('`size`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar.rb
@@ -1,9 +1,3 @@
 class SageAvatar < SageComponent
-  set_attribute_schema({
-    centered: [:optional, TrueClass],
-    color: [:optional, NilClass, SageSchemas::COLORS],
-    image: [:optional, {alt: [:optional, String], src: String}],
-    initials: [:optional, String],
-    size: [:optional, String],
-  })
+  set_attribute_schema(SageSchemas::AVATAR)
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_avatar_group.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_avatar_group.rb
@@ -1,9 +1,5 @@
 class SageAvatarGroup < SageComponent
   set_attribute_schema({
-    items: [[
-      color: [:optional, NilClass, SageSchemas::COLORS],
-      css_classes: [:optional, String],
-      initials: String,
-    ]]
+    items: [[SageSchemas::AVATAR]]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -27,6 +27,15 @@ module SageSchemas
 
   # Components
 
+  AVATAR = {
+    centered: [:optional, TrueClass],
+    color: [:optional, NilClass, SageSchemas::COLORS],
+    image: [:optional, {alt: [:optional, String], src: String}],
+    initials: [:optional, String],
+    lazy_load_initials: [:optional, NilClass, TrueClass],
+    size: [:optional, String],
+  }
+
   CHOICE = {
     active: [:optional, NilClass, TrueClass],
     align_center: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -1,3 +1,6 @@
+<%
+lazy_load_initials = component.lazy_load_initials.present? ? component.lazy_load_initials : true
+%>
 <div
   class="
     sage-avatar
@@ -12,7 +15,9 @@
 >
   <% if component.image %>
     <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image" %>
-  <% else %>
+  <% end %>
+
+  <% if lazy_load_initials %>
     <svg class="sage-avatar__initials" viewBox="0 0 32 32">
       <text x="16" y="20"><%= component.initials %></text>
     </svg>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -1,6 +1,12 @@
 <%
-lazy_load_initials = component.lazy_load_initials.present? ? component.lazy_load_initials : true
+lazy_load_initials = true
+
+if component.lazy_load_initials == false
+  lazy_load_initials = false
+end
 %>
+<%= component.lazy_load_initials.inspect() %>
+<%= lazy_load_initials.inspect() %>
 <div
   class="
     sage-avatar

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -5,8 +5,6 @@ if component.lazy_load_initials == false
   lazy_load_initials = false
 end
 %>
-<%= component.lazy_load_initials.inspect() %>
-<%= lazy_load_initials.inspect() %>
 <div
   class="
     sage-avatar

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -9,6 +9,7 @@ export const Avatar = ({
   color,
   image,
   initials,
+  lazyLoadInitials,
   size,
   ...rest
 }) => {
@@ -30,15 +31,14 @@ export const Avatar = ({
 
   return (
     <div className={classNames} style={style} {...rest}>
-      {image.src
-        ? (
-          <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
-        )
-        : (
-          <svg className="sage-avatar__initials" viewBox="0 0 32 32">
-            <text x="16" y="20">{initials}</text>
-          </svg>
-        )}
+      {image.src && (
+        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
+      )}
+      {lazyLoadInitials && (
+        <svg className="sage-avatar__initials" viewBox="0 0 32 32">
+          <text x="16" y="20">{initials}</text>
+        </svg>
+      )}
     </div>
   );
 };
@@ -50,7 +50,8 @@ Avatar.defaultProps = {
   className: '',
   color: AVATAR_COLORS.DEFAULT,
   image: {},
-  initials: null,
+  initials: '',
+  lazyLoadInitials: true,
   size: null,
 };
 
@@ -63,5 +64,6 @@ Avatar.propTypes = {
     src: PropTypes.string
   }),
   initials: PropTypes.string,
+  lazyLoadInitials: PropTypes.bool,
   size: PropTypes.string,
 };

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -6,14 +6,15 @@ export default {
   title: 'Sage/Avatar',
   component: Avatar,
   args: {
+    centered: true,
+    color: Avatar.COLORS.SAGE,
     image: {
       alt: null,
       src: null,
     },
     initials: 'QJ',
-    color: Avatar.COLORS.SAGE,
+    lazyLoadInitials: true,
     size: null,
-    centered: true,
   },
   argTypes: {
     ...selectArgs({


### PR DESCRIPTION
## Description

This PR adds the ability to layer initials and an image. This allows for both lazy loading of the initials while the image loads and for a fallback to be visible if the image does not load or is transparent (as in the use case for working with the Gravatar API).

## Testing in `sage-lib`

See Avatar in main site and Storybook. 


## Testing in `kajabi-products`

1. (LOW) Avatar updated to allow initials to layer behind an image for lazy loading and fallback. No adverse impact on existing uses expected. See the following:
   - [ ] People > table shows avatar initials as before
   - [ ] App header > shows avatar with initials or image as before


## Related

Closes #975 
