### PR TITLE
Add font CDN test file for temp production testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,6 @@ jobs:
           && rm yarn-v$YARN_VERSION.tar.gz \
           && rm node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz
 
-      - name: Clone Sage-Lib Repo
-        uses: actions/checkout@v2
-        with:
-          # pulls all commits (needed for lerna / semantic release to correctly version)
-          fetch-depth: "0"
-
       - name: Documentation Site Deploy
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,12 @@ jobs:
           && rm yarn-v$YARN_VERSION.tar.gz \
           && rm node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz
 
+      - name: Clone Sage-Lib Repo
+        uses: actions/checkout@v2
+        with:
+          # pulls all commits (needed for lerna / semantic release to correctly version)
+          fetch-depth: "0"
+
       - name: Documentation Site Deploy
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/docs/app/views/async/style-test.html.erb
+++ b/docs/app/views/async/style-test.html.erb
@@ -1,0 +1,54 @@
+<style type="text/css">
+@font-face {
+  font-family: "Circular";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local("Circular"),
+    url("https://sage.kajabi-cdn.com/fonts/circular/CircularXXSub-Black.woff2") format("woff2"),
+    url("https://sage.kajabi-cdn.com/fonts/circular/CircularXXSub-Black.woff") format("woff");
+}
+
+.font-not {
+  font-family: cursive, sans-serif;
+}
+
+.font-circular {
+  font-family: "Circular", cursive, sans-serif;
+}
+
+.lineup {
+  display: flex;
+  gap: 48px;
+}
+</style>
+
+<div class="lineup">
+  <div>
+    <p>This side should use the Circular font. It should be a bold sans serif font. Check the lowercase t's for a rounded bevel on the top left side of the ascender.</p>
+    <div class="font-circular">
+      <h1>Vivamus id sagittis dolor.</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Maecenas condimentum ipsum sem, in gravida est accumsan non.
+        Maecenas sagittis interdum condimentum.
+        Etiam ultricies lorem sit amet ex gravida, nec porta erat porta.
+        Pellentesque blandit mi sem, ac varius turpis pulvinar eu.
+      </p>
+    </div>
+  </div>
+
+  <div>
+    <p>This is side shows an obvious cursive fallback font. If both sides looke like this side then the Circular font is not applying in this context.</p>
+    <div class="font-not">
+      <h1>Vivamus id sagittis dolor.</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Maecenas condimentum ipsum sem, in gravida est accumsan non.
+        Maecenas sagittis interdum condimentum.
+        Etiam ultricies lorem sit amet ex gravida, nec porta erat porta.
+        Pellentesque blandit mi sem, ac varius turpis pulvinar eu.
+      </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Description

This PR adds a temporary test page for validating the new Circular font works from a CDN in our production environment.

## Screenshots

This screenshot shows the test page working as expected in local environment:

<img width="991" alt="Screen Shot 2022-01-26 at 9 53 39 PM" src="https://user-images.githubusercontent.com/17955295/151284105-9de191eb-7b92-47f8-b7e9-b69d17b1cffa.png">

## Testing in `sage-lib`

Visit http://localhost:4000/async/style-test locally or https://sage-design-system.kajabi.com/async/style-test in production.

## Testing in `kajabi-products`

1. (N/A) Adds a test page only to the Sage docs site. No imapct on `kp`
