### PR TITLE
[SAGE-161] Optional Tab Icon

### DIFF
--- a/docs/app/views/examples/components/tab/_preview.html.erb
+++ b/docs/app/views/examples/components/tab/_preview.html.erb
@@ -2,10 +2,22 @@
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTab, {
       target: "example-tab1",
-      text: "Page 1"
+      text: "Page 1",
     }
   %>
 <% end %>
+
+<h3 class="t-sage-heading-6">As a button and icon with a target pane in mind</h3>
+<%= sage_component SagePanelBlock, {} do %>
+  <%= sage_component SageTab, {
+      target: "example-tab2",
+      text: "Page 1",
+      icon: "pen"
+    }
+  %>
+<% end %>
+
+
 
 <h3 class="t-sage-heading-6">As a link with a route or site in mind</h3>
 <%= sage_component SagePanelBlock, {} do %>
@@ -14,6 +26,18 @@
         href: "//example.com",
       },
       text: "Page 1"
+    }
+  %>
+<% end %>
+
+<h3 class="t-sage-heading-6">As a link with a route and icon</h3>
+<%= sage_component SagePanelBlock, {} do %>
+  <%= sage_component SageTab, {
+      attributes: {
+        href: "//example.com",
+      },
+      text: "Page 1",
+      icon: "pen"
     }
   %>
 <% end %>

--- a/docs/app/views/examples/components/tab/_preview.html.erb
+++ b/docs/app/views/examples/components/tab/_preview.html.erb
@@ -17,8 +17,6 @@
   %>
 <% end %>
 
-
-
 <h3 class="t-sage-heading-6">As a link with a route or site in mind</h3>
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageTab, {

--- a/docs/app/views/examples/components/tab/_props.html.erb
+++ b/docs/app/views/examples/components/tab/_props.html.erb
@@ -16,6 +16,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`icon`') %></td>
+  <td><%= md('Provides the name of the Sage Icon to be displayed before the text content.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`target`') %></td>
   <td><%= md('Provides the `id` for the corresponding Tab Pane that this tab will activate.') %></td>
   <td><%= md('String') %></td>

--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -1,7 +1,6 @@
 <h3 class="t-sage-heading-6">Regular tabs</h3>
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
-      id: "example-tabs1",
       navigational: true,
       items: [
         {
@@ -27,18 +26,36 @@
     }
   %>
 
-  <%= sage_component SageTabsPane, { id: "basic-test1", card: true } do %>
-    <p>Sub page 1 content</p>
-  <% end %>
-
-  <%= sage_component SageTabsPane, { id: "basic-test2", card: true } do %>
-    <p>Sub page 2 content</p>
-  <% end %>
-
-  <%= sage_component SageTabsPane, { id: "basic-test3", card: true } do %>
-    <p>Sub page 3 content</p>
-  <% end %>
-</div>
+<h3 class="t-sage-heading-6">Regular tabs w/ icons</h3>
+<div class="sage-tabs-container">
+  <%= sage_component SageTabs, {
+      navigational: true,
+      items: [
+        {
+          text: "Sub Page 1",
+          attributes: {
+            href: "//example.com/basic-test1",
+          },
+          active: true,
+          icon: "pen"
+        },
+        {
+          text: "Sub Page 2",
+          attributes: {
+            href: "//example.com/basic-test2"
+          },
+          icon: "calendar-date"
+        },
+        {
+          text: "Sub Page 3",
+          attributes: {
+            href: "//example.com/basic-test3"
+          },
+          icon: "users"
+        },
+      ]
+    }
+  %>
 
 <h3 class="t-sage-heading-6">Progress styled tabs</h3>
 <div class="sage-tabs-container">

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -94,6 +94,7 @@ module SageSchemas
     active: [:optional, NilClass, TrueClass],
     attributes: [:optional, NilClass, Hash],
     disabled: [:optional, NilClass, TrueClass],
+    icon: [:optional, NilClass, String],
     target: [:optional, NilClass, String],
     text: String,
   }

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tab.html.erb
@@ -18,6 +18,7 @@ html_tag = is_button ? "button" : "a"
   <% end %>
   class="
     sage-tab
+    <%= "sage-tab--icon-#{component.icon}" if component.icon.present? %>
     <%= css_active_class if component.active %>
     <%= component.generated_css_classes %>"
   data-sage-active-class="<%= css_active_class %>"

--- a/packages/sage-assets/lib/stylesheets/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_icon.scss
@@ -70,6 +70,11 @@ $-icon-beside-type: (
   @include sage-button-icon-generator($icon-name, $icon-code, left);
   @include sage-button-icon-generator($icon-name, $icon-code, right);
 
+  .sage-tab--icon-#{$icon-name}::before {
+    @include sage-icon-base($icon-name);
+    margin-right: sage-spacing(xs);
+  }
+
   .sage-choice--icon-#{$icon-name}::before {
     @include sage-icon-base($icon-name);
   }


### PR DESCRIPTION
## Description
With the new design updates that will incorporate tabs into the page heading component, the tab component will need to be able to support an optional icon to be displayed next to the tab text.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-01-24 at 3 22 28 PM](https://user-images.githubusercontent.com/1175111/150881637-f00ec0a4-6177-4d62-86cd-b74af749cc4b.png)|![Screen Shot 2022-01-24 at 3 22 21 PM](https://user-images.githubusercontent.com/1175111/150881671-b131f312-01d8-4310-be56-896bec23a133.png)|


## Testing in `sage-lib`
Navigate to tab: http://localhost:4000/pages/component/tab
Verify updated preview displays example of tab with icon.

Navigate to tabs: http://localhost:4000/pages/component/tabs
Verify updated preview displays an example of multiple tabs with icons.


## Testing in `kajabi-products`

1. (**LOW**) Adds an optional icon to the tab component. No effect on kajabi-products expected.

## Related
https://kajabi.atlassian.net/browse/SAGE-161
