### PR TITLE
Next version bump ~v4.28.7

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Setup Auth token to push to github packages
       - name: Set NPM Config
-        run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.ACCESS_TOKEN }}'
+        run: npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.UPDATE_RELEASE_WORKFLOW_TOKEN }}'
 
       - name: Unsafe Perm set
         run: npm config set unsafe-perm true

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Update Release based on Tag"
         uses: "ncipollo/release-action@v1"
         with:
-          token: "${{ secrets.UPDATE_RELEASE_WORKFLOW_TOKEN }}"
+          token: "${{ secrets.ACCESS_TOKEN }}"
           tag: "v${{ steps.extract_version.outputs.version }}"
           body: "See [changelog](https://github.com/Kajabi/sage-lib/blob/main/docs/CHANGELOG.md) for more information."
 

--- a/docs/app/helpers/mocks/new_plans_upgrade_helper.rb
+++ b/docs/app/helpers/mocks/new_plans_upgrade_helper.rb
@@ -1,0 +1,225 @@
+module Mocks::NewPlansUpgradeHelper
+
+  def feature_usage_display_demo_data
+    {
+      current_value: 100,
+      upgrade_action: {
+        attributes: { href: "#" },
+        value: "Choose a new plan",
+      },
+      data: [
+        { label: "Broadcasts", value: 200 },
+        { label: "Sequences", value: 600 },
+        { label: "Events", value: 200 },
+      ],
+      feature_name: "[feature name]",
+      limit_value: 200,
+    }
+  end
+
+  def feature_usage_display_button_configs(opened)
+    {
+      icon: {
+        name: opened ? "caret-up" : "caret-down",
+        style: "only"
+      },
+      style: "secondary",
+      subtle: true,
+      value: opened ? "Collapse" : "Expand"
+    }
+  end
+
+  def feature_usage_display_current_display(props)
+    "#{props[:current_value].to_s} #{props[:feature_name]}"
+  end
+
+  def feature_usage_display_limit_display(props)
+    "#{props[:limit_value].to_s} #{props[:feature_name]}"
+  end
+
+  def feature_usage_display_progress_configs(props)
+    {
+      percent: (props[:current_value].to_f / props[:limit_value] * 100).to_i,
+      label: "#{props[:current_value]} out of #{props[:limit_value]} #{props[:feature_name]}",
+    }
+  end
+
+  def plan_ugrade_panel_demo_plan
+    {
+      title: "Basic plan",
+      total_cost: 1428,
+      billing: [
+        {
+          label: "today",
+          items: []
+        },
+        {
+          label: "Oct 4, 2022",
+          items: [
+            {
+              label: "Basic plan",
+              amount: 1428,
+            },
+          ]
+        }
+      ]
+    }
+  end
+
+  def plan_tiers_demo_plans
+    [
+      {
+        name: "Beginner",
+        price: 69,
+        duration: "mo",
+        billing: "Billed annually",
+        description: "Try out the core features",
+        current: true,
+        features: [
+          "1 Products",
+          "250 Members",
+          "1k marketing emails",
+          "10K Contacts",
+          "1 Pipeline",
+          "50 landing pages",
+          "1 Admin user",
+          "1 Site",
+          "Kajabi branding",
+          "0% Transaction fee",
+          "Chat bot support",
+          "Live webinars",
+          "Standard analytics",
+        ]
+      },
+      {
+        name: "Basic",
+        price: 149,
+        duration: "mo",
+        billing: "Billed annually",
+        description: "All the basics for starting your new business",
+        current: false,
+        features: [
+          "3 Products",
+          "1k Members",
+          "Unlimited marketing emails",
+          "10K Contacts",
+          "3 Pipelines",
+          "Unlimited landing pages",
+          "1 Admin user",
+          "1 Site",
+          "Kajabi branding",
+          "0% Transaction fee",
+          "Email support",
+          "9-5 PST chat support",
+          "Activation call",
+          "Live webinars",
+          "Standard analytics",
+          "Standard integrations",
+        ]
+      },
+      {
+        name: "Growth",
+        price: 199,
+        duration: "mo",
+        billing: "Billed annually",
+        description: "Everything you need for your growing business",
+        current: false,
+        features: [
+          "15 Products",
+          "10k Members",
+          "Unlimited marketing emails",
+          "25K Contacts",
+          "100 Pipelines",
+          "Unlimited landing pages",
+          "10 Admin user",
+          "1 Site",
+          "Custom branding",
+          "0% Transaction fee",
+          "Email support",
+          "24/7 chat support",
+          "Activation call",
+          "Live webinars",
+          "Affiliate program",
+          "Standard analytics",
+          "Standard integrations",
+        ]
+      },
+      {
+        name: "Pro",
+        price: 399,
+        duration: "mo",
+        billing: "Billed annually",
+        description: "Advanced features for scaling your business",
+        current: false,
+        features: [
+          "100 Products",
+          "20k Members",
+          "Unlimited marketing emails",
+          "100K Contacts",
+          "100 Pipelines",
+          "Unlimited landing pages",
+          "25 Admin user",
+          "3 Sites",
+          "Custom branding",
+          "0% Transaction fee",
+          "Email support",
+          "24/7 chat support",
+          "Activation call",
+          "Live webinars",
+          "Affiliate program",
+          "Standard analytics",
+          "Standard integrations",
+        ]
+      }
+    ]
+  end
+
+  def plan_usage_alert_configs(feature)
+    actions = {
+      primary: {
+        value: "Upgrade plan",
+        attributes: {
+          href: "#",
+        },
+      },
+      secondary: {
+        value: "Check usage",
+        attributes: {
+          href: "#",
+        },
+      }
+    }
+
+    configs = {
+      dismissable: true,
+      primary_action: actions[:primary],
+      secondary_actions: [actions[:secondary]],
+    }
+
+    case feature[:percentage]
+    when 0..99
+      configs = configs.merge({
+        color: "warning",
+        desc: "Upgrade your plan to access more #{feature[:name]}.",
+        icon_name: "sage-icon-warning",
+        title: "You’ve used #{feature[:percentage]}% of available #{feature[:name]}",
+      })
+    when 100
+      configs = configs.merge({
+        color: "warning",
+        desc: "Upgrade your plan to access more #{feature[:name]}.",
+        icon_name: "sage-icon-flag",
+        title: "You’ve reached your #{feature[:name]} limit",
+      })
+    else
+      configs = configs.merge({
+        color: "danger",
+        desc: "To avoid any issues with your experience, upgrade your plan now.",
+        icon_name: "sage-icon-danger",
+        title: "You’ve exceeded your #{feature[:name]} limit",
+      })
+    end
+
+    configs
+  end
+end

