### PR TITLE
[Sage-7] Typography - Type Specs Update

### DIFF
--- a/docs/app/views/pages/typography.html.erb
+++ b/docs/app/views/pages/typography.html.erb
@@ -8,9 +8,9 @@ type_specs = [
       React: `SageClassnames.TYPE.HEADING_1`
     )),
     weight: "700",
-    kerning: "0.3px",
-    desktop: "29px / 36px",
-    mobile: "26px / 32px",
+    kerning: "-0.6px",
+    desktop: "40px / 60px",
+    mobile: "40px / 60px",
   },
   {
     style: md(%(
@@ -20,9 +20,9 @@ type_specs = [
       React: `SageClassnames.TYPE.HEADING_2`
     )),
     weight: "700",
-    kerning: "0.3px",
-    desktop: "26px / 32px",
-    mobile: "23px / 32px",
+    kerning: "-0.5px",
+    desktop: "32px / 48px",
+    mobile: "32px / 48px",
   },
   {
     style: md(%(
@@ -32,9 +32,9 @@ type_specs = [
       React: `SageClassnames.TYPE.HEADING_3`
     )),
     weight: "700",
-    kerning: "0.3px",
-    desktop: "23px / 32px",
-    mobile: "20px / 28px",
+    kerning: "-0.15px",
+    desktop: "28px / 40px",
+    mobile: "28px / 40px",
   },
   {
     style: md(%(
@@ -43,10 +43,10 @@ type_specs = [
       Rails: `SageClassnames::TYPE::HEADING_4`<br/>
       React: `SageClassnames.TYPE.HEADING_4`
     )),
-    weight: "600",
-    kerning: "0.3px",
-    desktop: "20px / 28px",
-    mobile: "18px / 28px",
+    weight: "400",
+    kerning: "-0.15px",
+    desktop: "24px / 32px",
+    mobile: "24px / 32px",
   },
   {
     style: md(%(
@@ -55,10 +55,10 @@ type_specs = [
       Rails: `SageClassnames::TYPE::HEADING_5`<br/>
       React: `SageClassnames.TYPE.HEADING_5`
     )),
-    weight: "600",
-    kerning: "0.3px",
+    weight: "400",
+    kerning: "0px",
     desktop: "18px / 28px",
-    mobile: "16px / 28px",
+    mobile: "18px / 28px",
   },
   {
     style: md(%(
@@ -67,10 +67,10 @@ type_specs = [
       Rails: `SageClassnames::TYPE::HEADING_6`<br/>
       React: `SageClassnames.TYPE.HEADING_6`
     )),
-    weight: "600",
-    kerning: "0.3px",
-    desktop: "14px / 24px",
-    mobile: "16px / 28px",
+    weight: "400",
+    kerning: "0px",
+    desktop: "16px / 24px",
+    mobile: "16px / 24px",
   },
   {
     style: md(%(
@@ -80,9 +80,9 @@ type_specs = [
       React: `SageClassnames.TYPE.BODY`
     )),
     weight: "400*",
-    kerning: "0.2px",
-    desktop: "14px / 24px",
-    mobile: "16px / 28px",
+    kerning: "0px",
+    desktop: "16px / 24px",
+    mobile: "16px / 24px",
   },
   {
     style: md(%(
@@ -92,9 +92,9 @@ type_specs = [
       React: `SageClassnames.TYPE.BODY_SMALL`
     )),
     weight: "400*",
-    kerning: "0.2px",
-    desktop: "13px / 24px",
-    mobile: "14px / 24px",
+    kerning: "0px",
+    desktop: "14px / 20px",
+    mobile: "14px / 20px",
   },
   {
     style: md(%(
@@ -104,9 +104,9 @@ type_specs = [
       React: `SageClassnames.TYPE.BODY_XSMALL`
     )),
     weight: "400*",
-    kerning: "0.2px",
-    desktop: "12px / 20px",
-    mobile: "12px / 20px",
+    kerning: "0px",
+    desktop: "12px / 16px",
+    mobile: "12px / 16px",
   }
 ]
 

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -10,7 +10,7 @@ $-body-font-version: 1;
 
 // Regular
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-Regular";
   font-style: normal;
   font-weight: 400;
   font-display: swap;
@@ -19,7 +19,7 @@ $-body-font-version: 1;
 
 // Regular Italic
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-Italic";
   font-style: italic;
   font-weight: 400;
   font-display: swap;
@@ -28,7 +28,7 @@ $-body-font-version: 1;
 
 // Medium
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-Book";
   font-style: normal;
   font-weight: 500;
   font-display: swap;
@@ -37,7 +37,7 @@ $-body-font-version: 1;
 
 // Medium Italic
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-BookItalic";
   font-style: italic;
   font-weight: 500;
   font-display: swap;
@@ -46,7 +46,7 @@ $-body-font-version: 1;
 
 // Semibold
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-Medium";
   font-style: normal;
   font-weight: 600;
   font-display: swap;
@@ -55,7 +55,7 @@ $-body-font-version: 1;
 
 // Semibold Italic
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-MediumItalic";
   font-style: italic;
   font-weight: 600;
   font-display: swap;
@@ -64,7 +64,7 @@ $-body-font-version: 1;
 
 // Bold
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-Bold";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
@@ -73,7 +73,7 @@ $-body-font-version: 1;
 
 // Bold Italic
 @font-face {
-  font-family: "Circular";
+  font-family: "CircularXXWeb-BoldItalic";
   font-style: italic;
   font-weight: 700;
   font-display: swap;

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -10,7 +10,7 @@ $-body-font-version: 1;
 
 // Regular
 @font-face {
-  font-family: "CircularXXWeb-Regular";
+  font-family: "Circular";
   font-style: normal;
   font-weight: 400;
   font-display: swap;
@@ -19,7 +19,7 @@ $-body-font-version: 1;
 
 // Regular Italic
 @font-face {
-  font-family: "CircularXXWeb-Italic";
+  font-family: "Circular";
   font-style: italic;
   font-weight: 400;
   font-display: swap;
@@ -28,7 +28,7 @@ $-body-font-version: 1;
 
 // Medium
 @font-face {
-  font-family: "CircularXXWeb-Book";
+  font-family: "Circular";
   font-style: normal;
   font-weight: 500;
   font-display: swap;
@@ -37,7 +37,7 @@ $-body-font-version: 1;
 
 // Medium Italic
 @font-face {
-  font-family: "CircularXXWeb-BookItalic";
+  font-family: "Circular";
   font-style: italic;
   font-weight: 500;
   font-display: swap;
@@ -46,7 +46,7 @@ $-body-font-version: 1;
 
 // Semibold
 @font-face {
-  font-family: "CircularXXWeb-Medium";
+  font-family: "Circular";
   font-style: normal;
   font-weight: 600;
   font-display: swap;
@@ -55,7 +55,7 @@ $-body-font-version: 1;
 
 // Semibold Italic
 @font-face {
-  font-family: "CircularXXWeb-MediumItalic";
+  font-family: "Circular";
   font-style: italic;
   font-weight: 600;
   font-display: swap;
@@ -64,7 +64,7 @@ $-body-font-version: 1;
 
 // Bold
 @font-face {
-  font-family: "CircularXXWeb-Bold";
+  font-family: "Circular";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
@@ -73,7 +73,7 @@ $-body-font-version: 1;
 
 // Bold Italic
 @font-face {
-  font-family: "CircularXXWeb-BoldItalic";
+  font-family: "Circular";
   font-style: italic;
   font-weight: 700;
   font-display: swap;

--- a/packages/sage-assets/lib/stylesheets/tokens/_font_size.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_font_size.scss
@@ -26,15 +26,15 @@ $sage-font-sizes: (
 /// Responsive font sizes use CSS custom properties to apply a raw font size for a given breakpoint range.
 ///
 :root {
-  --sage-font-size-body-xs: #{map-get($sage-font-sizes, 2xs)};
+  --sage-font-size-body-xs: #{map-get($sage-font-sizes, xs)};
   --sage-font-size-body-sm: #{map-get($sage-font-sizes, sm)};
   --sage-font-size-body: #{map-get($sage-font-sizes, md)};
   --sage-font-size-h6: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h5: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h4: #{map-get($sage-font-sizes, lg)};
-  --sage-font-size-h3: #{map-get($sage-font-sizes, xl)};
-  --sage-font-size-h2: #{map-get($sage-font-sizes, 2xl)};
-  --sage-font-size-h1: #{map-get($sage-font-sizes, 3xl)};
+  --sage-font-size-h5: #{map-get($sage-font-sizes, lg)};
+  --sage-font-size-h4: #{map-get($sage-font-sizes, xl)};
+  --sage-font-size-h3: #{map-get($sage-font-sizes, 2xl)};
+  --sage-font-size-h2: #{map-get($sage-font-sizes, 3xl)};
+  --sage-font-size-h1: #{map-get($sage-font-sizes, 4xl)};
 }
 
 @media screen and (min-width: sage-breakpoint(lg-min)) {

--- a/packages/sage-assets/lib/stylesheets/tokens/_font_size.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_font_size.scss
@@ -10,15 +10,14 @@
 /// Sage allows for responsive typography, that uses these raw font sizes as the source of truth for its possible sizes.
 ///
 $sage-font-sizes: (
-  2xs: rem(12px),
   xs: rem(13px),
   sm: rem(14px),
   md: rem(16px),
   lg: rem(18px),
-  xl: rem(20px),
-  2xl: rem(23px),
-  3xl: rem(26px),
-  4xl: rem(29px)
+  xl: rem(24px),
+  2xl: rem(28px),
+  3xl: rem(32px),
+  4xl: rem(40px)
 );
 
 ///
@@ -41,14 +40,14 @@ $sage-font-sizes: (
 @media screen and (min-width: sage-breakpoint(lg-min)) {
   :root {
     // --sage-font-size-body-xs is same
-    --sage-font-size-body-sm: #{map-get($sage-font-sizes, xs)};
-    --sage-font-size-body: #{map-get($sage-font-sizes, sm)};
-    --sage-font-size-h6: #{map-get($sage-font-sizes, sm)};
-    --sage-font-size-h5: #{map-get($sage-font-sizes, lg)};
-    --sage-font-size-h4: #{map-get($sage-font-sizes, xl)};
-    --sage-font-size-h3: #{map-get($sage-font-sizes, 2xl)};
-    --sage-font-size-h2: #{map-get($sage-font-sizes, 3xl)};
-    --sage-font-size-h1: #{map-get($sage-font-sizes, 4xl)};
+    // --sage-font-size-body-sm: same
+    // --sage-font-size-body: same
+    // --sage-font-size-h6: same
+    // --sage-font-size-h5: same 
+    // --sage-font-size-h4: same
+    // --sage-font-size-h3: same
+    // --sage-font-size-h2: same
+    // --sage-font-size-h1: same
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/tokens/_letter_spacing.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_letter_spacing.scss
@@ -9,10 +9,9 @@
 /// Sage letter spacing/kerning token
 ///
 $sage-letter-spacings: (
-  xs: rem(0.2px),
-  sm: rem(0.3px),
-  md: rem(0.5px),
-  lg: rem(0.8px)
+  xs: rem(-0.15px),
+  sm: rem(-0.5px),
+  md: rem(-0.6px),
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
@@ -31,24 +31,24 @@ $sage-line-heights: (
   --sage-line-height-body-sm: #{map-get($sage-line-heights, sm)};
   --sage-line-height-body: #{map-get($sage-line-heights, md)};
   --sage-line-height-h6: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h5: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h4: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h3: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h2: #{map-get($sage-line-heights, lg)};
-  --sage-line-height-h1: #{map-get($sage-line-heights, lg)};
+  --sage-line-height-h5: #{map-get($sage-line-heights, lg)};
+  --sage-line-height-h4: #{map-get($sage-line-heights, xl)};
+  --sage-line-height-h3: #{map-get($sage-line-heights, 2xl)};
+  --sage-line-height-h2: #{map-get($sage-line-heights, 3xl)};
+  --sage-line-height-h1: #{map-get($sage-line-heights, 4xl)};
 }
 
 @media screen and (min-width: sage-breakpoint(lg-min)) {
   :root {
     // --sage-line-height-body-xs: same
     // --sage-line-height-body-sm: same
-    --sage-line-height-body: #{map-get($sage-line-heights, sm)};
-    --sage-line-height-h6: #{map-get($sage-line-heights, sm)};
+    // --sage-line-height-body: same
+    // --sage-line-height-h6: same
     // --sage-line-height-h5: same
     // --sage-line-height-h4: same
-    --sage-line-height-h3: #{map-get($sage-line-heights, lg)};
+    // --sage-line-height-h3: same
     // --sage-line-height-h2: same
-    --sage-line-height-h1: #{map-get($sage-line-heights, xl)};
+    // --sage-line-height-h1: same
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
@@ -9,11 +9,14 @@
 /// Sage raw line height/leading token (non-responsive)
 ///
 $sage-line-heights: (
-  xs: sage-baseline(5), // 20
-  sm: sage-baseline(6), // 24
-  md: sage-baseline(7), // 28
-  lg: sage-baseline(8), // 32
-  xl: sage-baseline(9), // 36
+  xs: sage-baseline(4), // 16
+  sm: sage-baseline(5), // 20
+  md: sage-baseline(6), // 24
+  lg: sage-baseline(7), // 28
+  xl: sage-baseline(8), // 32
+  2xl: sage-baseline(10), // 40
+  3xl: sage-baseline(12), // 48
+  4xl: sage-baseline(15), // 60
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/tokens/_type_pairings.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_type_pairings.scss
@@ -11,23 +11,23 @@
 $sage-type-pairings: (
   4xl: (
     font-size: sage-font-size(4xl, false),
-    line-height: sage-line-height(xl),
+    line-height: sage-line-height(4xl),
   ),
   3xl: (
     font-size: sage-font-size(3xl, false),
-    line-height: sage-line-height(lg),
+    line-height: sage-line-height(3xl),
   ),
   2xl: (
     font-size: sage-font-size(2xl, false),
-    line-height: sage-line-height(lg),
+    line-height: sage-line-height(2xl),
   ),
   xl: (
     font-size: sage-font-size(xl, false),
-    line-height: sage-line-height(md),
+    line-height: sage-line-height(xl),
   ),
   lg: (
     font-size: sage-font-size(lg, false),
-    line-height: sage-line-height(md),
+    line-height: sage-line-height(lg),
   ),
   md: (
     font-size: sage-font-size(md, false),
@@ -39,10 +39,6 @@ $sage-type-pairings: (
   ),
   xs: (
     font-size: sage-font-size(xs, false),
-    line-height: sage-line-height(sm),
-  ),
-  2xs: (
-    font-size: sage-font-size(2xs, false),
     line-height: sage-line-height(xs),
   ),
 );

--- a/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
@@ -59,19 +59,19 @@ $sage-type-specs: (
     kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h4,
-    weight: sage-font-weight(semibold),
+    weight: sage-font-weight(regular),
   ),
   "heading-5": (
     kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h5,
-    weight: sage-font-weight(semibold),
+    weight: sage-font-weight(regular),
   ),
   "heading-6": (
     kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h6,
-    weight: sage-font-weight(semibold),
+    weight: sage-font-weight(regular),
   ),
   "nav": (
     kerning: sage-letter-spacing(sm),
@@ -83,7 +83,7 @@ $sage-type-specs: (
     kerning: sage-letter-spacing(sm),
     responsive: false,
     type-pairing: sm,
-    weight: sage-font-weight(meidum),
+    weight: sage-font-weight(medium),
   ),
 
   // Body

--- a/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
@@ -62,25 +62,21 @@ $sage-type-specs: (
     weight: sage-font-weight(regular),
   ),
   "heading-5": (
-    // kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h5,
     weight: sage-font-weight(regular),
   ),
   "heading-6": (
-    // kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h6,
     weight: sage-font-weight(regular),
   ),
   "nav": (
-    // kerning: sage-letter-spacing(sm),
     responsive: false,
     type-pairing: md,
     weight: sage-font-weight(medium),
   ),
   "nav-sub": (
-    // kerning: sage-letter-spacing(sm),
     responsive: false,
     type-pairing: sm,
     weight: sage-font-weight(medium),

--- a/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
@@ -38,49 +38,49 @@ $-t-body-xsmall-spec: (
 $sage-type-specs: (
   // Headings
   "heading-1": (
-    kerning: sage-letter-spacing(sm),
+    kerning: sage-letter-spacing(md),
     responsive: true,
     type-pairing: h1,
     weight: sage-font-weight(bold),
   ),
   "heading-2": (
-    kerning: sage-letter-spacing(sm),
+    kerning: sage-letter-spacing(md),
     responsive: true,
     type-pairing: h2,
     weight: sage-font-weight(bold),
   ),
   "heading-3": (
-    kerning: sage-letter-spacing(sm),
+    kerning: sage-letter-spacing(xs),
     responsive: true,
     type-pairing: h3,
     weight: sage-font-weight(bold),
   ),
   "heading-4": (
-    kerning: sage-letter-spacing(sm),
+    kerning: sage-letter-spacing(xs),
     responsive: true,
     type-pairing: h4,
     weight: sage-font-weight(regular),
   ),
   "heading-5": (
-    kerning: sage-letter-spacing(sm),
+    // kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h5,
     weight: sage-font-weight(regular),
   ),
   "heading-6": (
-    kerning: sage-letter-spacing(sm),
+    // kerning: sage-letter-spacing(sm),
     responsive: true,
     type-pairing: h6,
     weight: sage-font-weight(regular),
   ),
   "nav": (
-    kerning: sage-letter-spacing(sm),
+    // kerning: sage-letter-spacing(sm),
     responsive: false,
     type-pairing: md,
     weight: sage-font-weight(medium),
   ),
   "nav-sub": (
-    kerning: sage-letter-spacing(sm),
+    // kerning: sage-letter-spacing(sm),
     responsive: false,
     type-pairing: sm,
     weight: sage-font-weight(medium),


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates type specs for Sage Foundations Update including:

- Font Size
- Line Height
- Font Weight
- Letter Spacing
- Typography page in docs

WhatFont extension was used to help check fonts at a glance in addition to usual browser devtools.

[Figma file](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/%E2%9A%A0%EF%B8%8F-%5BDO-NOT-USE-WIP%5D-Sage-Update?node-id=3%3A1097) for reference of spec updates.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1302" alt="Screen Shot 2022-02-08 at 9 39 04 AM" src="https://user-images.githubusercontent.com/14791307/153021724-99d63d6c-3ce0-4265-9a80-96ef8eb0582c.png">|<img width="1309" alt="Screen Shot 2022-02-08 at 9 12 23 AM" src="https://user-images.githubusercontent.com/14791307/153021768-79966e34-b532-4e84-b246-39a8096fab02.png">
<img width="517" alt="Screen Shot 2022-02-08 at 9 39 28 AM" src="https://user-images.githubusercontent.com/14791307/153021812-afb41dd9-b786-4d21-b109-db20b70589a6.png">|<img width="627" alt="Screen Shot 2022-02-08 at 9 12 40 AM" src="https://user-images.githubusercontent.com/14791307/153021841-0244cc43-7199-4d66-a2a4-3034295e46c6.png">
<img width="496" alt="Screen Shot 2022-02-08 at 9 39 34 AM" src="https://user-images.githubusercontent.com/14791307/153021869-0c660aab-71e3-4c3a-9737-fb6fbc1b80d3.png">|<img width="536" alt="Screen Shot 2022-02-08 at 9 13 00 AM" src="https://user-images.githubusercontent.com/14791307/153021905-1850a281-d3d5-46e5-b606-00e048d3c185.png">
<img width="523" alt="Screen Shot 2022-02-08 at 9 39 43 AM" src="https://user-images.githubusercontent.com/14791307/153021980-2708e3cd-e959-4c67-a259-4cb41fe403a5.png">|<img width="507" alt="Screen Shot 2022-02-08 at 9 13 08 AM" src="https://user-images.githubusercontent.com/14791307/153022015-2e51b5d5-cd22-477b-bc08-219029492c43.png">
<img width="502" alt="Screen Shot 2022-02-08 at 9 39 51 AM" src="https://user-images.githubusercontent.com/14791307/153022038-04849fcf-815d-4260-9359-5df9680a580c.png">|<img width="533" alt="Screen Shot 2022-02-08 at 9 13 19 AM" src="https://user-images.githubusercontent.com/14791307/153022086-fee6c933-79f6-441b-a4f9-989bb0f1e1c4.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Check that typography updates mentioned in Jira ticket and Figma file exist in Sage docs as expected.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(HIGH) Updates type specs for Sage Foundations Update. There are Sass files in Kajabi Products that will need to be updated to match new type specs. 


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-7](https://kajabi.atlassian.net/browse/SAGE-7)