### PR TITLE
[SAGE-710] Button: loading/spinner truncated aria-label

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -19,7 +19,9 @@
     <%= "sage-btn--icon-#{component.icon[:style]}-#{component.icon[:name]}" if component.icon %>
     <%= component.generated_css_classes %>
   "
-  <%= "data-js-sage-spinner-on-submit=#{component.spinner_on_submit}" if component.spinner_on_submit.present? %>
+  <% if component.spinner_on_submit.present? %>
+    data-js-sage-spinner-on-submit="<%= component.spinner_on_submit %>"
+  <% end %>
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.icon&.dig(:style) == "only" %>


### PR DESCRIPTION
## Description
Addresses an issue where `SageButton` with `spinner_on_submit` enabled truncates the user-supplied data-attribute and `aria-label`.  Rails-only; the React version has not been implemented.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![button-before](https://user-images.githubusercontent.com/816579/146290606-dd87ef11-cecf-406d-9be3-4815d17b0e4f.png)|![button-after](https://user-images.githubusercontent.com/816579/146290619-7055f0ec-9905-4e43-9dc4-19e8de1f0f1b.png)|


## Testing in `sage-lib`
1. View the Sage button examples page
2. Navigate to the "Loading State" example
3. Inspect the button and note the value for `data-js-sage-spinner-on-submit`
4. Click the button and verify that the `aria-label` matches the `data-js-sage-spinner-on-submit` value

## Testing in `kajabi-products`
1. (**LOW**) Button loading state: corrects output of label. 
   - [ ] Super admin Probationary mailings audit risk logs: `app/views/super_admin/probationary_mailings_audit_risk_logs/_audit_risk_logs.html.erb`


## Related
- Closes #710 
