### PR TITLE
feat(progress): Add optional color prop

### DIFF
--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -1,4 +1,12 @@
+<h2 class="t-sage-heading-6">Default</h2>
 <%= sage_component SageProgressBar, {
   percent: 70,
   label: "Cloning product"
+} %>
+
+<h2 class="t-sage-heading-6">Custom color</h2>
+<%= sage_component SageProgressBar, {
+  color: SageTokens::COLOR_PALETTE[:ORANGE_300],
+  percent: 100,
+  label: "Reached limit"
 } %>

--- a/docs/app/views/examples/components/progress_bar/_props.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_props.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= md('`color`') %></td>
-  <td><%= md('Optional hex value for the progess bar value') %></td>
+  <td><%= md('Optional hex or `SageTokens::COLOR_PALETTE` value for the progress bar color.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/progress_bar/_props.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_props.html.erb
@@ -1,12 +1,18 @@
 <tr>
-  <td><%= md('`percent`') %></td>
-  <td><%= md('Sets `value`, `aria-valuenow` and inline `width` style of progress bar.') %></td>
-  <td><%= md('Integer') %></td>
+  <td><%= md('`color`') %></td>
+  <td><%= md('Optional hex value for the progess bar value') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`label`') %></td>
   <td><%= md('Sets `aria-valuetext` and content text for `<progress>` element.') %></td>
   <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`percent`') %></td>
+  <td><%= md('Sets `value`, `aria-valuenow` and inline `width` style of progress bar.') %></td>
+  <td><%= md('Integer') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
@@ -1,6 +1,7 @@
 class SageProgressBar < SageComponent
   set_attribute_schema({
-    percent: 0..100,
+    color: [:optional, String],
     label: String,
+    percent: 0..100,
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -1,5 +1,8 @@
-<% content = component.label ? "#{component.label}: " : "" %>
-<% content << "#{component.percent}%&nbsp;progress" %>
+<%
+content = component.label ? "#{component.label}: " : ""
+content << "#{component.percent}%&nbsp;progress"
+color = component.color || SageTokens::COLOR_PALETTE[:SAGE_300]
+%>
 
 <div
   class="sage-progress-bar <%= component.generated_css_classes %>"
@@ -17,5 +20,5 @@
   >
     <%= content %>
   </progress>
-  <div class="sage-progress-bar__value" style="width: <%= component.percent %>%;"></div>
+  <div class="sage-progress-bar__value" style="--progress-bar-value-color: <%= color %>; width: <%= component.percent %>%;"></div>
 </div>

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -24,7 +24,7 @@
 .sage-progress-bar__value {
   transform-origin: center left;
   height: 100%;
-  background-color: sage-color(sage, 300);
+  background-color: var(--progress-bar-value-color, sage-color(sage, 300));
   border-radius: sage-border(radius-large);
   animation: 3s sage-progress-bar--slide ease;
 }


### PR DESCRIPTION
## Description
Adds a custom color prop to change the color of the progress bar value element.

## Screenshots
<img width="769" alt="After" src="https://user-images.githubusercontent.com/7331038/145880640-daedc771-4aa8-4227-b8fd-d34ef7bc8a20.png">

## Testing in `sage-lib`
1. Visit http://0.0.0.0:4000/pages/component/progress_bar
2. Ensure that the default color (sage_300) and custom color option (orange_300) appear

## Testing in `kajabi-products`
1. (**LOW/MEDIUM/HIGH/BREAKING**) This is an optional prop and should not affect existing implementations, but always good to check.