### PR TITLE
[SAGE-202] Allow `nil` as option for dropdown and page heading attributes and adjust help link check in markup

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dropdown.rb
@@ -1,19 +1,19 @@
 class SageDropdown < SageComponent
   set_attribute_schema({
     align: [:optional, Set.new(["left", "center", "right"])],
-    contained: [:optional, TrueClass],
+    contained: [:optional, NilClass, TrueClass],
     content: [:optional, String],
-    customized: [:optional, TrueClass],
-    custom_modifier: [:optional, Set.new(["actions", "sort"])],
-    full_width_panel: [:optional, TrueClass],
-    id: [:optional, String],
+    customized: [:optional, NilClass, TrueClass],
+    custom_modifier: [:optional, NilClass, Set.new(["actions", "sort"])],
+    full_width_panel: [:optional, NilClass, TrueClass],
+    id: [:optional, NilClass, String],
     items: [:optional, [[SageSchemas::DROPDOWN_ITEM]]],
-    panel_size: [:optional, Set.new(["small"])],
-    panel_type: [:optional, Set.new(["custom", "dropdown", "choice", "checkbox", "status", "searchable"])],
-    panel_width: [:optional, String],
-    search: [:optional, TrueClass],
-    trigger_type: [:optional, Set.new(["select", "select-labeled"])],
-    wrap_footer: [:optional, TrueClass],
+    panel_size: [:optional, NilClass, Set.new(["small"])],
+    panel_type: [:optional, NilClass, Set.new(["custom", "dropdown", "choice", "checkbox", "status", "searchable"])],
+    panel_width: [:optional, NilClass, String],
+    search: [:optional, NilClass, TrueClass],
+    trigger_type: [:optional, NilClass, Set.new(["select", "select-labeled"])],
+    wrap_footer: [:optional, NilClass, TrueClass],
   })
 
   def sections

--- a/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
@@ -3,7 +3,7 @@ class SagePageHeading < SageComponent
     help_html: [:optional, NilClass, String],
     help_link: [:optional, NilClass, Hash],
     help_title: [:optional, NilClass, String],
-    secondary_text: [:optional, String],
+    secondary_text: [:optional, NilClass, String],
     title: [:optional, String],
   })
 

--- a/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_page_heading.rb
@@ -1,8 +1,8 @@
 class SagePageHeading < SageComponent
   set_attribute_schema({
-    help_html: [:optional, String],
-    help_link: [:optional, Hash],
-    help_title: [:optional, String],
+    help_html: [:optional, NilClass, String],
+    help_link: [:optional, NilClass, Hash],
+    help_title: [:optional, NilClass, String],
     secondary_text: [:optional, String],
     title: [:optional, String],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -28,7 +28,7 @@
         </span>
       </a>
     <% end %>
-    <% if component.help_title && component.help_link && component.help_html %>
+    <% if component.help_title.present? && component.help_link.present? && component.help_html.present? %>
       <%= sage_component SagePopover, {
         title: component.help_title,
         icon: "question-circle",


### PR DESCRIPTION
## Description
Updates conditional in page heading markup to use `.present?` for help popover and adjusts attributes to allow for `nil` for both PageHeadings and Dropdown.

These adjustments are in preparation for the new page level tabs updates and incoming page heading help in KP.


## Screenshots
No visual changes expected


## Testing in `sage-lib`
Navigate to page heading and verify headings still appear as expected.
Navigate to dropdown and verify dropdowns appear and function expected.


## Testing in `kajabi-products`
1. (**MED**) Allows `nil` as an option for page heading and dropdown attributes and adjusts conditional markup for help popover. A quick sanity check of page headings and dropdowns should be performed.


## Related
https://kajabi.atlassian.net/browse/SAGE-202
