### PR TITLE
[SAGE-157] Page Heading Actions Alignment

### DIFF
--- a/docs/app/views/examples/components/page_heading/_preview.html.erb
+++ b/docs/app/views/examples/components/page_heading/_preview.html.erb
@@ -148,7 +148,9 @@
     <% content_for :sage_page_heading_actions do %>
       <%= sage_component SageButton, {
         style: "secondary",
-        icon: { name: "preview-on", style: "left" },
+        icon: { name: "preview-on", style: "only" },
+        attributes: { "data-js-tooltip": "Preview" },
+        subtle: true,
         value: "Preview",
       } %>
       <%= sage_component SageButton, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -47,7 +47,9 @@
   <% end %>
   <% if content_for? :sage_page_heading_actions %>
     <div class="sage-page-heading__actions">
-      <%= content_for :sage_page_heading_actions %>
+      <div class="sage-page-heading__actions-inner">
+        <%= content_for :sage_page_heading_actions %>
+      </div>
     </div>
   <% end %>
   <% if content_for? :sage_page_heading_toolbar %>

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -171,7 +171,7 @@ $-btn-loading-min-height: rem(36px);
   .sage-panel-controls__toolbar > &,
   .sage-panel-controls__toolbar-btn-group > &,
   .sage-panel-controls__pagination > &,
-  .sage-toolbar > & 
+  .sage-toolbar > &
   .sage-toolbar__group > & {
     position: relative;
     z-index: sage-z-index(default);
@@ -277,10 +277,6 @@ $-btn-loading-min-height: rem(36px);
     &:not(:last-child) {
       margin-right: sage-spacing();
     }
-  }
-
-  .sage-page-heading__actions & {
-    align-self: flex-start;
   }
 
   .sage-sortable__item-actions & {
@@ -390,10 +386,10 @@ $-btn-loading-min-height: rem(36px);
       }
       @else {
         @include sage-focus-outline--update-color(map-get($-style-type-configs, ring-color));
-        
+
         color: map-get($-style-type-configs, color);
         background-color: map-get($-style-type-configs, background-color);
-        
+
         .sage-toolbar > &,
         .sage-toolbar__group > & {
           @include sage-focus-outline--update-color(transparent);
@@ -417,7 +413,7 @@ $-btn-loading-min-height: rem(36px);
       .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger &:hover {
         box-shadow: map-get($sage-toolbar-button-borders, hover);
       }
-    
+
       .sage-toolbar > &:focus,
       .sage-toolbar > .sage-dropdown .sage-dropdown__trigger &:focus,
       .sage-toolbar__group > &:focus,
@@ -486,7 +482,7 @@ $-alert-colors: (
           border-color: sage-color($color, 200);
           background-color: transparent;
         }
-  
+
         @include sage-focus-outline--update-color(sage-color($color, 400));
       }
     }

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -62,6 +62,7 @@ $-page-heading-image-height-mobile: rem(120px);
 .sage-page-heading__title {
   @extend %t-sage-heading-1;
   grid-area: title;
+  margin-right: sage-spacing(sm);
 }
 
 .sage-page-heading__intro {
@@ -111,7 +112,7 @@ $-page-heading-image-height-mobile: rem(120px);
 .sage-page-heading__actions {
   display: flex;
   grid-area: actions;
-  align-items: center;
+  align-items: flex-start;
 
   @media (max-width: sage-breakpoint(sm-max)) {
     flex-wrap: wrap;


### PR DESCRIPTION
## Description
Within the page heading component, buttons do not align vertically when using a subtle button alongside a standard button with the `:sage_page_heading_actions` content area.

Based on the new page heading design and incoming tabs, these will need to align vertically.

Also, see https://github.com/Kajabi/sage-lib/pull/653 for why a child div element was added.

![Screen Shot 2022-01-24 at 12 38 53 PM](https://user-images.githubusercontent.com/1175111/150866364-19cf510b-860e-4eda-b35e-64653fc72a77.png)


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-01-24 at 1 11 46 PM](https://user-images.githubusercontent.com/1175111/150866397-8db059c3-ee4f-4f05-afa5-6b42fb9ba411.png)|![Screen Shot 2022-01-24 at 1 11 17 PM](https://user-images.githubusercontent.com/1175111/150866579-a18f7e9d-9eda-4d37-9b12-be1e1b89e899.png)|


## Testing in `sage-lib`

Navigate to [page heading component](http://localhost:4000/pages/component/page_heading)
In the last example at the bottom of the page, verify the preview icon button and full-size button align. (see screenshot above)


## Testing in `kajabi-products`

1. (**LOW**) Adjusts alignment of the subtle button and full-size buttons when used within `:sage_page_heading_actions` area. Quick sanity of page headings within kajabi-products should be performed.


## Related
https://kajabi.atlassian.net/browse/SAGE-157
