### PR TITLE
[SAGE-233] Truncation - add line clamping utility class

### DIFF
--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -81,8 +81,12 @@
             text: "Spacing",
             link: pages_helpers_path(:spacing),
             active: current_page?(pages_helpers_path(:spacing)),
+          }, {
+            text: "Truncation",
+            link: pages_helpers_path(:truncation),
+            active: current_page?(pages_patterns_path(:truncation)),
           }
-        ] }
+        ] },
       ]
     } %>
   <% end %>

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -10,7 +10,7 @@ Use this scratchpad to test out elements and components in context. Just be sure
   <%= sage_component SagePanelRow, { grid_template: "ete" } do %>
     <i class="sage-icon-check-circle-xl t-sage--color-sage"></i>
     <%= sage_component SagePanelBlock, {} do %>
-      <p class="t-sage-body-semi">LoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLorem</p>
+      <p class="t-sage-body-semi t-sage--line-clamp">LoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLorem</p>
       <p class="t-sage-body-small t-sage--color-grey">consectetur adipiscing elit</p>
     <% end %>
     <%= sage_component SageButton, {

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -5,3 +5,22 @@
 Use this scratchpad to test out elements and components in context. Just be sure not to commit your changes. ❤️
 ") %>
 <% end %>
+
+<%= sage_component SagePanel, {} do %>
+  <%= sage_component SagePanelRow, { grid_template: "ete" } do %>
+    <i class="sage-icon-check-circle-xl t-sage--color-sage"></i>
+    <%= sage_component SagePanelBlock, {} do %>
+      <p class="t-sage-body-semi">LoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLoremLorem</p>
+      <p class="t-sage-body-small t-sage--color-grey">consectetur adipiscing elit</p>
+    <% end %>
+    <%= sage_component SageButton, {
+      value: "Options",
+      style: "secondary",
+      subtle: true,
+      icon: {
+        name: "dot-menu-horizontal",
+        style: "only"
+      }
+    } %>
+  <% end %>
+<% end %>

--- a/docs/app/views/pages/truncation.html.erb
+++ b/docs/app/views/pages/truncation.html.erb
@@ -9,8 +9,6 @@
 
   <%= md(%(
   We have helper classes to assist with truncation and the necessary pairings on parent elements:
-
-  - `.t-sage--truncate-min-width` -- This class must be added to a parent element of `.t-sage--truncate`. This element must also be either a child element whose parent contains `display: grid;`.
   - `.t-sage--truncate` -- This class is can be added to the text intended to be truncated.
   )) %>
 </div>

--- a/docs/app/views/pages/truncation.html.erb
+++ b/docs/app/views/pages/truncation.html.erb
@@ -5,28 +5,4 @@
 )) %>
 <% end %>
 
-<div class="<%= SageClassnames::TYPE_BLOCK %>">
-
-  <%= md(%(
-  We have helper classes to assist with truncation and the necessary pairings on parent elements:
-  - `.t-sage--truncate` -- This class is can be added to the text intended to be truncated.
-  )) %>
-</div>
-
-<%= sage_component SageCard, {} do %>
-  <h2 class="t-sage-heading-3">Examples</h2>
-  <h3 class="t-sage-heading-3">Basic truncation</h3>
-  <%= sage_component SageAlert, {
-    color: "warning",
-    desc: "TODO: example of truncation.",
-    icon_name: "sage-icon-warning",
-    small: true
-  } %>
-  <h3 class="t-sage-heading-3">Truncation within CSS Grid</h3>
-  <%= sage_component SageAlert, {
-    color: "warning",
-    desc: "TODO: example of truncation when exists as a child of CSS grid content.",
-    icon_name: "sage-icon-warning",
-    small: true
-  } %>
-<% end %>
+<p class="t-sage-body">Coming Soon</p>

