### PR TITLE
[Sage-1041] Docs - Color Tokens

### DIFF
--- a/docs/app/views/pages/_color_values.html.erb
+++ b/docs/app/views/pages/_color_values.html.erb
@@ -1,5 +1,5 @@
 <div class="colors">
-  <div class="colors__block color-<%= color %>-300">sage-color(<%= color %>)</div>
+  <div class="colors__block color-<%= color %>-300"><%= color.capitalize %> 300</div>
 </div>
 <div class="colors">
   <% (1..5).each do |i| %>

--- a/docs/app/views/pages/_color_values.html.erb
+++ b/docs/app/views/pages/_color_values.html.erb
@@ -3,6 +3,19 @@
 </div>
 <div class="colors">
   <% (1..5).each do |i| %>
-    <div class="colors__block color-<%= color %>-<%= i %>00">sage-color(<%= color %>, <%= i %>00)</div>
+    <div class="colors__block color-<%= color %>-<%= i %>00">
+      <div class="colors__tokens">
+        <div class="colors__classname-token">
+          <h3>Classname Tokens</h3>
+          <p>Rails: <code>SageClassnames::TYPE_COLORS::<%= color.upcase %>_<%= i %>00</code></p>
+          <p>React: <code>SageClassnames.TYPE_COLORS.<%= color.upcase %>_<%= i %>00</code></p>
+        </div>
+        <div class="colors__hex-token"> 
+          <h3>Hex Tokens</h3>
+          <p>Rails: <code>SageTokens::COLOR_PALETTE::<%= color.upcase %>_<%= i %>00</code></p>
+          <p>React: <code>SageTokens.COLOR_PALETTE::<%= color.upcase %>_<%= i %>00</code></p>
+        </div>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/docs/app/views/pages/_color_values.html.erb
+++ b/docs/app/views/pages/_color_values.html.erb
@@ -6,14 +6,34 @@
     <div class="colors__block color-<%= color %>-<%= i %>00">
       <div class="colors__tokens">
         <div class="colors__classname-token">
-          <h3>Classname Tokens</h3>
-          <p>Rails: <code>SageClassnames::TYPE_COLORS::<%= color.upcase %>_<%= i %>00</code></p>
-          <p>React: <code>SageClassnames.TYPE_COLORS.<%= color.upcase %>_<%= i %>00</code></p>
+          <h3>Classname Token</h3>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageClassnames::TYPE_COLORS::#{color.upcase}_#{i}00"
+            } %>
+          </div>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageClassnames.TYPE_COLORS.#{color.upcase}_#{i}00"
+            } %>
+          </div>
         </div>
         <div class="colors__hex-token"> 
-          <h3>Hex Tokens</h3>
-          <p>Rails: <code>SageTokens::COLOR_PALETTE::<%= color.upcase %>_<%= i %>00</code></p>
-          <p>React: <code>SageTokens.COLOR_PALETTE.<%= color.upcase %>_<%= i %>00</code></p>
+          <h3>Hex Token</h3>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageTokens::COLOR_PALETTE::#{color.upcase}_#{i}00"
+            } %>
+          </div>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageTokens.COLOR_PALETTE.#{color.upcase}_#{i}00"
+            } %>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/app/views/pages/_color_values.html.erb
+++ b/docs/app/views/pages/_color_values.html.erb
@@ -13,7 +13,7 @@
         <div class="colors__hex-token"> 
           <h3>Hex Tokens</h3>
           <p>Rails: <code>SageTokens::COLOR_PALETTE::<%= color.upcase %>_<%= i %>00</code></p>
-          <p>React: <code>SageTokens.COLOR_PALETTE::<%= color.upcase %>_<%= i %>00</code></p>
+          <p>React: <code>SageTokens.COLOR_PALETTE.<%= color.upcase %>_<%= i %>00</code></p>
         </div>
       </div>
     </div>

--- a/docs/app/views/pages/color.html.erb
+++ b/docs/app/views/pages/color.html.erb
@@ -92,16 +92,18 @@ We’ll use them when we need an element to stand out.
   <h3>White</h3>
   <%= md("All values passed for white will return the same value.", use_sage_type: true) %>
   <div class="colors">
