### PR TITLE
Form Section - Adds Missing React Link

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -560,6 +560,7 @@ module ComponentsHelper
         rails: "done",
         react: "todo",
         a11y: "todo",
+        react_component_slug: "sage-formsection--default",
         figma_embed: "",
       },
       {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds missing React link in docs.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1326" alt="Screen Shot 2022-01-05 at 10 41 31 AM" src="https://user-images.githubusercontent.com/14791307/148255079-14f4e249-40e5-40b9-9bbc-a33dad2c1dff.png">|<img width="1318" alt="Screen Shot 2022-01-05 at 10 41 02 AM" src="https://user-images.githubusercontent.com/14791307/148255085-92818869-1016-4695-80bd-7e7ab992bc67.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/form_section)
- Check that React link now exists.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds missing React link in docs. No effect on Kajabi Products.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
N/A