### PR TITLE
[Pagination] add window property with description to docs

### DIFF
--- a/docs/app/views/examples/components/pagination/_props.html.erb
+++ b/docs/app/views/examples/components/pagination/_props.html.erb
@@ -52,3 +52,9 @@
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
+<tr>
+  <td><%= md('`window`') %></td>
+  <td><%= md('Sets the number of items on either side of the `...` item. (Note: the left side will be `window` + 1). Has no affect when `hide_pages` is set to true.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `window` property description to docs site


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the `SagePagination` rails page and verify `window` and the prop description

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**N/A**) Updated the pagination documentation page.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
