### PR TITLE
[Sage-1107] Stat Box - Fixes Default Props

### DIFF
--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -127,21 +127,11 @@ StatBox.defaultProps = {
   },
   customLabel: null,
   hasData: true,
-  icon: {
-    cardColor: null,
-    color: null,
-    name: null,
-  },
-  image: {
-    alt: null,
-    src: null
-  },
+  icon: null,
+  image: null,
   legendDotColor: null,
   legendDotCustomColor: null,
-  link: {
-    href: null,
-    value: null,
-  },
+  link: null,
   popover: null,
   raised: false,
   timeframe: null,

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -22,7 +22,6 @@ Default.args = {
     value: '38%',
   },
   data: '4,010',
-  image: null,
   link: {
     value: 'View More',
     href: '#'
@@ -38,7 +37,6 @@ DefaultWithSageColorLegendDot.args = {
     value: '38%',
   },
   data: '4,010',
-  image: null,
   legendDotColor: StatBox.LEGEND_COLORS.PRIMARY,
   link: {
     value: 'View More',
@@ -55,7 +53,6 @@ DefaultWithSageCustomColorLegendDot.args = {
     value: '42%',
   },
   data: '242',
-  image: null,
   legendDotCustomColor: '#cf23a9',
   link: {
     value: 'View More',
@@ -72,7 +69,6 @@ DefaultRaised.args = {
     value: '76%',
   },
   data: '309',
-  image: null,
   link: {
     value: 'View More',
     href: '#'
@@ -90,7 +86,6 @@ SimpleWithImage.args = {
     alt: 'Example',
     src: 'https://via.placeholder.com/150'
   },
-  link: null,
   title: 'Title'
 };
 
@@ -98,12 +93,10 @@ export const SimpleWithIcon = Template.bind({});
 SimpleWithIcon.args = {
   change: null,
   data: '1,000',
-  image: null,
   icon: {
     cardColor: Icon.CARD_COLORS.PUBLISHED,
     name: Icon.ICONS.CHECK
   },
-  link: null,
   title: 'Title'
 };
 
@@ -112,7 +105,5 @@ NullView.args = {
   change: null,
   data: 'No insights to show',
   hasData: false,
-  image: null,
-  link: null,
   title: 'In Progress'
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes default props for icon, image, and link properties. This should address the issue of being forced to manually set those props to `null` to fix alignment issues based on the prop's existence.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1189" alt="Screen Shot 2021-12-15 at 5 08 09 PM" src="https://user-images.githubusercontent.com/14791307/146279256-d0c564e7-82a3-45ce-b519-d4288e93a8fc.png">|<img width="1157" alt="Screen Shot 2021-12-15 at 5 08 45 PM" src="https://user-images.githubusercontent.com/14791307/146279275-51114a65-b0b2-45ac-9eef-82f565bbfabb.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Check that props `icon`, `image`, and `link` no longer have to be manually set to `null` for alignment issues to be fixed.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) UI bug. Fixes default props for icon, image, and link properties. This should address the issue of being forced to manually set those props to `null` to fix alignment issues based on the prop's existence.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #1107 