### PR TITLE
[SAGE-189] Fix(creation wizard mock): scopes payment dropdown JS to page

### DIFF
--- a/docs/lib/sage-frontend/javascript/docs/mocks/creation_wizard/index.js
+++ b/docs/lib/sage-frontend/javascript/docs/mocks/creation_wizard/index.js
@@ -1,41 +1,42 @@
 // ==================================================
 // creation wizard payment dropdown
 // ==================================================
+if (document.querySelector(".creation-payment-dropdown") !== null) {
+  const paymentDropdownClass = ".creation-payment-dropdown";
+  const paymentDropdown = document.querySelector(paymentDropdownClass);
+  const paymentOptions = paymentDropdown.querySelectorAll(".sage-dropdown__panel > .sage-panel__row");
 
-const paymentDropdownClass = ".creation-payment-dropdown";
-const paymentDropdown = document.querySelector(paymentDropdownClass);
-const paymentOptions = paymentDropdown.querySelectorAll(".sage-dropdown__panel > .sage-panel__row");
-
-document.addEventListener("DOMContentLoaded", function () {
-  let paymentOptionSelected = document.querySelector(".creation-payment-selected.sage-panel__row");
-  if (paymentOptionSelected !== null) {
-    updateOption(paymentOptionSelected);
-  }
-});
-
-paymentOptions.forEach(function (option) {
-  option.addEventListener("click", function () {
-    updateSelected();
-    updateOption(option);
+  document.addEventListener("DOMContentLoaded", function () {
+    let paymentOptionSelected = document.querySelector(".creation-payment-selected.sage-panel__row");
+    if (paymentOptionSelected !== null) {
+      updateOption(paymentOptionSelected);
+    }
   });
-});
 
-function updateSelected(option) {
   paymentOptions.forEach(function (option) {
-    option.classList.remove("creation-payment-selected");
+    option.addEventListener("click", function () {
+      updateSelected();
+      updateOption(option);
+    });
   });
-}
 
-function updateOption(option) {
-  let name = option.querySelector(".t-sage-heading-6").innerText;
-  let desc = option.querySelector(".t-sage-body > p").innerText;
-  let icon = option.querySelector(".sage-icon-background").outerHTML;
-  let screen = document.querySelector(".creation-payment-dropdown .sage-dropdown__screen");
+  function updateSelected(option) {
+    paymentOptions.forEach(function (option) {
+      option.classList.remove("creation-payment-selected");
+    });
+  }
 
-  paymentDropdown.querySelector(".t-sage-heading-6").innerText = name;
-  paymentDropdown.querySelector(".t-sage-body > p").innerText = desc;
-  paymentDropdown.querySelector(".sage-icon-background").outerHTML = icon;
+  function updateOption(option) {
+    let name = option.querySelector(".t-sage-heading-6").innerText;
+    let desc = option.querySelector(".t-sage-body > p").innerText;
+    let icon = option.querySelector(".sage-icon-background").outerHTML;
+    let screen = document.querySelector(".creation-payment-dropdown .sage-dropdown__screen");
 
-  option.classList.add("creation-payment-selected");
-  screen.click();
+    paymentDropdown.querySelector(".t-sage-heading-6").innerText = name;
+    paymentDropdown.querySelector(".t-sage-body > p").innerText = desc;
+    paymentDropdown.querySelector(".sage-icon-background").outerHTML = icon;
+
+    option.classList.add("creation-payment-selected");
+    screen.click();
+  }
 }


### PR DESCRIPTION
## Description
Reduces JS scope to Creation Wizard mock page only. The script is currently running on all pages, locking up the remainder of the JS and blocking rendering in some cases.

![console](https://user-images.githubusercontent.com/816579/151635803-db6bb460-2d41-42f3-a370-9428c51f9bd0.png)


Follow-ups to consider:
- separate namespace for Sage mock JS modules
- router to conditionally init mock JS
- apply a custom class to mock pages for scoping (rather than individual components)


## Testing in `sage-lib`
1. View the Sage docs site
2. Navigate to any page and inspect using your browser dev tools
3. Confirm that no errors are displayed in the console.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (N/A) Creation Wizard Payment Dropdown: Affects Sage docs site only.


