### PR TITLE
Next version bump ~v4.33.0

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -17,7 +17,8 @@
   <%= sage_component SageAvatar, {
     image: {
       alt: "Court's profile image",
-      src: "avatar/court.png"
+      src: "avatar/court.png",
+      id: "custom_id"
     }
   } %>
 </div>

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -31,7 +31,7 @@ module SageSchemas
     badge: [:optional, TrueClass],
     centered: [:optional, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],
-    image: [:optional, {alt: [:optional, String], src: String}],
+    image: [:optional, {alt: [:optional, String], src: String, id: [:optional, String]}],
     initials: [:optional, String],
     lazy_load_initials: [:optional, NilClass, TrueClass],
     size: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -44,7 +44,13 @@ end
   <% end %>
 
   <% if component.image %>
-    <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image" %>
+  <%
+    image_id = nil
+    if component.image[:id]
+      image_id = component.image[:id]
+    end
+    %>
+    <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image", id: image_id  %>
   <% end %>
 
   <% if lazy_load_initials %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -44,11 +44,11 @@ end
   <% end %>
 
   <% if component.image %>
-  <%
-    image_id = nil
-    if component.image[:id]
-      image_id = component.image[:id]
-    end
+    <%
+      image_id = nil
+      if component.image[:id]
+        image_id = component.image[:id]
+      end
     %>
     <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image", id: image_id  %>
   <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel_controls.scss
@@ -31,6 +31,7 @@
 .sage-panel-controls__default-controls {
   display: flex;
   flex-flow: row wrap;
+  row-gap: sage-spacing(xs);
   align-items: center;
   justify-content: space-between;
 

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -65,7 +65,7 @@ export const Avatar = ({
         </div>
       )}
       {image.src && (
-        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} />
+        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
       )}
       {lazyLoadInitials && (
         <svg className="sage-avatar__initials" viewBox="0 0 32 32">
@@ -96,7 +96,8 @@ Avatar.propTypes = {
   color: PropTypes.oneOf(Object.values(AVATAR_COLORS)),
   image: PropTypes.shape({
     alt: PropTypes.string,
-    src: PropTypes.string
+    src: PropTypes.string,
+    id: PropTypes.string
   }),
   initials: PropTypes.string,
   lazyLoadInitials: PropTypes.bool,

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -11,6 +11,7 @@ export default {
     image: {
       alt: null,
       src: null,
+      id: null,
     },
     initials: 'QJ',
     lazyLoadInitials: true,

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -127,21 +127,11 @@ StatBox.defaultProps = {
   },
   customLabel: null,
   hasData: true,
-  icon: {
-    cardColor: null,
-    color: null,
-    name: null,
-  },
-  image: {
-    alt: null,
-    src: null
-  },
+  icon: null,
+  image: null,
   legendDotColor: null,
   legendDotCustomColor: null,
-  link: {
-    href: null,
-    value: null,
-  },
+  link: null,
   popover: null,
   raised: false,
   timeframe: null,

--- a/packages/sage-react/lib/StatBox/StatBox.story.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.story.jsx
@@ -22,7 +22,6 @@ Default.args = {
     value: '38%',
   },
   data: '4,010',
-  image: null,
   link: {
     value: 'View More',
     href: '#'
@@ -38,7 +37,6 @@ DefaultWithSageColorLegendDot.args = {
     value: '38%',
   },
   data: '4,010',
-  image: null,
   legendDotColor: StatBox.LEGEND_COLORS.PRIMARY,
   link: {
     value: 'View More',
@@ -55,7 +53,6 @@ DefaultWithSageCustomColorLegendDot.args = {
     value: '42%',
   },
   data: '242',
-  image: null,
   legendDotCustomColor: '#cf23a9',
   link: {
     value: 'View More',
@@ -72,7 +69,6 @@ DefaultRaised.args = {
     value: '76%',
   },
   data: '309',
-  image: null,
   link: {
     value: 'View More',
     href: '#'
@@ -90,7 +86,6 @@ SimpleWithImage.args = {
     alt: 'Example',
     src: 'https://via.placeholder.com/150'
   },
-  link: null,
   title: 'Title'
 };
 
@@ -98,12 +93,10 @@ export const SimpleWithIcon = Template.bind({});
 SimpleWithIcon.args = {
   change: null,
   data: '1,000',
-  image: null,
   icon: {
     cardColor: Icon.CARD_COLORS.PUBLISHED,
     name: Icon.ICONS.CHECK
   },
-  link: null,
   title: 'Title'
 };
 
@@ -112,7 +105,5 @@ NullView.args = {
   change: null,
   data: 'No insights to show',
   hasData: false,
-  image: null,
-  link: null,
   title: 'In Progress'
 };


### PR DESCRIPTION
1. (**LOW**) - kajabi/sage-lib#1106 - Fixes issue with Panel Controls spacing overlapping on mobile. A small patch will be applied to the next bump to update override styling for the one instance of Panel Controls in Kajabi Products.
2. (**LOW**) - kajabi/sage-lib#1108 - UI bug. Fixes default props for icon, image, and link properties. This should address the issue of being forced to manually set those props to `null` to fix alignment issues based on the prop's existence.
3. (**LOW**) - kajabi/sage-lib#1110 - Adds an optional ID to the SageAvatar Image element. Not expected to affect KP.