### PR TITLE
[SAGE-145] Allow nil as option in dropdown item styles

### DIFF
--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -61,7 +61,7 @@ Array<{
     "disabled" | "border-before" | "border-after" | nil,
   ],
   selected: Boolean,
-  style: "primary" | "danger" | "muted",
+  style: "primary" | "danger" | "muted" | nil,
   value: String,
 }>
 ```

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -65,7 +65,7 @@ module SageSchemas
     is_heading: [:optional, TrueClass],
     modifiers: [:optional, [[Set.new(["disabled", "border-before", "border-after", nil])]]],
     selected: [:optional, TrueClass],
-    style: [:optional, Set.new(["primary", "danger", "muted"])],
+    style: [:optional, NilClass, Set.new(["primary", "danger", "muted"])],
     value: String,
   }
 


### PR DESCRIPTION
## Description
Updates dropdown items styles to allow for NilClass

## Screenshots
No visual changes.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->

Open docs/app/views/examples/components/dropdown/_preview.html.erb
Add `style: nil` to any `items:` or update existing with `styles: nil`
Navigate to: http://localhost:4000/pages/component/dropdown
Verify no errors are displayed.


## Testing in `kajabi-products`
Should have no effect on kajabi-products.

## Related
https://kajabi.atlassian.net/browse/SAGE-145
