### PR TITLE
[SAGE-869] Toast events and `test_id` additions

### DIFF
--- a/docs/app/views/examples/components/toast/_preview.html.erb
+++ b/docs/app/views/examples/components/toast/_preview.html.erb
@@ -48,7 +48,7 @@
     value: "Example",
     style: "primary",
     attributes: {
-      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'I will not dismiss via timer', timer: false}))",
+      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'I will not dismiss via timer', timer: false, testId: 'toast_example'}))",
     },
   } %>
 
@@ -56,7 +56,7 @@
     value: "Uploading",
     style: "secondary",
     attributes: {
-      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'Uploading image...', type: 'loading', timer: false}))",
+      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'Uploading image...', type: 'loading', timer: false, testId: 'uploading_toast'}))",
     },
   } %>
 

--- a/docs/app/views/examples/components/toast/_preview.html.erb
+++ b/docs/app/views/examples/components/toast/_preview.html.erb
@@ -1,7 +1,6 @@
 <h3>Triggering with <code>Sage.toast.trigger()</code></h3>
 <p>
-  Toasts do not have a SageRails component template. They are Javascript-only, <br/>templating is defined in
-  <a href="https://github.com/Kajabi/sage-lib/blob/main/packages/sage-system/lib/toast/toast.template.js" target="_blank"><code>sage-system/lib/toast/toast.template.js</code></a>.
+  Toasts do not have a SageRails component template. They are JavaScript-only, templating is defined in <a href="https://github.com/Kajabi/sage-lib/blob/main/packages/sage-system/lib/toast/toast.template.js" target="_blank" rel="noopener"><code>sage-system/lib/toast/toast.template.js</code></a>.
 </p>
 
 <%= sage_component SageButtonGroup, { gap: :sm } do %>
@@ -38,7 +37,7 @@
   } %>
 <% end %>
 
-<hr>
+<%= sage_component SageCardDivider, {} %>
 
 <h3>Non-dismissing Toast patterns</h3>
 <p>Non-dismissable toasts are used in our app to display 'loading' messages or to provide a CTA upon a interaction.</p>
@@ -77,29 +76,9 @@
   } %>
 <% end %>
 
-<script>
-  const showDismissInstructions = (toastId) => {
-    document.getElementById('dismiss-instructions').innerHTML = `
-      <strong>Toast Id:</strong> <code>${toastId}</code>
-      <br/>
-      <br/>
-      <h4>Dismiss toast with:</h4>
-      <br/>
-      <div class='prettyprint'>
-        <code>Sage.toast.dismiss('${toastId}')</code>
-      </div>
-      <br/>
-      <h4>Dismiss all toasts with:</h4>
-      <br/>
-      <div class='prettyprint'>
-        <code>Sage.toast.reset()</code>
-      </div>
-    `
-  };
-</script>
 <div id="dismiss-instructions"></div>
 
-<hr>
+<%= sage_component SageCardDivider, {} %>
 
 <pre class="prettyprint">
   <code>
@@ -145,7 +124,8 @@
   </code>
 </pre>
 
-<hr>
+<%= sage_component SageCardDivider, {} %>
+
 <%= sage_component SagePanelStack, {} do %>
   <h3>Events</h3>
 
@@ -174,6 +154,24 @@
 <% end %>
 
 <script>
