### PR TITLE
[Sage-1126] Checkbox - Custom Content Slot

### DIFF
--- a/docs/app/views/examples/components/checkbox/_preview.html.erb
+++ b/docs/app/views/examples/components/checkbox/_preview.html.erb
@@ -7,7 +7,11 @@
     disabled: false,
     has_error: false,
     partial_selection: true
-  } %>
+  } do %>
+    <% content_for :sage_checkbox_custom_content do %>
+      <h1>Testing</h1>
+    <% end %>
+  <% end %>
 
   <%= sage_component SageCheckbox, {
     id:"c1b",

--- a/docs/app/views/examples/components/checkbox/_preview.html.erb
+++ b/docs/app/views/examples/components/checkbox/_preview.html.erb
@@ -7,11 +7,7 @@
     disabled: false,
     has_error: false,
     partial_selection: true
-  } do %>
-    <% content_for :sage_checkbox_custom_content do %>
-      <h1>Testing</h1>
-    <% end %>
-  <% end %>
+  } %>
 
   <%= sage_component SageCheckbox, {
     id:"c1b",
@@ -20,7 +16,11 @@
     disabled: false,
     has_error: false,
     message: 'This is where a "hint" message would appear.',
-  } %>
+  } do %>
+    <% content_for :sage_checkbox_custom_content do %>
+      <p>Paragraph for testing custom content.</p>
+    <% end %>
+  <% end %>
 
   <%= sage_component SageCheckbox, {
     id:"c1c",

--- a/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
@@ -13,4 +13,7 @@ class SageCheckbox < SageComponent
     standalone:  [:optional, TrueClass],
     value: [:optional, String],
   })
+
+  def sections
+    %w(checkbox_custom_content)
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_checkbox.rb
@@ -16,4 +16,5 @@ class SageCheckbox < SageComponent
 
   def sections
     %w(checkbox_custom_content)
+  end
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
@@ -48,9 +48,9 @@
     <% if component.message.present? %>
       <div class="sage-checkbox__message"><%= component.message %></div>
     <% end %>
-    <% if :sage_checkbox_custom_content %>
+    <% if content_for? :sage_checkbox_custom_content %>
       <div class="sage-checkbox__custom-content">
-        <%= :sage_checkbox_custom_content %>
+        <%= content_for :sage_checkbox_custom_content %>
       </div>
     <% end %>
   </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
@@ -48,6 +48,11 @@
     <% if component.message.present? %>
       <div class="sage-checkbox__message"><%= component.message %></div>
     <% end %>
+    <% if :sage_checkbox_custom_content %>
+      <div class="sage-checkbox__custom-content">
+        <%= :sage_checkbox_custom_content %>
+      </div>
+    <% end %>
   </div>
 <% end %>
 

--- a/packages/sage-react/lib/Toggle/Checkbox.story.jsx
+++ b/packages/sage-react/lib/Toggle/Checkbox.story.jsx
@@ -22,6 +22,13 @@ const Template = (args) => <Checkbox {...args} />;
 
 export const Default = Template.bind({});
 
+export const DefaultWithCustomContent = Template.bind({});
+DefaultWithCustomContent.args = {
+  customContent: (
+    <div>hi</div>
+  )
+}
+
 export const MultipleExample = (args) => {
   const items = [
     {

--- a/packages/sage-react/lib/Toggle/Toggle.jsx
+++ b/packages/sage-react/lib/Toggle/Toggle.jsx
@@ -6,6 +6,7 @@ import { TOGGLE_POSITIONS, TOGGLE_STYLES, TOGGLE_TYPES } from './configs';
 export const Toggle = ({
   checked,
   className,
+  customContent,
   disabled,
   hasBorder,
   hasError,
@@ -70,6 +71,16 @@ export const Toggle = ({
 
   const Tag = itemInList ? 'li' : 'div';
 
+  const renderCustomContent = ()=> {
+    if (customContent && type == Toggle.TYPES.CHECKBOX) {
+      return (
+        <div className={`${baseClass}__custom-content`}>
+          {customContent}
+        </div>
+      );
+    }
+  };
+
   return (
     <Tag className={classNames}>
       <input
@@ -88,6 +99,7 @@ export const Toggle = ({
       {message && (
         <div className={`${baseClass}__message`}>{message}</div>
       )}
+      {renderCustomContent()}
     </Tag>
   );
 };
@@ -99,6 +111,7 @@ Toggle.TYPES = TOGGLE_TYPES;
 Toggle.defaultProps = {
   checked: false,
   className: null,
+  customContent: null,
   disabled: false,
   hasBorder: false,
   hasError: false,
@@ -116,6 +129,7 @@ Toggle.defaultProps = {
 Toggle.propTypes = {
   checked: PropTypes.bool,
   className: PropTypes.string,
+  customContent: PropTypes.node,
   disabled: PropTypes.bool,
   hasBorder: PropTypes.bool,
   hasError: PropTypes.bool,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a new slot for custom content for the Checkbox component in Rails and React.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
WIP

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/checkbox)
- Check that new custom content slot works as intended

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-checkbox--default-with-custom-content)
- Check that hidden content cannot be tabbed through

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds new prop for custom content slot in Checkbox component. No effect on existing Kajabi Products work.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #1126 