### PR TITLE
[SAGE-233] Page Heading: add truncation to title

### DIFF
--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -81,8 +81,13 @@
             text: "Spacing",
             link: pages_helpers_path(:spacing),
             active: current_page?(pages_helpers_path(:spacing)),
-          }
-        ] }
+          },
+          {
+            text: "Truncation",
+            link: pages_helpers_path(:truncation),
+            active: current_page?(pages_patterns_path(:truncation)),
+          },
+        ] },
       ]
     } %>
   <% end %>

--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -1,6 +1,6 @@
 <h3 class="t-sage-heading-6">Basic Card</h3>
 <%= sage_component SageCard, {} do %>
-  <%= sage_component SageCardHeader, { title: "Card heading" } do %>
+  <%= sage_component SageCardHeader, { title: "headingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheadingheading" } do %>
     <%= sage_component SageButton, {
       value: "Learn more",
       subtle: true,

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -5,3 +5,45 @@
 Use this scratchpad to test out elements and components in context. Just be sure not to commit your changes. ❤️
 ") %>
 <% end %>
+
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SagePanelRow, { grid_template: "ete" } do %>
+    <i class="sage-icon-check-circle-xl t-sage--color-sage"></i>
+    <%= sage_component SagePanelBlock, {
+      css_classes: "t-sage--truncate-min-width"
+    } do %>
+      <p class="t-sage-body-semi t-sage--truncate-parent">
+        <span class="t-sage--truncate">LoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLorem</span>
+      </p>
+      <p class="t-sage-body-small t-sage--color-grey">consectetur adipiscing elit</p>
+    <% end %>
+    <%= sage_component SageButton, {
+      value: "Options",
+      style: "secondary",
+      subtle: true,
+      icon: {
+        name: "dot-menu-horizontal",
+        style: "only"
+      }
+    } %>
+  <% end %>
+<% end %>
+
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SagePanelRow, { grid_template: "ete" } do %>
+    <i class="sage-icon-check-circle-xl t-sage--color-sage"></i>
+    <%= sage_component SagePanelBlock, {} do %>
+      <p class="t-sage-body-semi"><span class="t-sage--truncate">LoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLorem</span></p>
+      <p class="t-sage-body-small t-sage--color-grey">consectetur adipiscing elit</p>
+    <% end %>
+    <%= sage_component SageButton, {
+      value: "Options",
+      style: "secondary",
+      subtle: true,
+      icon: {
+        name: "dot-menu-horizontal",
+        style: "only"
+      }
+    } %>
+  <% end %>
+<% end %>

--- a/docs/app/views/pages/truncation.html.erb
+++ b/docs/app/views/pages/truncation.html.erb
@@ -1,0 +1,35 @@
+<%= content_for :heading do %>
+<%= md(%(
+# Truncation
+<p class="docs-heading__lead">Truncation is a wrapper that shortens a string of text when there is overflow.</p>
+)) %>
+<% end %>
+
+<div class="<%= SageClassnames::TYPE_BLOCK %>">
+
+  <%= md(%(
+  We have helper classes to assist with truncation and the necessary pairings on parent elements:
+
+  - `.t-sage--truncate-min-width` -- This class must be added to a parent element of `.t-sage--truncate`. This element must also be either a child element whose parent contains `display: grid;` .
+  - `.t-sage--truncate-parent` -- This must be added to the parent element of `.t-sage--truncate`.
+  - `.t-sage--truncate` -- This class is can be added to the text intended to be truncated.
+  )) %>
+</div>
+
+<%= sage_component SageCard, {} do %>
+  <h2 class="t-sage-heading-3">Examples</h2>
+  <h3 class="t-sage-heading-3">Basic truncation</h3>
+  <%= sage_component SageAlert, {
+    color: "warning",
+    desc: "TODO: example of truncation.",
+    icon_name: "sage-icon-warning",
+    small: true
+  } %>
+  <h3 class="t-sage-heading-3">Truncation within CSS Grid</h3>
+  <%= sage_component SageAlert, {
+    color: "warning",
+    desc: "TODO: example of truncation when exists as a child of CSS grid content.",
+    icon_name: "sage-icon-warning",
+    small: true
+  } %>
+<% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card_header.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card_header.html.erb
@@ -1,9 +1,9 @@
 <header
-  class="sage-card__header <%= component.generated_css_classes %>"
+  class="sage-card__header t-sage--truncate-parent <%= component.generated_css_classes %>"
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.title %>
-    <h1 class="sage-card__title">
+    <h1 class="sage-card__title t-sage--truncate">
       <%= component.title %>
     </h1>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -18,29 +18,29 @@
   <div class="sage-page-heading__title-wrapper">
     <h1 class="sage-page-heading__title">
       <%= component.title %>
-      <% if component.help_link.present? && component.help_html.blank? %>
-        <a href="<%= component.help_link[:href] %>"
-          class="sage-link--no-launch sage-link--help-icon-only"
-          target="_blank"
-          rel="noopener"
-        >
-          <span class="visually-hidden">
-            <%= component.help_link[:name] %>
-          </span>
-        </a>
-      <% end %>
-      <% if component.help_title.present? && component.help_link.present? && component.help_html.present? %>
-        <%= sage_component SagePopover, {
-          title: component.help_title,
-          icon: "question-circle",
-          trigger_value: "Open Menu",
-          trigger_icon_only: true,
-          link: component.help_link,
-        } do %>
-          <%= component.help_html.html_safe %>
-        <% end %>
-      <% end %>
     </h1>
+    <% if component.help_link.present? && component.help_html.blank? %>
+      <a href="<%= component.help_link[:href] %>"
+        class="sage-link--no-launch sage-link--help-icon-only"
+        target="_blank"
+        rel="noopener"
+      >
+        <span class="visually-hidden">
+          <%= component.help_link[:name] %>
+        </span>
+      </a>
+    <% end %>
+    <% if component.help_title.present? && component.help_link.present? && component.help_html.present? %>
+      <%= sage_component SagePopover, {
+        title: component.help_title,
+        icon: "question-circle",
+        trigger_value: "Open Menu",
+        trigger_icon_only: true,
+        link: component.help_link,
+      } do %>
+        <%= component.help_html.html_safe %>
+      <% end %>
+    <% end %>
   </div>
   <% if content_for? :sage_page_heading_image %>
     <div class="sage-page-heading__image">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_page_heading.html.erb
@@ -15,31 +15,33 @@
       <%= content_for :sage_page_heading_intro %>
     </div>
   <% end %>
-  <h1 class="sage-page-heading__title">
-    <%= component.title %>
-    <% if component.help_link.present? && component.help_html.blank? %>
-      <a href="<%= component.help_link[:href] %>"
-        class="sage-link--no-launch sage-link--help-icon-only"
-        target="_blank"
-        rel="noopener"
-      >
-        <span class="visually-hidden">
-          <%= component.help_link[:name] %>
-        </span>
-      </a>
-    <% end %>
-    <% if component.help_title.present? && component.help_link.present? && component.help_html.present? %>
-      <%= sage_component SagePopover, {
-        title: component.help_title,
-        icon: "question-circle",
-        trigger_value: "Open Menu",
-        trigger_icon_only: true,
-        link: component.help_link,
-      } do %>
-        <%= component.help_html.html_safe %>
+  <div class="sage-page-heading__title-wrapper">
+    <h1 class="sage-page-heading__title">
+      <%= component.title %>
+      <% if component.help_link.present? && component.help_html.blank? %>
+        <a href="<%= component.help_link[:href] %>"
+          class="sage-link--no-launch sage-link--help-icon-only"
+          target="_blank"
+          rel="noopener"
+        >
+          <span class="visually-hidden">
+            <%= component.help_link[:name] %>
+          </span>
+        </a>
       <% end %>
-    <% end %>
-  </h1>
+      <% if component.help_title.present? && component.help_link.present? && component.help_html.present? %>
+        <%= sage_component SagePopover, {
+          title: component.help_title,
+          icon: "question-circle",
+          trigger_value: "Open Menu",
+          trigger_icon_only: true,
+          link: component.help_link,
+        } do %>
+          <%= component.help_html.html_safe %>
+        <% end %>
+      <% end %>
+    </h1>
+  </div>
   <% if content_for? :sage_page_heading_image %>
     <div class="sage-page-heading__image">
       <%= content_for :sage_page_heading_image %>

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -59,10 +59,15 @@ $-page-heading-image-height-mobile: rem(120px);
   }
 }
 
