### PR TITLE
[SAGE-1000] Icon Background Sizing on Smaller Screens

### DIFF
--- a/docs/app/views/examples/components/icon/_preview.html.erb
+++ b/docs/app/views/examples/components/icon/_preview.html.erb
@@ -49,7 +49,7 @@ and also be used with a vareity of layout techniques or components such as CSS f
 <%= sage_component SageCardList, {} do %>
   <% SageTokens::STATUSES.each do | color | %>
     <%= sage_component SageCardListItem, { grid_template: "o" } do %>
-      <%= color %>
+      <p><%= color %></p>
       <%= sage_component SageIcon, { icon: "pen", card_color: color } %>
       <%= sage_component SageIcon, { icon: "pen", card_color: color, circular: true, } %>
     <% end %>
@@ -59,7 +59,7 @@ and also be used with a vareity of layout techniques or components such as CSS f
 <%= sage_component SageCardList, {} do %>
   <% SageTokens::ICON_SIZES.each do | size | %>
     <%= sage_component SageCardListItem, { grid_template: "o" } do %>
-      <%= size == "md" ? "Default (#{size})" : size %>
+      <p><%= size == "md" ? "Default (#{size})" : size %></p>
       <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft" } %>
       <%= sage_component SageIcon, { icon: "pen", size: (size == "md" ? nil : size), card_color: "draft", circular: true, } %>
     <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -147,6 +147,10 @@ $-icon-beside-type: (
   &:not(.sage-icon-background--circular) {
     border-radius: sage-border(radius);
   }
+
+  @media screen and (max-width: sage-breakpoint(md-max)) {
+    max-width: sage-spacing(xl);
+  }
 }
 
 .sage-icon-background--circular {
@@ -159,6 +163,9 @@ $-icon-beside-type: (
   .sage-icon-background-#{$suffix} {
     width: $size;
     height: $size;
+    @media screen and (max-width: sage-breakpoint(md-max)) {
+      max-width: $size;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Adjusts widths of SageIcons to prevent stretching on smaller screensizes.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2021-11-15 at 11 47 18 AM](https://user-images.githubusercontent.com/1175111/141844552-d24aec13-ddfd-4ed1-8522-0bf214ff15b2.png)|![Screen Shot 2021-11-15 at 1 28 39 PM](https://user-images.githubusercontent.com/1175111/141856360-49065650-410e-491e-8315-e3b99379de1c.png)|

## Testing in `sage-lib`

- Navigate to Icons http://localhost:4000/pages/component/icon
- Resize screen and verify icons no longer stretch on smaller screens.

## Testing in `kajabi-products`
1. (**LOW**) Sizing adjustments to SageIcons on smaller screen sizes. No impact is expected in kajabi-products.

## Related
Closes #1000 
