### PR TITLE
JBH Carousel Indicator and Start Index Update

### DIFF
--- a/docs/app/views/examples/components/carousel/_preview.html.erb
+++ b/docs/app/views/examples/components/carousel/_preview.html.erb
@@ -4,7 +4,6 @@
     fixedWidth: 544,
     gutter: 24,
     loop: false,
-    mouseDrag: true,
   },
 } do %>
   <%= content_for :sage_carousel_items do %>

--- a/docs/app/views/examples/components/carousel/_preview.html.erb
+++ b/docs/app/views/examples/components/carousel/_preview.html.erb
@@ -4,6 +4,7 @@
     fixedWidth: 544,
     gutter: 24,
     loop: false,
+    mouseDrag: true,
   },
 } do %>
   <%= content_for :sage_carousel_items do %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_carousel.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_carousel.html.erb
@@ -35,5 +35,5 @@
       } %>
     </div>
   </div>
-  <div class="sage-carousel__dots"></div>
+  <div class="sage-carousel__indicator"></div>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_carousel.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_carousel.html.erb
@@ -35,5 +35,10 @@
       } %>
     </div>
   </div>
-  <div class="sage-carousel__dots"></div>
+  <div class="sage-carousel__dots">
+    <%= sage_component SageIndicator, {
+      current_item: 1,
+      num_items: 4,
+    } %>
+  </div>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_carousel.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_carousel.html.erb
@@ -35,10 +35,5 @@
       } %>
     </div>
   </div>
-  <div class="sage-carousel__dots">
-    <%= sage_component SageIndicator, {
-      current_item: 1,
-      num_items: 4,
-    } %>
-  </div>
+  <div class="sage-carousel__dots"></div>
 </div>

--- a/packages/sage-assets/lib/stylesheets/components/_carousel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_carousel.scss
@@ -5,8 +5,6 @@
 ////
 
 $-sage-carousel-arrow-width: sage-spacing(lg);
-$-sage-carousel-dot-size: rem(6px);
-$-sage-carousel-dot-spacing: sage-spacing(2xs);
 $-sage-carousel-active-color: sage-color(charcoal, 100);
 $-sage-carousel-inactive-color: sage-color(grey, 400);
 
