### PR TITLE
docs(docs): Remove the Generated HTML Code section

### DIFF
--- a/docs/app/views/examples/shared/_code.html.erb
+++ b/docs/app/views/examples/shared/_code.html.erb
@@ -17,13 +17,4 @@
       title: "This component does not provide a SageRails class.",
     } %>
   <% end %>
-  <%= sage_component SageCard, { spacer: { bottom: :md } } do %>
-    <%= sage_component SageCardHeader, { title: "Generated HTML Code"} %>
-    <div class="example__code">
-      <button class="example__expand-btn" aria-expanded="false" aria-controls="example-html-code-<%= title %>">Expand this code snippet</button>
-      <div id="example-html-code-<%= title %>" class="sage-code-snippet" tabindex="-1">
-        <pre class="prettyprint"><code><%= CGI.unescapeHTML(CGI.escapeHTML(render("examples/#{type.pluralize}/#{title}/preview"))) %></code></pre>
-      </div>
-    </div>
-  <% end %>
 </div>


### PR DESCRIPTION
## Description
This PR removes the Generated HTML Code section from the component docs pages.

https://kajabi.atlassian.net/browse/SAGE-55

## Screenshots
|  Before  |  After  |
|--------|--------|
|<img width="1792" alt="Before" src="https://user-images.githubusercontent.com/7331038/150839694-25dc7cb4-0ba0-4cb1-915b-3f5f27689292.png">|<img width="1792" alt="After" src="https://user-images.githubusercontent.com/7331038/150839727-f3d42afa-5484-4b9a-aca5-b39ea356755d.png">|

## Testing in `sage-lib`
1. Visit any component page
2. Select the `Code` tab
3. Ensure that the `Generated HTML Code` section no longer appears

## Testing in `kajabi-products`
N/A