### PR TITLE
[SAGE-180] Table Settings Modal

### DIFF
--- a/docs/app/helpers/mocks_helper.rb
+++ b/docs/app/helpers/mocks_helper.rb
@@ -12,7 +12,7 @@ module MocksHelper
 
   # Jira URLs
   JIRA_BASE_URL = "https://kajabi.atlassian.net/"
-  
+
   # Storybook live URL
   STORYBOOK_BASE_URL = "https://sage-lib-storybook.herokuapp.com"
 
@@ -81,6 +81,14 @@ module MocksHelper
         alias: "payments_index",
         jira_epic: "SAGE-172",
         name: "Payments Index",
+        no_rails_js: true,
+        status: DOING,
+        team: "Commerce",
+      },
+      {
+        alias: "customize_columns",
+        jira_epic: "SAGE-180",
+        name: "Table Settings Modal",
         no_rails_js: true,
         status: DOING,
         team: "Commerce",

--- a/docs/app/views/mocks/customize_columns/_main.html.erb
+++ b/docs/app/views/mocks/customize_columns/_main.html.erb
@@ -36,7 +36,7 @@ columns = [
       } %>
     <% end %>
 
-    <%= sage_component SageCardBlock, { spacer: { bottom: :md } } do %>
+    <%= sage_component SagePanelBlock, { spacer: { bottom: :sm } } do %>
       Add, remove or reorder columns to customize your table properties.
     <% end %>
 

--- a/docs/app/views/mocks/customize_columns/_main.html.erb
+++ b/docs/app/views/mocks/customize_columns/_main.html.erb
@@ -1,0 +1,77 @@
+<%
+columns = [
+  { customizable: false, name: "Member email" },
+  { customizable: true, active: true, name: "Amount" },
+  { customizable: true, active: true, name: "Next payment" },
+  { customizable: true, active: true, name: "Status" },
+  { customizable: true, active: true, name: "Offer title" },
+  { customizable: true, active: true, name: "Start date" },
+  { customizable: true, active: false, name: "Name" },
+  { customizable: true, active: false, name: "Billing / type" },
+  { customizable: true, active: false, name: "Net value" },
+  { customizable: true, active: false, name: "Ends on" },
+]
+%>
+
+<%= sage_component SageButton, {
+  attributes: {
+    "data-js-modaltrigger": "customize-settings-modal",
+  },
+  icon: { name: "launch", style: "right" },
+  style: "primary",
+  value: "Customize table",
+} %>
+
+<%= sage_component SageModal, { id: "customize-settings-modal" } do %>
+  <%= sage_component SageModalContent, {
+    title: "Table properties",
+  } do %>
+    <% content_for :sage_header_aside do %>
+      <%= sage_component SageButton, {
+        attributes: { "data-js-modal": true },
+        icon: { name: "remove", style: "only" },
+        style: "secondary",
+        subtle: true,
+        value: "Close Modal",
+      } %>
+    <% end %>
+
+    <%= sage_component SageCardBlock, { spacer: { bottom: :md } } do %>
+      Add, remove or reorder columns to customize your table properties.
+    <% end %>
+
+    <%= sage_component SagePanelList, {} do %>
+      <%= sage_component SageSortable, { resource_name: "column" } do %>
+        <% columns.each_with_index do |column, index| %>
+          <%= sage_component SageSortableItemCustom, { grid_template: "te" } do %>
+            <span class="<%= "#{SageClassnames::TYPE::BODY_MED} #{SageClassnames::TYPE_COLORS::CHARCOAL_400}" %>"><%= column[:name] %></span>
+            <% if column[:customizable] %>
+              <%= sage_component SageSwitch, {
+                hide_text: true,
+                id: index.to_s,
+                label_text: column[:name],
+                name: index.to_s,
+                type: "checkbox",
+              } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% content_for :sage_footer do %>
+      <% content_for :sage_footer_aside do %>
+        <%= sage_component SageButton, {
+          attributes: { "data-js-modal": true },
+          style: "primary",
+          subtle: true,
+          value: "Reset to default",
+        } %>
+      <% end %>
+      <%= sage_component SageButton, {
+        style: "primary",
+        value: "Apply",
+      } %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
## Description
This PR adds a mock for the Table Settings Modal.

## Screenshots
<img src="https://user-images.githubusercontent.com/7331038/153049437-5aee25ca-25b0-4e02-be38-69b3eb87835f.png" width="480"> 

## Figma
https://www.figma.com/file/pOqIiSaJGEsxH8hMmt811I/COMM-1443-Subscriptions?node-id=1672%3A2789

## Notes/Issues/Concerns
1. The modal size is larger than the figma mockup. 
    We may want to add a `size` prop to Modal to set sizes that correspond to Container and remove the `large` prop.
2. The footer border cannot be achieved using `ButtonGroup` and a custom class cannot be assigned to modal footer.
    We may want to add a `borderTop: true` prop to Modal to achieve this.
3. The `SageSortable` and `SageSortableItemCustom` were used to achieve the sortable design

## Testing in `sage-lib`
http://0.0.0.0:4000/pages/mock/customize_columns

## Related
https://kajabi.atlassian.net/browse/SAGE-180
