### PR TITLE
[Sage-194] Dropdown - Custom Panel Width

### DIFF
--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -47,6 +47,55 @@
   } %>
 <% end %>
 
+<h3 class="t-sage-heading-6">Menu Button with Custom Panel Width</h3>
+<%= sage_component SageDropdown, {
+  panel_width: "512px",
+  items: [{
+    value: "Edit",
+    icon: "pen",
+    attributes: { "href": "#" },
+  },
+  {
+    value: "Disabled link w/ tooltip",
+    icon: "pen",
+    modifiers: ["disabled"],
+    attributes: {
+      "href": "https://kajabi.com",
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "right",
+    }
+  },
+  {
+    value: "New",
+    icon: "add",
+    style: "primary",
+    attributes: { "href": "#" },
+   }, {
+    value: "Share Element",
+    icon: "url",
+    modifiers: ["border-before"],
+    attributes: { "href": "#" },
+   }, {
+    value: "Take A Dangerous Action",
+    icon: "remove-circle",
+    style: "danger",
+    attributes: { "href": "#" },
+  }, {
+    value: "Disabled w/ Tooltip",
+    icon: "users",
+    attributes: {
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "right"
+      },
+    modifiers: ["disabled"]
+  }
+  ]
+} do %>
+  <%= sage_component SageButton, {
+    style: "primary",
+    value: "Add An Element"
+  } %>
+<% end %>
 <h3 class="t-sage-heading-6">Dropdown menu with Headings</h3>
 <%= sage_component SageDropdown, {
   contained: true,

--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -76,6 +76,12 @@ Array<{
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`panel_width`') %></td>
+  <td><%= md('Sets a custom width for the dropdown panel.') %></td>
+  <td><%= md('`"small"`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`search`') %></td>
   <td><%= md('When true, adds a search component to the dropdown.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -10,6 +10,7 @@ class SageDropdown < SageComponent
     items: [:optional, [[SageSchemas::DROPDOWN_ITEM]]],
     panel_size: [:optional, Set.new(["small"])],
     panel_type: [:optional, Set.new(["custom", "dropdown", "choice", "checkbox", "status", "searchable"])],
+    panel_width: [:optional, String],
     search: [:optional, TrueClass],
     trigger_type: [:optional, Set.new(["select", "select-labeled"])],
     wrap_footer: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -24,7 +24,15 @@
   >
     <%= component.content %>
   </div>
-  <div class="sage-dropdown__panel">
+  <div 
+    class="
+      sage-dropdown__panel
+      <%= "sage-dropdown__panel--custom-width" if component.panel_width %>
+    "
+    <% if component.panel_width %>
+      style="--custom-panel-width: <%= component.panel_width %>"
+    <% end %>
+  >
     <% if component.search %>
       <%= sage_component SageSearch, {
         placeholder: "Search",

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -340,6 +340,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   padding: sage-spacing();
 }
 
+.sage-dropdown__panel--custom-width {
+  width: var(--custom-panel-width);
+}
+
 .sage-dropdown__panel-footer {
   padding: sage-spacing(sm) sage-spacing();
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a new prop to allow a custom panel with for the Dropdown component.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="445" alt="Screen Shot 2022-02-01 at 11 20 27 AM" src="https://user-images.githubusercontent.com/14791307/152017963-051ae940-4522-441b-b397-055493957291.png">|<img width="1029" alt="Screen Shot 2022-02-01 at 11 19 22 AM" src="https://user-images.githubusercontent.com/14791307/152017975-46bc7655-fbf4-4efc-959c-53f750222b1b.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Rails component](http://localhost:4000/pages/component/dropdown)
- Adds prop `panel_width` to any preview component
- Verify that prop works as intended.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds a new prop to allow a custom panel with for the Dropdown component. No effect on existing Kajabi Products work.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-194](https://kajabi.atlassian.net/browse/SAGE-194)