### PR TITLE
[Sage-208] Link - Foundations Update

### DIFF
--- a/docs/app/views/examples/components/link/_preview.html.erb
+++ b/docs/app/views/examples/components/link/_preview.html.erb
@@ -69,38 +69,6 @@
   } %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Help/Info links</h3>
-<%= sage_component SagePanelStack, { css_classes: "sage-type" } do %>
-  <%= sage_component SageLink, {
-    url: "#",
-    label: "Get help",
-    external: false,
-    launch: false,
-    help_link: true,
-    show_label: true
-  } %>
-  <%= sage_component SageLink, {
-    url: "#",
-    label: "Get help (hidden)",
-    external: false,
-    launch: false,
-    help_link: true,
-    show_label: false
-  } %>
-  <%= sage_component SageLink, {
-    url: "#",
-    label: "Help link w/ tooltip",
-    external: false,
-    launch: false,
-    help_link: true,
-    show_label: true,
-    html_attributes: {
-      "data-js-tooltip": "Tooltip",
-      "data-js-tooltip-position": "bottom"
-    },
-  } %>
-<% end %>
-
 <h3 class="t-sage-heading-6">Subtext links</h3>
 <%= sage_component SageLink, {
   css_classes: "sage-link--subtext",

--- a/docs/app/views/examples/components/link/_props.html.erb
+++ b/docs/app/views/examples/components/link/_props.html.erb
@@ -5,12 +5,6 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`help_link`') %></td>
-  <td><%= md('When set to `true`, the `help` icon will accompany the link text.') %></td>
-  <td><%= md('Booean') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td><%= md('`label`') %></td>
   <td><%= md('Sets the text for the link. Overrides any content passed in.') %></td>
   <td><%= md('String') %></td>

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -16,6 +16,7 @@
 
   &:hover {
     color: sage-color(primary, 700);
+    text-decoration: underline;
   }
 
   &:focus {
@@ -25,7 +26,7 @@
   @include sage-focus-outline(
     $outline-width: 4px,
     $outline-offset-inline: 4px,
-    $outline-border-radius: 10px,
+    $outline-border-radius: sage-border(radius-input),
   );
   @include sage-focus-outline--update-color(sage-color(primary, 300));
 }

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -6,13 +6,28 @@
 
 
 .sage-link {
+  @extend %t-sage-body-med;
+
   display: inline-flex;
   position: relative;
   max-width: 100%;
   min-width: 0; /* the is needed so that truncation work when the link doesn't have an explicit width set  */
+  text-decoration: underline;
 
-  @include sage-focus-outline($outline-offset-inline: 6px, $outline-offset-block: 0);
-  @include sage-focus-outline--update-color(sage-color(primary, 500));
+  &:hover {
+    color: sage-color(primary, 700);
+  }
+
+  &:focus {
+    color: sage-color(primary, 300);
+  }
+
+  @include sage-focus-outline(
+    $outline-width: 4px,
+    $outline-offset-inline: 4px,
+    $outline-border-radius: 10px,
+  );
+  @include sage-focus-outline--update-color(sage-color(primary, 300));
 }
 
 .sage-link--launch .t-sage--truncate,
@@ -27,6 +42,7 @@
 .sage-link--help,
 .sage-link--help-icon-only {
   position: relative;
+  text-decoration: none;
 
   &::before {
     @include sage-icon-base(question-circle, lg);

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -135,6 +135,7 @@ body:not(.sage-excluded),
   > a:not([class]),
   > a[class*="sage-link"] {
     color: sage-color(primary, 500);
+    text-decoration: underline;
   }
 
   > table:not(:last-child) {

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -136,6 +136,10 @@ body:not(.sage-excluded),
   > a[class*="sage-link"] {
     color: sage-color(primary, 500);
     text-decoration: underline;
+
+    &:hover {
+      color: sage-color(primary, 700);
+    }
   }
 
   > table:not(:last-child) {

--- a/packages/sage-react/lib/Link/Link.jsx
+++ b/packages/sage-react/lib/Link/Link.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { SageClassnames } from '../configs';
 import { Tooltip } from '../Tooltip';
 
@@ -9,19 +10,28 @@ const tagPropTypes = PropTypes.oneOfType([
 ]);
 
 export const Link = ({
+  className,
   children,
   tag,
   tooltip,
   truncate,
   ...rest
 }) => {
+  const classNames = classnames(
+    'sage-link',
+    className,
+  );
+
   const SelfTag = tag || 'a';
 
   return (
     <>
       {tooltip ? (
         <Tooltip {...tooltip}>
-          <SelfTag {...rest}>
+          <SelfTag
+            className={classNames}
+            {...rest}
+          >
             {truncate ? (
               <span className="t-sage--truncate">
                 {children}
@@ -30,7 +40,10 @@ export const Link = ({
           </SelfTag>
         </Tooltip>
       ) : (
-        <SelfTag {...rest}>
+        <SelfTag
+          className={classNames}
+          {...rest}
+        >
           {truncate ? (
             <span className="t-sage--truncate">
               {children}
@@ -43,6 +56,7 @@ export const Link = ({
 };
 
 Link.defaultProps = {
+  className: null,
   children: null,
   tag: null,
   tooltip: null,
@@ -54,6 +68,7 @@ Link.CLASSNAMES = { ...SageClassnames.LINK };
 Link.tagPropTypes = tagPropTypes;
 
 Link.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node,
   tag: tagPropTypes,
   tooltip: PropTypes.shape({


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates Link component with the following:
- Adds `text-decoration: underline`
- Updates focus outline
- Updates colors and type spec

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="274" alt="Screen Shot 2022-02-22 at 1 04 42 PM" src="https://user-images.githubusercontent.com/14791307/155201126-6cda1d73-2c32-46dd-ac27-a29514e3f9dd.png">|<img width="279" alt="Screen Shot 2022-02-22 at 1 05 47 PM" src="https://user-images.githubusercontent.com/14791307/155201430-ad842cc3-d74a-41d7-bfab-23d8b97babe6.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Rails component](http://localhost:4000/pages/component/link)
- Check that component is properly updated to design specs.

### React
- View [Storybook](http://localhost:4100/?path=/docs/sage-link--primary)
- Check that component is properly updated to design specs.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Visual updates for Link component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-208](https://kajabi.atlassian.net/browse/SAGE-208)