--- a/docs/app/helpers/mocks_helper.rb
+++ b/docs/app/helpers/mocks_helper.rb
@@ -56,6 +56,14 @@ module MocksHelper
         no_rails_js: true,
         status: DONE,
         team: "Commerce",
+      },
+      {
+        alias: "new_plans_upgrade",
+        milestone_id: 23,
+        name: "New Plans and Upgrade",
+        no_rails_js: true,
+        status: DOING,
+        team: "Growth",
       }
     ]
   end

--- a/docs/app/views/examples/components/toast/_preview.html.erb
+++ b/docs/app/views/examples/components/toast/_preview.html.erb
@@ -1,7 +1,6 @@
 <h3>Triggering with <code>Sage.toast.trigger()</code></h3>
 <p>
-  Toasts do not have a SageRails component template. They are Javascript-only, <br/>templating is defined in
-  <a href="https://github.com/Kajabi/sage-lib/blob/main/packages/sage-system/lib/toast/toast.template.js" target="_blank"><code>sage-system/lib/toast/toast.template.js</code></a>.
+  Toasts do not have a SageRails component template. They are JavaScript-only, templating is defined in <a href="https://github.com/Kajabi/sage-lib/blob/main/packages/sage-system/lib/toast/toast.template.js" target="_blank" rel="noopener"><code>sage-system/lib/toast/toast.template.js</code></a>.
 </p>
 
 <%= sage_component SageButtonGroup, { gap: :sm } do %>
