### PR TITLE
Next version bump ~v4.30.0

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -10,6 +10,14 @@ jobs:
       - name: Clone Sage-Lib Repo
         uses: actions/checkout@v2
 
+      - name: Set Node Version
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
       - name: Yarn Install
         run: yarn install
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.29.1](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@4.29.0...@kajabi/sage@4.29.1) (2021-12-03)
+
+**Note:** Version bump only for package @kajabi/sage
+
+
+
+
+
 # [4.29.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@4.28.6...@kajabi/sage@4.29.0) (2021-12-01)
 
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (4.29.0)
+    sage_rails (4.29.1)
       classy_hash
       rails
 

--- a/docs/app/views/application/_home_developer.html.erb
+++ b/docs/app/views/application/_home_developer.html.erb
@@ -43,7 +43,7 @@
               }
             } %>
             <h3 class="t-sage-heading-3">Contributing</h3>
-            <p class="t-sage-body">we encourage any member of the Kajabi team to feel empowered to participate. Understanding and contributing to the system are the keys to the system's longevity.</p>
+            <p class="t-sage-body">We encourage any member of the Kajabi team to feel empowered to participate. Understanding and contributing to the system are the keys to the system's longevity.</p>
             <%= sage_component SageButton, {
               value: "Guidelines",
               attributes: {

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "4.29.0"
+  VERSION = "4.29.1"
 end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "4.29.0",
+  "version": "4.29.1",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {


### PR DESCRIPTION
1. (**N/A**) Updates github actions for Sage docs build process. No impact to `kajab-products`.
1. 