-    <div class="colors__tokens">
-      <div class="colors__classname-token">
-        <h3>Classname Tokens</h3>
-        <p>Rails: <code>SageClassnames::TYPE_COLORS::WHITE</code></p>
-        <p>React: <code>SageClassnames.TYPE_COLORS.WHITE</code></p>
-      </div>
-      <div class="colors__hex-token"> 
-        <h3>Hex Tokens</h3>
-        <p>Rails: <code>SageTokens::COLOR_PALETTE::WHITE</code></p>
-        <p>React: <code>SageTokens.COLOR_PALETTE.WHITE</code></p>
+    <div class="colors__block color-white-300">
+      <div class="colors__tokens">
+        <div class="colors__classname-token">
+          <h3>Classname Tokens</h3>
+          <p>Rails: <code>SageClassnames::TYPE_COLORS::WHITE</code></p>
+          <p>React: <code>SageClassnames.TYPE_COLORS.WHITE</code></p>
+        </div>
+        <div class="colors__hex-token"> 
+          <h3>Hex Tokens</h3>
+          <p>Rails: <code>SageTokens::COLOR_PALETTE::WHITE</code></p>
+          <p>React: <code>SageTokens.COLOR_PALETTE.WHITE</code></p>
+        </div>
       </div>
     </div>
   </div>

--- a/docs/app/views/pages/color.html.erb
+++ b/docs/app/views/pages/color.html.erb
@@ -96,13 +96,33 @@ We’ll use them when we need an element to stand out.
       <div class="colors__tokens">
         <div class="colors__classname-token">
           <h3>Classname Tokens</h3>
-          <p>Rails: <code>SageClassnames::TYPE_COLORS::WHITE</code></p>
-          <p>React: <code>SageClassnames.TYPE_COLORS.WHITE</code></p>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageClassnames::TYPE_COLORS::WHITE"
+            } %>
+          </div>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageClassnames.TYPE_COLORS.WHITE"
+            } %>
+          </div>
         </div>
         <div class="colors__hex-token"> 
           <h3>Hex Tokens</h3>
-          <p>Rails: <code>SageTokens::COLOR_PALETTE::WHITE</code></p>
-          <p>React: <code>SageTokens.COLOR_PALETTE.WHITE</code></p>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageTokens::COLOR_PALETTE::WHITE"
+            } %>
+          </div>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageTokens.COLOR_PALETTE.WHITE"
+            } %>
+          </div>
         </div>
       </div>
     </div>
@@ -114,13 +134,33 @@ We’ll use them when we need an element to stand out.
       <div class="colors__tokens">
         <div class="colors__classname-token">
           <h3>Classname Tokens</h3>
-          <p>Rails: <code>SageClassnames::TYPE_COLORS::BLACK</code></p>
-          <p>React: <code>SageClassnames.TYPE_COLORS.BLACK</code></p>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageClassnames::TYPE_COLORS::BLACK"
+            } %>
+          </div>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageClassnames.TYPE_COLORS.BLACK"
+            } %>
+          </div>
         </div>
         <div class="colors__hex-token"> 
           <h3>Hex Tokens</h3>
-          <p>Rails: <code>SageTokens::COLOR_PALETTE::BLACK</code></p>
-          <p>React: <code>SageTokens.COLOR_PALETTE.BLACK</code></p>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageTokens::COLOR_PALETTE::BLACK"
+            } %>
+          </div>
+          <div>
+            <%= sage_component SageCopyButton, {
+              borderless: true,
+              value: "SageTokens.COLOR_PALETTE.BLACK"
+            } %>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/app/views/pages/color.html.erb
+++ b/docs/app/views/pages/color.html.erb
@@ -92,12 +92,36 @@ We’ll use them when we need an element to stand out.
   <h3>White</h3>
   <%= md("All values passed for white will return the same value.", use_sage_type: true) %>
   <div class="colors">
-    <div class="colors__block color-white-300">sage-color(white)</div>
+    <div class="colors__tokens">
+      <div class="colors__classname-token">
+        <h3>Classname Tokens</h3>
+        <p>Rails: <code>SageClassnames::TYPE_COLORS::WHITE</code></p>
+        <p>React: <code>SageClassnames.TYPE_COLORS.WHITE</code></p>
+      </div>
+      <div class="colors__hex-token"> 
+        <h3>Hex Tokens</h3>
+        <p>Rails: <code>SageTokens::COLOR_PALETTE::WHITE</code></p>
+        <p>React: <code>SageTokens.COLOR_PALETTE.WHITE</code></p>
+      </div>
+    </div>
   </div>
   <h3>Black</h3>
   <%= md("All values passed for black will return the same value.", use_sage_type: true) %>
   <div class="colors">