@@ -38,7 +37,7 @@
   } %>
 <% end %>
 
-<hr/>
+<%= sage_component SageCardDivider, {} %>
 
 <h3>Non-dismissing Toast patterns</h3>
 <p>Non-dismissable toasts are used in our app to display 'loading' messages or to provide a CTA upon a interaction.</p>
@@ -48,7 +47,7 @@
     value: "Example",
     style: "primary",
     attributes: {
-      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'I will not dismiss via timer', timer: false}))",
+      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'I will not dismiss via timer', timer: false, testId: 'toast_example'}))",
     },
   } %>
 
@@ -56,7 +55,7 @@
     value: "Uploading",
     style: "secondary",
     attributes: {
-      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'Uploading image...', type: 'loading', timer: false}))",
+      "onClick": "showDismissInstructions(Sage.toast.trigger({text: 'Uploading image...', type: 'loading', timer: false, testId: 'uploading_toast'}))",
     },
   } %>
 
@@ -77,29 +76,9 @@
   } %>
 <% end %>
 
-<script type="text/javascript">
-  const showDismissInstructions = (toastId) => {
-    document.getElementById('dismiss-instructions').innerHTML = `
-      <strong>Toast Id:</strong> <code>${toastId}</code>
-      <br/>
-      <br/>
-      <h4>Dismiss toast with:</h4>
-      <br/>
-      <div class='prettyprint'>
-        <code>Sage.toast.dismiss('${toastId}')</code>
-      </div>
-      <br/>
-      <h4>Dismiss all toasts with:</h4>
-      <br/>
-      <div class='prettyprint'>
-        <code>Sage.toast.reset()</code>
-      </div>
-    `
-  };
-</script>
 <div id="dismiss-instructions"></div>
 
-<hr />
+<%= sage_component SageCardDivider, {} %>
 
 <pre class="prettyprint">
   <code>
@@ -108,7 +87,7 @@
     // Triggers a toast with a toast options object and
     // returns the unique id of the toast.
     //
-    // @param {{ message, icon, type, timer, link = {text, href} }} - Toast options
+    // @param {{ message, icon, testId, type, timer, link = {text, href} }} - Toast options
     // @returns {unique id}
     //
     // Example:
@@ -118,6 +97,7 @@
         icon: 'check',
         type: 'danger',
         link: { text: 'next step', href 'example.com' },
+        testId: 'toast_test_example',
       });
 
 
@@ -143,3 +123,62 @@
     Sage.toast.reset();
   </code>
 </pre>
