### PR TITLE
[Modal] - add z-index to fullscreen modal header

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -146,7 +146,7 @@ $-modal-fullscreen-top-spacing: rem(104px);
 
   .sage-modal--fullscreen & {
     position: fixed;
-    z-index: sage-z-indexes(default, 1);
+    z-index: sage-z-index(default, 1);
     left: 0;
     right: 0;
     margin: 0;

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -146,6 +146,7 @@ $-modal-fullscreen-top-spacing: rem(104px);
 
   .sage-modal--fullscreen & {
     position: fixed;
+    z-index: sage-z-indexes(default, 1);
     left: 0;
     right: 0;
     margin: 0;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `z-index`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![fullscreenModalBefore](https://user-images.githubusercontent.com/1241836/152045859-5852ee7d-913b-4282-bf9c-3aab19914472.gif)|![fullscreenModalAfter](https://user-images.githubusercontent.com/1241836/152045875-bd9adfa1-5019-4efe-a1b7-024c396584c6.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
On the fullscreen modal variation, scroll overflowed body text to verify that the content falls behind the header

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Description of the change and its impact with QA as the audience.
   - [ ] Product Product Creation Wizard. (behind FF: `:product_creation_wizard`)


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
