### PR TITLE
React select patches

### DIFF
--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -19,6 +19,7 @@ export const Select = ({
     'sage-select',
     className,
     {
+      'sage-form-field--error': hasError,
       'sage-select--error': hasError,
       'sage-select--value-selected': value,
     }

--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -9,6 +9,7 @@ export const Select = ({
   hasError,
   id,
   label,
+  includeLabelInOptions,
   message,
   onChange,
   options,
@@ -36,7 +37,7 @@ export const Select = ({
         disabled={disabled}
         {...rest}
       >
-        {label && <option label={label} />}
+        {(label && includeLabelInOptions) && <option label={label} />}
 
         {options.map((option, i) => {
           let optionLabel,
@@ -72,6 +73,7 @@ Select.defaultProps = {
   className: null,
   disabled: false,
   hasError: false,
+  includeLabelInOptions: false,
   label: null,
   message: null,
   onChange: (evt) => evt,
@@ -84,6 +86,7 @@ Select.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   hasError: PropTypes.bool,
+  includeLabelInOptions: PropTypes.bool,
   label: PropTypes.string,
   message: PropTypes.string,
   onChange: PropTypes.func,

--- a/packages/sage-react/lib/Select/Select.story.jsx
+++ b/packages/sage-react/lib/Select/Select.story.jsx
@@ -7,6 +7,13 @@ export default {
   decorators: [(Story) => <div style={{ width: 300, marginLeft: 'auto', marginRight: 'auto' }}><Story /></div>],
   args: {
     label: 'Select',
+    includeLabelInOptions: false,
+    options: [
+      "Option 1",
+      "Option 2",
+      "Option 3",
+      "Option 4",
+    ]
   },
 };
 
@@ -26,13 +33,14 @@ export const SearchWithState = (args) => {
 };
 SearchWithState.args = {
   id: 'field-2',
-  label: 'Choose...',
+  label: 'Cool stuff',
   options: [
     'Option 1',
     'Option 2',
     'Option 3',
     'Option 4',
-  ]
+  ],
+  placeholder: 'Choose...'
 };
 
 export const SearchDisabled = (args) => {

--- a/packages/sage-react/lib/Select/Select.story.jsx
+++ b/packages/sage-react/lib/Select/Select.story.jsx
@@ -9,10 +9,10 @@ export default {
     label: 'Select',
     includeLabelInOptions: false,
     options: [
-      "Option 1",
-      "Option 2",
-      "Option 3",
-      "Option 4",
+      'Option 1',
+      'Option 2',
+      'Option 3',
+      'Option 4',
     ]
   },
 };


### PR DESCRIPTION
## Description

- [x] React Select forces the `label` provided as the first `option` in the option list. We should provide other options for when this is not desired.
- [x] React Select also does not enforce proper color on error message when in error state.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2021-11-04 at 1 31 52 PM](https://user-images.githubusercontent.com/17955295/140389983-495b9f85-d08f-48e2-96d2-733439ec965f.png) | ![Screen Shot 2021-11-04 at 4 15 01 PM](https://user-images.githubusercontent.com/17955295/140413423-fa28f004-d22b-4129-a65b-bc2aa77eeeee.png) |
| ![Screen Shot 2021-11-04 at 1 31 47 PM](https://user-images.githubusercontent.com/17955295/140390024-5dbae9eb-dae6-43cd-a0f6-f88de43f324f.png) | ![Screen Shot 2021-11-04 at 4 15 05 PM](https://user-images.githubusercontent.com/17955295/140413481-cf8f017b-e0c1-42e1-b114-0a99eb5369fa.png) |
| ![Screen Shot 2021-11-04 at 2 31 40 PM](https://user-images.githubusercontent.com/17955295/140399279-73d3faec-c13a-4e85-b8db-dbaf4a7c0722.png) | ![Screen Shot 2021-11-04 at 4 15 22 PM](https://user-images.githubusercontent.com/17955295/140413550-bca7a569-68e7-41a7-aaeb-3009fec07289.png) |

## Testing in `sage-lib`

See Storybook > Select

## Testing in `kajabi-products`
1. (**LOW**) React Select component is updated with fix to show error colors and label as expected. No adverse effect expect on existing uses.

## Related

Closes #990 