+
+<%= sage_component SageCardDivider, {} %>
+
+<%= sage_component SagePanelStack, {} do %>
+  <h3>Events</h3>
+
+  <%= sage_component SageTable, {
+    striped: true,
+    responsive: true,
+    headers: [
+      "Event name",
+      "Description"
+    ],
+    rows: [
+      {
+        col_1: md("`sage.toast.open`"),
+        col_2: md("Sent when a Toast has been opened")
+      },
+      {
+        col_1: md("`sage.toast.close`"),
+        col_2: md("Sent when a Toast has been closed")
+      },
+      {
+        col_1: md("`sage.toast.dismiss`"),
+        col_2: md("Sent when a Toast has been dismissed by user interaction, such as clicking the close button. The `sage.toast.close` event will follow afterwards.")
+      },
+    ]
+  } %>
+<% end %>
+
+<script>
+  const showDismissInstructions = (toastId) => {
+    document.getElementById('dismiss-instructions').innerHTML = `
+      <strong>Toast Id:</strong> <code>${toastId}</code>
+      <br/>
+      <br/>
+      <h4>Dismiss toast with:</h4>
+      <br/>
+      <div class='prettyprint'>
+        <code>Sage.toast.dismiss('${toastId}')</code>
+      </div>
+      <br/>
+      <h4>Dismiss all toasts with:</h4>
+      <br/>
+      <div class='prettyprint'>
+        <code>Sage.toast.reset()</code>
+      </div>
+    `
+  };
+  document.addEventListener("sage.toast.open", function(e) {
+    console.info("sage.toast.open event", e);
+  });
+  document.addEventListener("sage.toast.close", function(e) {
+    console.info("sage.toast.close event", e);
+  });
+  document.addEventListener("sage.toast.dismiss", function(e) {
+    console.info("sage.toast.dismiss event", e);
+  });
+</script>

--- a/docs/app/views/examples/components/toast/_props.html.erb
+++ b/docs/app/views/examples/components/toast/_props.html.erb
@@ -5,6 +5,18 @@
   <td><%= md('`check`') %></td>
 </tr>
 <tr>
+  <td><%= md('`link`') %></td>
+  <td><%= md('Add a CTA button following `text` in the toast; expects `text` and `href` keys.') %></td>
+  <td><%= md('{ text: String, href: String }') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`testId`') %></td>
+  <td><%= md('Unique identifier for testing, output using `data-kjb-element') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`text`') %></td>
   <td><%= md('The message to be displayed in the toast.') %></td>
   <td><%= md('String') %></td>
@@ -21,10 +33,4 @@
   <td><%= md('Assign a type/style, options include: `notice` `danger`.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`notice`') %></td>
-</tr>
-<tr>
-  <td><%= md('`link`') %></td>
-  <td><%= md('Add a CTA button following `text` in the toast; expects `text` and `href` keys.') %></td>
-  <td><%= md('{ text: String, href: String }') %></td>
-  <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/layouts/mocks.html.erb
+++ b/docs/app/views/layouts/mocks.html.erb
@@ -23,6 +23,6 @@
       <% end %>
       <%= sage_component(SageOverlay, {}) %>
     <% end %>
-    <%= render "scripts" %>
+    <%= render "application/scripts" %>
   <% end %>
 </html>

