### PR TITLE
Add Dot component

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -172,10 +172,10 @@ module ComponentsHelper
       {
         title: "dot",
         description: "Dots provide a subtle color cue to place beside text or other elements.", 
-        scss: "todo",
-        rails: "todo",
-        react: "todo",
-        a11y: "todo",
+        scss: "done",
+        rails: "done",
+        react: "done",
+        a11y: "done",
         react_component_slug: "sage-dot--default",
         figma_embed: nil, # TODO: We'll have a link for this in the new design system
       },

--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -170,6 +170,16 @@ module ComponentsHelper
         figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F9Km09NjlZHYWsMP7EGT8tI%2FSage-3-for-Admin%3Fnode-id%3D4195%253A20283",
       },
       {
+        title: "dot",
+        description: "Dots provide a subtle color cue to place beside text or other elements.", 
+        scss: "todo",
+        rails: "todo",
+        react: "todo",
+        a11y: "todo",
+        react_component_slug: "sage-dot--default",
+        figma_embed: nil, # TODO: We'll have a link for this in the new design system
+      },
+      {
         title: "description",
         description: "A description is composed of title and data content and is structured as a definition list.",
         scss: "done",

--- a/docs/app/views/examples/components/dot/_preview.html.erb
+++ b/docs/app/views/examples/components/dot/_preview.html.erb
@@ -1,0 +1,47 @@
+<h3>Default</h3>
+
+<%= md("Dots can be used easily with any of the standard Sage colors.") %>
+
+<%= sage_component SageDot, {} %>
+<%= sage_component SageDot, { color: "primary" } %>
+<%= sage_component SageDot, { color: "red" } %>
+<%= sage_component SageDot, { color: "yellow" } %>
+<%= sage_component SageDot, { color: "purple" } %>
+<%= sage_component SageDot, { color: "charcoal" } %>
+<%= sage_component SageDot, { color: "grey" } %>
+
+<h3>Custom color</h3>
+<%= md("
+Dots can also be set to use a custom hex color.
+Note that the `SageTokens::COLOR_PALETTE` exposes additional hex colors for the full Sage color palette.
+") %>
+<%= sage_component SageDot, { color: SageTokens::COLOR_PALETTE[:PRIMARY_200] } %>
+<%= sage_component SageDot, { color: "#ef45c2" } %>
+
+<h3>With text</h3>
+<%= md("
+Dots can simply be placed inside styled typography elements, and works best with the specs shown below.
+Additional, it can be placed as an item inside a flex row or grid template
+for improved alignment with other type specs or other elements altogether.
+") %>
+<p class="<%= SageClassnames::TYPE::BODY_SMALL %>">
+  <%= sage_component SageDot, {} %>
+  Body small spec
+</p>
+<p class="<%= SageClassnames::TYPE::BODY %>">
+  <%= sage_component SageDot, {} %>
+  Body spec
+</p>
+<p class="<%= SageClassnames::TYPE::HEADING_6 %>">
+  <%= sage_component SageDot, {} %>
+  Heading 6 spec
+</p>
+<p class="<%= SageClassnames::TYPE::HEADING_5 %>">
+  <%= sage_component SageDot, {} %>
+  Heading 5 spec
+</p>
+<p class="<%= SageClassnames::TYPE::HEADING_4 %>">
+  <%= sage_component SageDot, {} %>
+  Heading 4 spec
+</p>
+

--- a/docs/app/views/examples/components/dot/_props.html.erb
+++ b/docs/app/views/examples/components/dot/_props.html.erb
@@ -1,0 +1,12 @@
+<tr>
+  <td><%= md('`label`') %></td>
+  <td><%= md('Provide an accessible label for the dot. Without this set, the element will instead be set to `aria-hidden="true".') %></td>
+  <td><%= md('`String`') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`color`') %></td>
+  <td><%= md('Provide either a Sage color name or a custom Hex color value. Use `SageTokens::COLOR_PALETTE` for hex values from the full Sage color palette.') %></td>
+  <td><%= md("Hex color string or `#{SageTokens::COLORS.inspect()}`") %></td>
+  <td><%= md('`"sage"`') %></td>
+</tr>

--- a/docs/app/views/examples/components/dot/_rules_do.html.erb
+++ b/docs/app/views/examples/components/dot/_rules_do.html.erb
@@ -1,0 +1,5 @@
+<!-- Uncomment when in use.
+<ul>
+  <li>Rules for what you should do with this component go here.</li>
+</ul>
+-->

--- a/docs/app/views/examples/components/dot/_rules_dont.html.erb
+++ b/docs/app/views/examples/components/dot/_rules_dont.html.erb
@@ -1,0 +1,5 @@
+<!-- Uncomment when in use.
+<ul>
+  <li>Rules for what you should not do with this component go here.</li>
+</ul>
+-->

--- a/docs/lib/sage_rails/app/sage_components/sage_dot.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_dot.rb
@@ -1,0 +1,6 @@
+class SageDot < SageComponent
+  set_attribute_schema({
+    color: [:optional, NilClass, Set.new(SageTokens::COLORS), String],
+    label: [:optional, NilClass, String],
+  })
+end

--- a/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_panel_row.rb
@@ -1,7 +1,7 @@
 class SagePanelRow < SageComponent
   set_attribute_schema({
     grid_template: [:optional, SageSchemas::GRID_TEMPLATE],
-    gap: [:optional, Set.new([:xs, :sm, :md, :lg])],
+    gap: [:optional, Set.new(SageTokens::SPACER_SIZES)],
     vertical_align: [:optional, Set.new(["start"])],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dot.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dot.html.erb
@@ -1,0 +1,26 @@
+<%
+custom_color = false
+color = component.color.present? ? component.color : "sage"
+
+if (!SageTokens::COLOR_SLIDERS.include?(color))
+  custom_color = true
+end
+%>
+<span
+  class="
+    sage-dot
+    sage-dot--color-<%= custom_color ? "custom" : color %>
+    <%= component.generated_css_classes %>
+  "
+  <% if custom_color %>
+    style="--sage-dot-color: <%= color %>"
+  <% end %>
+  <%= component.generated_html_attributes.html_safe %>
+  <% if component.label %>
+    aria-label="<%= component.label %>"
+  <% else %>
+    aria-hidden="true"
+  <% end %>
+>
+  <%= component.content %>
+</span>

--- a/packages/sage-assets/lib/stylesheets/components/_dot.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dot.scss
@@ -1,0 +1,31 @@
+////
+/// Dot
+///
+/// @group sage
+////
+
+$-sage-dot-size: rem(8px);
+$-sage-dot-color: sage-color(black);
+$-sage-dot-gap: sage-spacing(2xs);
+
+.sage-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sage-dot-gap, #{$-sage-dot-gap});
+  vertical-align: middle;
+
+  &::before {
+    content: "";
+    display: block;
+    width: var(--sage-dot-size, #{$-sage-dot-size});
+    height: var(--sage-dot-size, #{$-sage-dot-size});
+    border-radius: sage-border(radius);
+    background-color: var(--sage-dot-color, #{$-sage-dot-color});
+  }
+}
+
+@each $-color-name, $-color-sliders in $sage-colors {
+  .sage-dot--color-#{"" + $-color-name} {
+    --sage-dot-color: #{sage-color($-color-name)};
+  }
+}

--- a/packages/sage-assets/lib/stylesheets/index.scss
+++ b/packages/sage-assets/lib/stylesheets/index.scss
@@ -28,6 +28,7 @@
 @import "utilities/spacer";
 
 // Components
+@import "components/dot";
 @import "components/carousel";
 @import "components/chart_legend";
 @import "components/chart_summary";

--- a/packages/sage-react/lib/Dot/Dot.jsx
+++ b/packages/sage-react/lib/Dot/Dot.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { DOT_COLORS } from './configs';
+
+export const Dot = ({
+  children,
+  className,
+  color,
+  label,
+  ...rest
+}) => {
+  const customColor = !Object.values(DOT_COLORS).includes(color);
+  const classNames = classnames(
+    'sage-dot',
+    className,
+    {
+      'sage-dot--color-custom': customColor,
+      [`sage-dot--color-${color}`]: !customColor && color,
+    }
+  );
+
+  const style = {};
+
+  if (customColor) {
+    style['--sage-dot-color'] = color;
+  }
+
+  const attrs = {};
+
+  if (label) {
+    attrs['aria-label'] = label;
+  } else {
+    attrs['aria-hidden'] = true;
+  }
+
+  return (
+    <span className={classNames} style={style} {...attrs} {...rest}>
+      {children}
+    </span>
+  );
+};
+
+Dot.COLORS = DOT_COLORS;
+
+Dot.defaultProps = {
+  children: null,
+  className: null,
+  color: Dot.COLORS.DEFAULT,
+  label: null,
+};
+
+Dot.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  color: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(Object.values(Dot.COLORS))
+  ]),
+  label: PropTypes.string,
+};

--- a/packages/sage-react/lib/Dot/Dot.spec.jsx
+++ b/packages/sage-react/lib/Dot/Dot.spec.jsx
@@ -1,0 +1,24 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Dot } from './Dot';
+
+describe('Sage Dot', () => {
+  let component,
+    defaultProps;
+
+  beforeEach(() => {
+    defaultProps = {};
+
+    component = shallow(
+      <Dot {...defaultProps} />
+    );
+  });
+
+  describe('construction', () => {
+    it('renders the component', () => {
+      expect(component).toHaveLength(1);
+    });
+  });
+});

--- a/packages/sage-react/lib/Dot/Dot.story.jsx
+++ b/packages/sage-react/lib/Dot/Dot.story.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { Dot } from './Dot';
+
+export default {
+  title: 'Sage/Dot',
+  component: Dot,
+  args: {
+    color: Dot.COLORS.SAGE,
+    label: 'What this dot means',
+  },
+  argTypes: {
+    ...selectArgs({
+      color: Dot.COLORS
+    })
+  }
+};
+
+const Template = (args) => <Dot {...args} />;
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/Dot/configs.js
+++ b/packages/sage-react/lib/Dot/configs.js
@@ -6,4 +6,5 @@ export const DOT_COLORS = {
   YELLOW: 'yellow',
   ORANGE: 'orange',
   RED: 'red',
+  GREY: 'grey',
 };

--- a/packages/sage-react/lib/Dot/configs.js
+++ b/packages/sage-react/lib/Dot/configs.js
@@ -1,0 +1,9 @@
+export const DOT_COLORS = {
+  DEFAULT: 'sage',
+  CHARCOAL: 'charcoal',
+  PURPLE: 'purple',
+  SAGE: 'sage',
+  YELLOW: 'yellow',
+  ORANGE: 'orange',
+  RED: 'red',
+};

--- a/packages/sage-react/lib/Dot/index.js
+++ b/packages/sage-react/lib/Dot/index.js
@@ -1,0 +1,1 @@
+export { Dot } from './Dot';

--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -8,6 +8,7 @@ export { Carousel } from './Carousel';
 export { Chart } from './Chart';
 export { Choice } from './Choice';
 export { Description } from './Description';
+export { Dot } from './Dot';
 export { Drawer } from './Drawer';
 export {
   Dropdown,


### PR DESCRIPTION
## Description

This PR adds a new component, `SageDot`, for adding a small colored dot distinctly into a layout or pattern, such as what is currently in the Legend and Statbox.

## Screenshots

<img width="842" alt="Screen Shot 2022-02-16 at 9 34 41 PM" src="https://user-images.githubusercontent.com/17955295/154393724-0ccb323e-be74-439e-9d85-b70a4a37bcfd.png">


## Testing in `sage-lib`

See Components > Dot and the same in React

## Testing in `kajabi-products`

1. (**N/A**) Adds new `SageDot` component.

