### PR TITLE
[SAGE-1127] Textarea error state (React)

### DIFF
--- a/packages/sage-react/lib/Textarea/Textarea.jsx
+++ b/packages/sage-react/lib/Textarea/Textarea.jsx
@@ -17,7 +17,7 @@ export const Textarea = ({
     'sage-textarea',
     className,
     {
-      'sage-textarea--error': hasError,
+      'sage-form-field--error': hasError,
     }
   );
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update class that is injected when error state is present

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![textarea-error](https://user-images.githubusercontent.com/1241836/148119817-497bf838-6957-4d40-8e43-c6d3ce6d03fd.gif)|![textarea-error-after](https://user-images.githubusercontent.com/1241836/148119833-be3bbb48-1eff-4eb6-a96f-6fab3270a2c9.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
On the textarea react docs page, click the `hasError` toggle and verify that the error state color is present

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update the error state color of the Textarea component.
   - [ ] Quiz Details


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