-    <div class="colors__block color-black-300">sage-color(black)</div>
+    <div class="colors__block color-black-300">
+      <div class="colors__tokens">
+        <div class="colors__classname-token">
+          <h3>Classname Tokens</h3>
+          <p>Rails: <code>SageClassnames::TYPE_COLORS::BLACK</code></p>
+          <p>React: <code>SageClassnames.TYPE_COLORS.BLACK</code></p>
+        </div>
+        <div class="colors__hex-token"> 
+          <h3>Hex Tokens</h3>
+          <p>Rails: <code>SageTokens::COLOR_PALETTE::BLACK</code></p>
+          <p>React: <code>SageTokens.COLOR_PALETTE.BLACK</code></p>
+        </div>
+      </div>
+    </div>
   </div>
   <% end %>
 <% end %>

--- a/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
@@ -31,7 +31,7 @@
       color: sage-color($color, 500);
     }
 
-    &::after {
+    .colors__block::after {
       content: "#{$hex}";
       padding-left: sage-spacing(xs);
       font-weight: sage-font-weight(semibold);
@@ -55,6 +55,12 @@
 
   @media screen and (min-width: sage-breakpoint(lg-min)) {
     flex-direction: row;
+  }
+}
+
+.colors__tokens {
+  code {
+    background-color: transparent;
   }
 }
 

--- a/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
@@ -31,12 +31,14 @@
       color: sage-color($color, 500);
     }
 
-    .colors__block::after {
+    &::after {
       content: "#{$hex}";
       padding-left: sage-spacing(xs);
       font-weight: sage-font-weight(semibold);
     }
   }
+
+
 }
 
 // color block groupings

--- a/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
@@ -10,7 +10,7 @@
 
 @mixin color-block-output {
   padding: sage-spacing(sm) sage-spacing();
-  font-size: sage-font-size(body-sm);
+  font-size: sage-font-size(body);
   color: sage-color(white);
 
   &::after {
@@ -37,8 +37,6 @@
       font-weight: sage-font-weight(semibold);
     }
   }
-
-
 }
 
 // color block groupings
@@ -64,6 +62,15 @@
   code {
     background-color: transparent;
   }
+}
+
+.sage-btn {
+  font-size: sage-font-size(body-sm);
+}
+
+.sage-btn--subtle.sage-btn--secondary,
+.sage-btn--subtle.sage-btn--secondary::before {
+  color: inherit;
 }
 
 // build individual color blocks

--- a/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
@@ -50,7 +50,7 @@ module SageTokens
   }
 
   COLOR_SLIDERS = [
-    "charcoal", "grey", "orange", "primary", "purple", "red", "sage", "yellow",
+    "charcoal", "grey", "orange", "primary", "purple", "red", "sage", "yellow", "black", "white",
     "charcoal-100", "grey-100", "orange-100", "primary-100", "purple-100", "red-100", "sage-100", "yellow-100",
     "charcoal-200", "grey-200", "orange-200", "primary-200", "purple-200", "red-200", "sage-200", "yellow-200",
     "charcoal-300", "grey-300", "orange-300", "primary-300", "purple-300", "red-300", "sage-300", "yellow-300",


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds color tokens as copy buttons to the Color page in Sage documentation.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="642" alt="Screen Shot 2021-12-08 at 3 24 31 PM" src="https://user-images.githubusercontent.com/14791307/145286592-4eab6a09-d9b8-4431-aa6b-d7b1fd85f314.png">|<img width="653" alt="Screen Shot 2021-12-14 at 3 52 50 PM" src="https://user-images.githubusercontent.com/14791307/146085420-f0212e79-fbbf-4f28-ab70-2063b66a2ad9.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Check that the new color information makes sense for the docs given the [original issue](https://github.com/Kajabi/sage-lib/issues/1041) filed
- Check that copy button properly copies the token

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Sage docs updates. No effect on Kajabi Products work.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #1041 