### PR TITLE
fix(input error): remove deprecated form field error class

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -21,14 +21,6 @@ $-input-text-height: sage-font-size(body);
   }
 }
 
-// TODO: deprecated in favor of sage-form-field--error
-.sage-input--error {
-  .sage-upload-card & {
-    margin-top: sage-spacing(sm);
-  }
-}
-
-// Note: this will be the block of code remaining after above is removed
 .sage-form-field--error {
   .sage-upload-card & {
     margin-top: sage-spacing(sm);


### PR DESCRIPTION
## Description

Remove deprecated class `sage-input--error` from CSS.


## Screenshots

|  Before  |  After - no changes |
|--------|--------|
| ![Screen Shot 2021-11-11 at 12 58 27 PM](https://user-images.githubusercontent.com/24237393/141353594-56f3dc63-49d4-4cf8-ab47-44f62cbd1c76.png) | ![Screen Shot 2021-11-11 at 12 58 27 PM](https://user-images.githubusercontent.com/24237393/141353594-56f3dc63-49d4-4cf8-ab47-44f62cbd1c76.png) |

## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/form_input
2. Verify that the input error field still renders correct error styles

## Testing in `kajabi-products`
1. (**N/A**) QE already complete. Removing `sage-input--error` class which could cause visual regressions in `kajabi-products`. This could cause error styles to not render when input fields have an error. This was QE'd as part of Kajabi/kajabi-products#21384

## Related
Closes #958 
