### PR TITLE
[Sage-876] Expandable Card - Adds a11y For Hidden Items

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_expandable_card.scss
@@ -14,12 +14,14 @@ $-expandable-card-padding-xs: sage-spacing(xs);
 
 .sage-expandable-card__body,
 .sage-expandable-card__body-bordered {
+  visibility: hidden;
   overflow: hidden;
   height: 0;
   margin: 0;
   padding: 0;
   
   .sage-expandable-card--expanded & {
+    visibility: visible;
     overflow: initial;
     height: auto;
     margin-top: sage-spacing(xs);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds `visibility: hidden` and `visibility: visible` styles to the appropriate states to prevent tabbing through elements when the card is not expanded.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
https://user-images.githubusercontent.com/14791307/148249749-9e879517-5d21-4f02-a4eb-54d04933f3fd.mov

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/expandable_card)
- Check that hidden content cannot be tabbed through

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-expandablecard--default)
- Check that hidden content cannot be tabbed through

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds `visibility: hidden` and `visibility: visible` styles to the appropriate states to prevent tabbing through elements when the card is not expanded.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #876 