### PR TITLE
[SAGE-226] Avatar - Foundations Update

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -1,20 +1,67 @@
-<h3>Sample Avatars</h3>
+<h3>Default Avatars</h3>
 <div class="sage-avatar-wrapper">
+  <%= sage_component SageAvatar, { size: "24px" } %>
+  <%= sage_component SageAvatar, { size: "32px" } %>
+  <%= sage_component SageAvatar, { size: "40px" } %>
+  <%= sage_component SageAvatar, { size: "56px" } %>
+  <%= sage_component SageAvatar, { size: "72px" } %>
+  <%= sage_component SageAvatar, { size: "88px" } %>
+</div>
 
-  <!-- Showing default -->
-  <%= sage_component SageAvatar, { color: nil, initials: "JC" } %>
+<h3>Initial Avatars</h3>
+<div class="sage-avatar-wrapper">
+  <%= sage_component SageAvatar, { size: "24px", initials: "KA" } %>
+  <%= sage_component SageAvatar, { size: "32px", initials: "JA" } %>
+  <%= sage_component SageAvatar, { size: "40px", initials: "BI" } %>
+  <%= sage_component SageAvatar, { size: "56px", initials: "IS" } %>
+  <%= sage_component SageAvatar, { size: "72px", initials: "CO" } %>
+  <%= sage_component SageAvatar, { size: "88px", initials: "OL" } %>
+</div>
 
