### PR TITLE
[SAGE-235] Dropdown width

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -27,10 +27,10 @@ export const Dropdown = ({
   label,
   onEscapeHook,
   panelModifier,
-  panelMaxWidth,
   panelSize,
   panelStateToken,
   panelType,
+  panelWidth,
   triggerButtonSubtle,
   triggerModifier,
 }) => {
@@ -149,11 +149,11 @@ export const Dropdown = ({
       </DropdownTrigger>
       {isActive && (
         <DropdownPanel
-          maxWidth={panelMaxWidth}
           modifier={panelModifier}
           onClickScreen={onClickScreen}
           onExit={onExit}
           coords={coords}
+          width={panelWidth}
         >
           {children}
         </DropdownPanel>
@@ -188,11 +188,11 @@ Dropdown.defaultProps = {
   isLabelVisible: true,
   isPinned: false,
   onEscapeHook: () => false,
-  panelMaxWidth: null,
   panelModifier: 'default',
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   panelStateToken: null,
   panelType: null,
+  panelWidth: null,
   triggerButtonSubtle: false,
   triggerModifier: 'default',
   label: null
@@ -214,11 +214,11 @@ Dropdown.propTypes = {
   isPinned: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   onEscapeHook: PropTypes.func,
-  panelMaxWidth: PropTypes.string,
   panelModifier: PropTypes.string,
   panelSize: PropTypes.oneOf(Object.values(Dropdown.PANEL_SIZES)),
   panelType: PropTypes.oneOf(Object.values(Dropdown.PANEL_TYPES)),
   panelStateToken: PropTypes.string,
+  panelWidth: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -34,8 +34,8 @@ export default {
     isLabelVisible: true,
     isPinned: false,
     label: 'Switch label',
-    panelMaxWidth: null,
     panelSize: Dropdown.PANEL_SIZES.DEFAULT,
+    panelWidth: null,
     triggerButtonSubtle: false,
     children: (
       <Dropdown.ItemList items={sampleMenuItems} />

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -7,10 +7,10 @@ import classnames from 'classnames';
 export const DropdownPanel = ({
   children,
   coords,
-  maxWidth,
   modifier,
   onClickScreen,
   onExit,
+  width,
 }) => {
   const menuEl = useRef(null);
   const classNames = classnames(
@@ -35,7 +35,7 @@ export const DropdownPanel = ({
       onClick={handlePanelClick}
       role="dialog"
       style={{
-        maxWidth,
+        width,
         ...positioningCoords
       }}
     >
@@ -47,10 +47,10 @@ export const DropdownPanel = ({
 DropdownPanel.defaultProps = {
   coords: null,
   children: null,
-  maxWidth: null,
   modifier: null,
   onClickScreen: (evt) => evt,
   onExit: (evt) => evt,
+  width: null,
 };
 
 DropdownPanel.propTypes = {
@@ -66,8 +66,8 @@ DropdownPanel.propTypes = {
       PropTypes.string,
     ]),
   }),
-  maxWidth: PropTypes.string,
   modifier: PropTypes.string,
   onClickScreen: PropTypes.func,
   onExit: PropTypes.func,
+  width: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -17,6 +17,7 @@ export const DropdownPanel = ({
     'sage-dropdown__panel',
     {
       [`sage-dropdown__panel--${modifier}`]: modifier,
+      [`sage-dropdown__panel--custom-width`]: width,
     }
   );
 
@@ -35,7 +36,7 @@ export const DropdownPanel = ({
       onClick={handlePanelClick}
       role="dialog"
       style={{
-        width,
+        "--custom-panel-width": width,
         ...positioningCoords
       }}
     >

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -17,7 +17,7 @@ export const DropdownPanel = ({
     'sage-dropdown__panel',
     {
       [`sage-dropdown__panel--${modifier}`]: modifier,
-      [`sage-dropdown__panel--custom-width`]: width,
+      'sage-dropdown__panel--custom-width': width,
     }
   );
 
@@ -36,7 +36,7 @@ export const DropdownPanel = ({
       onClick={handlePanelClick}
       role="dialog"
       style={{
-        "--custom-panel-width": width,
+        '--custom-panel-width': width,
         ...positioningCoords
       }}
     >

--- a/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/OptionsDropdown.jsx
@@ -11,7 +11,7 @@ export const OptionsDropdown = ({
   exitPanelHandler,
   isPinned,
   onEscapeHook,
-  panelMaxWidth,
+  panelWidth,
   panelSize,
   options,
   triggerButtonSubtle,
@@ -25,8 +25,8 @@ export const OptionsDropdown = ({
     isPinned={isPinned}
     label="Options"
     onEscapeHook={onEscapeHook}
-    panelMaxWidth={panelMaxWidth}
     panelSize={panelSize}
+    panelWidth={panelWidth}
     triggerModifier="options"
     triggerButtonSubtle={triggerButtonSubtle}
   >
@@ -43,8 +43,8 @@ OptionsDropdown.defaultProps = {
   exitPanelHandler: (evt) => evt,
   isPinned: true,
   onEscapeHook: () => false,
-  panelMaxWidth: null,
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
+  panelWidth: null,
   options: null,
   triggerButtonSubtle: true,
 };
@@ -55,8 +55,8 @@ OptionsDropdown.propTypes = {
   exitPanelHandler: PropTypes.func,
   isPinned: PropTypes.bool,
   onEscapeHook: PropTypes.func,
-  panelMaxWidth: PropTypes.string,
   panelSize: PropTypes.oneOf(Object.values(DROPDOWN_PANEL_SIZES)),
+  panelWidth: PropTypes.string,
   options: DropdownItemList.itemsPropTypes,
   triggerButtonSubtle: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Panel/Panel.story.jsx
+++ b/packages/sage-react/lib/Panel/Panel.story.jsx
@@ -52,7 +52,7 @@ export const Default = (args) => (
               label: 'Option 3',
             }
           ]}
-          panelMaxWidth="240px"
+          panelWidth="240px"
         />
       </Panel.Header>
       <Panel.Block sageType={true}>


### PR DESCRIPTION
## Description
This PR replaces the `panelMaxWidth` prop with `panelWidth` in the React DropdownPanel to better match how the Rails version works.

`panelMaxWidth` is not currently used in KP nor is it in the Rails component.

This enables one to use `panelWidth: "500px"` to be able to set a custom width. The custom width does not override the `min-width` setting as doing so could allow the menu to get cut off and override the `small` panel size.

## Testing in `sage-lib`
1. Visit http://0.0.0.0:4100/?path=/story/sage-dropdown--default
2. Ensure that the `panelSize` and `panelWidth` settings work as expected

## Testing in `kajabi-products`
Please test any area in KP that uses React dropdowns:

1. (**MED**) Contacts
   - [ ] http://www.kajabi.test:3000/admin/sites/1/contacts
2. (**MED**) Website -> Design
   - [ ] http://www.kajabi.test:3000/admin/sites/1/website_designs

## Related
https://kajabi.atlassian.net/browse/SAGE-235
