### PR TITLE
Adjust form section subtitle for a temporary stop-gap

### DIFF
--- a/docs/app/views/examples/components/form_section/_preview.html.erb
+++ b/docs/app/views/examples/components/form_section/_preview.html.erb
@@ -40,8 +40,8 @@
       icon_name: "sage-icon-info-circle",
     } %>
     <%= content_for :sage_form_section_subtitle do %>
-      <p class="<%= "#{SageClassnames::SPACERS::XS_BOTTOM} #{SageClassnames::TYPE::BODY}"%>">Helpful text that lets the customer have an idea how to work with the section.</p>
-      <p class="<%= "#{SageClassnames::TYPE::BODY}" %>">Additional helpful text that lets the customer have an idea how to work with the section.</p>
+      <p>Helpful text that lets the customer have an idea how to work with the section.</p>
+      <p>Additional helpful text that lets the customer have an idea how to work with the section.</p>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_section.html.erb
@@ -11,10 +11,14 @@
         <%= component.title %>
       </<%= html_tag %>>
     <% end %>
-    <% if component.subtitle.present? or content_for? :sage_form_section_subtitle %>
+    <% if component.subtitle.present? %>
+      <p class="sage-form-section__subtitle sage-form-section__subtitle--legacy">
+        <%= component.subtitle %>
+      </p>
+    <% end %>
+    <% if content_for? :sage_form_section_subtitle %>
       <div class="sage-form-section__subtitle">
-        <%= component.subtitle if component.subtitle.present? %>
-        <%= content_for :sage_form_section_subtitle if content_for? :sage_form_section_subtitle %>
+        <%= content_for :sage_form_section_subtitle %>
       </div>
     <% end %>
   </div>

--- a/packages/sage-assets/lib/stylesheets/components/_form_section.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_section.scss
@@ -26,7 +26,17 @@
 }
 
 .sage-form-section__subtitle {
+  @extend %t-sage-body;
+  
+  display: flex;
+  flex-direction: column;
+  gap: sage-spacing(sm);
   color: sage-color(charcoal, 200);
+}
+
+.sage-form-section__subtitle {
+  display: block;
+  gap: unset;
 }
 
 .sage-form-section__content {

--- a/packages/sage-assets/lib/stylesheets/components/_form_section.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_section.scss
@@ -34,7 +34,7 @@
   color: sage-color(charcoal, 200);
 }
 
-.sage-form-section__subtitle {
+.sage-form-section__subtitle--legacy {
   display: block;
   gap: unset;
 }


### PR DESCRIPTION
## Description

This PR updates the new `subtitle` slot for a temporary patching period.

## Testing in `sage-lib`

See Components > FormSection

## Testing in `kajabi-products`
1. **LOW** Stabilizes existing uses of Form Section subtitle that contain nested markup for a period of patching.


## Related

#1116 
