### PR TITLE
[Sage-983] Label - Custom Icon Color

### DIFF
--- a/docs/app/views/examples/components/label/_preview.html.erb
+++ b/docs/app/views/examples/components/label/_preview.html.erb
@@ -83,6 +83,24 @@ configs = [
 <% end %>
 
 <%= sage_component SagePanelBlock, {} do %>
+  <h3 class="t-sage-heading-6">With Icons - Custom Icon Color</h3>
+  <%= sage_component SageLabelGroup, {} do %>
+    <%= sage_component SageLabel, {
+      custom_icon_color: "#e08a1f",
+      color: "draft",
+      value: "Add",
+      icon: "add-small",
+    } %>
+    <%= sage_component SageLabel, {
+      custom_icon_color: "#f58cc2",
+      color: "draft",
+      value: "Tag",
+      icon: "tag"
+    } %>
+  <% end %>
+<% end %>
+
+<%= sage_component SagePanelBlock, {} do %>
   <h3 class="t-sage-heading-6">Interactive Default</h3>
   <%= sage_component SageLabelGroup, {} do %>
     <% configs.each do | config | %>

--- a/docs/app/views/examples/components/label/_props.html.erb
+++ b/docs/app/views/examples/components/label/_props.html.erb
@@ -7,10 +7,17 @@
   <td><%= md('Required') %></td>
 </tr>
 <tr>
-<tr>
   <td><%= md('`container_attributes`') %></td>
   <td><%= md('Additional attributes to provide bindings or actions to the label container.') %></td>
   <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`custom_icon_color`') %></td>
+  <td><%= md('
+    Sets a custom color for the icon.
+  ') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -38,7 +45,7 @@
     If `true` is passed then a `LabelSecondaryButton` is rendered with default configurations.
     If a hash is passed it is treated as configurations for the prepackaged `LabelSecondaryButton` (see below).
   ') %></td>
-  <td><%= md('`String`, `true`, or has with configurations for `LabelSecondaryButton` (see below)') %></td>
+  <td><%= md('String, `true`, or has with configurations for `LabelSecondaryButton` (see below)') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -50,7 +57,7 @@
 <tr>
   <td><%= md('`value`') %></td>
   <td><%= md('The text to use as the label\'s content') %></td>
-  <td><%= md('`String`') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('Required') %></td>
 </tr>
 <tr>
@@ -59,7 +66,7 @@
 <tr>
   <td><%= md('`attributes`') %></td>
   <td><%= md('Additional attributes such as to provide `data-` bindings or actions to the button.') %></td>
-  <td><%= md('`String`') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`"Remove"`') %></td>
 </tr>
 <tr>
@@ -79,7 +86,7 @@
     so this label should accurately reflect the purpose of this button for accessibility.
     Default value is based on the common use of a "remove" button with Label values.
   ') %></td>
-  <td><%= md('`String`') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`"Remove"`') %></td>
 </tr>
 

--- a/docs/lib/sage_rails/app/sage_components/sage_label.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_label.rb
@@ -2,6 +2,7 @@ class SageLabel < SageComponent
   set_attribute_schema({
     container_attributes: [:optional, Hash],
     color: [:optional, SageSchemas::STATUSES],
+    custom_icon_color: [:optional, String],
     icon: [:optional, String],
     interactive_type: [:optional, Set.new([:dropdown, :default, :secondary_button])],
     secondary_button: [:optional, String, TrueClass, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -8,7 +8,7 @@
     <%= "sage-label--interactive" if component.interactive_type %>
     <%= "sage-label--interactive-right-cta-affordance" if (component.interactive_type === :dropdown) || (component.interactive_type === :secondary_button) %>
     <%= "sage-label--icon-#{component.icon}" if component.icon %>
-    <%= "sage-label--icon-#{component.icon}--custom-color" if component.icon && component.custom_icon_color %>
+    <%= "sage-label--icon--custom-color" if component.icon && component.custom_icon_color %>
     <%= component.generated_css_classes %>
   "
   <% if component.icon && component.custom_icon_color %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_label.html.erb
@@ -8,8 +8,12 @@
     <%= "sage-label--interactive" if component.interactive_type %>
     <%= "sage-label--interactive-right-cta-affordance" if (component.interactive_type === :dropdown) || (component.interactive_type === :secondary_button) %>
     <%= "sage-label--icon-#{component.icon}" if component.icon %>
+    <%= "sage-label--icon-#{component.icon}--custom-color" if component.icon && component.custom_icon_color %>
     <%= component.generated_css_classes %>
   "
+  <% if component.icon && component.custom_icon_color %>
+    style="--sage-label-custom-icon-color: <%= component.custom_icon_color %>"
+  <% end %>
   <% component.container_attributes.each do |key, value| %>
     <%= "#{key}='#{value}'".html_safe %>
   <% end if component.container_attributes&.is_a?(Hash) %>

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -78,6 +78,12 @@ $-icon-beside-type: (
     margin: 0 sage-spacing(xs) 0 0;
   }
 
+  .sage-label--icon--custom-color .sage-label__value::before {
+    --sage-label-custom-icon-color: inherit;
+
+    color: var(--sage-label-custom-icon-color);
+  }
+
   .sage-label__decor-icon--#{$icon-name}::before {
     @include sage-icon-base($icon-name, md);
     align-self: center;

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -13,6 +13,7 @@ import { LabelGroup } from './LabelGroup';
 export const Label = React.forwardRef(({
   className,
   color,
+  customIconColor,
   containerAttributes,
   icon,
   interactiveType,
@@ -34,11 +35,26 @@ export const Label = React.forwardRef(({
       'sage-label--interactive': interactiveType,
       'sage-label--interactive-right-cta-affordance': interactiveType && interactiveType !== LABEL_INTERACTIVE_TYPES.DEFAULT,
       [`sage-label--icon-${icon}`]: icon,
+      'sage-label--icon--custom-color': customIconColor,
     }
   );
 
+  const setCustomIconColor = () => {
+    const props = {};
+
+    if (customIconColor) {
+      props['--sage-label-custom-icon-color'] = customIconColor;
+    }
+     return props;
+  };
+
   return (
-    <span className={classNames} ref={ref} {...containerAttributes}>
+    <span
+      className={classNames}
+      ref={ref}
+      style={setCustomIconColor()}
+      {...containerAttributes}
+    >
       <TagName
         className="sage-label__value"
         type={interactiveType ? 'button' : null}
@@ -65,6 +81,7 @@ Label.Group = LabelGroup;
 Label.defaultProps = {
   className: null,
   color: LABEL_COLORS.DRAFT,
+  customIconColor: null,
   icon: null,
   interactiveType: null,
   isDropdown: false,
@@ -77,6 +94,7 @@ Label.defaultProps = {
 Label.propTypes = {
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(LABEL_COLORS)),
+  customIconColor: PropTypes.string,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   interactiveType: PropTypes.oneOf(Object.values(LABEL_INTERACTIVE_TYPES)),
   isDropdown: PropTypes.bool,

--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -45,7 +45,8 @@ export const Label = React.forwardRef(({
     if (customIconColor) {
       props['--sage-label-custom-icon-color'] = customIconColor;
     }
-     return props;
+
+    return props;
   };
 
   return (

--- a/packages/sage-react/lib/Label/Label.story.jsx
+++ b/packages/sage-react/lib/Label/Label.story.jsx
@@ -26,6 +26,12 @@ const Template = (args) => <Label {...args} />;
 
 export const Default = Template.bind({});
 
+export const CustomIconColor = Template.bind({});
+CustomIconColor.args = {
+  icon: SageTokens.ICONS.ADD,
+  customIconColor: '#ff33ff',
+};
+
 export const InteractiveDefault = Template.bind({});
 InteractiveDefault.args = {
   interactiveType: Label.INTERACTIVE_TYPES.DEFAULT


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a new prop to allow for a custom icon color. No effect on existing Kajabi Products work.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="235" alt="Screen Shot 2021-11-10 at 2 36 39 PM" src="https://user-images.githubusercontent.com/14791307/141189656-ca61f9b4-71d4-40ee-af59-49d299e2e563.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/label)
- Check that new prop functions as expected

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-label--custom-icon-color)
- Check that new prop functions as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds a new prop to allow for a custom icon color. No effect on existing Kajabi Products work.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #983 