--- a/docs/app/views/mocks/new_plans_upgrade/_feature_usage_display.html.erb
+++ b/docs/app/views/mocks/new_plans_upgrade/_feature_usage_display.html.erb
@@ -1,0 +1,51 @@
+<%= sage_component SageCard, { css_classes: "feature-usage-display" } do %>
+  <%= sage_component SageCardRow, { grid_template: "eti" } do %>
+    <%= sage_component SageIcon, { icon: "product" } %>
+    <h2 class="<%= "#{SageClassnames::TYPE::HEADING_6}" %>">
+      <%= feature_usage_display_current_display(usage_data) %>
+    </h2>
+    <span class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+      Limit
+      <strong class="<%= "#{SageClassnames::TYPE::BODY_XSMALL_MED}" %>">
+        <%= feature_usage_display_limit_display(usage_data) %>
+      </strong>
+    </span>
+    <%= sage_component SageButton, feature_usage_display_button_configs(opened) %>
+  <% end %>
+
+  <%= sage_component SageProgressBar, feature_usage_display_progress_configs(usage_data) %>
+  
+  <% if opened %>
+    <div class="sage-card-grid">
+      <%= sage_component SageCardBlock, { spacer: { bottom: :xs, top: :xs } } do %>
+        <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL_MED} #{SageClassnames::TYPE_COLORS::CHARCOAL}" %>">
+          You are about to reach the maximum number of landing pages available on your current plan.
+        </p>
+        <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL}" %>">
+          Upgrade your plan to unlock unlimited landing pages.
+        </p>
+
+        <%= sage_component SageButton, {
+          attributes: usage_data[:upgrade_action][:attributes],
+          style: "primary",
+          value: usage_data[:upgrade_action][:value],
+          spacer: { top: "xs" }
+        } %>
+      <% end if usage_data[:upgrade_action] %>
+
+      <%= sage_component SageCardBlock, {} do %>
+        <% usage_data[:data].each_with_index do | d, i | %>
+          <%= sage_component SageCardDivider, {} if i > 0 %>
+          <%= sage_component SageCardRow, { grid_template: "te" } do %>
+            <h3 class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_500}" %>">
+              <%= d[:label] %>
+            </h3>
+            <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+              <%= d[:value] %>
+            </span>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/new_plans_upgrade/_main.html.erb
+++ b/docs/app/views/mocks/new_plans_upgrade/_main.html.erb
@@ -1,0 +1,62 @@
+<div class="sage-tabs-container">
+  <%= sage_component SageTabs, {
+    id: "example-tabs1",
+    items: [
+      {
+        text: "Feature usage display",
+        target: "feature-1",
+        active: true
+      },
+      {
+        text: "Plan upgrade panel",
+        target: "feature-2",
+      },
+      {
+        text: "Plan tiers",
+        target: "feature-3",
+      },
+      {
+        text: "Usag alerts",
+        target: "feature-4",
+      },
+      {
+        text: "Upgrade modal",
+        target: "feature-5",
+      },
+    ]
+  } %>
+
+  <%= sage_component SageTabsPane, { id: "feature-1" } do %>
+    <%= render "mocks/new_plans_upgrade/feature_usage_display", usage_data: feature_usage_display_demo_data(), opened: false %>
+    <%= render "mocks/new_plans_upgrade/feature_usage_display", usage_data: feature_usage_display_demo_data(), opened: true %>
+  <% end %>
+
+  <%= sage_component SageTabsPane, { id: "feature-2" } do %>
+    <%= render "mocks/new_plans_upgrade/plan_upgrade_panel", plan: plan_ugrade_panel_demo_plan %>
+  <% end %>
+
+  <%= sage_component SageTabsPane, { id: "feature-3" } do %>
+    <%= render "mocks/new_plans_upgrade/plan_tiers", plans: plan_tiers_demo_plans %>
+  <% end %>
+
+  <%= sage_component SageTabsPane, { id: "feature-4" } do %>
+    <%= render "mocks/new_plans_upgrade/usage_alert", feature: { name: "[feature name]", percentage: 50 } %>
+    <%= render "mocks/new_plans_upgrade/usage_alert", feature: { name: "[feature name]", percentage: 100 } %>
+    <%= render "mocks/new_plans_upgrade/usage_alert", feature: { name: "[feature name]", percentage: 101 } %>
+  <% end %>
+
+  <%= sage_component SageTabsPane, { id: "feature-5" } do %>
+    <%= render "mocks/new_plans_upgrade/upgrade_modal", feature: "[feature name]", action: "[act on]" %>
+    <%= sage_component SageButton, {
+      attributes: {
+        "data-js-modaltrigger": "plan-upgrade-modal",
+      },
+      style: "primary",
+      value: "Launch upgrade modal",
+    } %>
+    <h3 class="<%= "#{SageClassnames::SPACERS::XS_BOTTOM} #{SageClassnames::SPACERS::SM_TOP}" %>">Manual Trigger</h3>
+    <code>
+    Sage.modal.openModal("plan-upgrade-modal");
+    </code>
+  <% end %>
+</div>