+  const showDismissInstructions = (toastId) => {
+    document.getElementById('dismiss-instructions').innerHTML = `
+      <strong>Toast Id:</strong> <code>${toastId}</code>
+      <br/>
+      <br/>
+      <h4>Dismiss toast with:</h4>
+      <br/>
+      <div class='prettyprint'>
+        <code>Sage.toast.dismiss('${toastId}')</code>
+      </div>
+      <br/>
+      <h4>Dismiss all toasts with:</h4>
+      <br/>
+      <div class='prettyprint'>
+        <code>Sage.toast.reset()</code>
+      </div>
+    `
+  };
   (function() {
     document.addEventListener("sage.toast.open", function(e) {
       console.info("sage.toast.open event", e);

--- a/docs/app/views/examples/components/toast/_preview.html.erb
+++ b/docs/app/views/examples/components/toast/_preview.html.erb
@@ -38,7 +38,7 @@
   } %>
 <% end %>
 
-<hr/>
+<hr>
 
 <h3>Non-dismissing Toast patterns</h3>
 <p>Non-dismissable toasts are used in our app to display 'loading' messages or to provide a CTA upon a interaction.</p>
@@ -77,7 +77,7 @@
   } %>
 <% end %>
 
-<script type="text/javascript">
+<script>
   const showDismissInstructions = (toastId) => {
     document.getElementById('dismiss-instructions').innerHTML = `
       <strong>Toast Id:</strong> <code>${toastId}</code>
@@ -99,7 +99,7 @@
 </script>
 <div id="dismiss-instructions"></div>
 
-<hr />
+<hr>
 
 <pre class="prettyprint">
   <code>
@@ -143,3 +143,49 @@
     Sage.toast.reset();
   </code>
 </pre>
+
+<hr>
+<%= sage_component SagePanelStack, {} do %>
+  <h3>Events</h3>
+
+  <%= sage_component SageTable, {
+    striped: true,
+    responsive: true,
+    headers: [
+      "Event name",
+      "Event type",
+      "Description"
+    ],
+    rows: [
+      {
+        col_1: md("`sage.toast.open`"),
+        col_2: "global",
+        col_3: md("Sent when a toast has been opened")
+      },
+      {
+        col_1: md("`sage.toast.close`"),
+        col_2: "global",
+        col_3: md("Sent when a toast has been closed")
+      },
+      {
+        col_1: md("`sage.toast.dismiss`"),
+        col_2: "global",
+        col_3: "Sent when a toast has been dismissed by user interaction, such as clicking the close button"
+      },
+    ]
+  } %>
+<% end %>
+
+<script>
+  (function() {
+    document.addEventListener("sage.toast.open", function(e) {
+      console.info("sage.toast.open event", e);
+    });
+    document.addEventListener("sage.toast.close", function(e) {
+      console.info("sage.toast.close event fired", e);
+    });
+    document.addEventListener("sage.toast.dismiss", function(e) {
+      console.info("sage.toast.dismiss event fired", e);
+    });
+  })();
+</script>

--- a/docs/app/views/examples/components/toast/_preview.html.erb
+++ b/docs/app/views/examples/components/toast/_preview.html.erb
@@ -108,7 +108,7 @@
     // Triggers a toast with a toast options object and
     // returns the unique id of the toast.
     //
-    // @param {{ message, icon, type, timer, link = {text, href} }} - Toast options
+    // @param {{ message, icon, testId, type, timer, link = {text, href} }} - Toast options
     // @returns {unique id}
     //
     // Example:
@@ -118,6 +118,7 @@
         icon: 'check',
         type: 'danger',
         link: { text: 'next step', href 'example.com' },
+        testId: 'toast_test_example',
       });
 
 
@@ -153,24 +154,20 @@
     responsive: true,
     headers: [
       "Event name",
-      "Event type",
       "Description"
     ],
     rows: [
       {
         col_1: md("`sage.toast.open`"),
-        col_2: "global",
-        col_3: md("Sent when a toast has been opened")
+        col_2: md("Sent when a Toast has been opened")
       },
       {
         col_1: md("`sage.toast.close`"),
-        col_2: "global",
-        col_3: md("Sent when a toast has been closed")
+        col_2: md("Sent when a Toast has been closed")
       },
       {
         col_1: md("`sage.toast.dismiss`"),
-        col_2: "global",
-        col_3: "Sent when a toast has been dismissed by user interaction, such as clicking the close button"
+        col_2: md("Sent when a Toast has been dismissed by user interaction, such as clicking the close button. The `sage.toast.close` event will follow afterwards.")
       },
     ]
   } %>
@@ -182,10 +179,10 @@
       console.info("sage.toast.open event", e);
     });
     document.addEventListener("sage.toast.close", function(e) {
-      console.info("sage.toast.close event fired", e);
+      console.info("sage.toast.close event", e);
     });
     document.addEventListener("sage.toast.dismiss", function(e) {
-      console.info("sage.toast.dismiss event fired", e);
+      console.info("sage.toast.dismiss event", e);
     });
   })();
 </script>

--- a/docs/app/views/examples/components/toast/_preview.html.erb
+++ b/docs/app/views/examples/components/toast/_preview.html.erb
@@ -172,15 +172,13 @@
       </div>
     `
   };
-  (function() {
-    document.addEventListener("sage.toast.open", function(e) {
-      console.info("sage.toast.open event", e);
-    });
-    document.addEventListener("sage.toast.close", function(e) {
-      console.info("sage.toast.close event", e);
-    });
-    document.addEventListener("sage.toast.dismiss", function(e) {
-      console.info("sage.toast.dismiss event", e);
-    });
-  })();
+  document.addEventListener("sage.toast.open", function(e) {
+    console.info("sage.toast.open event", e);
+  });
+  document.addEventListener("sage.toast.close", function(e) {
+    console.info("sage.toast.close event", e);
+  });
+  document.addEventListener("sage.toast.dismiss", function(e) {
+    console.info("sage.toast.dismiss event", e);
+  });
 </script>

--- a/docs/app/views/examples/components/toast/_props.html.erb
+++ b/docs/app/views/examples/components/toast/_props.html.erb
@@ -5,6 +5,18 @@
   <td><%= md('`check`') %></td>
 </tr>
 <tr>
+  <td><%= md('`link`') %></td>
+  <td><%= md('Add a CTA button following `text` in the toast; expects `text` and `href` keys.') %></td>
+  <td><%= md('{ text: String, href: String }') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`testId`') %></td>
+  <td><%= md('Unique identifier for testing, output using `data-kjb-element') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`text`') %></td>
   <td><%= md('The message to be displayed in the toast.') %></td>
   <td><%= md('String') %></td>
@@ -21,10 +33,4 @@
   <td><%= md('Assign a type/style, options include: `notice` `danger`.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`notice`') %></td>
-</tr>
-<tr>
-  <td><%= md('`link`') %></td>
-  <td><%= md('Add a CTA button following `text` in the toast; expects `text` and `href` keys.') %></td>
-  <td><%= md('{ text: String, href: String }') %></td>
-  <td><%= md('`nil`') %></td>
 </tr>

--- a/packages/sage-system/lib/toast/toast.config.js
+++ b/packages/sage-system/lib/toast/toast.config.js
@@ -2,6 +2,9 @@ export const ID_TOAST_CONTAINER = 'SageToastContainer';
 export const DATA_ATTR = 'data-js-toast';
 export const DATA_ATTR_CLOSE_BUTTON = 'data-js-toast-close';
 export const CLASS_DISMISSED_STATE = 'sage-toast--dismissed';
+export const EVENT_OPEN = "sage.toast.open";
+export const EVENT_CLOSE = "sage.toast.close";
+export const EVENT_DISMISS = "sage.toast.dismiss";
 
 export const DEFAULT_CONFIG = {
   icon: 'check',

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -36,7 +36,7 @@ Sage.toast = (function () {
     if (!elToast) return false;
 
     elToast.classList.add(CLASS_DISMISSED_STATE);
-    dispatchEvent(EVENT_CLOSE);
+    _dispatchEvent(EVENT_CLOSE);
     _unbindEvents(elToast);
     return true;
   }
@@ -45,7 +45,7 @@ Sage.toast = (function () {
     const elContainer = document.getElementById(ID_TOAST_CONTAINER);
     if (!elContainer) return false;
 
-    dispatchEvent(EVENT_CLOSE);
+    _dispatchEvent(EVENT_CLOSE);
     _unbindEvents(elContainer);
     elContainer.remove();
     return true;
@@ -66,7 +66,7 @@ Sage.toast = (function () {
 
     const toastFragment = stringToHtmlFragment(content);
     _bindEvents(toastFragment);
-    dispatchEvent(EVENT_OPEN);
+    _dispatchEvent(EVENT_OPEN);
     scope.appendChild(toastFragment);
   }
 
@@ -84,10 +84,10 @@ Sage.toast = (function () {
 
   function _handleCloseButtonClick(evt) {
     dismiss(evt.target.parentElement.id);
-    dispatchEvent(EVENT_DISMISS);
+    _dispatchEvent(EVENT_DISMISS);
   }
 
-  function dispatchEvent(evt) {
+  function _dispatchEvent(evt) {
     document.dispatchEvent(new Event(evt));
   }
 

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -88,9 +88,7 @@ Sage.toast = (function () {
   }
 
   function dispatchEvent(evt) {
-    var event = new Event(evt);
-    console.info(event);
-    document.dispatchEvent(event);
+    document.dispatchEvent(new Event(evt));
   }
 
   return {

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -8,6 +8,9 @@ import {
   DEFAULT_CONFIG,
   CLASS_DISMISSED_STATE,
   DATA_ATTR_CLOSE_BUTTON,
+  EVENT_OPEN,
+  EVENT_CLOSE,
+  EVENT_DISMISS,
 } from './toast.config.js';
 
 import {
@@ -33,6 +36,7 @@ Sage.toast = (function () {
     if (!elToast) return false;
 
     elToast.classList.add(CLASS_DISMISSED_STATE);
+    dispatchEvent(EVENT_CLOSE);
     _unbindEvents(elToast);
     return true;
   }
@@ -61,6 +65,7 @@ Sage.toast = (function () {
 
     const toastFragment = stringToHtmlFragment(content);
     _bindEvents(toastFragment);
+    dispatchEvent(EVENT_OPEN);
     scope.appendChild(toastFragment);
   }
 
@@ -78,6 +83,13 @@ Sage.toast = (function () {
 
   function _handleCloseButtonClick(evt) {
     dismiss(evt.target.parentElement.id);
+    dispatchEvent(EVENT_DISMISS);
+  }
+
+  function dispatchEvent(evt) {
+    var event = new Event(evt);
+    console.info(event);
+    document.dispatchEvent(event);
   }
 
   return {

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -45,6 +45,7 @@ Sage.toast = (function () {
     const elContainer = document.getElementById(ID_TOAST_CONTAINER);
     if (!elContainer) return false;
 
+    dispatchEvent(EVENT_CLOSE);
     _unbindEvents(elContainer);
     elContainer.remove();
     return true;

--- a/packages/sage-system/lib/toast/toast.template.js
+++ b/packages/sage-system/lib/toast/toast.template.js
@@ -8,10 +8,11 @@ import {
   DATA_ATTR_CLOSE_BUTTON,
 } from './toast.config.js';
 
-export const toastTemplate = ({id, type, icon, text, link}) => (`
+export const toastTemplate = ({id, type, icon, text, link, testId = null}) => (`
   <dialog
     class="sage-toast sage-toast--style-${type}"
     id="${id}"
+    ${(testId !== null) ? `data-kjb-element="${testId}"` : ""}
     ${DATA_ATTR}
   >
     ${type === "loading" ? loadingTemplate() : iconTemplate(icon)}


### PR DESCRIPTION
## Description
Various features to help out specs when verifying the appearance of Sage Toasts:

- ability to apply `test_id` (`data-kjb-element`) on individual toasts
- emit events tied to toast state

|  State   |  Event  |
|--------|--------|
| Open|`sage.toast.open`|
|Closed|`sage.toast.close`|
|Dismiss (user interaction)|`sage.toast.dismiss`|


## Screenshots
No visual changes.


## Testing in `sage-lib`
1. Navigate to the [Sage Toast preview](http://localhost:4000/pages/component/toast)
2. Open your browser devtools
3. Click the "Example" button in the "Non-dismissing Toast patterns" and inspect the Toast that appears
4. Confirm that the expected `test_id` (`data-kjb-element`) is rendered on the Toast
5. Open the devtools console, or press `esc` to open the Console drawer
6. Open and close any of the example Toasts on the preview page, and verify that the events appear in the Console as expected


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Added Sage Toast lifecycle events and `test_id` ability. No impact to existing functionality expected; sanity check to ensure backwards compatibility.


## Related
- Closes #869 