@@ -52,22 +50,9 @@ $-sage-carousel-inactive-color: sage-color(grey, 400);
   width: calc(100% - (#{$-sage-carousel-arrow-width} * 2));
 }
 
-.sage-carousel__dots {
+.sage-carousel__indicator {
   display: flex;
   justify-content: center;
   width: 100%;
   margin-top: sage-spacing(sm);
-}
-
-.sage-carousel__dot {
-  width: $-sage-carousel-dot-size;
-  height: $-sage-carousel-dot-size;
-  margin: 0 $-sage-carousel-dot-spacing;
-  background-color: $-sage-carousel-inactive-color;
-  border-radius: sage-border(radius-round);
-  cursor: pointer;
-}
-
-.sage-carousel__dot--active {
-  background-color: $-sage-carousel-active-color;
 }

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -16,8 +16,9 @@ export const Carousel = ({
 
   const containerClass = '.sage-carousel__carousel';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
+  const startIndex = options.startIndex !== undefined ? options.startIndex : 0;
 
-  const [slidesIndex, setSlidesIndex] = useState(options.startIndex || 0);
+  const [slidesIndex, setSlidesIndex] = useState(startIndex);
   const [slidesLength, setSlidesLength] = useState(0);
   const [mySlider, setMySlider] = useState(null);
   const [looping, setLooping] = useState(false);

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -16,9 +16,8 @@ export const Carousel = ({
 
   const containerClass = '.sage-carousel__carousel';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
-  const startIndex = options.startIndex !== undefined ? options.startIndex : 0;
 
-  const [slidesIndex, setSlidesIndex] = useState(startIndex);
+  const [slidesIndex, setSlidesIndex] = useState(0);
   const [slidesLength, setSlidesLength] = useState(0);
   const [mySlider, setMySlider] = useState(null);
   const [looping, setLooping] = useState(false);
@@ -67,6 +66,8 @@ export const Carousel = ({
 
     setArrowPrev(document.querySelector('.sage-carousel__arrow--prev'));
     setArrowNext(document.querySelector('.sage-carousel__arrow--next'));
+
+    setSlidesIndex(options.startIndex !== undefined ? options.startIndex : 0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -62,8 +62,7 @@ export const Carousel = ({
     }));
     setLooping(!(options.loop !== undefined && !options.loop));
     setSlidesIndex(options.startIndex !== undefined ? options.startIndex : 0);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [options, slidesLength]);
 
   useEffect(() => {
     if (mySlider !== null) {

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -15,14 +15,13 @@ export const Carousel = ({
   );
 
   const containerClass = '.sage-carousel__carousel';
-  const arrowDisabledClass = 'sage-carousel__arrow--disabled';
 
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [slidesLength, setSlidesLength] = useState(0);
   const [mySlider, setMySlider] = useState(null);
   const [looping, setLooping] = useState(false);
-  const [arrowPrev, setArrowPrev] = useState(null);
-  const [arrowNext, setArrowNext] = useState(null);
+  const [arrowPrevDisabled, setArrowPrevDisabled] = useState(false);
+  const [arrowNextDisabled, setArrowNextDisabled] = useState(false);
 
   function handlePrevArrowClick() {
     if (!looping) {
@@ -61,12 +60,7 @@ export const Carousel = ({
       controls: false,
       nav: false,
     }));
-
     setLooping(!(options.loop !== undefined && !options.loop));
-
-    setArrowPrev(document.querySelector('.sage-carousel__arrow--prev'));
-    setArrowNext(document.querySelector('.sage-carousel__arrow--next'));
-
     setSlidesIndex(options.startIndex !== undefined ? options.startIndex : 0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -74,14 +68,14 @@ export const Carousel = ({
   useEffect(() => {
     if (mySlider !== null) {
       if (!looping) {
-        if (slidesIndex === 0) arrowPrev.classList.add(arrowDisabledClass);
-        else arrowPrev.classList.remove(arrowDisabledClass);
-        if (slidesIndex === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
-        else arrowNext.classList.remove(arrowDisabledClass);
+        if (slidesIndex === 0) setArrowPrevDisabled(true);
+        else setArrowPrevDisabled(false);
+        if (slidesIndex === slidesLength - 1) setArrowNextDisabled(true);
+        else setArrowNextDisabled(false);
       }
       mySlider.goTo(slidesIndex);
     }
-  });
+  }, [mySlider, looping, slidesIndex, slidesLength]);
 
   useEffect(() => {
     if (mySlider !== null) {
@@ -95,6 +89,7 @@ export const Carousel = ({
     <div className={classNames} aria-roledescription="carousel">
       <div className="sage-carousel__container">
         <CarouselArrow
+          disabled={arrowPrevDisabled}
           icon="caret-left"
           id="prev"
           onClickCallback={handlePrevArrowClick}
@@ -105,6 +100,7 @@ export const Carousel = ({
           </div>
         </div>
         <CarouselArrow
+          disabled={arrowNextDisabled}
           icon="caret-right"
           id="next"
           onClickCallback={handleNextArrowClick}

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -13,47 +13,64 @@ export const Carousel = ({
   const classNames = classnames(
     baseClass
   );
+
   const containerClass = '.sage-carousel__carousel';
+  const arrowDisabledClass = 'sage-carousel__arrow--disabled';
 
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [slidesLength, setSlidesLength] = useState(0);
   const [mySlider, setMySlider] = useState(null);
+  const [looping, setLooping] = useState(false);
+  const [arrowPrev, setArrowPrev] = useState(null);
+  const [arrowNext, setArrowNext] = useState(null);
+
+  function goToSlide(num) {
+    if (!looping) {
+      if (num === 0) arrowPrev.classList.add(arrowDisabledClass);
+      else arrowPrev.classList.remove(arrowDisabledClass);
+      if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
+      else arrowNext.classList.remove(arrowDisabledClass);
+      setSlidesIndex(num);
+    }
+  }
 
   function handleKeyDown() {}
 
   function handlePrevArrowClick() {
-    if (slidesIndex !== 0) setSlidesIndex(slidesIndex - 1);
+    if (slidesIndex !== 0) goToSlide(slidesIndex - 1);
   }
 
   function handleNextArrowClick() {
-    if (slidesIndex !== slidesLength - 1) setSlidesIndex(slidesIndex + 1);
+    if (slidesIndex !== slidesLength - 1) goToSlide(slidesIndex + 1);
   }
 
   useEffect(() => {
-    function init() {
-      const slider = document.querySelector(containerClass);
-      const slides = [...slider.children];
-      let slideContainer;
-      setSlidesLength(slides.length);
-      slides.forEach((slide, index) => {
-        slideContainer = document.createElement('div');
-        slideContainer.classList.add('slide');
-        slideContainer.setAttribute('aria-roledescription', 'slide');
-        slideContainer.setAttribute('role', 'group');
-        slideContainer.setAttribute('aria-label', `${index + 1} of ${slidesLength}`);
-        slideContainer.appendChild(slide);
-        slider.appendChild(slideContainer);
-      });
+    const slider = document.querySelector(containerClass);
+    const slides = [...slider.children];
+    let slideContainer;
+    setSlidesLength(slides.length);
+    slides.forEach((slide, index) => {
+      slideContainer = document.createElement('div');
+      slideContainer.classList.add('slide');
+      slideContainer.setAttribute('aria-roledescription', 'slide');
+      slideContainer.setAttribute('role', 'group');
+      slideContainer.setAttribute('aria-label', `${index + 1} of ${slidesLength}`);
+      slideContainer.appendChild(slide);
+      slider.appendChild(slideContainer);
+    });
 
-      const basicSlider = tns({
-        ...options,
-        container: containerClass,
-        controls: false,
-        nav: false,
-      });
-      setMySlider(basicSlider);
-    }
-    init();
+    const basicSlider = tns({
+      ...options,
+      container: containerClass,
+      controls: false,
+      nav: false,
+    });
+    setMySlider(basicSlider);
+
+    setLooping(!(options.loop !== undefined && !options.loop));
+
+    setArrowPrev(document.querySelector('.sage-carousel__arrow--prev'));
+    setArrowNext(document.querySelector('.sage-carousel__arrow--next'));
   }, [options, slidesLength]);
 
   useEffect(() => {

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -83,6 +83,14 @@ export const Carousel = ({
     }
   });
 
+  useEffect(() => {
+    if (mySlider !== null) {
+      mySlider.events.on('dragEnd', () => {
+        setSlidesIndex(mySlider.getInfo().index);
+      });
+    }
+  }, [mySlider]);
+
   return (
     <div className={classNames} aria-roledescription="carousel">
       <div className="sage-carousel__container">

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { tns } from 'tiny-slider/dist/tiny-slider';
 import { CarouselArrow } from './CarouselArrow';
 import { Indicator } from '../Indicator';
+import { CarouselSlide } from './CarouselSlide';
 
 export const Carousel = ({
   children,
@@ -18,6 +19,7 @@ export const Carousel = ({
 
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [slidesLength, setSlidesLength] = useState(0);
+  const [slides, setSlides] = useState(null);
   const [mySlider, setMySlider] = useState(null);
   const [looping, setLooping] = useState(false);
   const [arrowPrevDisabled, setArrowPrevDisabled] = useState(false);
@@ -40,20 +42,14 @@ export const Carousel = ({
   }
 
   useEffect(() => {
-    const slider = document.querySelector(containerClass);
-    const slides = [...slider.children];
-    let slideContainer;
-    setSlidesLength(slides.length);
-    slides.forEach((slide, index) => {
-      slideContainer = document.createElement('div');
-      slideContainer.classList.add('slide');
-      slideContainer.setAttribute('aria-roledescription', 'slide');
-      slideContainer.setAttribute('role', 'group');
-      slideContainer.setAttribute('aria-label', `${index + 1} of ${slidesLength}`);
-      slideContainer.appendChild(slide);
-      slider.appendChild(slideContainer);
-    });
+    const childrenArray = children.props.children;
+    setSlides(childrenArray.map((item) => (
+      <CarouselSlide content={item} />
+    )));
+    setSlidesLength(childrenArray.length);
+  }, [children]);
 
+  useEffect(() => {
     setMySlider(tns({
       ...options,
       container: containerClass,
@@ -62,10 +58,10 @@ export const Carousel = ({
     }));
     setLooping(!(options.loop !== undefined && !options.loop));
     setSlidesIndex(options.startIndex !== undefined ? options.startIndex : 0);
-  }, [options, slidesLength]);
+  }, [options, slides]);
 
   useEffect(() => {
-    if (mySlider !== null) {
+    if (mySlider) {
       if (!looping) {
         if (slidesIndex === 0) setArrowPrevDisabled(true);
         else setArrowPrevDisabled(false);
@@ -77,7 +73,7 @@ export const Carousel = ({
   }, [mySlider, looping, slidesIndex, slidesLength]);
 
   useEffect(() => {
-    if (mySlider !== null) {
+    if (mySlider) {
       mySlider.events.on('dragEnd', () => {
         setSlidesIndex(mySlider.getInfo().index);
       });
@@ -95,7 +91,7 @@ export const Carousel = ({
         />
         <div className="sage-carousel__sizer">
           <div className="sage-carousel__carousel">
-            {children}
+            {slides}
           </div>
         </div>
         <CarouselArrow

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -26,11 +26,19 @@ export const Carousel = ({
   const [arrowNext, setArrowNext] = useState(null);
 
   function handlePrevArrowClick() {
-    if (slidesIndex !== 0) setSlidesIndex(slidesIndex - 1);
+    if (!looping) {
+      if (slidesIndex !== 0) setSlidesIndex(slidesIndex - 1);
+    } else {
+      mySlider.goTo('prev');
+    }
   }
 
   function handleNextArrowClick() {
-    if (slidesIndex !== slidesLength - 1) setSlidesIndex(slidesIndex + 1);
+    if (!looping) {
+      if (slidesIndex !== slidesLength - 1) setSlidesIndex(slidesIndex + 1);
+    } else {
+      mySlider.goTo('next');
+    }
   }
 
   useEffect(() => {
@@ -60,7 +68,7 @@ export const Carousel = ({
     setArrowPrev(document.querySelector('.sage-carousel__arrow--prev'));
     setArrowNext(document.querySelector('.sage-carousel__arrow--next'));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options]);
+  }, []);
 
   useEffect(() => {
     if (mySlider !== null) {
@@ -71,9 +79,6 @@ export const Carousel = ({
         else arrowNext.classList.remove(arrowDisabledClass);
       }
       mySlider.goTo(slidesIndex);
-      mySlider.events.on('indexChanged', () => {
-        setSlidesIndex(mySlider.getInfo().index);
-      });
     }
   });
 
@@ -97,10 +102,12 @@ export const Carousel = ({
         />
       </div>
       <div className="sage-carousel__indicator">
-        <Indicator
-          numItems={slidesLength}
-          currentItem={slidesIndex + 1}
-        />
+        {!looping && (
+          <Indicator
+            numItems={slidesLength}
+            currentItem={slidesIndex + 1}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -59,13 +59,12 @@ export const Carousel = ({
       slider.appendChild(slideContainer);
     });
 
-    const basicSlider = tns({
+    setMySlider(tns({
       ...options,
       container: containerClass,
       controls: false,
       nav: false,
-    });
-    setMySlider(basicSlider);
+    }));
 
     setLooping(!(options.loop !== undefined && !options.loop));
 
@@ -74,8 +73,13 @@ export const Carousel = ({
   }, [options, slidesLength]);
 
   useEffect(() => {
-    if (mySlider !== null) mySlider.goTo(slidesIndex);
-  }, [mySlider, slidesIndex]);
+    if (mySlider !== null) {
+      mySlider.goTo(slidesIndex);
+      mySlider.events.on('dragEnd', () => {
+        goToSlide(mySlider.getInfo().index);
+      });
+    }
+  });
 
   return (
     <div className={classNames} aria-roledescription="carousel">

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -98,14 +98,13 @@ export const Carousel = ({
           onClickCallback={handleNextArrowClick}
         />
       </div>
-      <div className="sage-carousel__indicator">
-        {!looping && (
-          <Indicator
-            numItems={slidesLength}
-            currentItem={slidesIndex + 1}
-          />
-        )}
-      </div>
+      {!looping && (
+        <Indicator
+          className="sage-carousel__indicator"
+          currentItem={slidesIndex + 1}
+          numItems={slidesLength}
+        />
+      )}
     </div>
   );
 };

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { tns } from 'tiny-slider/dist/tiny-slider';
 import { Icon } from '../Icon';
+import { Indicator } from '../Indicator';
 
 export const Carousel = ({
   children,
@@ -12,18 +13,21 @@ export const Carousel = ({
   const classNames = classnames(
     baseClass
   );
-
   const containerClass = '.sage-carousel__carousel';
-  const dotActiveClass = 'sage-carousel__dot--active';
+  // const dotActiveClass = 'sage-carousel__dot--active';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
+
+  const [indicatorDotsIndex, setIndicatorDotsIndex] = useState(1);
+  const [indicatorDotsNum, setIndicatorDotsNum] = useState(0);
 
   let arrowPrev;
   let arrowNext;
   let mySlider;
   let mySliderInfo;
   let slidesLength;
-  let dots;
+  // let dots;
   let looping;
+  // let indicatorElement;
 
   function goToSlide(num) {
     if (!looping) {
@@ -31,18 +35,19 @@ export const Carousel = ({
       else arrowPrev.classList.remove(arrowDisabledClass);
       if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
       else arrowNext.classList.remove(arrowDisabledClass);
-      dots = [...document.getElementsByClassName('sage-carousel__dot')];
-      dots.forEach((dot) => {
-        dot.classList.remove(dotActiveClass);
-      });
-      dots[num].classList.add(dotActiveClass);
+      // dots = [...document.getElementsByClassName('sage-carousel__dot')];
+      // dots.forEach((dot) => {
+      //   dot.classList.remove(dotActiveClass);
+      // });
+      // dots[num].classList.add(dotActiveClass);
+      setIndicatorDotsIndex(num + 1);
       mySlider.goTo(num);
     }
   }
 
-  function handleDotClick(evt) {
-    goToSlide(parseInt(evt.target.getAttribute('index'), 10));
-  }
+  // function handleDotClick(evt) {
+  //   goToSlide(parseInt(evt.target.getAttribute('index'), 10));
+  // }
 
   function handlePrevArrowClick() {
     mySliderInfo = mySlider.getInfo();
@@ -77,6 +82,7 @@ export const Carousel = ({
     const slides = [...slider.children];
     let slideContainer;
     slidesLength = slides.length;
+    setIndicatorDotsNum(slidesLength);
     slides.forEach((slide, index) => {
       slideContainer = document.createElement('div');
       slideContainer.classList.add('slide');
@@ -101,18 +107,18 @@ export const Carousel = ({
     arrowPrev = document.querySelector('.sage-carousel__arrow--prev');
     arrowNext = document.querySelector('.sage-carousel__arrow--next');
 
-    if (!looping) {
-      let dot;
-      for (let i = 0; i < slidesLength; i += 1) {
-        dot = document.createElement('div');
-        dot.classList.add('sage-carousel__dot');
-        dot.setAttribute('index', i);
-        dot.setAttribute('role', 'button');
-        dot.setAttribute('tabIndex', '-1');
-        dot.addEventListener('click', handleDotClick);
-        document.querySelector('.sage-carousel__dots').appendChild(dot);
-      }
-    }
+    // if (!looping) {
+    //   let dot;
+    //   for (let i = 0; i < slidesLength; i += 1) {
+    //     dot = document.createElement('div');
+    //     dot.classList.add('sage-carousel__dot');
+    //     dot.setAttribute('index', i);
+    //     dot.setAttribute('role', 'button');
+    //     dot.setAttribute('tabIndex', '-1');
+    //     dot.addEventListener('click', handleDotClick);
+    //     document.querySelector('.sage-carousel__dots').appendChild(dot);
+    //   }
+    // }
 
     goToSlide(0);
   }
@@ -148,7 +154,12 @@ export const Carousel = ({
           <Icon icon="caret-right" size="lg" />
         </div>
       </div>
-      <div className="sage-carousel__dots" />
+      <div className="sage-carousel__dots">
+        <Indicator
+          numItems={indicatorDotsNum}
+          currentItem={indicatorDotsIndex}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -14,118 +14,51 @@ export const Carousel = ({
     baseClass
   );
   const containerClass = '.sage-carousel__carousel';
-  // const dotActiveClass = 'sage-carousel__dot--active';
-  const arrowDisabledClass = 'sage-carousel__arrow--disabled';
 
-  const [indicatorDotsIndex, setIndicatorDotsIndex] = useState(1);
-  const [indicatorDotsNum, setIndicatorDotsNum] = useState(0);
+  const [slidesIndex, setSlidesIndex] = useState(0);
+  const [slidesLength, setSlidesLength] = useState(0);
+  const [mySlider, setMySlider] = useState(null);
 
-  let arrowPrev;
-  let arrowNext;
-  let mySlider;
-  let mySliderInfo;
-  let slidesLength;
-  // let dots;
-  let looping;
-  // let indicatorElement;
-
-  function goToSlide(num) {
-    if (!looping) {
-      if (num === 0) arrowPrev.classList.add(arrowDisabledClass);
-      else arrowPrev.classList.remove(arrowDisabledClass);
-      if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
-      else arrowNext.classList.remove(arrowDisabledClass);
-      // dots = [...document.getElementsByClassName('sage-carousel__dot')];
-      // dots.forEach((dot) => {
-      //   dot.classList.remove(dotActiveClass);
-      // });
-      // dots[num].classList.add(dotActiveClass);
-      setIndicatorDotsIndex(num + 1);
-      mySlider.goTo(num);
-    }
-  }
-
-  // function handleDotClick(evt) {
-  //   goToSlide(parseInt(evt.target.getAttribute('index'), 10));
-  // }
+  function handleKeyDown() {}
 
   function handlePrevArrowClick() {
-    mySliderInfo = mySlider.getInfo();
-    if (!looping) {
-      if (mySliderInfo.index !== 0) goToSlide(mySliderInfo.index - 1);
-    } else {
-      mySlider.goTo('prev');
-    }
+    if (slidesIndex !== 0) setSlidesIndex(slidesIndex - 1);
   }
 
   function handleNextArrowClick() {
-    mySliderInfo = mySlider.getInfo();
-    if (!looping) {
-      if (mySliderInfo.index !== slidesLength - 1) goToSlide(mySliderInfo.index + 1);
-    } else {
-      mySlider.goTo('next');
-    }
-  }
-
-  function handleDragEnd() {
-    mySliderInfo = mySlider.getInfo();
-    goToSlide(mySliderInfo.index);
-  }
-
-  function handleKeyDown(evt) {
-    if (evt.keyCode === 37) handlePrevArrowClick();
-    else if (evt.keyCode === 39) handleNextArrowClick();
-  }
-
-  function init() {
-    const slider = document.querySelector(containerClass);
-    const slides = [...slider.children];
-    let slideContainer;
-    slidesLength = slides.length;
-    setIndicatorDotsNum(slidesLength);
-    slides.forEach((slide, index) => {
-      slideContainer = document.createElement('div');
-      slideContainer.classList.add('slide');
-      slideContainer.setAttribute('aria-roledescription', 'slide');
-      slideContainer.setAttribute('role', 'group');
-      slideContainer.setAttribute('aria-label', `${index + 1} of ${slidesLength}`);
-      slideContainer.appendChild(slide);
-      slider.appendChild(slideContainer);
-    });
-
-    mySlider = tns({
-      ...options,
-      container: containerClass,
-      controls: false,
-      nav: false,
-    });
-    mySliderInfo = mySlider.getInfo();
-    mySlider.events.on('dragEnd', handleDragEnd);
-
-    looping = !(options.loop !== undefined && !options.loop);
-
-    arrowPrev = document.querySelector('.sage-carousel__arrow--prev');
-    arrowNext = document.querySelector('.sage-carousel__arrow--next');
-
-    // if (!looping) {
-    //   let dot;
-    //   for (let i = 0; i < slidesLength; i += 1) {
-    //     dot = document.createElement('div');
-    //     dot.classList.add('sage-carousel__dot');
-    //     dot.setAttribute('index', i);
-    //     dot.setAttribute('role', 'button');
-    //     dot.setAttribute('tabIndex', '-1');
-    //     dot.addEventListener('click', handleDotClick);
-    //     document.querySelector('.sage-carousel__dots').appendChild(dot);
-    //   }
-    // }
-
-    goToSlide(0);
+    if (slidesIndex !== slidesLength - 1) setSlidesIndex(slidesIndex + 1);
   }
 
   useEffect(() => {
+    function init() {
+      const slider = document.querySelector(containerClass);
+      const slides = [...slider.children];
+      let slideContainer;
+      setSlidesLength(slides.length);
+      slides.forEach((slide, index) => {
+        slideContainer = document.createElement('div');
+        slideContainer.classList.add('slide');
+        slideContainer.setAttribute('aria-roledescription', 'slide');
+        slideContainer.setAttribute('role', 'group');
+        slideContainer.setAttribute('aria-label', `${index + 1} of ${slidesLength}`);
+        slideContainer.appendChild(slide);
+        slider.appendChild(slideContainer);
+      });
+
+      const basicSlider = tns({
+        ...options,
+        container: containerClass,
+        controls: false,
+        nav: false,
+      });
+      setMySlider(basicSlider);
+    }
     init();
-  });
+  }, [options, slidesLength]);
+
+  useEffect(() => {
+    if (mySlider !== null) mySlider.goTo(slidesIndex);
+  }, [mySlider, slidesIndex]);
 
   return (
     <div className={classNames} aria-roledescription="carousel">
@@ -156,8 +89,8 @@ export const Carousel = ({
       </div>
       <div className="sage-carousel__dots">
         <Indicator
-          numItems={indicatorDotsNum}
-          currentItem={indicatorDotsIndex}
+          numItems={slidesLength}
+          currentItem={slidesIndex + 1}
         />
       </div>
     </div>

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -1,22 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { tns } from 'tiny-slider/dist/tiny-slider';
 import { CarouselArrow } from './CarouselArrow';
-import { Indicator } from '../Indicator';
 import { CarouselSlide } from './CarouselSlide';
+import { Indicator } from '../Indicator';
 
 export const Carousel = ({
   children,
   options,
 }) => {
-  const baseClass = 'sage-carousel';
-  const classNames = classnames(
-    baseClass
-  );
-
-  const containerClass = '.sage-carousel__carousel';
-
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [slidesLength, setSlidesLength] = useState(0);
   const [slides, setSlides] = useState(null);
@@ -43,16 +35,21 @@ export const Carousel = ({
 
   useEffect(() => {
     const childrenArray = children.props.children;
-    setSlides(childrenArray.map((item) => (
-      <CarouselSlide content={item} />
+    const childrenLength = childrenArray.length;
+    setSlides(childrenArray.map((item, index) => (
+      <CarouselSlide
+        content={item}
+        index={index}
+        length={childrenLength}
+      />
     )));
-    setSlidesLength(childrenArray.length);
+    setSlidesLength(childrenLength);
   }, [children]);
 
   useEffect(() => {
     setMySlider(tns({
       ...options,
-      container: containerClass,
+      container: '.sage-carousel__carousel',
       controls: false,
       nav: false,
     }));
@@ -81,7 +78,7 @@ export const Carousel = ({
   }, [mySlider]);
 
   return (
-    <div className={classNames} aria-roledescription="carousel">
+    <div className="sage-carousel" aria-roledescription="carousel">
       <div className="sage-carousel__container">
         <CarouselArrow
           disabled={arrowPrevDisabled}

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -71,6 +71,10 @@ export const Carousel = ({
   }, [options, slidesLength]);
 
   useEffect(() => {
+    if (mySlider !== null) arrowPrev.classList.add(arrowDisabledClass);
+  }, [arrowPrev, mySlider]);
+
+  useEffect(() => {
     if (mySlider !== null) {
       mySlider.goTo(slidesIndex);
       mySlider.events.on('indexChanged', () => {

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -102,7 +102,7 @@ export const Carousel = ({
           onClickCallback={handleNextArrowClick}
         />
       </div>
-      <div className="sage-carousel__dots">
+      <div className="sage-carousel__indicator">
         <Indicator
           numItems={slidesLength}
           currentItem={slidesIndex + 1}

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -17,29 +17,19 @@ export const Carousel = ({
   const containerClass = '.sage-carousel__carousel';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
 
-  const [slidesIndex, setSlidesIndex] = useState(0);
+  const [slidesIndex, setSlidesIndex] = useState(options.startIndex || 0);
   const [slidesLength, setSlidesLength] = useState(0);
   const [mySlider, setMySlider] = useState(null);
   const [looping, setLooping] = useState(false);
   const [arrowPrev, setArrowPrev] = useState(null);
   const [arrowNext, setArrowNext] = useState(null);
 
-  function goToSlide(num) {
-    if (!looping) {
-      if (num === 0) arrowPrev.classList.add(arrowDisabledClass);
-      else arrowPrev.classList.remove(arrowDisabledClass);
-      if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
-      else arrowNext.classList.remove(arrowDisabledClass);
-      setSlidesIndex(num);
-    }
-  }
-
   function handlePrevArrowClick() {
-    if (slidesIndex !== 0) goToSlide(slidesIndex - 1);
+    if (slidesIndex !== 0) setSlidesIndex(slidesIndex - 1);
   }
 
   function handleNextArrowClick() {
-    if (slidesIndex !== slidesLength - 1) goToSlide(slidesIndex + 1);
+    if (slidesIndex !== slidesLength - 1) setSlidesIndex(slidesIndex + 1);
   }
 
   useEffect(() => {
@@ -68,17 +58,20 @@ export const Carousel = ({
 
     setArrowPrev(document.querySelector('.sage-carousel__arrow--prev'));
     setArrowNext(document.querySelector('.sage-carousel__arrow--next'));
-  }, [options, slidesLength]);
-
-  useEffect(() => {
-    if (mySlider !== null) arrowPrev.classList.add(arrowDisabledClass);
-  }, [arrowPrev, mySlider]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options]);
 
   useEffect(() => {
     if (mySlider !== null) {
+      if (!looping) {
+        if (slidesIndex === 0) arrowPrev.classList.add(arrowDisabledClass);
+        else arrowPrev.classList.remove(arrowDisabledClass);
+        if (slidesIndex === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
+        else arrowNext.classList.remove(arrowDisabledClass);
+      }
       mySlider.goTo(slidesIndex);
       mySlider.events.on('indexChanged', () => {
-        goToSlide(mySlider.getInfo().index);
+        setSlidesIndex(mySlider.getInfo().index);
       });
     }
   });
@@ -121,5 +114,6 @@ Carousel.propTypes = {
   children: PropTypes.node,
   options: PropTypes.shape({
     loop: PropTypes.bool,
+    startIndex: PropTypes.number,
   }),
 };

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -34,8 +34,6 @@ export const Carousel = ({
     }
   }
 
-  function handleKeyDown() {}
-
   function handlePrevArrowClick() {
     if (slidesIndex !== 0) goToSlide(slidesIndex - 1);
   }
@@ -75,7 +73,7 @@ export const Carousel = ({
   useEffect(() => {
     if (mySlider !== null) {
       mySlider.goTo(slidesIndex);
-      mySlider.events.on('dragEnd', () => {
+      mySlider.events.on('indexChanged', () => {
         goToSlide(mySlider.getInfo().index);
       });
     }
@@ -88,7 +86,6 @@ export const Carousel = ({
           icon="caret-left"
           id="prev"
           onClickCallback={handlePrevArrowClick}
-          onKeyDownCallback={handleKeyDown}
         />
         <div className="sage-carousel__sizer">
           <div className="sage-carousel__carousel">
@@ -99,7 +96,6 @@ export const Carousel = ({
           icon="caret-right"
           id="next"
           onClickCallback={handleNextArrowClick}
-          onKeyDownCallback={handleKeyDown}
         />
       </div>
       <div className="sage-carousel__dots">

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { tns } from 'tiny-slider/dist/tiny-slider';
-import { Icon } from '../Icon';
+import { CarouselArrow } from './CarouselArrow';
 import { Indicator } from '../Indicator';
 
 export const Carousel = ({
@@ -80,29 +80,23 @@ export const Carousel = ({
   return (
     <div className={classNames} aria-roledescription="carousel">
       <div className="sage-carousel__container">
-        <div
-          className="sage-carousel__arrow sage-carousel__arrow--prev"
-          onClick={handlePrevArrowClick}
-          onKeyDown={handleKeyDown}
-          role="button"
-          tabIndex={-1}
-        >
-          <Icon icon="caret-left" size="lg" />
-        </div>
+        <CarouselArrow
+          icon="caret-left"
+          id="prev"
+          onClickCallback={handlePrevArrowClick}
+          onKeyDownCallback={handleKeyDown}
+        />
         <div className="sage-carousel__sizer">
           <div className="sage-carousel__carousel">
             {children}
           </div>
         </div>
-        <div
-          className="sage-carousel__arrow sage-carousel__arrow--next"
-          onClick={handleNextArrowClick}
-          onKeyDown={handleKeyDown}
-          role="button"
-          tabIndex={-1}
-        >
-          <Icon icon="caret-right" size="lg" />
-        </div>
+        <CarouselArrow
+          icon="caret-right"
+          id="next"
+          onClickCallback={handleNextArrowClick}
+          onKeyDownCallback={handleKeyDown}
+        />
       </div>
       <div className="sage-carousel__dots">
         <Indicator

--- a/packages/sage-react/lib/Carousel/Carousel.story.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.story.jsx
@@ -37,7 +37,6 @@ export default {
       </>
     ),
     options: {
-      arrowKeys: true,
       fixedWidth: 544,
       gutter: 24,
       loop: false,

--- a/packages/sage-react/lib/Carousel/Carousel.story.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.story.jsx
@@ -60,6 +60,40 @@ export default {
           }}
           title="Hello, world"
         />
+        <NextBestAction
+          actions={(
+            <Button
+              color={Button.COLORS.PRIMARY}
+            >
+              Add an Upsell
+            </Button>
+          )}
+          cardColor="draft"
+          description={(
+            <p>Lorem ipsum dolor sit amet.</p>
+          )}
+          graphic={{
+            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
+          }}
+          title="Hello, world"
+        />
+        <NextBestAction
+          actions={(
+            <Button
+              color={Button.COLORS.PRIMARY}
+            >
+              Add an Upsell
+            </Button>
+          )}
+          cardColor="draft"
+          description={(
+            <p>Lorem ipsum dolor sit amet.</p>
+          )}
+          graphic={{
+            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
+          }}
+          title="Hello, world"
+        />
       </>
     ),
     options: {

--- a/packages/sage-react/lib/Carousel/Carousel.story.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.story.jsx
@@ -101,6 +101,7 @@ export default {
       fixedWidth: 544,
       gutter: 24,
       loop: false,
+      mouseDrag: true,
     },
   },
 };

--- a/packages/sage-react/lib/Carousel/Carousel.story.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.story.jsx
@@ -3,97 +3,37 @@ import { Carousel } from './Carousel';
 import { Button } from '../Button';
 import { NextBestAction } from '../NextBestAction';
 
+const carouselSlides = [...Array(6)].map((e, i) => (
+  <NextBestAction
+    actions={(
+      <Button
+        color={Button.COLORS.PRIMARY}
+      >
+        Add an Upsell
+      </Button>
+    )}
+    cardColor="draft"
+    description={(
+      <p>Lorem ipsum dolor sit amet.</p>
+    )}
+    graphic={{
+      element: (<img src="https://sage-design-system.kajabi.com/assets/next_best_action_graphic-7ee408e5df4afae92cdc499aae59083f5d3ff9aef3c2e8b6e2ea761784deca79.png" alt="" />)
+    }}
+    // Since there is nothing unique about these slides, using
+    // the index as the key is fine.
+    // eslint-disable-next-line react/no-array-index-key
+    key={i}
+    title="Hello, world"
+  />
+));
+
 export default {
   title: 'Sage/Carousel',
   component: Carousel,
   args: {
     children: (
       <>
-        <NextBestAction
-          actions={(
-            <Button
-              color={Button.COLORS.PRIMARY}
-            >
-              Add an Upsell
-            </Button>
-          )}
-          cardColor="draft"
-          description={(
-            <p>Lorem ipsum dolor sit amet.</p>
-          )}
-          graphic={{
-            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
-          }}
-          title="Hello, world"
-        />
-        <NextBestAction
-          actions={(
-            <Button
-              color={Button.COLORS.PRIMARY}
-            >
-              Add an Upsell
-            </Button>
-          )}
-          cardColor="draft"
-          description={(
-            <p>Lorem ipsum dolor sit amet.</p>
-          )}
-          graphic={{
-            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
-          }}
-          title="Hello, world"
-        />
-        <NextBestAction
-          actions={(
-            <Button
-              color={Button.COLORS.PRIMARY}
-            >
-              Add an Upsell
-            </Button>
-          )}
-          cardColor="draft"
-          description={(
-            <p>Lorem ipsum dolor sit amet.</p>
-          )}
-          graphic={{
-            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
-          }}
-          title="Hello, world"
-        />
-        <NextBestAction
-          actions={(
-            <Button
-              color={Button.COLORS.PRIMARY}
-            >
-              Add an Upsell
-            </Button>
-          )}
-          cardColor="draft"
-          description={(
-            <p>Lorem ipsum dolor sit amet.</p>
-          )}
-          graphic={{
-            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
-          }}
-          title="Hello, world"
-        />
-        <NextBestAction
-          actions={(
-            <Button
-              color={Button.COLORS.PRIMARY}
-            >
-              Add an Upsell
-            </Button>
-          )}
-          cardColor="draft"
-          description={(
-            <p>Lorem ipsum dolor sit amet.</p>
-          )}
-          graphic={{
-            element: (<img src="//source.unsplash.com/random/272x272" alt="" />)
-          }}
-          title="Hello, world"
-        />
+        {carouselSlides}
       </>
     ),
     options: {
@@ -105,5 +45,6 @@ export default {
     },
   },
 };
+
 const Template = (args) => <Carousel {...args} />;
 export const Default = Template.bind({});

--- a/packages/sage-react/lib/Carousel/Carousel.story.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.story.jsx
@@ -63,6 +63,7 @@ export default {
       </>
     ),
     options: {
+      arrowKeys: true,
       fixedWidth: 544,
       gutter: 24,
       loop: false,

--- a/packages/sage-react/lib/Carousel/Carousel.story.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.story.jsx
@@ -101,7 +101,6 @@ export default {
       fixedWidth: 544,
       gutter: 24,
       loop: false,
-      mouseDrag: true,
     },
   },
 };

--- a/packages/sage-react/lib/Carousel/CarouselArrow.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselArrow.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from '../Icon';
+
+export const CarouselArrow = ({
+  icon,
+  id,
+  onClickCallback,
+  onKeyDownCallback,
+}) => (
+  <div
+    className={`sage-carousel__arrow sage-carousel__arrow--${id}`}
+    onClick={onClickCallback}
+    onKeyDown={onKeyDownCallback}
+    role="button"
+    tabIndex={-1}
+  >
+    <Icon icon={icon} size="lg" />
+  </div>
+);
+
+CarouselArrow.propTypes = {
+  icon: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  onClickCallback: PropTypes.func.isRequired,
+  onKeyDownCallback: PropTypes.func.isRequired,
+};

--- a/packages/sage-react/lib/Carousel/CarouselArrow.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselArrow.jsx
@@ -6,12 +6,11 @@ export const CarouselArrow = ({
   icon,
   id,
   onClickCallback,
-  onKeyDownCallback,
 }) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events
   <div
     className={`sage-carousel__arrow sage-carousel__arrow--${id}`}
     onClick={onClickCallback}
-    onKeyDown={onKeyDownCallback}
     role="button"
     tabIndex={-1}
   >
@@ -23,5 +22,4 @@ CarouselArrow.propTypes = {
   icon: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   onClickCallback: PropTypes.func.isRequired,
-  onKeyDownCallback: PropTypes.func.isRequired,
 };

--- a/packages/sage-react/lib/Carousel/CarouselArrow.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselArrow.jsx
@@ -1,24 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { Icon } from '../Icon';
 
 export const CarouselArrow = ({
+  disabled,
   icon,
   id,
   onClickCallback,
-}) => (
-  // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-  <div
-    className={`sage-carousel__arrow sage-carousel__arrow--${id}`}
-    onClick={onClickCallback}
-    role="button"
-    tabIndex={-1}
-  >
-    <Icon icon={icon} size="lg" />
-  </div>
-);
+}) => {
+  const baseClass = 'sage-carousel__arrow';
+  const classNames = classnames(
+    baseClass,
+    {
+      [`${baseClass}--${id}`]: id,
+      [`${baseClass}--disabled`]: disabled,
+    }
+  );
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      className={classNames}
+      onClick={onClickCallback}
+      role="button"
+      tabIndex={-1}
+    >
+      <Icon icon={icon} size="lg" />
+    </div>
+  );
+};
+
+CarouselArrow.defaultProps = {
+  disabled: false,
+};
 
 CarouselArrow.propTypes = {
+  disabled: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   onClickCallback: PropTypes.func.isRequired,

--- a/packages/sage-react/lib/Carousel/CarouselSlide.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselSlide.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const CarouselSlide = ({
+  content
+}) => (
+  <div
+    aria-label="benzo"
+    aria-roledescription="slide"
+    className="sage-carousel__slide"
+    role="group"
+  >
+    {content}
+  </div>
+);
+
+CarouselSlide.defaultProps = {
+  content: null,
+};
+
+CarouselSlide.propTypes = {
+  content: PropTypes.node,
+};

--- a/packages/sage-react/lib/Carousel/CarouselSlide.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselSlide.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const CarouselSlide = ({
-  content
+  content,
+  index,
+  length,
 }) => (
   <div
-    aria-label="benzo"
+    aria-label={`${index + 1} of ${length}`}
     aria-roledescription="slide"
     className="sage-carousel__slide"
     role="group"
@@ -20,4 +22,6 @@ CarouselSlide.defaultProps = {
 
 CarouselSlide.propTypes = {
   content: PropTypes.node,
+  index: PropTypes.number.isRequired,
+  length: PropTypes.number.isRequired,
 };

--- a/packages/sage-react/lib/Indicator/Indicator.jsx
+++ b/packages/sage-react/lib/Indicator/Indicator.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 export const Indicator = ({
+  className,
   currentItem,
   label,
   numItems,
@@ -39,7 +40,7 @@ export const Indicator = ({
         <p className="sage-indicator-text">{label} {currentItem} {preposition} {numItems}</p>
       ) : (
         <ul
-          className="sage-indicator-list"
+          className={`sage-indicator-list ${className}`}
           aria-label={`Showing ${label} ${currentItem} ${preposition} ${numItems}`}
         >
           {items}
@@ -50,6 +51,7 @@ export const Indicator = ({
 };
 
 Indicator.defaultProps = {
+  className: null,
   currentItem: null,
   label: null,
   numItems: 0,
@@ -58,6 +60,7 @@ Indicator.defaultProps = {
 };
 
 Indicator.propTypes = {
+  className: PropTypes.string,
   currentItem: PropTypes.number,
   label: PropTypes.string,
   numItems: PropTypes.number,

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -3,7 +3,7 @@ import { tns } from "tiny-slider/src/tiny-slider";
 Sage.carousel = (function() {
 
   const containerClass = '.sage-carousel__carousel';
-  // const dotActiveClass = 'sage-carousel__dot--active';
+  const dotActiveClass = 'sage-indicator--current';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
 
   let arrowPrev;
@@ -12,7 +12,6 @@ Sage.carousel = (function() {
   let mySliderInfo;
   let options;
   let slidesLength;
-  let dots;
   let looping;
 
   function init() {
@@ -44,7 +43,6 @@ Sage.carousel = (function() {
       nav: false,
     });
     mySliderInfo = mySlider.getInfo();
-    mySlider.events.on('dragEnd', handleDragEnd);
 
     arrowPrev = document.querySelector('.sage-carousel__arrow--prev');
     arrowPrev.addEventListener('click', handlePrevArrowClick);
@@ -55,6 +53,11 @@ Sage.carousel = (function() {
     if (!looping) {
       let dot;
       let dotNumber;
+      let dotContainer = document.createElement('ul');
+      let dots = document.querySelector('.sage-carousel__dots');
+      dotContainer.classList.add('sage-indicator-list');
+      dotContainer.setAttribute('aria-label', 'Showing 1 of ' + slidesLength);
+      dots.appendChild(dotContainer);
       for (let i = 0; i < slidesLength; i++) {
         dot = document.createElement('li');
         dot.classList.add('sage-indicator');
@@ -66,6 +69,15 @@ Sage.carousel = (function() {
       };
     }
 
+    const indicators = document.querySelectorAll('.sage-indicator');
+    indicators[0].classList.add(dotActiveClass);
+    mySlider.events.on('indexChanged', () => {
+      indicators.forEach((indicator) => {
+        indicator.classList.remove(dotActiveClass);
+      });
+      indicators[mySlider.getInfo().index].classList.add(dotActiveClass);
+    });
+
     goToSlide(0);
   }
 
@@ -75,17 +87,8 @@ Sage.carousel = (function() {
       else arrowPrev.classList.remove(arrowDisabledClass);
       if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
       else arrowNext.classList.remove(arrowDisabledClass);
-      // dots = [...document.getElementsByClassName('sage-carousel__dot')];
-      // dots.forEach((dot) => {
-      //   dot.classList.remove(dotActiveClass);
-      // });
-      // dots[num].classList.add(dotActiveClass);
       mySlider.goTo(num);
     };
-  }
-
-  function handleDotClick(evt) {
-    goToSlide(parseInt(evt.target.getAttribute('index')));
   }
 
   function handlePrevArrowClick() {
@@ -104,11 +107,6 @@ Sage.carousel = (function() {
     } else {
       mySlider.goTo('next');
     }
-  }
-
-  function handleDragEnd() {
-    mySliderInfo = mySlider.getInfo();
-    goToSlide(mySliderInfo.index);
   }
 
   return {

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -3,8 +3,8 @@ import { tns } from "tiny-slider/src/tiny-slider";
 Sage.carousel = (function() {
 
   const containerClass = '.sage-carousel__carousel';
-  const dotActiveClass = 'sage-indicator--current';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
+  const indicatorActiveClass = 'sage-indicator--current';
 
   let arrowPrev;
   let arrowNext;
@@ -51,31 +51,31 @@ Sage.carousel = (function() {
     arrowNext.addEventListener('click', handleNextArrowClick);
 
     if (!looping) {
-      let dot;
-      let dotNumber;
-      let dotContainer = document.createElement('ul');
-      let dots = document.querySelector('.sage-carousel__dots');
-      dotContainer.classList.add('sage-indicator-list');
-      dotContainer.setAttribute('aria-label', 'Showing 1 of ' + slidesLength);
-      dots.appendChild(dotContainer);
+      let indicator;
+      let indicatorNumber;
+      let indicatorList = document.createElement('ul');
+      let indicatorContainer = document.querySelector('.sage-carousel__indicator');
+      indicatorList.classList.add('sage-indicator-list');
+      indicatorList.setAttribute('aria-label', 'Showing 1 of ' + slidesLength);
+      indicatorContainer.appendChild(indicatorList);
       for (let i = 0; i < slidesLength; i++) {
-        dot = document.createElement('li');
-        dot.classList.add('sage-indicator');
-        dotNumber = document.createElement('span');
-        dotNumber.classList.add('visually-hidden');
-        dotNumber.innerHTML = i + 1;
-        dot.appendChild(dotNumber);
-        document.querySelector('.sage-indicator-list').appendChild(dot);
+        indicator = document.createElement('li');
+        indicator.classList.add('sage-indicator');
+        indicatorNumber = document.createElement('span');
+        indicatorNumber.classList.add('visually-hidden');
+        indicatorNumber.innerHTML = i + 1;
+        indicator.appendChild(indicatorNumber);
+        document.querySelector('.sage-indicator-list').appendChild(indicator);
       };
     }
 
     const indicators = document.querySelectorAll('.sage-indicator');
-    indicators[0].classList.add(dotActiveClass);
+    indicators[0].classList.add(indicatorActiveClass);
     mySlider.events.on('indexChanged', () => {
       indicators.forEach((indicator) => {
-        indicator.classList.remove(dotActiveClass);
+        indicator.classList.remove(indicatorActiveClass);
       });
-      indicators[mySlider.getInfo().index].classList.add(dotActiveClass);
+      indicators[mySlider.getInfo().index].classList.add(indicatorActiveClass);
     });
 
     goToSlide(0);

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -13,6 +13,7 @@ Sage.carousel = (function() {
   let options;
   let slidesLength;
   let looping;
+  let startingSlide;
 
   function init() {
     const slider = document.querySelector(containerClass);
@@ -35,6 +36,7 @@ Sage.carousel = (function() {
     );
 
     looping = !(options.loop !== undefined && !options.loop);
+    startingSlide = options.startIndex || 0;
 
     mySlider = tns({
       ...options,
@@ -70,7 +72,7 @@ Sage.carousel = (function() {
     }
 
     const indicators = document.querySelectorAll('.sage-indicator');
-    indicators[0].classList.add(indicatorActiveClass);
+    indicators[mySlider.getInfo().index].classList.add(indicatorActiveClass);
     mySlider.events.on('indexChanged', () => {
       indicators.forEach((indicator) => {
         indicator.classList.remove(indicatorActiveClass);
@@ -78,7 +80,7 @@ Sage.carousel = (function() {
       indicators[mySlider.getInfo().index].classList.add(indicatorActiveClass);
     });
 
-    goToSlide(0);
+    goToSlide(startingSlide);
   }
 
   function goToSlide(num) {

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -45,6 +45,9 @@ Sage.carousel = (function() {
       controls: false,
       nav: false,
     });
+    mySlider.events.on('dragEnd', () => {
+      goToSlide(mySlider.getInfo().index);
+    });
     mySliderInfo = mySlider.getInfo();
 
     arrowPrev = document.querySelector('.sage-carousel__arrow--prev');

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -3,7 +3,7 @@ import { tns } from "tiny-slider/src/tiny-slider";
 Sage.carousel = (function() {
 
   const containerClass = '.sage-carousel__carousel';
-  const dotActiveClass = 'sage-carousel__dot--active';
+  // const dotActiveClass = 'sage-carousel__dot--active';
   const arrowDisabledClass = 'sage-carousel__arrow--disabled';
 
   let arrowPrev;
@@ -54,14 +54,15 @@ Sage.carousel = (function() {
 
     if (!looping) {
       let dot;
+      let dotNumber;
       for (let i = 0; i < slidesLength; i++) {
-        dot = document.createElement('div');
-        dot.classList.add('sage-carousel__dot');
-        dot.setAttribute('index', i);
-        dot.setAttribute('role', 'button');
-        dot.setAttribute('tabIndex', '-1');
-        dot.addEventListener('click', handleDotClick);
-        document.querySelector('.sage-carousel__dots').appendChild(dot);
+        dot = document.createElement('li');
+        dot.classList.add('sage-indicator');
+        dotNumber = document.createElement('span');
+        dotNumber.classList.add('visually-hidden');
+        dotNumber.innerHTML = i + 1;
+        dot.appendChild(dotNumber);
+        document.querySelector('.sage-indicator-list').appendChild(dot);
       };
     }
 
@@ -74,11 +75,11 @@ Sage.carousel = (function() {
       else arrowPrev.classList.remove(arrowDisabledClass);
       if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
       else arrowNext.classList.remove(arrowDisabledClass);
-      dots = [...document.getElementsByClassName('sage-carousel__dot')];
-      dots.forEach((dot) => {
-        dot.classList.remove(dotActiveClass);
-      });
-      dots[num].classList.add(dotActiveClass);
+      // dots = [...document.getElementsByClassName('sage-carousel__dot')];
+      // dots.forEach((dot) => {
+      //   dot.classList.remove(dotActiveClass);
+      // });
+      // dots[num].classList.add(dotActiveClass);
       mySlider.goTo(num);
     };
   }

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -14,6 +14,7 @@ Sage.carousel = (function() {
   let slidesLength;
   let looping;
   let startingSlide;
+  let indicators;
 
   function init() {
     const slider = document.querySelector(containerClass);
@@ -71,14 +72,7 @@ Sage.carousel = (function() {
       };
     }
 
-    const indicators = document.querySelectorAll('.sage-indicator');
-    indicators[mySlider.getInfo().index].classList.add(indicatorActiveClass);
-    mySlider.events.on('indexChanged', () => {
-      indicators.forEach((indicator) => {
-        indicator.classList.remove(indicatorActiveClass);
-      });
-      indicators[mySlider.getInfo().index].classList.add(indicatorActiveClass);
-    });
+    indicators = document.querySelectorAll('.sage-indicator');
 
     goToSlide(startingSlide);
   }
@@ -89,6 +83,10 @@ Sage.carousel = (function() {
       else arrowPrev.classList.remove(arrowDisabledClass);
       if (num === slidesLength - 1) arrowNext.classList.add(arrowDisabledClass);
       else arrowNext.classList.remove(arrowDisabledClass);
+      indicators.forEach((indicator) => {
+        indicator.classList.remove(indicatorActiveClass);
+      });
+      indicators[num].classList.add(indicatorActiveClass);
       mySlider.goTo(num);
     };
   }


### PR DESCRIPTION
## Description
This branch adds
- SageIndicator component in place of the JS-generated dots for React
- JS-generated `sage-indicator` elements
- `startIndex` option for starting on a particular slide, mapped to the [tiny-slider option](https://github.com/ganlanyuan/tiny-slider#options)
- Switched some functionality to `useEffect` for dynamic updates and working event listeners

## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/5650617/141017068-20d4c79c-aec7-4853-90b0-1640bd2fd5fe.png)|![image](https://user-images.githubusercontent.com/5650617/141017084-d1850058-1ea7-4c31-b8d5-815b513693fa.png)|
|![image](https://user-images.githubusercontent.com/5650617/141017134-ae001421-bd1f-4b3b-950e-28153df070f3.png)|![image](https://user-images.githubusercontent.com/5650617/141017156-cbb748c0-383f-443a-af1b-f8bdc596c426.png)|

## Testing in `sage-lib`
### Rails
- View [Rails component](http://localhost:4000/pages/component/carousel)
- Check that component styling updates are there
- Check that passing `startIndex` works correctly

### React
- View [Storybook](http://localhost:4100/?path=/story/sage-carousel--default)
- Check that component styling updates are there
- Check that passing `startIndex` works correctly

## Testing in `kajabi-products`
1. (**LOW**) Depends on if there's any usage of the Rails or React SageCarousel component. This should be a drop-in replacement.