--- a/docs/app/views/mocks/new_plans_upgrade/_plan_tiers.html.erb
+++ b/docs/app/views/mocks/new_plans_upgrade/_plan_tiers.html.erb
@@ -1,0 +1,50 @@
+<%= sage_component SageContainer, { size: "xl" } do %>
+  <%= sage_component SagePanelRow, { grid_template: "ot", vertical_align: "start" } do %>
+    <% plans.each do |plan| %>
+      <%= sage_component SagePanel, {} do %>
+        <%= sage_component SagePanelHeader, {
+          title: plan[:name]
+        } %>
+        <%= sage_component SagePanelBlock, { } do %>
+          <h2 class="<%= "#{SageClassnames::TYPE::HEADING_2} #{SageClassnames::SPACERS::XS_BOTTOM}" %>">
+            $<%= plan[:price] %><span style="font-weight: 500">/<%= plan[:duration] %></span>
+          </h2>
+
+          <h3 class="<%= "#{SageClassnames::TYPE::BODY} #{SageClassnames::TYPE_COLORS::CHARCOAL} #{SageClassnames::SPACERS::SM_BOTTOM}" %>">
+            <%= plan[:billing] %>
+          </h3>
+
+          <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_400} #{SageClassnames::SPACERS::MD_BOTTOM}" %>">
+            <%= plan[:description] %>
+          </p>
+
+          <%= sage_component SageButton, {
+            disabled: plan[:current],
+            full_width: true,
+            style: "primary",
+            value: plan[:current] ? "Current plan" : "Select",
+          } %>
+
+          <hr>
+
+          <%= sage_component SagePanelStack, {} do %>
+            <h3 class="<%= "#{SageClassnames::TYPE::HEADING_6} #{SageClassnames::SPACERS::XS_BOTTOM}" %>">Features</h3>
+
+            <% plan[:features].each do | feature | %>
+              <%= sage_component SageCardRow, { grid_template: "et" } do %>
+                <%= sage_component SageIcon, {
+                  card_color: "published",
+                  circular: true,
+                  color: "sage",
+                  icon: "check",
+                  size: "sm"
+                } %>
+                <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_400}" %>"><%= feature %></span>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/new_plans_upgrade/_plan_upgrade_panel.html.erb
+++ b/docs/app/views/mocks/new_plans_upgrade/_plan_upgrade_panel.html.erb
@@ -1,0 +1,47 @@
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SagePanelHeader, { title: plan[:title] } do %>
+    <%= content_for :sage_panel_header_subtext do %>
+      <p>$<%= plan[:total_cost] %>/year (plus tax)</p>
+    <% end %>
+  <% end %>
+  <%= sage_component SagePanelBlock, {} do %>
+    <%= sage_component SageLink, {
+      label: "Your billing cycle will begin today.",
+      url: "#"
+    } %>
+    <% plan[:billing].each do | b | %>
+      <%= sage_component SageCard, { spacer: { top: :md } } do %>
+        <%= sage_component SageCardBlock, {} do %>
+          <h2 class="<%= "#{SageClassnames::TYPE::HEADING_6} #{SageClassnames::SPACERS::SM_BOTTOM}" %>">
+            Billed <%= b[:label] %>
+          </h2>
+          <% total = 0 %>
+          <% b[:items].each do | item | %>
+            <% total += item[:amount] %>
+            <%= sage_component SageCardRow, { grid_template: "te", spacer: { top: :xs } } do %>
+              <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL}" %>">
+                <%= item[:label] %>
+              </p>
+              <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL}" %>">
+                $<%= item[:amount] %>
+              </span>
+            <% end %>
+          <% end %>
+          <%= sage_component SageCardDivider, {} %>
+          <%= sage_component SageCardRow, { grid_template: "te", spacer: { top: :xs } } do %>
+            <strong class="<%= SageClassnames::TYPE::BODY_MED %>">Total</strong>
+            <span class="<%= SageClassnames::TYPE::BODY %>">$<%= total %></span>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= sage_component SagePanelFooter, {} do %>
+    <%= sage_component SageButton, {
+      raised: false,
+      style: "secondary",
+      value: "Cancel",
+    } %>
+    <%= sage_component SageButton, { value: "Confirm upgrade", style: "primary" } %>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/new_plans_upgrade/_upgrade_modal.html.erb
+++ b/docs/app/views/mocks/new_plans_upgrade/_upgrade_modal.html.erb
@@ -1,0 +1,43 @@
+<%= sage_component SageModal, { id: "plan-upgrade-modal" } do %>
+  <%= sage_component SageModalContent, {} do %>
+    <%= sage_component SagePanelRow, { grid_template: "te", spacer: { bottom: :sm } } do %>
+      <svg width="52" height="52" xmlns="http://www.w3.org/2000/svg"><g transform="translate(4 4)" fill="none" fill-rule="evenodd"><rect fill="#86D5BC" fill-rule="nonzero" width="44" height="44" rx="22"/><path d="M23.188 13.746c.331.156.522.51.47.872l-.697 4.882H29.5a.833.833 0 0 1 .616 1.394l-8.333 9.167a.833.833 0 0 1-1.441-.679l.697-4.882h-6.54a.833.833 0 0 1-.616-1.394l8.334-9.167c.246-.27.64-.349.971-.193Zm-6.804 9.087H22a.833.833 0 0 1 .825.952l-.45 3.147 5.241-5.765H22a.834.834 0 0 1-.825-.952l.45-3.147-5.241 5.765Z" fill="#183E3B"/><rect stroke="#DDF8F0" stroke-width="8" width="44" height="44" rx="22"/></g></svg>
+      <%= sage_component SageButton, {
+        attributes: { "data-js-modal": true },
+        icon: { name: "remove", style: "only" },
+        style: "secondary",
+        subtle: true,
+        value: "Close Modal",
+      } %>
+    <% end %>
+
+    <h3 class="<%= SageClassnames::SPACERS::XS_BOTTOM %>">
+      Upgrade plan for more <%= feature %>
+    </h3>
+    <p class="<%= SageClassnames::TYPE::BODY %>">
+      You&rsquo;ve reached the <%= feature %> limit for your plan.
+      To <%= action %> a <%= feature %>, upgrade your plan.
+    </p>
+
+    <% content_for :sage_footer do %>
+      <% content_for :sage_footer_aside do %>
+        <%= sage_component SageButton, {
+          icon: { name: "email-activity", style: "left" },
+          style: "primary",
+          subtle: true,
+          value: "Check usage",
+        } %>
+      <% end %>
+      <%= sage_component SageButton, {
+        attributes: { "data-js-modal": true },
+        raised: false,
+        style: "secondary",
+        value: "Maybe later",
+      } %>
+      <%= sage_component SageButton, {
+        style: "primary",
+        value: "Upgrade now",
+      } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/new_plans_upgrade/_usage_alert.html.erb
+++ b/docs/app/views/mocks/new_plans_upgrade/_usage_alert.html.erb
@@ -1,0 +1,1 @@
+<%= sage_component SageAlert, plan_usage_alert_configs(feature) %>

