### PR TITLE
[SAGE-1109] SageAvatar ID on image_tag

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -17,7 +17,8 @@
   <%= sage_component SageAvatar, {
     image: {
       alt: "Court's profile image",
-      src: "avatar/court.png"
+      src: "avatar/court.png",
+      id: "custom_id"
     }
   } %>
 </div>

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -31,7 +31,7 @@ module SageSchemas
     badge: [:optional, TrueClass],
     centered: [:optional, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],
-    image: [:optional, {alt: [:optional, String], src: String}],
+    image: [:optional, {alt: [:optional, String], src: String, id: [:optional, String]}],
     initials: [:optional, String],
     lazy_load_initials: [:optional, NilClass, TrueClass],
     size: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -44,7 +44,13 @@ end
   <% end %>
 
   <% if component.image %>
-    <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image" %>
+  <%
+    image_id = nil
+    if component.image[:id]
+      image_id = component.image[:id]
+    end
+    %>
+    <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image", id: image_id  %>
   <% end %>
 
   <% if lazy_load_initials %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -44,11 +44,11 @@ end
   <% end %>
 
   <% if component.image %>
-  <%
-    image_id = nil
-    if component.image[:id]
-      image_id = component.image[:id]
-    end
+    <%
+      image_id = nil
+      if component.image[:id]
+        image_id = component.image[:id]
+      end
     %>
     <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image", id: image_id  %>
   <% end %>

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -65,7 +65,7 @@ export const Avatar = ({
         </div>
       )}
       {image.src && (
-        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
+        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
       )}
       {lazyLoadInitials && (
         <svg className="sage-avatar__initials" viewBox="0 0 32 32">
@@ -96,7 +96,8 @@ Avatar.propTypes = {
   color: PropTypes.oneOf(Object.values(AVATAR_COLORS)),
   image: PropTypes.shape({
     alt: PropTypes.string,
-    src: PropTypes.string
+    src: PropTypes.string,
+    id: PropTypes.string
   }),
   initials: PropTypes.string,
   lazyLoadInitials: PropTypes.bool,

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -11,6 +11,7 @@ export default {
     image: {
       alt: null,
       src: null,
+      id: null,
     },
     initials: 'QJ',
     lazyLoadInitials: true,


### PR DESCRIPTION
## Description
Adjusts the `SageAvatar` `img_tag` to allow for an optional `ID` to be set on the image element.

## Screenshots
![Screen Shot 2021-12-15 at 4 08 17 PM](https://user-images.githubusercontent.com/1175111/146284893-d1552748-0b08-49af-9003-c1af95a49209.png)

## Testing in `sage-lib`

RAILS:
- Navigate to [http://localhost:4000/pages/component/avatar](http://localhost:4000/pages/component/avatar)
- Inspect the avatar in the Sample Avatars section that has the photo and verify the image has an id applied.
- Additionally, open `docs/app/views/examples/components/avatar/_preview.html.erb` update the ID and make sure changes are reflected.

REACT/STORYBOOK:
- Navigate to http://localhost:4100/?path=/story/sage-avatar--default
- Add image src, alt, and id. Make sure changes are applied and appear as expected

## Testing in `kajabi-products`
1. (**LOW**) Adds an optional ID to the SageAvatar Image element. Not expected to affect KP.

## Related
Closes #1109 
