### PR TITLE
[MAN-2229] PanelHeader Title: Allow for custom classes

### DIFF
--- a/packages/sage-react/lib/Panel/Panel.story.jsx
+++ b/packages/sage-react/lib/Panel/Panel.story.jsx
@@ -31,6 +31,7 @@ export const Default = (args) => (
     <Panel {...args}>
       <Panel.Header
         title="Panel header"
+        titleClassName="custom-panel-header-class"
         subtext={(
           <p>All kinds of awesome, wonderful content can go in here! <a href="https://example.com">Learn more</a></p>
         )}

--- a/packages/sage-react/lib/Panel/PanelHeader.jsx
+++ b/packages/sage-react/lib/Panel/PanelHeader.jsx
@@ -10,6 +10,7 @@ export const PanelHeader = ({
   subtext,
   title,
   titleTag,
+  titleClassName,
   ...rest
 }) => {
   let hasSubtextChild = false;
@@ -33,7 +34,7 @@ export const PanelHeader = ({
     <header className={classNames} {...rest}>
       <div className="sage-panel__header-inner">
         {title && (
-          <PanelTitle tag={titleTag}>{title}</PanelTitle>
+          <PanelTitle className={titleClassName} tag={titleTag}>{title}</PanelTitle>
         )}
         {subtext && (
           <PanelSubtext>{subtext}</PanelSubtext>
@@ -46,10 +47,11 @@ export const PanelHeader = ({
 
 PanelHeader.defaultProps = {
   children: null,
-  className: '',
+  className: null,
   subtext: null,
   title: null,
   titleTag: 'h2',
+  titleClassName: null,
 };
 
 PanelHeader.propTypes = {
@@ -58,4 +60,5 @@ PanelHeader.propTypes = {
   subtext: PropTypes.node,
   title: PropTypes.string,
   titleTag: PropTypes.string,
+  titleClassName: PropTypes.string,
 };

--- a/packages/sage-react/lib/Panel/PanelTitle.jsx
+++ b/packages/sage-react/lib/Panel/PanelTitle.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
-export const PanelTitle = ({ children, tag, ...rest }) => {
+export const PanelTitle = ({ children, className, tag, ...rest }) => {
   const TagName = tag || 'h2';
 
+  const classNames = classnames(
+    'sage-panel__title',
+    className,
+  );
+
   return (
-    <TagName className="sage-panel__title" {...rest}>
+    <TagName className={classNames} {...rest}>
       {children}
     </TagName>
   );
@@ -13,10 +19,12 @@ export const PanelTitle = ({ children, tag, ...rest }) => {
 
 PanelTitle.defaultProps = {
   children: null,
+  className: null,
   tag: null,
 };
 
 PanelTitle.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   tag: PropTypes.string,
 };


### PR DESCRIPTION
## Description

Allow for React `Panel.Header` `title` prop to take in custom classes.


## Screenshots

### Before Upgrade your account Modal title

![Screen Shot 2021-11-22 at 1 56 48 PM](https://user-images.githubusercontent.com/24237393/143057511-67c09053-d832-4f4c-8199-757565a5968c.png)


|  Before Allowing Custom Classes  |  After Allowing Custom Classes  |
|--------|--------|
| ![Screen Shot 2021-11-23 at 9 45 36 AM](https://user-images.githubusercontent.com/24237393/143056376-7a6f4e9f-12f2-4f58-885c-49b97c0fb54b.png) | ![after](https://user-images.githubusercontent.com/24237393/143056409-1013bfd4-7a06-469e-b040-d0882017c73b.png) |

## Testing in `sage-lib`
1. Navigate to http://localhost:4100/?path=/docs/sage-panel--default
2. Inspect "Panel Header" title and see the custom class, `custom-panel-header-class`, is added via the Story

## Testing in `kajabi-products`

Pull this PR and use the bridge to test in `kajabi-products` 

1. (**MEDIUM**) - Allow custom title class within Panel.Header for React components
   - [ ] People / All People / Filters Button - observe "Filtering by:" title is the correct size
   - [ ] With a basic or growth plan that is at or over its contact limit, try to upload through the CSV flow and the modal should appear aligned and sized correctly for "Upgrade your account"


## Related
* Related to [MAN-2229](https://kajabi.atlassian.net/browse/MAN-2229)
* Related to kajabi/kajabi-products#21533