### PR TITLE
[SAGE-1042] Switch value output fix

### DIFF
--- a/docs/app/views/application/_home_sections.html.erb
+++ b/docs/app/views/application/_home_sections.html.erb
@@ -146,7 +146,7 @@
               }
             } %>
             <h3 class="t-sage-heading-3">Helpers</h3>
-            <p class="t-sage-body">Helpers that are designed to give the system the flexability it requires for developers to use it at scale.</p>
+            <p class="t-sage-body">Helpers that are designed to give the system the flexibility it requires for developers to use at scale.</p>
             <%= sage_component SageButton, {
               value: "Browse Helpers",
               attributes: {

--- a/docs/app/views/examples/components/description/_preview.html.erb
+++ b/docs/app/views/examples/components/description/_preview.html.erb
@@ -33,7 +33,7 @@
   ],
 } %>
 
-<h2>Mulitple items (inline layout)</h2>
+<h2>Multiple items (inline layout)</h2>
 <%= sage_component SageDescription, {
   items: [
     {

--- a/docs/app/views/examples/components/switch/_preview.html.erb
+++ b/docs/app/views/examples/components/switch/_preview.html.erb
@@ -1,7 +1,7 @@
 <%= sage_component SagePanelRow, { grid_template: "m" } do %>
   <%= sage_component SagePanelStack, {} do %>
     <!-- Checkbox Default -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       id: "sage-switch-1",
       label_text: "Switch (checkbox)",
       name: "sage-switch-1",
@@ -9,7 +9,7 @@
       value: "switch-1-value",
     } %>
     <!-- Checkbox Error -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       has_error: true,
       id: "sage-switch-2",
       label_text: "Switch (checkbox) with error",
@@ -19,7 +19,7 @@
       value: "switch-2-value",
     } %>
     <!-- Checkbox Disabled -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       disabled: true,
       id: "sage-switch-3",
       label_text: "Switch disabled",
@@ -28,7 +28,7 @@
       value: "switch-3-value",
     } %>
     <!-- Checkbox On & Disabled -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       checked: true,
       disabled: true,
       id: "sage-switch-4",
@@ -38,7 +38,7 @@
       value: "switch-4-value",
     } %>
     <!-- Checkbox w/ Message -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       id: "sage-switch-5",
       label_text: "Switch (checkbox) with info",
       message: "Additional Info 1",
@@ -46,7 +46,7 @@
       type: "checkbox",
       value: "switch-5-value",
     } %>
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       has_error: true,
       id: "sage-switch-6",
       label_text: "Switch (checkbox) error with info",
@@ -59,7 +59,7 @@
   <% end %>
   <%= sage_component SagePanelStack, {} do %>
     <!-- Radio Default -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       checked: true,
       id: "sage-switch-7",
       label_text: "Switch (radio)",
@@ -67,7 +67,7 @@
       type: "radio",
       value: "switch-7-value",
     } %>
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       id: "sage-switch-8",
       label_text: "Switch (radio)",
       name: "sage-switch-7",
@@ -76,7 +76,7 @@
     } %>
     <hr/>
     <!-- Radio Error -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       has_error: true,
       id: "sage-switch-9",
       label_text: "Switch (radio) error",
@@ -86,7 +86,7 @@
       value: "switch-9-value",
     } %>
     <!-- Radio Disabled -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       disabled: true,
       id: "sage-switch-10",
       label_text: "Switch (radio) disabled",
@@ -95,7 +95,7 @@
       value: "switch-10-value",
     } %>
     <!-- Radio On & Disabled -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       checked: true,
       disabled: true,
       id: "sage-switch-11",
@@ -105,7 +105,7 @@
       value: "switch-11-value",
     } %>
     <!-- Hidden Label Text -->
