### PR TITLE
[SAGE-969] Sage Tabs aria-controls fix

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
@@ -5,21 +5,22 @@ html_tag = is_button ? "button" : "a"
 %>
 
 <<%= html_tag %>
-  <%= "type=button" if is_button %>
+  <%= "type=button role=tab" if is_button %>
   <% component.attributes.each do |key, value| %>
     <%= "#{key}='#{value}'".html_safe %>
   <% end if component.attributes&.is_a?(Hash) %>
   <% if component.disabled %>
     <%= is_button ? "disabled" : "aria-disabled=true" %>
   <% end %>
+  <% if component.target.present? %>
+    data-js-tabs-target="<%= component.target %>"
+    aria-controls="<%= component.target %>"
+  <% end %>
   class="
     sage-tab
     <%= css_active_class if component.active %>
     <%= component.generated_css_classes %>"
-  data-js-tabs-target="<%= component.target %>"
   data-sage-active-class="<%= css_active_class %>"
-  aria-controls="<%= component.target %>"
-  role="tab"
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.text.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
@@ -18,8 +18,8 @@ html_tag = is_button ? "button" : "a"
     <%= component.generated_css_classes %>"
   data-js-tabs-target="<%= component.target %>"
   data-sage-active-class="<%= css_active_class %>"
+  aria-controls="<%= component.target %>"
   role="tab"
-  <%= "aria-controls='#{component.target}'" if component.target.present? %>
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.text.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
 css_active_class = "sage-tab--active"
 is_button = !component.attributes&.has_key?(:href)
 html_tag = is_button ? "button" : "a"
@@ -13,13 +13,13 @@ html_tag = is_button ? "button" : "a"
     <%= is_button ? "disabled" : "aria-disabled=true" %>
   <% end %>
   class="
-    sage-tab 
+    sage-tab
     <%= css_active_class if component.active %>
     <%= component.generated_css_classes %>"
   data-js-tabs-target="<%= component.target %>"
   data-sage-active-class="<%= css_active_class %>"
   role="tab"
-  aria-controls="<%= component.target.present? %>"
+  <%= "aria-controls='#{component.target}'" if component.target.present? %>
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.text.present? %>


### PR DESCRIPTION
## Description
Minor updates correcting the output of various attributes on SageTab for improved a11y support. Functionality is not affected.
- Render `aria-controls` and `data-js-tabs-target` only if a `target` is provided
- Only assign `role=tab` when the tab is a button. Links should not be treated as such

Current component outputs the boolean result of `component.target.present?` rather than the string for the target tab panel's `id`. This applies only to the Rails component; the React component works as intended.


## Screenshots
No visual changes.


## Testing in `sage-lib`
1. Navigate to the [Tabs preview page](http://localhost:4000/pages/component/tabs) in your local environment.
2. Using your browser developer tools, inspect a tab control
3. Verify that the `aria-controls` value matches the `data-js-tabs-target` value
4. Confirm that tab switching functionality works as intended

## Testing in `kajabi-products`
1. (**LOW**) Tab `aria-controls` attribute value correction. No visual changes or functionality impact expected. Cursory check for examples where SageTabs are implemented:
   - [ ] Marketing -> Forms -> Form Settings -> Form Fields (toggle between "Active" and "Archived")
   - [ ] Sales -> Coupons -> New Coupon
   - [ ] Sales -> Offers -> Edit Offer -> Post Purchase Email (requires `comm_offer_detail` feature flag)


## Related
- Closes #969
