### PR TITLE
[Sage-792] Form Input - Multiple Words for Affixes

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -1,6 +1,3 @@
-<script>
-console.log("<%= "#{component.prefix}" %>")
-</script>
 <div
   class="sage-input
     <%= "sage-form-field--error" if component.has_error %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_input.html.erb
@@ -1,3 +1,6 @@
+<script>
+console.log("<%= "#{component.prefix}" %>")
+</script>
 <div
   class="sage-input
     <%= "sage-form-field--error" if component.has_error %>
@@ -6,8 +9,12 @@
     <%= "sage-input--has-popover" if content_for? :sage_form_input_popover %>
     <%= "sage-input--has-icon" if component.icon.present? %>
     <%= component.generated_css_classes %>"
-  <%= "data-js-input-prefix=#{component.prefix}" if component.prefix.present? -%>
-  <%= "data-js-input-suffix=#{component.suffix}" if component.suffix.present? -%>
+  <% if component.prefix.present? %>
+    data-js-input-prefix="<%= component.prefix %>"
+  <% end %>
+  <% if component.suffix.present? %>
+    data-js-input-suffix="<%= component.suffix %>"
+  <% end %>
   <%= component.generated_html_attributes.html_safe -%>
 >
   <input


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes an issue with the prefixes and suffixes only outputting the first word in a string.

The issue seems to be caused by the expectation that the data attribute value is wrapped in quotes. Writing the data attribute conditional inline doesn't allow for that:

<img width="788" alt="Screen Shot 2022-01-12 at 4 12 56 PM" src="https://user-images.githubusercontent.com/14791307/149231458-6de8481d-41c0-45a4-bb6c-db7de84b0926.png">

It's likely that any other instance of this approach to data attributes within Sage is suffering from the same bug, just unnoticeable because they haven't been used for strings longer than one word.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="227" alt="Screen Shot 2022-01-12 at 4 17 36 PM" src="https://user-images.githubusercontent.com/14791307/149231871-c9c76199-88c3-4ff5-91ea-bac350ab4b1a.png">|<img width="318" alt="Screen Shot 2022-01-12 at 4 17 20 PM" src="https://user-images.githubusercontent.com/14791307/149231879-47fbf05e-3bc9-48a2-af8a-89e8a71fc0ca.png">
<img width="344" alt="Screen Shot 2022-01-12 at 4 22 43 PM" src="https://user-images.githubusercontent.com/14791307/149232401-fdeca4f2-8cc6-401a-a00d-03f5efbd9e57.png">|<img width="341" alt="Screen Shot 2022-01-12 at 4 23 23 PM" src="https://user-images.githubusercontent.com/14791307/149232454-12bc72f3-9d3e-406b-ad9c-55f2a53c9cad.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/form_input)
- Check that inputting a prefix or suffix with multiple words in `_preview.html.erb` renders in data attribute as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Fixes a bug where multiple words were unable to be used as prefixes and suffixes for form inputs.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes #792 