### PR TITLE
fix(panel heading): fix spacing for title within panel heading

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -88,8 +88,11 @@
 
 .sage-panel__title {
   @extend %t-sage-heading-5;
-  margin-bottom: sage-spacing(xs);
   color: sage-color(charcoal, 500);
+
+  & + .sage-panel__subtext {
+    margin-top: sage-spacing(xs);
+  }
 }
 
 .sage-panel__subtext {


### PR DESCRIPTION
## Description

Spacing on `sage-panel__title` without `sage-panel__subtext` is causing too much spacing for heading.

## Fix

Move spacing to be contextual when subtext is present.

## Screenshots

|  Before  |  After  |
|--------|--------|
| ![before](https://user-images.githubusercontent.com/24237393/142911425-39d8c39c-360e-475c-98e0-17b7ff096d60.png) | ![after](https://user-images.githubusercontent.com/24237393/142911435-2c4f70b7-49f1-4f56-b401-b19c6acd8416.png) |


## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/panel
2. Verify spacing is correct on title and subtext


## Testing in `kajabi-products`

1. (**MEDIUM**) Spacing in SagePanelHeader between title and subtext needs to be correct
   - [ ] Upsell offers panel - v3 Upsell offer 


## Related
Closes #1047 
