### PR TITLE
[Fix]: Patch optional grid template

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_sortable_item_custom.html.erb
@@ -9,10 +9,14 @@
   <%= "id=#{component.id}" if component.id %>
   <%= component.generated_html_attributes.html_safe %>
 >
-  <%= sage_component SageCardRow, {
-    grid_template: component.grid_template,
-    gap: component.gap,
-  } do %>
+  <% if component.grid_template.present? %>
+    <%= sage_component SageCardRow, {
+      grid_template: component.grid_template,
+      gap: component.gap,
+    } do %>
+      <%= component.content %>
+    <% end %>
+  <% else %>
     <%= component.content %>
   <% end %>
 </li>

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -258,7 +258,7 @@
 /// Adjusts to a wrapping flex layout below the `min` breakpoint.
 ///
 @mixin sage-grid-card-row() {
-  justify-content: start;
+  justify-content: space-between;
   align-items: center;
   gap: sage-spacing(card);
 
@@ -280,7 +280,7 @@
 /// Adjusts to a wrapping flex layout below the `min` breakpoint.
 ///
 @mixin sage-grid-panel-row() {
-  justify-content: start;
+  justify-content: space-between;
   align-items: center;
   gap: sage-spacing();
 


### PR DESCRIPTION
## Description

This PR patches some recent work on Grid templates that were made optional:

- [x] In SortableItemCustom we open up the layout even more when no grid template is provided, leaving it wide open for any content or layout desired.
- [x] Reverts the default `justify-content` setting to `space-between` as was originally set as a safeguard for fewer changes making the grid template optional.


## Testing in `sage-lib`

See that no layouts are adversely affected in Patterns > Grid Templates, and Components > Card, Panel, and Sortable.


## Testing in `kajabi-products`

1. (**LOW**) Stabilizes the revisions to optional grid templates. No affect on existing components expected.

