### PR TITLE
fix(panel): updates to gap

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -114,7 +114,7 @@
 }
 
 @each $-key, $-value in $sage-spacings {
-  .sage-panel__row--gap-#{$-key}
+  .sage-panel__row--gap-#{$-key},
   .sage-panel__list-item--gap-#{$-key} {
     gap: sage-spacing($-key);
   }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update `gap` to fire for sage panel rows

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-11-09 at 7 43 12 PM](https://user-images.githubusercontent.com/1241836/141035062-ec3b6a8d-d22f-4d47-bd8f-2ddace37b879.png)|![Screen Shot 2021-11-09 at 7 46 04 PM](https://user-images.githubusercontent.com/1241836/141035076-bfe8a22e-b519-42ad-93ed-b36133610e95.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
In the rails or react panel page, add a `gap` to the row and verify that it's working

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Doesn't affect Panel Rows currently as this is a new addition.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
