### PR TITLE
fix(page heading): add alignment to page heading actions

### DIFF
--- a/docs/app/views/examples/components/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/components/page_heading/_preview.html.erb
@@ -55,11 +55,14 @@
   spacer: { bottom: :xl },
 } do %>
     <% content_for :sage_page_heading_actions do %>
-      <%= sage_component SageButton, {
-        style: "secondary",
-        icon: { name: "preview-on", style: "left" },
-        value: "Preview",
-      } %>
+      <%= sage_component SagePopover, {
+        icon: "preview-on",
+        trigger_value: "Preview",
+        trigger_icon_only: false,
+        popover_position: "bottom-right"
+      } do %>
+        👋
+      <% end %>
       <%= sage_component SageButton, {
         style: "primary",
         icon: { name: "add", style: "left" },

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -111,6 +111,7 @@ $-page-heading-image-height-mobile: rem(120px);
 .sage-page-heading__actions {
   display: flex;
   grid-area: actions;
+  align-items: center;
 
   @media (max-width: sage-breakpoint(sm-max)) {
     flex-wrap: wrap;


### PR DESCRIPTION
## Description

Page heading actions are not aligning center.


## Screenshots

_Note: Hover state is active in screenshots to highlight misalignment in the before image and alignment in the after image._
|  Before  |  After  |
|--------|--------|
| ![before](https://user-images.githubusercontent.com/24237393/142696455-564868eb-8838-4a59-8fe3-f46d92be71b9.png) | ![after](https://user-images.githubusercontent.com/24237393/142696485-19a70f43-a4e8-4f42-b5fe-46725f17a2be.png) |



## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/page_heading
2. Verify that the alignment is center for actions


## Testing in `kajabi-products`
1. (**LOW**) This resolves a visual regression for actions. 

## Related
Closes #1043 