--- a/docs/app/views/pages/truncation.html.erb
+++ b/docs/app/views/pages/truncation.html.erb
@@ -1,0 +1,34 @@
+<%= content_for :heading do %>
+<%= md(%(
+# Truncation
+<p class="docs-heading__lead">Truncation is a wrapper that shortens a string of text when there is overflow.</p>
+)) %>
+<% end %>
+
+<div class="<%= SageClassnames::TYPE_BLOCK %>">
+
+  <%= md(%(
+  We have helper classes to assist with truncation and the necessary pairings on parent elements:
+
+  - `.t-sage--truncate-min-width` -- This class must be added to a parent element of `.t-sage--truncate`. This element must also be either a child element whose parent contains `display: grid;`.
+  - `.t-sage--truncate` -- This class is can be added to the text intended to be truncated.
+  )) %>
+</div>
+
+<%= sage_component SageCard, {} do %>
+  <h2 class="t-sage-heading-3">Examples</h2>
+  <h3 class="t-sage-heading-3">Basic truncation</h3>
+  <%= sage_component SageAlert, {
+    color: "warning",
+    desc: "TODO: example of truncation.",
+    icon_name: "sage-icon-warning",
+    small: true
+  } %>
+  <h3 class="t-sage-heading-3">Truncation within CSS Grid</h3>
+  <%= sage_component SageAlert, {
+    color: "warning",
+    desc: "TODO: example of truncation when exists as a child of CSS grid content.",
+    icon_name: "sage-icon-warning",
+    small: true
+  } %>
+<% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -177,3 +177,12 @@
 .sage-card__title {
   @extend %t-sage-heading-6;
 }
+
+.sage-card__header,
+.sage-card__block,
+.sage-card__stack,
+.sage-card__list,
+.sage-card__row,
+.sage-card__figure {
+  min-width: 0;
+}

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -60,8 +60,6 @@ $-page-heading-image-height-mobile: rem(120px);
 }
 
 .sage-page-heading__title {
-  @include line-clamp(2);
-
   @extend %t-sage-heading-1;
   grid-area: title;
   margin-right: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -60,7 +60,7 @@ $-page-heading-image-height-mobile: rem(120px);
 }
 
 .sage-page-heading__title {
-  @include line-clamp($lines: 2);
+  @include line-clamp(2);
 
   @extend %t-sage-heading-1;
   grid-area: title;

--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -60,6 +60,8 @@ $-page-heading-image-height-mobile: rem(120px);
 }
 
 .sage-page-heading__title {
+  @include line-clamp($lines: 2);
+
   @extend %t-sage-heading-1;
   grid-area: title;
   margin-right: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -206,3 +206,13 @@
   grid-template-rows: min-content;
   grid-gap: sage-spacing(stage);
 }
+
+.sage-panel,
+.sage-panel__block,
+.sage-panel__stack,
+.sage-panel__list,
+.sage-panel__row,
+.sage-panel__tiles,
+.sage-panel-grid {
+  min-width: 0;
+}

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -188,3 +188,13 @@ body:not(.sage-excluded),
 .t-sage--truncate {
   @include truncate;
 }
+
+.t-sage--line-clamp {
+  @include line-clamp(1);
+}
+
+@for $i from 2 through 4 {
+  .t-sage--line-clamp-#{$i} {
+    ---webkit-line-clamp: #{$i};
+  }
+}

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -189,6 +189,10 @@ body:not(.sage-excluded),
   @include truncate;
 }
 
+.t-sage--truncate-min-width {
+  min-width: 0;
+}
+
 .t-sage--line-clamp {
   @include line-clamp(1);
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -635,3 +635,25 @@
     font-family: "Inter var", $-body-font-stack;
   }
 }
+
+///
+/// Truncates the text
+///
+/// @param {number} $lines Number of lines of visible text before truncation
+///
+@mixin line-clamp($lines: null) {
+  overflow-wrap: break-word; /* to wrap long singular strings */
+
+  @if $lines != null {
+    display: -webkit-box;
+    -webkit-line-clamp: $lines;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  @else{
+    display: block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+}

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -645,15 +645,15 @@
   overflow-wrap: break-word; /* to wrap long singular strings */
 
   @if $lines != null {
-    display: -webkit-box;
+    display: -webkit-box; // stylelint-disable value-no-vendor-prefix
     -webkit-line-clamp: $lines;
-    -webkit-box-orient: vertical;
+    -webkit-box-orient: vertical; // stylelint-disable property-no-vendor-prefix
     overflow: hidden;
   }
-  @else{
+  @else {
     display: block;
-    text-overflow: ellipsis;
     overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add line clamp mixin
- [x] add utility classes
- [x] update docs with truncation page

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-02-18 at 2 57 04 PM](https://user-images.githubusercontent.com/1241836/154760253-cba2f0d6-8c71-48a7-b610-6d862d2d9c69.png)|![Screen Shot 2022-02-18 at 2 56 12 PM](https://user-images.githubusercontent.com/1241836/154760277-1485cdd6-310d-46e9-97e9-1da11833a790.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Page Heading and enter very long text in the `title`:
- [Rails](http://localhost:4000/pages/component/page_heading)
- [React](http://localhost:4100/?path=/story/sage-pageheading--default)
### Removed Page Heading implementation as we don't want a visual on this PR, just the mixin and prep
## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Added new line clamping utility for multiline truncation. Adds `min-width` to all grouping selectors.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
