### PR TITLE
[Sage-1008] Table - New Prop, Caption Side

### DIFF
--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -111,6 +111,7 @@ sample_table = {
   headers: sample_table[:headers],
   rows: sample_table[:rows],
   caption: "Responsive tables require the use of two parent containers",
+  caption_side: "top",
 } %>
 
 <h3 class="t-sage-heading-6">Striped table</h3>

--- a/docs/app/views/examples/components/table/_props.html.erb
+++ b/docs/app/views/examples/components/table/_props.html.erb
@@ -5,6 +5,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`caption_side`') %></td>
+  <td><%= md('Sets the caption position for the component.') %></td>
+  <td><%= md('`"bottom"`, `"top"`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`condensed`') %></td>
   <td><%= md('Decreases vertical padding between items in the component.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -1,6 +1,7 @@
 class SageTable < SageComponent
   set_attribute_schema({
     caption: [:optional, String],
+    caption_side: [:optional, Set.new(["bottom", "top"])],
     condensed: [:optional, TrueClass],
     headers: [:optional, Array],
     reset_above: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -21,7 +21,11 @@ is_responsive = component.responsive.present? ? component.responsive : true
     <%= component.generated_html_attributes.html_safe %>
   >
     <% if component.caption.present? %>
-      <caption><%= component.caption.html_safe %></caption>
+      <caption class="
+        <%= "sage-table__caption--#{component.caption_side}" %>
+      ">
+        <%= component.caption.html_safe %>
+      </caption>
     <% end %>
     <% if component.headers.present? %>
       <thead>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -22,7 +22,8 @@ is_responsive = component.responsive.present? ? component.responsive : true
   >
     <% if component.caption.present? %>
       <caption class="
-        <%= "sage-table__caption--#{component.caption_side}" %>
+        sage-table__caption
+        <%= "sage-table__caption--#{component.caption_side}" if component.caption_side %>
       ">
         <%= component.caption.html_safe %>
       </caption>

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -121,6 +121,14 @@ $-table-avatar-width: rem(32px);
   }
 }
 
+.sage-table__caption--bottom {
+  caption-side: bottom;
+}
+
+.sage-table__caption--top {
+  caption-side: top;
+}
+
 // Decreased vertical padding
 .sage-table--condensed {
   thead,

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import uuid from 'react-uuid';
 import { TableHelpers } from '../helpers';
-import { cellPropTypes, dataPropTypes } from './configs';
+import { CAPTION_SIDE, cellPropTypes, dataPropTypes } from './configs';
 import { TableHeader } from './TableHeader';
 import { TableRow } from './TableRow';
 import { SELECTION_TYPES } from '../PanelControls/configs';
@@ -32,6 +32,8 @@ import { SELECTION_TYPES } from '../PanelControls/configs';
 // for a properly formatted table.
 //
 export const Table = ({
+  caption,
+  captionSide,
   className,
   headers,
   isResponsive,
@@ -238,6 +240,11 @@ export const Table = ({
   // Renders the table itself
   const renderTable = () => (
     <table className={tableClassNames} {...tableAttributes}>
+      {caption && (
+        <caption className={`sage-table__caption--${captionSide}`}>
+          {caption}
+        </caption>
+      )}
       {selfHeaders && (
         <thead>
           <tr>
@@ -265,9 +272,12 @@ export const Table = ({
 
 Table.Header = TableHeader;
 Table.Row = TableRow;
+Table.CAPTION_SIDE = CAPTION_SIDE;
 Table.DATA_TYPES = TableHelpers.DATA_TYPES;
 
 Table.defaultProps = {
+  caption: null,
+  captionSide: null,
   className: null,
   headers: [],
   isResponsive: true,
@@ -283,6 +293,8 @@ Table.defaultProps = {
 };
 
 Table.propTypes = {
+  caption: PropTypes.string,
+  captionSide: PropTypes.oneOf(Object.values(Table.CAPTION_SIDE)),
   className: PropTypes.string,
   // Headers provide a simpler alternative to schema
   headers: PropTypes.oneOfType([

--- a/packages/sage-react/lib/Table/Table.story.jsx
+++ b/packages/sage-react/lib/Table/Table.story.jsx
@@ -3,10 +3,16 @@ import { Panel } from '../Panel';
 import { Table } from './Table';
 import { dataCollection } from './sample-data/contacts';
 import { domains } from './sample-data/domains';
+import { selectArgs } from '../story-support/helpers';
 
 export default {
   title: 'Sage/Table',
   component: Table,
+  argTypes: {
+    ...selectArgs({
+      captionSide: Table.CAPTION_SIDE
+    })
+  },
   args: {
     headers: {
       first: {

--- a/packages/sage-react/lib/Table/configs.js
+++ b/packages/sage-react/lib/Table/configs.js
@@ -1,5 +1,10 @@
 import PropTypes from 'prop-types';
 
+export const CAPTION_SIDE = {
+  BOTTOM: 'bottom',
+  TOP: 'top',
+};
+
 // Basic data value types
 export const dataPropTypes = PropTypes.oneOfType([
   PropTypes.string,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds new prop `caption_side` to coincide with caption placement via CSS property `caption-side`.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="1329" alt="Screen Shot 2022-01-06 at 11 03 44 AM" src="https://user-images.githubusercontent.com/14791307/148421552-3fedead7-7b83-4687-a717-0f5b18a705e3.png">

<img width="984" alt="Screen Shot 2022-01-06 at 11 04 51 AM" src="https://user-images.githubusercontent.com/14791307/148421562-63fc47a6-4f0e-4809-b7ec-7b087bd9e831.png">

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/table)
- Check that caption can be positioned at the top with new prop

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-table--default)
- Check that new caption prop exists and can be placed either on top or bottom of table

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds new prop `caption_side` to coincide with caption placement via CSS property `caption-side`. Also adds missing caption prop to React component. No effect on existing Kajabi Products work.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #1008 