### PR TITLE
[SAGE-1101] added drag class option to Sortable

### DIFF
--- a/packages/sage-react/lib/Sortable/Sortable.jsx
+++ b/packages/sage-react/lib/Sortable/Sortable.jsx
@@ -20,6 +20,7 @@ export const Sortable = ({
         onEnd={onEnd}
         ghostClass="sage-sortable__item--ghost"
         chosenClass="sage-sortable__item--active"
+        dragClass="sage-sortable__item--drag"
         {...rest}
       >
         {list.map((item) => renderItem(item))}


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `dragClass` option to Sortable per the documentation to extend for any drag specific styles

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
On the sortable component, drag one of the rows and verify that `.sage-sortable__item--drag`


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Description of the change and its impact with QA as the audience.
   - [ ] Product Outline
   - [ ] Quizzes Admin


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #1101