### PR TITLE
[Sage-94] Choice - Disabled Prop Fix

### DIFF
--- a/docs/app/views/examples/components/choice/_preview.html.erb
+++ b/docs/app/views/examples/components/choice/_preview.html.erb
@@ -7,10 +7,8 @@ long_description = "Description with longer text to cause wrapping and make the 
     target: "example",
     text: "Option 1",
     type: "radio",
-    disabled: true,
-  } do %>
-  <h1>test</h1>
-<% end %>
+    active: true,
+} %>
 
 <h3 class="t-sage-heading-6">With Radio</h3>
 <%= sage_component SageChoice, {

--- a/docs/app/views/examples/components/choice/_preview.html.erb
+++ b/docs/app/views/examples/components/choice/_preview.html.erb
@@ -7,9 +7,10 @@ long_description = "Description with longer text to cause wrapping and make the 
     target: "example",
     text: "Option 1",
     type: "radio",
-    active: true
-  }
-%>
+    disabled: true,
+  } do %>
+  <h1>test</h1>
+<% end %>
 
 <h3 class="t-sage-heading-6">With Radio</h3>
 <%= sage_component SageChoice, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_choice.html.erb
@@ -17,7 +17,10 @@ end
     <%= "#{key}='#{value}'".html_safe %>
   <% end if component.attributes&.is_a?(Hash) %>
   <% if component.disabled %>
-    <%= is_button ? "disabled" : "aria-disabled=true" %>
+    <%= is_button && html_tag != "div" ? "disabled" : "aria-disabled=true" %>
+  <% end %>
+  <% if html_tag === "div" %>
+    tabindex="0"
   <% end %>
   class="
     sage-choice

--- a/packages/sage-react/lib/Choice/Choice.jsx
+++ b/packages/sage-react/lib/Choice/Choice.jsx
@@ -62,7 +62,7 @@ export const Choice = ({
     'data-js-tabs-target': target,
     disabled: TagName !== 'div' && disabled,
     tabIndex: TagName === 'div' ? '0' : null,
-    role: "tab",
+    role: 'tab',
     ...(hasRadioConfigs && { htmlFor: radioConfigs.id }),
     ...(isButton && { type: 'button' }),
     ...rest,

--- a/packages/sage-react/lib/Choice/Choice.jsx
+++ b/packages/sage-react/lib/Choice/Choice.jsx
@@ -62,6 +62,7 @@ export const Choice = ({
     'data-js-tabs-target': target,
     disabled: TagName !== 'div' && disabled,
     tabIndex: TagName === 'div' ? '0' : null,
+    role: "tab",
     ...(hasRadioConfigs && { htmlFor: radioConfigs.id }),
     ...(isButton && { type: 'button' }),
     ...rest,

--- a/packages/sage-react/lib/Choice/Choice.jsx
+++ b/packages/sage-react/lib/Choice/Choice.jsx
@@ -56,10 +56,12 @@ export const Choice = ({
 
   const attrs = {
     'aria-controls': target,
+    'aria-disabled': TagName === 'div' && disabled,
     'aria-selected': isActive,
     className: classNames,
     'data-js-tabs-target': target,
-    disabled,
+    disabled: TagName !== 'div' && disabled,
+    tabIndex: TagName === 'div' ? '0' : null,
     ...(hasRadioConfigs && { htmlFor: radioConfigs.id }),
     ...(isButton && { type: 'button' }),
     ...rest,

--- a/packages/sage-react/lib/Choice/Choice.jsx
+++ b/packages/sage-react/lib/Choice/Choice.jsx
@@ -56,7 +56,7 @@ export const Choice = ({
 
   const attrs = {
     'aria-controls': target,
-    'aria-disabled': TagName === 'div' && disabled,
+    'aria-disabled': TagName === 'div' ? disabled : null,
     'aria-selected': isActive,
     className: classNames,
     'data-js-tabs-target': target,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates logic for handling the disabled prop. Adds `aria-disabled` to the div variation of this component as well as a missing `tabindex` for keyboard navigation.

This direction was taken over a docs update to improve accessibility and leave the heavy-lifting for a11y within Sage.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="814" alt="Screen Shot 2022-01-20 at 4 29 28 PM" src="https://user-images.githubusercontent.com/14791307/150432689-35b4bb5c-46f7-4712-90fd-5d81eea0baea.png">|<img width="909" alt="Screen Shot 2022-01-20 at 4 29 34 PM" src="https://user-images.githubusercontent.com/14791307/150432697-8f32afe5-6026-4635-b09a-594f2f571f21.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/choice)
- Add content to any preview component.
- Check that `aria-disabled` is properly added to the div variation of the component.
- Check that `tabindex` also exists for the div variation.

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-choice--default)
- Add custom content in the `children` prop.
- Check that `aria-disabled` is properly added to the div variation of the component.
- Check that `disabled` prop does not exist on the div variation.
- Check that `tabindex` also exists for the div variation.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates logic for handling the disabled prop. Adds `aria-disabled` to the div variation of this component as well as a missing `tabindex` for keyboard navigation.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-94](https://kajabi.atlassian.net/browse/SAGE-94)