### PR TITLE
[Sage-942] Responsive PanelTile

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -165,35 +165,26 @@
 }
 
 .sage-panel__tiles {
-  display: grid;
-  grid-gap: sage-spacing();
-  list-style: none;
-}
+  --sage-panel-tiles-gap: #{sage-spacing()};
 
-@for $i from 2 through 4 {
-  .sage-panel__tiles--#{$i}-up-condensed {
-    grid-gap: sage-spacing(xs);
+  display: grid;
+  grid-gap: var(--sage-panel-tiles-gap);
+  grid-template-columns: repeat(var(--sage-panel-tiles-columns), calc((100% - (var(--sage-panel-tiles-gap) * (var(--sage-panel-tiles-columns) - 1))) / var(--sage-panel-tiles-columns)));
+  list-style: none;
+
+  @media (max-width: sage-breakpoint(xs-max)) {
+    --sage-panel-tiles-columns: 1;
   }
 
   @media (min-width: sage-breakpoint(sm-min)) and (max-width: sage-breakpoint(md-max)) {
-    .sage-panel__tiles--#{$i}-up {
-      grid-template-columns: repeat(2, calc((100% - #{sage-spacing() * ($i - 1)}) / 2));
-    }
-
-    .sage-panel__tiles--#{$i}-up-condensed {
-      grid-gap: sage-spacing(xs);
-      grid-template-columns: repeat(2, calc((100% - #{sage-spacing(xs) * ($i - 1)}) / 2));
-    }
+    --sage-panel-tiles-columns: 2;
   }
+}
 
+@for $i from 2 through 4 {
   @media (min-width: sage-breakpoint(lg-min)) {
     .sage-panel__tiles--#{$i}-up {
-      grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing() * ($i - 1)}) / #{$i}));
-    }
-
-    .sage-panel__tiles--#{$i}-up-condensed {
-      grid-gap: sage-spacing(xs);
-      grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing(xs) * ($i - 1)}) / #{$i}));
+      --sage-panel-tiles-columns: #{$i};
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -172,7 +172,19 @@
 
 @for $i from 2 through 4 {
   .sage-panel__tiles--#{$i}-up {
-    grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing() * ($i - 1)}) / #{$i}));
+    grid-template-columns: repeat(100%);
+  }
+
+  @media (min-width: sage-breakpoint(sm-min)) and (max-width: sage-breakpoint(md-max)) {
+    .sage-panel__tiles--#{$i}-up {
+      grid-template-columns: repeat(2, calc((100% - #{sage-spacing() * ($i - 1)}) / 2));
+    }
+  }
+
+  @media (min-width: sage-breakpoint(lg-min)) {
+    .sage-panel__tiles--#{$i}-up {
+      grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing() * ($i - 1)}) / #{$i}));
+    }
   }
 
   .sage-panel__tiles--#{$i}-up-condensed {

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -171,10 +171,6 @@
 }
 
 @for $i from 2 through 4 {
-  .sage-panel__tiles--#{$i}-up {
-    grid-template-columns: repeat(100%);
-  }
-
   @media (min-width: sage-breakpoint(sm-min)) and (max-width: sage-breakpoint(md-max)) {
     .sage-panel__tiles--#{$i}-up {
       grid-template-columns: repeat(2, calc((100% - #{sage-spacing() * ($i - 1)}) / 2));

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -171,9 +171,18 @@
 }
 
 @for $i from 2 through 4 {
+  .sage-panel__tiles--#{$i}-up-condensed {
+    grid-gap: sage-spacing(xs);
+  }
+
   @media (min-width: sage-breakpoint(sm-min)) and (max-width: sage-breakpoint(md-max)) {
     .sage-panel__tiles--#{$i}-up {
       grid-template-columns: repeat(2, calc((100% - #{sage-spacing() * ($i - 1)}) / 2));
+    }
+
+    .sage-panel__tiles--#{$i}-up-condensed {
+      grid-gap: sage-spacing(xs);
+      grid-template-columns: repeat(2, calc((100% - #{sage-spacing(xs) * ($i - 1)}) / 2));
     }
   }
 
@@ -181,11 +190,11 @@
     .sage-panel__tiles--#{$i}-up {
       grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing() * ($i - 1)}) / #{$i}));
     }
-  }
 
-  .sage-panel__tiles--#{$i}-up-condensed {
-    grid-gap: sage-spacing(xs);
-    grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing(xs) * ($i - 1)}) / #{$i}));
+    .sage-panel__tiles--#{$i}-up-condensed {
+      grid-gap: sage-spacing(xs);
+      grid-template-columns: repeat(#{$i}, calc((100% - #{sage-spacing(xs) * ($i - 1)}) / #{$i}));
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Adds responsiveness for PanelTile. All instances of 4-up, 3-up, and 2-up change to 2-up on a tablet, and 1-up on mobile.

## Related
Closes #942 

## Screenshots
|  Desktop  |  Tablet  |  Mobile  |
|--------|--------|--------|
|![image](https://user-images.githubusercontent.com/5650617/142072959-fa93df13-11be-441e-a1f3-f0dee251cfbf.png)|![image](https://user-images.githubusercontent.com/5650617/142072984-7c454156-d5c0-4363-bda2-f62a5fe9e6ad.png)|![image](https://user-images.githubusercontent.com/5650617/142073004-3d271324-b5fd-454d-9447-51f73a268ec1.png)|

## Testing in `sage-lib`
### Rails
- View [Rails component](http://localhost:4000/pages/component/panel)
- Check that the responsive layout works consistently no matter the number of tile columns.

### React
- View [Storybook](http://localhost:4100/?path=/story/sage-panel--panel-tiles)
- Check that the responsive layout works consistently no matter the number of tile columns.

## Testing in `kajabi-products`
1. (**LOW**) This simply adjusts the number of panel tiles on different screens. No updates or retrofitting is necessary.