-    <%= sage_component SageSwitch, { 
+    <%= sage_component SageSwitch, {
       hide_text: true,
       id: "sage-switch-12",
       label_text: "Switch - visually hidden text",
@@ -117,7 +117,7 @@
 <% end %>
 
 <h3 class="t-sage-heading-6">Right aligned</h3>
-<%= sage_component SageSwitch, { 
+<%= sage_component SageSwitch, {
   id: "sage-switch-20",
   label_text: "Switch (checkbox) with info",
   message: "Additional Info",
@@ -128,7 +128,7 @@
 } %>
 
 <h3 class="t-sage-heading-6">Bordered Switch</h3>
-<%= sage_component SageSwitch, { 
+<%= sage_component SageSwitch, {
   has_border: true,
   id: "sage-switch-21",
   label_text: "Switch (checkbox) with info",
@@ -138,7 +138,7 @@
   toggle_position: "right",
   value: "switch-21-value",
 } %>
-<%= sage_component SageSwitch, { 
+<%= sage_component SageSwitch, {
   has_border: true,
   has_error: true,
   id: "sage-switch-22",
@@ -151,7 +151,7 @@
 } %>
 
 <h3 class="t-sage-heading-6">Bordered Switch (Radio)</h3>
-<%= sage_component SageSwitch, { 
+<%= sage_component SageSwitch, {
   has_border: true,
   id: "sage-switch-23",
   label_text: "Switch (radio) with info",
@@ -161,7 +161,7 @@
   type: "radio",
   value: "switch-23-value",
 } %>
-<%= sage_component SageSwitch, { 
+<%= sage_component SageSwitch, {
   has_border: true,
   id: "sage-switch-24",
   label_text: "Switch (radio) with info",
@@ -174,7 +174,7 @@
 
 <h3 class="t-sage-heading-6">Multiple switches in a list</h3>
 <ul>
-  <%= sage_component SageSwitch, { 
+  <%= sage_component SageSwitch, {
     id: "sage-switch-25",
     in_list: true,
     label_text: "Option A",
@@ -182,7 +182,7 @@
     type: "checkbox",
     value: "switch-25-value",
   } %>
-  <%= sage_component SageSwitch, { 
+  <%= sage_component SageSwitch, {
     id: "sage-switch-26",
     in_list: true,
     label_text: "Option B",
@@ -190,7 +190,7 @@
     type: "checkbox",
     value: "switch-26-value",
   } %>
-  <%= sage_component SageSwitch, { 
+  <%= sage_component SageSwitch, {
     id: "sage-switch-27",
     in_list: true,
     label_text: "Option C",

--- a/docs/app/views/examples/components/switch/_props.html.erb
+++ b/docs/app/views/examples/components/switch/_props.html.erb
@@ -78,13 +78,13 @@
 </tr>
 <tr>
   <td><%= md('`type`') %></td>
-  <td><%= md('Sets the \"type\" attribute of the component.') %></td>
+  <td><%= md('Sets the "type" attribute of the component.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`value`') %></td>
-  <td><%= md('Assigns the value the switch will submit in forms. If not assigned, this will default to the `id`.') %></td>
+  <td><%= md('Assigns a string to submit in forms. **If not assigned, this will default to the `id`**. Take note that <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value" target="_blank" rel="nofollow">"unchecked" values will *not* be submitted in forms</a>.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/switch/_props.html.erb
+++ b/docs/app/views/examples/components/switch/_props.html.erb
@@ -1,42 +1,42 @@
 <tr>
   <td><%= md('`checked`') %></td>
-  <td><%= md('Sets the state to \"checked\" by default.') %></td>
+  <td><%= md('Set the switch state to `checked`.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`disabled`') %></td>
-  <td><%= md('Sets the state to \"disabled\" by default.') %></td>
+  <td><%= md('Set the switch as `disabled`, fully preventing all user interaction. Disabling the control in this way will also prevent its `value` from being included in form data.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`has_border`') %></td>
-  <td><%= md('When set, the focus styles affect the parent container, not the form element.') %></td>
+  <td><%= md('Applies a styled border to the parent container.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`has_error`') %></td>
-  <td><%= md('This will display error styles on the component.') %></td>
+  <td><%= md('Displays error styles on the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`hide_text`') %></td>
-  <td><%= md('This will visually hide the text but will remain accessible for assistive technologies.') %></td>
+  <td><%= md('Visually hide the text, remaining accessible for assistive technologies.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`id`') %></td>
-  <td><%= md('ID.') %></td>
+  <td><%= md('Sets the component `id`.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`in_list`') %></td>
-  <td><%= md('Whether or not to render the container tag as an `li` for when the switch is used in a list.') %></td>
+  <td><%= md('Render the container tag as a list-item (`li`) when the switch is used in a list.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
@@ -54,14 +54,14 @@
 </tr>
 <tr>
   <td><%= md('`name`') %></td>
-  <td><%= md('Sets the \"label\" attribute for the component. This is usedful for grouping form elements') %></td>
+  <td><%= md('Sets the "label" attribute for the component. Useful for grouping form elements.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`required`') %></td>
-  <td><%= md('Adding this attribute allows basic HTML form validation on this field.') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md('Applies basic HTML form validation on this field, requiring user interaction.') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -84,7 +84,7 @@
 </tr>
 <tr>
   <td><%= md('`value`') %></td>
-  <td><%= md('Sets the value of the form component.') %></td>
+  <td><%= md('Assigns the value the switch will submit in forms. If not assigned, this will default to the `id`.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/switch/_rules_do.html.erb
+++ b/docs/app/views/examples/components/switch/_rules_do.html.erb
@@ -1,4 +1,4 @@
 <%= md("
-- IMPORTANT: Be sure that the label element **follows** the input in the HTML
-- Remember to check that the ID of the input and the label's `for` attribute match
+- Remember to check that the `id` of the input and the label's `for` attribute match
+- Radio button switches <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#data_representation_of_a_radio_group' target='_blank' rel='noopener'>each must have a unique `value`</a> to accurately represent the selection
 ", use_sage_type: true) %>

--- a/docs/lib/sage_rails/app/sage_components/sage_switch.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_switch.rb
@@ -14,6 +14,6 @@ class SageSwitch < SageComponent
     standalone: [:optional, TrueClass],
     toggle_position: [:optional, Set.new(["right"])],
     type: String,
-    value: String,
+    value: [:optional, String],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_switch.html.erb
@@ -1,15 +1,15 @@
 <% if component.standalone %>
-  <input 
-    type="<%= component.type %>" 
-    id="<%= component.id %>" 
+  <input
+    type="<%= component.type %>"
+    id="<%= component.id %>"
     class="
       sage-switch
       sage-switch--standalone
       <%= component.has_error ? "sage-switch--error" : "" %>
       <%= component.generated_css_classes %>
-    " 
-    name="<%= component.name %>" 
-    value="<%= component.id %>"
+    "
+    name="<%= component.name %>"
+    value="<%= component.value.present?  ? component.value : component.id %>"
     <%= "checked" if component.checked %>
     <%= "disabled" if component.disabled %>
     <%= "required" if component.required %>
@@ -28,12 +28,12 @@ tag = component.in_list ? 'li' : 'div'
     "
     <%= component.generated_html_attributes.html_safe %>
   >
-    <input 
-      type="<%= component.type %>" 
-      id="<%= component.id %>" 
-      class="sage-switch__input" 
-      name="<%= component.name %>" 
-      value="<%= component.id %>"
+    <input
+      type="<%= component.type %>"
+      id="<%= component.id %>"
+      class="sage-switch__input"
+      name="<%= component.name %>"
+      value="<%= component.value.present?  ? component.value : component.id %>"
       <%= "checked" if component.checked %>
       <%= "disabled" if component.disabled %>
       <%= "required" if component.required %>


### PR DESCRIPTION
## Description
Corrects a bug in the Rails version of Sage Switch where `id` strings were output in place of `value` (see #1042 for full details).

- `value` is now optional for the Rails component. In current implementations, `value` was set as a duplicate of `id` in the majority of cases, suggesting that it was only being provided to bypass the component requirement
- When omitted, `value` falls back to `id` as a way to duplicate existing behavior 

Also addresses two unrelated typos on the documentation site.

## Screenshots
No visual changes


## Testing in `sage-lib`
1. View the Sage Switch documentation
2. Click the "Code" tab, and expand the "Sage Component" markup
3. Verify that the `id` and `value` of one of the examples have unique strings
4. Scroll down and expand the "Generated HTML Code" markup, or switch back to the "Preview" tab
5. Locate your example from step 3, and confirm that the `value` and `id` output as expected


## Testing in `kajabi-products`
1. (**MED**) Updates Sage Switch to output optional `value` property with fallback to `id`. Verify that instances save correctly and state is maintained on refresh. This includes uses of the shared `kajabi-products` partial `app/views/admin/shared/_sage_switch.html.erb`
   - [ ] Affiliates -> Affiliate commissions
   - [ ] Offers -> Offer Additional Settings -> (multiple items) Cart Abandonment, Affiliate Commissions (requires `comm_offer_detail`)
   - [ ] Landing pages -> Page Meta Fields
   - [ ] Website pages -> Form Fields



## Related
- Closes #1042 