-  <!-- Showing color variation -->
-  <%= sage_component SageAvatar, { color: "purple", initials: "PS" } %>
-
-  <!-- Showing one initial -->
-  <%= sage_component SageAvatar, { color: "sage", initials: "Q" } %>
-
-  <!-- Showing custom class -->
-  <%= sage_component SageAvatar, { color: "orange", initials: "KJ", css_classes: "my-custom-class" } %>
-
-  <!-- Showing profile image -->
+<h3>Image Avatars</h3>
+<div class="sage-avatar-wrapper">
   <%= sage_component SageAvatar, {
+    size: "24px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    size: "32px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    size: "40px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    size: "56px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    size: "72px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    size: "88px",
     image: {
       alt: "Court's profile image",
       src: "avatar/court.png",
@@ -23,32 +70,64 @@
   } %>
 </div>
 
-<h3>Avatar centered + custom size</h3>
-<%= sage_component SageAvatar, { centered: true, initials: "JC", size: "128px" } %>
+<h3>Avatar Badges</h3>
+<div class="sage-avatar-wrapper">
+  <%= sage_component SageAvatar, { size: "24px", badge: true } %>
+  <%= sage_component SageAvatar, { size: "32px", badge: true } %>
+  <%= sage_component SageAvatar, { size: "40px", initials: "BI", badge: true } %>
+  <%= sage_component SageAvatar, { size: "56px", initials: "RO", badge: true } %>
+  <%= sage_component SageAvatar, {
+    badge: true,
+    size: "72px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    badge: true,
+    size: "88px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+</div>
+
+<h3>Custom Colors</h3>
+<div class="sage-avatar-wrapper">
+  <%= sage_component SageAvatar, { size: "24px", initials: "CO", color: "purple" } %>
+  <%= sage_component SageAvatar, { size: "32px", initials: "LO", color: "sage" } %>
+  <%= sage_component SageAvatar, { size: "40px", initials: "RS", color: "orange" } %>
+  <%= sage_component SageAvatar, { size: "56px", initials: "RF", color: "yellow" } %>
+  <%= sage_component SageAvatar, { size: "72px", initials: "UN", color: "red" } %>
+</div>
 
 <h3>Avatar Groups</h3>
 <div class="sage-avatar-wrapper">
   <%= sage_component SageAvatarGroup, {
     items: [
-      { color: nil, initials: "JC" },
+      { initials: "JC" },
+    ]
+  } %>
+  <%= sage_component SageAvatarGroup, {
+    items: [
+      { color: nil },
+      { color: "purple", initials: "PS" },
     ]
   } %>
   <%= sage_component SageAvatarGroup, {
     items: [
       { initials: "JC" },
       { color: "purple", initials: "PS" },
-    ]
-  } %>
-  <%= sage_component SageAvatarGroup, {
-    items: [
-      { color: nil, initials: "JC" },
-      { color: "purple", initials: "PS" },
       { color: "sage", initials: "Q" },
     ]
   } %>
   <%= sage_component SageAvatarGroup, {
     items: [
-      { color: nil, initials: "JC" },
+      { color: nil },
       { color: "purple", initials: "PS" },
       { color: "sage", initials: "Q" },
       { color: "orange", initials: "KJ" },
@@ -56,34 +135,8 @@
   } %>
 </div>
 
-<!-- Showing default -->
-<h3>Avatar With Badge</h3>
-<div class="sage-avatar-wrapper">
-  <%= sage_component SageAvatar, {
-    badge: true,
-    size: "32px",
-    color: nil,
-    initials: "JC"
-  } %>
-  <%= sage_component SageAvatar, {
-    badge: true,
-    size: "64px",
-    color: nil,
-    initials: "JC"
-  } %>
-  <%= sage_component SageAvatar, {
-    badge: true,
-    size: "96px",
-    color: nil,
-    initials: "JC"
-  } %>
-  <%= sage_component SageAvatar, {
-    badge: true,
-    size: "128px",
-    color: nil,
-    initials: "JC"
-  } %>
-</div>
+<h3>Avatar centered + custom size</h3>
+<%= sage_component SageAvatar, { centered: true, initials: "JC", size: "128px" } %>
 
 <h3>Layering and lazy loading</h3>
 <%= md('
@@ -114,4 +167,3 @@ the initials are seen rather than a generic "anonymous user" image.
   image: { src: "https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?" },
   lazy_load_initials: false
 } %>
-

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -11,7 +11,7 @@ avatar_size_as_integer = component.size.to_i;
 
 case avatar_size_as_integer
   when 32..47 then badge_icon_size = "sm"
-  when 48..63 then badge_icon_size = "md"
+  when 48..63 then badge_icon_size = nil # should be update to md once -md classes supported
   when 64..79 then badge_icon_size = "lg"
   when 80..95 then badge_icon_size = "xl"
   when 96..111 then badge_icon_size = "2xl"
@@ -38,9 +38,13 @@ end
       <%= sage_component SageIcon, {
         icon: "check-circle-filled",
         size: badge_icon_size,
-        color: "primary-500",
+        color: "primary-600",
       } %>
     </div>
+  <% end %>
+
+  <% if !component.initials && !component.image %>
+    <svg class="sage-avatar__graphic" viewBox="0 0 28 28"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.038 14.594a8.167 8.167 0 1 0-10.077 0C3.767 16.236 0 21.094 0 26.834a1.167 1.167 0 1 0 2.333 0c0-5.8 4.701-10.5 10.5-10.5h2.334c5.799 0 10.5 4.7 10.5 10.5a1.167 1.167 0 1 0 2.333 0c0-5.74-3.766-10.598-8.962-12.24ZM8.167 8.167a5.833 5.833 0 1 1 11.666 0 5.833 5.833 0 0 1-11.666 0Z" fill="#054FB8"/></svg>
   <% end %>
 
   <% if component.image %>
@@ -53,9 +57,11 @@ end
     <%= image_tag component.image[:src], alt: (component.image[:alt] || ""), class: "sage-avatar__image", id: image_id  %>
   <% end %>
 
+<% if component.initials %>
   <% if lazy_load_initials %>
     <svg class="sage-avatar__initials" viewBox="0 0 32 32">
       <text x="16" y="20"><%= component.initials %></text>
     </svg>
+  <% end %>
   <% end %>
 </div>

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -132,6 +132,7 @@ $-avatar-group-item-sizes: (
 // Documentation-specific styles
 .sage-avatar-wrapper {
   display: flex;
+  flex-wrap: wrap;
   margin-bottom: sage-spacing();
 }
 
@@ -153,10 +154,11 @@ $-avatar-group-item-sizes: (
 .sage-avatar__badge {
   position: absolute;
   z-index: sage-z-index(default, 3);
-  bottom: 0;
-  right: 0;
+  bottom: rem(-4px);
+  right: rem(-4px);
   background-color: sage-color(white);
   border-radius: sage-border(radius-round);
+  border: rem(2px) solid sage-color(white);
 
   i {
     display: flex;
@@ -167,8 +169,8 @@ $-avatar-group-item-sizes: (
   grid-area: full;
   width: 100%;
   text-align: center;
-  color: sage-color(primary, 500);
-  fill: sage-color(primary, 500);
+  color: sage-color(primary, 700);
+  fill: sage-color(primary, 700);
 
   @extend %t-sage-body-xsmall-bold;
 
@@ -201,6 +203,12 @@ $-avatar-group-item-sizes: (
     max-width: $-avatar-tile-size;
     max-height: $-avatar-tile-size;
   }
+}
+
+.sage-avatar__graphic {
+  grid-area: full;
+  height: 36.36%;
+  width: 36.36%;
 }
 
 .sage-avatar-group {


### PR DESCRIPTION
## Description

Foundational updates to avatar component with the following updates:

- Add new default avatar
- Adjust colors to match design updates
- Adjust preview to better display avatar types.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-02-16 at 10 18 00 AM](https://user-images.githubusercontent.com/1175111/154330028-c84ac792-3e7c-47ab-9197-6dd423d7b3d6.png)|![Screen Shot 2022-02-16 at 10 17 42 AM](https://user-images.githubusercontent.com/1175111/154330082-054ce3cc-9e55-4bc7-a15b-53046dc90101.png)|


## Testing in `sage-lib`

- Navigate to http://localhost:4000/pages/component/avatar
- Verify the new default avatar.
- Verify color adjustments
- Verify adjustments match [design mock](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/%E2%9A%A0%EF%B8%8F-%5BDO-NOT-USE-WIP%5D-Sage-Update?node-id=449%3A19850).


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
https://kajabi.atlassian.net/browse/SAGE-226
