### PR TITLE
fix(workflow): update-release workflow token switch

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Setup Auth token to push to github packages
       - name: Set NPM Config
-        run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.ACCESS_TOKEN }}'
+        run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.UPDATE_RELEASE_WORKFLOW_TOKEN }}'
 
       - name: Unsafe Perm set
         run: npm config set unsafe-perm true

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Update Release based on Tag"
         uses: "ncipollo/release-action@v1"
         with:
-          token: "${{ secrets.UPDATE_RELEASE_WORKFLOW_TOKEN }}"
+          token: "${{ secrets.ACCESS_TOKEN }}"
           tag: "v${{ steps.extract_version.outputs.version }}"
           body: "See [changelog](https://github.com/Kajabi/sage-lib/blob/main/docs/CHANGELOG.md) for more information."
 


### PR DESCRIPTION
## Description

`update-release` workflow is not triggering. Trying to swap tokens around from release-deploy.yml to update-release.yml so the first workflow is not triggering off the default key. 

_Note: if this is successful, I will get Smitty to update the token name in the repo._

## Testing in `sage-lib`

1. Workflow view in https://github.com/Kajabi/sage-lib/actions

## Testing in `kajabi-products`
1. (**N/A**) Workflow changes for `sage-lib` only. No `kajabi-products` testing needed.