### PR TITLE
Next version bump ~v4.33.0

### DIFF
--- a/docs/app/views/examples/components/form_section/_preview.html.erb
+++ b/docs/app/views/examples/components/form_section/_preview.html.erb
@@ -28,4 +28,20 @@
         icon_name: "sage-icon-info-circle",
       } %>
   <% end %>
+
+  <h3 class="t-sage-heading-6">With Custom Subtitle</h3>
+  <%= sage_component SageFormSection, { 
+    id:"c1",
+    title: "Form Section Title",
+  } do %>
+    <%= sage_component SageAlert, {
+      title: "Form Section Content Will Go Here",
+      desc: "This component is designed to be very flexible and take any sort of content you want to pass to it.",
+      icon_name: "sage-icon-info-circle",
+    } %>
+    <%= content_for :sage_form_section_subtitle do %>
+      <p class="<%= "#{SageClassnames::SPACERS::XS_BOTTOM} #{SageClassnames::TYPE::BODY}"%>">Helpful text that lets the customer have an idea how to work with the section.</p>
+      <p class="<%= "#{SageClassnames::TYPE::BODY}" %>">Additional helpful text that lets the customer have an idea how to work with the section.</p>
+    <% end %>
+  <% end %>
 <% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_form_section.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_section.rb
@@ -5,4 +5,8 @@ class SageFormSection < SageComponent
     title_tag: [:optional, String],
     title: [:optional, NilClass, String],
   })
+
+  def sections
+    %w(form_section_subtitle)
+  end
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
@@ -11,8 +11,11 @@
         <%= component.title %>
       </<%= html_tag %>>
     <% end %>
-    <% if component.subtitle.present? %>
-      <p class="sage-form-section__subtitle"><%= component.subtitle %></p>
+    <% if component.subtitle.present? or content_for? :sage_form_section_subtitle %>
+      <div class="sage-form-section__subtitle">
+        <%= component.subtitle if component.subtitle.present? %>
+        <%= content_for :sage_form_section_subtitle if content_for? :sage_form_section_subtitle %>
+      </div>
     <% end %>
   </div>
   <div class="sage-form-section__content">

--- a/packages/sage-react/lib/FormSection/FormSection.jsx
+++ b/packages/sage-react/lib/FormSection/FormSection.jsx
@@ -11,7 +11,7 @@ export const FormSection = ({
     <div className="sage-form-section__info">
       <h3 className="sage-form-section__title">{title}</h3>
       {subtitle && (
-        <p className="sage-form-section__subtitle">{subtitle}</p>
+        <div className="sage-form-section__subtitle">{subtitle}</div>
       )}
     </div>
     <div className="sage-form-section__content">
@@ -29,6 +29,6 @@ FormSection.defaultProps = {
 
 FormSection.propTypes = {
   children: PropTypes.node,
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
   title: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
1. (LOW) - kajabi/sage-lib#1116 - Adds a `content_for` affordance for the Form Section `subtitle` prop. Update allows existing subtitles to remain but allows flexibility for longer content within `content_for` if needed. Existing instances of the `subtitle` prop should have no changes.