### PR TITLE
[SAGE-1069] Statbox add optional icon

### DIFF
--- a/docs/app/views/examples/components/stat_box/_preview.html.erb
+++ b/docs/app/views/examples/components/stat_box/_preview.html.erb
@@ -1,13 +1,13 @@
 
 <h3 class="t-sage-heading-6">Default with Data</h3>
 <%= sage_component SageStatBox, {
-  change: { 
-    type: "positive", 
-    value: "30%", 
+  change: {
+    type: "positive",
+    value: "30%",
   },
   data: "1,342",
   has_data: true,
-  
+
   link: {
     href: "#",
     value: "View More",
@@ -18,9 +18,9 @@
 
 <h3 class="t-sage-heading-6">Default with Legend Dot - Sage Color</h3>
 <%= sage_component SageStatBox, {
-  change: { 
-    type: "positive", 
-    value: "30%", 
+  change: {
+    type: "positive",
+    value: "30%",
   },
   data: "1,342",
   has_data: true,
@@ -35,9 +35,9 @@
 
 <h3 class="t-sage-heading-6">Default with Legend Dot - Custom Color</h3>
 <%= sage_component SageStatBox, {
-  change: { 
-    type: "positive", 
-    value: "30%", 
+  change: {
+    type: "positive",
+    value: "30%",
   },
   data: "1,342",
   has_data: true,
@@ -52,9 +52,9 @@
 
 <h3 class="t-sage-heading-6">Default with Data - Raised</h3>
 <%= sage_component SageStatBox, {
-  change: { 
-    type: "positive", 
-    value: "30%", 
+  change: {
+    type: "positive",
+    value: "30%",
   },
   data: "1,342",
   has_data: true,
@@ -73,6 +73,17 @@
   has_data: false,
   image: {
     src: "card-placeholder-sm.png"
+  },
+  title: "Completed",
+} %>
+
+<h3 class="t-sage-heading-6">Simple with Icon</h3>
+<%= sage_component SageStatBox, {
+  data: "No insights to show",
+  has_data: false,
+  icon: {
+    name: "check",
+    card_color: "published"
   },
   title: "Completed",
 } %>

--- a/docs/app/views/examples/components/stat_box/_props.html.erb
+++ b/docs/app/views/examples/components/stat_box/_props.html.erb
@@ -28,6 +28,18 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Optional. Shows icon to the left of data.') %></td>
+  <td><%= md('```
+  {
+    card_color: Sage system statuses (optional)
+    color: Sage system colors (optional)
+    name: String
+  }
+  ```') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`image`') %></td>
   <td><%= md('Optional. Shows image to the left of data.') %></td>
   <td><%= md('```

--- a/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_stat_box.rb
@@ -7,6 +7,11 @@ class SageStatBox < SageComponent
     }],
     data: String,
     has_data: [:optional, TrueClass],
+    icon: [:optional, {
+      card_color: [:optional, SageSchemas::STATUSES],
+      color: [:optional, SageSchemas::COLOR_SLIDER],
+      name: SageSchemas::ICON,
+    }],
     image: [:optional, {
       alt: [:optional, String],
       src: String

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_stat_box.html.erb
@@ -18,6 +18,7 @@ end
   class="sage-stat-box
   <%= "sage-stat-box--raised" if component.raised %>
   <%= "sage-stat-box--with-img" if component.image %>
+  <%= "sage-stat-box--with-icon" if component.icon %>
   <%= component.generated_css_classes %>"
   <%= component.generated_html_attributes.html_safe %>
 >
@@ -26,8 +27,18 @@ end
       <%= image_tag component.image[:src], alt: component.image[:alt].present? ? component.image[:alt] : '' %>
     </div>
   <% end %>
+
+  <% if component.icon.present? %>
+    <div class="sage-stat-box__icon">
+      <%= sage_component SageIcon, {
+        icon: component.icon[:name],
+        card_color: component.icon[:card_color],
+        color: component.icon[:color]
+      } %>
+    </div>
+  <% end %>
   <header class="sage-stat-box__header">
-    <h2 
+    <h2
       class="
         sage-stat-box__title
         <%= "sage-stat-box__title--legend-#{component.legend_dot_color}" if component.legend_dot_color %>

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -5,7 +5,6 @@
 ////
 
 $-stat-box-image-max-width: rem(48px);
-$-stat-box-icon-max-width: auto;
 
 .sage-stat-box {
   // Styles here
@@ -20,29 +19,20 @@ $-stat-box-icon-max-width: auto;
   &.sage-stat-box--with-img,
   &.sage-stat-box--with-icon {
     display: grid;
+    grid-column-gap: sage-spacing(sm);
 
     grid-template-areas:
       "image header header"
       "image body body";
     grid-template-columns: $-stat-box-image-max-width 1fr;
   }
-
-  &.sage-stat-box--with-icon {
-    grid-template-columns: $-stat-box-icon-max-width 1fr;
-  }
 }
 
 .sage-stat-box__img {
   position: relative;
   grid-area: image;
-  overflow: hidden;
-  min-height: $-stat-box-image-max-width;
-  margin-right: sage-spacing(sm);
 
   img {
-    position: absolute;
-    transform: translateY(-50%);
-    top: 50%;
     width: 100%;
     border-radius: sage-border(radius);
   }
@@ -50,7 +40,6 @@ $-stat-box-icon-max-width: auto;
 
 .sage-stat-box__icon {
   grid-area: image;
-  margin-right: sage-spacing(sm);
 }
 
 .sage-stat-box__header {

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -5,6 +5,7 @@
 ////
 
 $-stat-box-image-max-width: rem(48px);
+$-stat-box-icon-max-width: auto;
 
 .sage-stat-box {
   // Styles here
@@ -15,13 +16,18 @@ $-stat-box-image-max-width: rem(48px);
     border: 0;
   }
 
-  &.sage-stat-box--with-img {
+  &.sage-stat-box--with-img,
+  &.sage-stat-box--with-icon {
     display: grid;
 
-    grid-template-areas: 
+    grid-template-areas:
       "image header header"
       "image body body";
     grid-template-columns: $-stat-box-image-max-width 1fr;
+  }
+
+  &.sage-stat-box--with-icon {
+    grid-template-columns: $-stat-box-icon-max-width 1fr;
   }
 }
 
@@ -39,6 +45,11 @@ $-stat-box-image-max-width: rem(48px);
     width: 100%;
     border-radius: sage-border(radius);
   }
+}
+
+.sage-stat-box__icon {
+  grid-area: image;
+  margin-right: sage-spacing(xs);
 }
 
 .sage-stat-box__header {

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -10,6 +10,7 @@ $-stat-box-icon-max-width: auto;
 .sage-stat-box {
   // Styles here
   @include sage-card($grid: false);
+  padding: rem(18px) sage-spacing(sm);
 
   &.sage-stat-box--raised {
     box-shadow: sage-shadow(sm);
@@ -36,7 +37,7 @@ $-stat-box-icon-max-width: auto;
   grid-area: image;
   overflow: hidden;
   min-height: $-stat-box-image-max-width;
-  margin-right: sage-spacing(xs);
+  margin-right: sage-spacing(sm);
 
   img {
     position: absolute;
@@ -49,7 +50,7 @@ $-stat-box-icon-max-width: auto;
 
 .sage-stat-box__icon {
   grid-area: image;
-  margin-right: sage-spacing(xs);
+  margin-right: sage-spacing(sm);
 }
 
 .sage-stat-box__header {

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -12,6 +12,7 @@ export const StatBox = ({
   change,
   data,
   hasData,
+  icon,
   image,
   legendDotColor,
   legendDotCustomColor,
@@ -26,6 +27,7 @@ export const StatBox = ({
     {
       'sage-stat-box--raised': raised,
       'sage-stat-box--with-img': image,
+      'sage-stat-box--with-icon': icon,
     }
   );
   const statBoxTitle = classnames(
@@ -62,6 +64,15 @@ export const StatBox = ({
     <article
       className={statBoxContainer}
     >
+      {icon && (
+        <div className="sage-stat-box__icon">
+          <Icon
+            cardColor={icon.cardColor}
+            color={icon.color}
+            icon={icon.name}
+          />
+        </div>
+      )}
       {image && (
         <div className="sage-stat-box__img">
           <img src={image.src} alt={image.alt || ''} />
@@ -116,6 +127,11 @@ StatBox.defaultProps = {
   },
   customLabel: null,
   hasData: true,
+  icon: {
+    cardColor: null,
+    color: null,
+    name: null,
+  },
   image: {
     alt: null,
     src: null
@@ -139,6 +155,11 @@ StatBox.propTypes = {
   customLabel: PropTypes.node,
   data: PropTypes.string.isRequired,
   hasData: PropTypes.bool,
+  icon: PropTypes.shape({
+    cardColor: PropTypes.oneOf(Object.values(Icon.CARD_COLORS)),
+    color: PropTypes.oneOf(Object.values(Icon.COLORS)),
+    name: PropTypes.oneOf(Object.values(Icon.ICONS)),
+  }),
   image: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { selectArgs } from '../story-support/helpers';
+import { Icon } from '../Icon';
 import { StatBox } from './StatBox';
 
 export default {
@@ -88,6 +89,19 @@ SimpleWithImage.args = {
   image: {
     alt: 'Example',
     src: 'https://via.placeholder.com/150'
+  },
+  link: null,
+  title: 'Title'
+};
+
+export const SimpleWithIcon = Template.bind({});
+SimpleWithIcon.args = {
+  change: null,
+  data: '1,000',
+  image: null,
+  icon: {
+    cardColor: Icon.CARD_COLORS.PUBLISHED,
+    name: Icon.ICONS.CHECK
   },
   link: null,
   title: 'Title'


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
[SAGE-1069](https://github.com/Kajabi/sage-lib/issues/1069)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|did not exist|![Screen Shot 2021-12-13 at 10 24 35 AM](https://user-images.githubusercontent.com/1241836/145849861-17d7b72a-3c29-4a31-8ad3-72443722df2b.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Go to the Rails Statbox page and scroll down to the `Simple with Icon` example and verify 
Go to the Storybook `Statbox -> Simple with Icon` example and verify

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) New property. Has no affect in the app


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-1069](https://github.com/Kajabi/sage-lib/issues/1069)