--- a/docs/lib/sage-frontend/stylesheets/docs/mocks/_index.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/mocks/_index.scss
@@ -1,3 +1,4 @@
 // Import mock custom styles here
 @import "contact_profile";
+@import "new_plans_upgrade";
 @import "upsell_downsell";

--- a/docs/lib/sage-frontend/stylesheets/docs/mocks/_new_plans_upgrade.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/mocks/_new_plans_upgrade.scss
@@ -1,0 +1,8 @@
+.feature-usage-display {
+  background-color: sage-color(white);
+  border-radius: 0;
+
+  &:not(:last-child) {
+    border-bottom: 0;
+  }
+}

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -150,6 +150,7 @@ $-modal-fullscreen-top-spacing: rem(104px);
     right: 0;
     margin: 0;
     padding: sage-spacing(sm) $-modal-padding-x;
+    background-color: sage-color(white);
     box-shadow: sage-shadow(sm);
   }
 }

--- a/packages/sage-system/lib/toast/toast.config.js
+++ b/packages/sage-system/lib/toast/toast.config.js
@@ -2,6 +2,9 @@ export const ID_TOAST_CONTAINER = 'SageToastContainer';
 export const DATA_ATTR = 'data-js-toast';
 export const DATA_ATTR_CLOSE_BUTTON = 'data-js-toast-close';
 export const CLASS_DISMISSED_STATE = 'sage-toast--dismissed';
