### PR TITLE
[Modal] add background color fullscreen modal header

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -150,6 +150,7 @@ $-modal-fullscreen-top-spacing: rem(104px);
     right: 0;
     margin: 0;
     padding: sage-spacing(sm) $-modal-padding-x;
+    background-color: sage-color(white);
     box-shadow: sage-shadow(sm);
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add a white background to the fullscreen modal

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- On the modal page, enable the fullscreen variation. 
- In the dev tools, inspect the header and verify that there's a white background

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] Quizzes Fullscreen Modal


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