+.sage-page-heading__title-wrapper {
+  grid-area: title;
+  min-width: 0;
+  margin-right: sage-spacing(sm);
+}
+
 .sage-page-heading__title {
   @extend %t-sage-heading-1;
-  grid-area: title;
-  margin-right: sage-spacing(sm);
+  @include truncate;
 }
 
 .sage-page-heading__intro {

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -60,7 +60,10 @@ $-page-heading-image-height-mobile: rem(120px);
 }
 
 .sage-page-heading__title-wrapper {
+  display: flex;
+  align-items: center;
   grid-area: title;
+  gap: sage-spacing(xs);
   min-width: 0;
   margin-right: sage-spacing(sm);
 }

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -200,6 +200,15 @@ mark {
   text-decoration: line-through;
 }
 
+.t-sage--truncate-min-width {
+  min-width: 0;
+}
+
+.t-sage--truncate-parent {
+  display: inline-flex;
+  width: 100%;
+}
+
 .t-sage--truncate {
   @include truncate;
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -206,10 +206,10 @@
     @include sage-grid-card();
   }
 
+  min-width: 0; /* to prevew grid blowouts */
   padding: sage-spacing(card);
   border: sage-border();
   border-radius: sage-border(radius);
-  min-width: 0; /* to prevew grid blowouts */
 }
 
 ///

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -209,6 +209,7 @@
   padding: sage-spacing(card);
   border: sage-border();
   border-radius: sage-border(radius);