+export const EVENT_OPEN = "sage.toast.open";
+export const EVENT_CLOSE = "sage.toast.close";
+export const EVENT_DISMISS = "sage.toast.dismiss";
 
 export const DEFAULT_CONFIG = {
   icon: 'check',

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -8,6 +8,9 @@ import {
   DEFAULT_CONFIG,
   CLASS_DISMISSED_STATE,
   DATA_ATTR_CLOSE_BUTTON,
+  EVENT_OPEN,
+  EVENT_CLOSE,
+  EVENT_DISMISS,
 } from './toast.config.js';
 
 import {
@@ -33,6 +36,7 @@ Sage.toast = (function () {
     if (!elToast) return false;
 
     elToast.classList.add(CLASS_DISMISSED_STATE);
+    _dispatchEvent(EVENT_CLOSE);
     _unbindEvents(elToast);
     return true;
   }
@@ -41,6 +45,7 @@ Sage.toast = (function () {
     const elContainer = document.getElementById(ID_TOAST_CONTAINER);
     if (!elContainer) return false;
 
+    _dispatchEvent(EVENT_CLOSE);
     _unbindEvents(elContainer);
     elContainer.remove();
     return true;
@@ -61,6 +66,7 @@ Sage.toast = (function () {
 
     const toastFragment = stringToHtmlFragment(content);
     _bindEvents(toastFragment);
+    _dispatchEvent(EVENT_OPEN);
     scope.appendChild(toastFragment);
   }
 
@@ -78,6 +84,11 @@ Sage.toast = (function () {
 
   function _handleCloseButtonClick(evt) {
     dismiss(evt.target.parentElement.id);
+    _dispatchEvent(EVENT_DISMISS);
+  }
+
+  function _dispatchEvent(evt) {
+    document.dispatchEvent(new Event(evt));
   }
 
   return {

--- a/packages/sage-system/lib/toast/toast.template.js
+++ b/packages/sage-system/lib/toast/toast.template.js
@@ -8,10 +8,11 @@ import {
   DATA_ATTR_CLOSE_BUTTON,
 } from './toast.config.js';
 
-export const toastTemplate = ({id, type, icon, text, link}) => (`
+export const toastTemplate = ({id, type, icon, text, link, testId = null}) => (`
   <dialog
     class="sage-toast sage-toast--style-${type}"
     id="${id}"
+    ${(testId !== null) ? `data-kjb-element="${testId}"` : ""}
     ${DATA_ATTR}
   >
     ${type === "loading" ? loadingTemplate() : iconTemplate(icon)}


### PR DESCRIPTION
1. (**MEDIUM**) - kajabi/sage-lib#1049 - Added Sage Toast lifecycle events and `test_id` ability. No impact to existing functionality expected; sanity check to ensure backward compatibility. Examples of areas verify:
    - [ ] Trigger a toast by deleting a contact under People 
    - [ ] Trigger a contact import to see the "Your import is in progress" Toast
---
2. (**LOW**) - kajabi/sage-lib#1058 - Add `background-color` to fullscreen modal headers. Only fullscreen modal header are affected in the app
3. (**N/A**) - kajabi/sage-lib#1055 - Workflow changes for sage-lib only. No kajabi-products testing is needed.
4. (**N/A**) - kajabi/sage-lib#1051 - Add new plan upgrade mocks. No impact on existing components.