+  min-width: 0; /* to prevew grid blowouts */
 }
 
 ///
@@ -233,6 +234,7 @@
   display: grid;
   gap: sage-spacing(sm);
   grid-template-rows: min-content;
+  min-width: 0; /* to prevew grid blowouts */
 }
 
 ///
@@ -244,6 +246,7 @@
   grid-template-columns: 100%;
   grid-template-rows: min-content;
   justify-items: start;
+  min-width: 0; /* to prevew grid blowouts */
 }
 
 ///
@@ -254,6 +257,7 @@
   gap: sage-spacing(panel);
   grid-template-columns: 100%;
   grid-template-rows: min-content;
+  min-width: 0; /* to prevew grid blowouts */
 }
 
 ///
@@ -265,6 +269,7 @@
   justify-content: space-between;
   align-items: center;
   gap: sage-spacing(card);
+  min-width: 0; /* to prevew grid blowouts */
 
   @media (max-width: sage-breakpoint(sm-max)) {
     display: flex;
@@ -287,6 +292,7 @@
   justify-content: space-between;
   align-items: center;
   gap: sage-spacing();
+  min-width: 0; /* to prevew grid blowouts */
 
   @media (max-width: sage-breakpoint(sm-max)) {
     display: flex;

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -26,9 +26,11 @@ export const PageHeading = ({
         <Breadcrumbs items={breadcrumbs} className="sage-page-heading__back" />
       </div>
     )}
-    <h1 className="sage-page-heading__title">
-      {children}
-    </h1>
+    <div className="sage-page-heading__title-wrapper">
+      <h1 className="sage-page-heading__title">
+        {children}
+      </h1>
+    </div>
     {toolbarItems && (
       <div className="sage-page-heading__toolbar">
         {toolbarItems.map((tool) => <React.Fragment key={uuid()}>{tool}</React.Fragment>)}

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -10,6 +10,7 @@ export const PageHeading = ({
   breadcrumbs,
   actionItems,
   help,
+  intro,
   toolbarItems,
   secondaryText,
   ...rest
@@ -25,6 +26,11 @@ export const PageHeading = ({
     {breadcrumbs && (
       <div className="sage-page-heading__crumbs">
         <Breadcrumbs items={breadcrumbs} className="sage-page-heading__back" />
+      </div>
+    )}
+    {intro && (
+      <div class="sage-page-heading__intro">
+      {intro}
       </div>
     )}
     <div className="sage-page-heading__title-wrapper">
@@ -60,6 +66,7 @@ PageHeading.defaultProps = {
   actionItems: null,
   toolbarItems: null,
   help: null,
+  intro: null,
   breadcrumbs: null,
   secondaryText: null,
 };
@@ -70,6 +77,7 @@ PageHeading.propTypes = {
   actionItems: PropTypes.arrayOf(PropTypes.node),
   toolbarItems: PropTypes.arrayOf(PropTypes.node),
   help: PropTypes.node,
+  intro: PropTypes.node,
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   secondaryText: PropTypes.string,
 };

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -29,8 +29,8 @@ export const PageHeading = ({
       </div>
     )}
     {intro && (
-      <div class="sage-page-heading__intro">
-      {intro}
+      <div className="sage-page-heading__intro">
+        {intro}
       </div>
     )}
     <div className="sage-page-heading__title-wrapper">

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -9,6 +9,7 @@ export const PageHeading = ({
   children,
   breadcrumbs,
   actionItems,
+  help,
   toolbarItems,
   secondaryText,
   ...rest
@@ -30,6 +31,11 @@ export const PageHeading = ({
       <h1 className="sage-page-heading__title">
         {children}
       </h1>
+      {help && (
+        <>
+          {help}
+        </>
+      )}
     </div>
     {toolbarItems && (
       <div className="sage-page-heading__toolbar">
@@ -53,6 +59,7 @@ PageHeading.defaultProps = {
   className: '',
   actionItems: null,
   toolbarItems: null,
+  help: null,
   breadcrumbs: null,
   secondaryText: null,
 };
@@ -62,6 +69,7 @@ PageHeading.propTypes = {
   children: PropTypes.node.isRequired,
   actionItems: PropTypes.arrayOf(PropTypes.node),
   toolbarItems: PropTypes.arrayOf(PropTypes.node),
+  help: PropTypes.node,
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   secondaryText: PropTypes.string,
 };

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -10,22 +10,10 @@ export default {
   args: {
     children: (
       <>
-        Page heading goes here
-      </>
-    ),
-    breadcrumbs: [
-      {
-        label: 'Back somewhere',
-        href: '#back'
-      }
-    ],
-    help: (
-      <>
-        <HelpLink href="//example.com" target="_blank" rel="noopener" />
+        Page heading title
       </>
     ),
     actionItems: null,
-    secondaryText: 'Secondary text here',
     toolbarItems: null
   }
 };
@@ -33,8 +21,95 @@ const Template = (args) => <PageHeading {...args} />;
 
 export const Default = Template.bind({});
 
+export const PageHeadingWithBackLink = Template.bind({});
+PageHeadingWithBackLink.args = {
+  breadcrumbs: [
+    {
+      label: 'Back somewhere',
+      href: '#back'
+    }
+  ]
+};
+export const PageHeadingWithHelpLink = Template.bind({});
+PageHeadingWithHelpLink.args = {
+  help: (
+    <>
+      <HelpLink href="//example.com" target="_blank" rel="noopener" />
+    </>
+  )
+};
+export const PageHeadingWithActionButtons = Template.bind({});
+PageHeadingWithActionButtons.args = {
+  actionItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.PREVIEW_ON}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.PRIMARY}
+      icon={SageTokens.ICONS.CART}
+    >
+      Create
+    </Button>
+  ],
+};
+export const PageHeadingWithToolbarAndSecondaryText = Template.bind({});
+PageHeadingWithToolbarAndSecondaryText.args = {
+  secondaryText: 'Secondary text here',
+  toolbarItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CART}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Report
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Settings
+    </Button>
+  ],
+};
+export const PageHeadingWithIntro = Template.bind({});
+PageHeadingWithIntro.args = {
+  intro: (
+    <>
+      <p>Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nemo dolorum esse modi ut ipsa corporis.</p>
+    </>
+  )
+};
+
 export const AllItems = Template.bind({});
 AllItems.args = {
+  breadcrumbs: [
+    {
+      label: 'Back somewhere',
+      href: '#back'
+    }
+  ],
+  help: (
+    <>
+      <HelpLink href="//example.com" target="_blank" rel="noopener" />
+    </>
+  ),
+  intro: (
+    <>
+      <p>Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nemo dolorum esse modi ut ipsa corporis.</p>
+    </>
+  ),
   actionItems: [
     <Button
       color={Button.COLORS.SECONDARY}

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { HelpLink } from '../HelpLink';
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
 import { PageHeading } from './PageHeading';
 
 export default {
@@ -26,3 +28,45 @@ export default {
 const Template = (args) => <PageHeading {...args} />;
 
 export const Default = Template.bind({});
+
+export const AllItems = Template.bind({});
+AllItems.args = {
+  actionItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.PREVIEW_ON}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.PRIMARY}
+      icon={SageTokens.ICONS.CART}
+    >
+      Create
+    </Button>
+  ],
+  toolbarItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CART}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Report
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Settings
+    </Button>
+  ],
+};

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -11,7 +11,6 @@ export default {
     children: (
       <>
         Page heading goes here
-        <HelpLink href="//example.com" target="_blank" rel="noopener" />
       </>
     ),
     breadcrumbs: [
@@ -20,6 +19,11 @@ export default {
         href: '#back'
       }
     ],
+    help: (
+      <>
+        <HelpLink href="//example.com" target="_blank" rel="noopener" />
+      </>
+    ),
     actionItems: null,
     secondaryText: 'Secondary text here',
     toolbarItems: null

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -87,7 +87,7 @@ export const PageHeadingWithIntro = Template.bind({});
 PageHeadingWithIntro.args = {
   intro: (
     <>
-      <p>Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nemo dolorum esse modi ut ipsa corporis.</p>
+      <p>Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit.</p>
     </>
   )
 };
@@ -107,7 +107,7 @@ AllItems.args = {
   ),
   intro: (
     <>
-      <p>Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nemo dolorum esse modi ut ipsa corporis.</p>
+      <p>Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit</p>
     </>
   ),
   actionItems: [


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add truncation to h1
- [x] move popover out of h1 and make a sibling
- [x] create general helper classes for truncation
- [x] react - create help prop similar to the rails side
- [x] react - create intro similar to rails side
- [ ] update docs with truncation section

### Breaking change
#### React Page Heading
- the `help` prop has now been added to bring in parity with rails. Currently `{children}` contains the `title` and `help`. With this change
**Note to implementation** @Kajabi/sage-implementation
The following files have mostly `<Popover />`s that will need to be moved with a `help` props:
- app/javascript/apps/click_report/views/ClickReport/ClickReport.jsx
- app/javascript/apps/click_report/views/LinkReport/LinkReport.jsx
- app/javascript/apps/dns_settings/DnsSettings.jsx
- app/javascript/apps/imports/views/BulkActions/BulkActionsContainer.jsx
- app/javascript/apps/imports/views/Confirm/ConfirmContainer.jsx
- app/javascript/apps/imports/views/ImportContacts/ImportContacts.jsx
- app/javascript/apps/imports/views/MapColumns/MapColumnsContainer.jsx
- app/javascript/apps/manage/insights/InsightsContainer.jsx
- app/javascript/apps/manage/peoples/contacts/ContactsHeader.jsx
- app/javascript/apps/products/PostContainer/components/PostHeader/PostHeader.jsx
- app/javascript/apps/products/ProductContainer/components/ProductHeader/ProductHeader.jsx
- app/javascript/apps/quizzes/admin/components/QuizHeader/QuizHeader.jsx
- app/javascript/apps/reporting/components/BaseReport/BaseReportContainer.jsx
- app/javascript/apps/reporting/reports/MemberProductProgressReport/MemberProductProgressReport.jsx
- app/javascript/stories/mocks/coaching/DashboardPageMock.jsx
- app/javascript/stories/mocks/coaching/OAuthPageMock.jsx
- app/javascript/stories/mocks/crm/CRMEngagementWidget.jsx
- app/javascript/stories/mocks/crm/CRMStatBox.jsx
- app/javascript/stories/mocks/domains/GetADomainPage.jsx
- app/javascript/stories/mocks/domains/OrderSummary.jsx

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|pending|pending|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Go to the page heading views and verify that overflow text does overflow the page heading:
- [Rails version](http://localhost:4000/pages/index)
- [React version](http://localhost:4100/?path=/story/sage-pageheading--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Description of the change and its impact with QA as the audience.
   - [ ] Product Index - React
   - [ ] Coaching Index - Rails


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-233](https://kajabi.atlassian.net/browse/SAGE-233)