### PR TITLE
[SAGE-303] Form Input parity REACT ONLY

### DIFF
--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -6,15 +6,24 @@ import { SageTokens } from '../configs';
 
 export const Input = ({
   className,
+  disabled,
   hasError,
+  hasPlaceholder,
   icon,
   id,
   label,
+  max,
+  maxLength,
   message,
+  min,
+  minLength,
   onChange,
+  pattern,
   popover,
   prefix,
+  readOnly,
   standalone,
+  step,
   suffix,
   value,
   ...rest
@@ -75,9 +84,17 @@ export const Input = ({
     <div className={classNames}>
       <input
         className="sage-form-field sage-input__field"
+        disabled={disabled}
         id={id}
+        max={max}
+        maxLength={maxLength}
+        min={min}
+        minLength={minLength}
         onChange={handleChange}
+        pattern={pattern}
         placeholder={label}
+        readOnly={readOnly}
+        step={step}
         style={inputStyles}
         value={fieldValue || value}
         {...rest}
@@ -120,13 +137,21 @@ export const Input = ({
 
 Input.defaultProps = {
   className: null,
+  disabled: false,
   hasError: false,
+  hasPlaceholder: false,
   icon: null,
   label: null,
+  max: null,
+  maxLength: null,
   message: null,
+  min: null,
+  minLength: null,
   onChange: null,
+  pattern: null,
   popover: null,
   prefix: null,
+  readOnly: false,
   standalone: false,
   suffix: null,
   value: '',
@@ -134,15 +159,24 @@ Input.defaultProps = {
 
 Input.propTypes = {
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,
   hasError: PropTypes.bool,
+  hasPlaceholder: PropTypes.bool,
   label: PropTypes.string,
+  max: PropTypes.string,
+  maxLength: PropTypes.string,
   message: PropTypes.string,
+  min: PropTypes.string,
+  minLength: PropTypes.string,
   onChange: PropTypes.func,
+  pattern: PropTypes.string,
   popover: PropTypes.node,
   prefix: PropTypes.string,
+  readOnly: PropTypes.bool,
   standalone: PropTypes.bool,
+  step: PropTypes.string,
   suffix: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -9,6 +9,7 @@ import {
 } from './configs';
 
 export const Input = ({
+  autocomplete,
   className,
   disabled,
   hasError,
@@ -23,6 +24,7 @@ export const Input = ({
   message,
   min,
   minLength,
+  name,
   onChange,
   pattern,
   placeholder,
@@ -92,6 +94,7 @@ export const Input = ({
   return (
     <div className={classNames}>
       <input
+        autocomplete={autocomplete}
         className="sage-form-field sage-input__field"
         disabled={disabled}
         id={id}
@@ -101,6 +104,7 @@ export const Input = ({
         maxLength={maxLength}
         min={min}
         minLength={minLength}
+        name={name}
         onChange={handleChange}
         pattern={pattern}
         placeholder={placeholder}
@@ -151,6 +155,7 @@ Input.Mode = INPUT_MODE;
 Input.Type = INPUT_TYPE;
 
 Input.defaultProps = {
+  autocomplete: null,
   className: null,
   disabled: false,
   hasError: false,
@@ -164,6 +169,7 @@ Input.defaultProps = {
   message: null,
   min: null,
   minLength: null,
+  name: null,
   onChange: null,
   pattern: null,
   placeholder: null,
@@ -177,6 +183,7 @@ Input.defaultProps = {
 };
 
 Input.propTypes = {
+  autocomplete: PropTypes.string,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
@@ -191,6 +198,7 @@ Input.propTypes = {
   message: PropTypes.string,
   min: PropTypes.string,
   minLength: PropTypes.string,
+  name: PropTypes.string,
   onChange: PropTypes.func,
   pattern: PropTypes.string,
   placeholder: PropTypes.string,

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Icon } from '../Icon';
 import { SageTokens } from '../configs';
+import {
+  INPUT_MODE,
+  INPUT_TYPE
+} from './configs';
 
 export const Input = ({
   className,
@@ -11,6 +15,8 @@ export const Input = ({
   hasPlaceholder,
   icon,
   id,
+  inputMode,
+  type,
   label,
   max,
   maxLength,
@@ -19,9 +25,11 @@ export const Input = ({
   minLength,
   onChange,
   pattern,
+  placeholder,
   popover,
   prefix,
-  readOnly,
+  readonly,
+  required,
   standalone,
   step,
   suffix,
@@ -37,6 +45,7 @@ export const Input = ({
     className,
     {
       'sage-form-field--error': hasError,
+      'sage-form-field--showplaceholder': hasPlaceholder,
       'sage-input--prefixed': prefix,
       'sage-input--suffixed': suffix,
       'sage-input--standalone': standalone,
@@ -86,14 +95,17 @@ export const Input = ({
         className="sage-form-field sage-input__field"
         disabled={disabled}
         id={id}
+        inputMode={inputMode}
+        type={type}
         max={max}
         maxLength={maxLength}
         min={min}
         minLength={minLength}
         onChange={handleChange}
         pattern={pattern}
-        placeholder={label}
-        readOnly={readOnly}
+        placeholder={placeholder}
+        readOnly={readonly}
+        required={required}
         step={step}
         style={inputStyles}
         value={fieldValue || value}
@@ -135,12 +147,17 @@ export const Input = ({
   );
 };
 
+Input.Mode = INPUT_MODE;
+Input.Type = INPUT_TYPE;
+
 Input.defaultProps = {
   className: null,
   disabled: false,
   hasError: false,
   hasPlaceholder: false,
   icon: null,
+  inputMode: null,
+  type: null,
   label: null,
   max: null,
   maxLength: null,
@@ -149,9 +166,11 @@ Input.defaultProps = {
   minLength: null,
   onChange: null,
   pattern: null,
+  placeholder: null,
   popover: null,
   prefix: null,
-  readOnly: false,
+  readonly: false,
+  required: false,
   standalone: false,
   suffix: null,
   value: '',
@@ -164,6 +183,8 @@ Input.propTypes = {
   id: PropTypes.string.isRequired,
   hasError: PropTypes.bool,
   hasPlaceholder: PropTypes.bool,
+  inputMode: PropTypes.oneOf(Object.values(Input.Mode)),
+  type: PropTypes.oneOf(Object.values(Input.Type)),
   label: PropTypes.string,
   max: PropTypes.string,
   maxLength: PropTypes.string,
@@ -172,9 +193,11 @@ Input.propTypes = {
   minLength: PropTypes.string,
   onChange: PropTypes.func,
   pattern: PropTypes.string,
+  placeholder: PropTypes.string,
   popover: PropTypes.node,
   prefix: PropTypes.string,
-  readOnly: PropTypes.bool,
+  readonly: PropTypes.bool,
+  required: PropTypes.bool,
   standalone: PropTypes.bool,
   step: PropTypes.string,
   suffix: PropTypes.string,

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -68,8 +68,8 @@ export const Input = ({
   };
 
   const setPlaceholder = () => {
-    if(placeholder) {
-      return;
+    if (placeholder) {
+      return placeholder;
     }
     return label;
   };

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -67,6 +67,13 @@ export const Input = ({
     }
   };
 
+  const setPlaceholder = () => {
+    if(placeholder) {
+      return;
+    }
+    return label;
+  };
+
   useEffect(() => {
     const newInputStyles = {
       ...inputStyles,
@@ -107,7 +114,7 @@ export const Input = ({
         name={name}
         onChange={handleChange}
         pattern={pattern}
-        placeholder={placeholder}
+        placeholder={setPlaceholder()}
         readOnly={readonly}
         required={required}
         step={step}

--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -94,7 +94,7 @@ export const Input = ({
   return (
     <div className={classNames}>
       <input
-        autocomplete={autocomplete}
+        autoComplete={autocomplete}
         className="sage-form-field sage-input__field"
         disabled={disabled}
         id={id}
@@ -178,6 +178,7 @@ Input.defaultProps = {
   readonly: false,
   required: false,
   standalone: false,
+  step: null,
   suffix: null,
   value: '',
 };

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -13,7 +13,9 @@ export default {
     }),
   },
   args: {
+    disabled: false,
     label: 'First name',
+    readyOnly: false
   }
 };
 
@@ -42,6 +44,26 @@ export const Default = (args) => {
   );
 };
 
+
+
+const Template = (args) => <Input {...args} />;
+
+export const InputWithError = Template.bind({});
+InputWithError.args = {
+  hasError: true
+};
+
+export const InputDisabled = Template.bind({});
+InputDisabled.args = {
+  disabled: true
+};
+
+export const InputReadonly = Template.bind({});
+InputReadonly.args = {
+  readOnly: true,
+  value: "You can't change me"
+};
+
 export const InputWithStaticIcon = (args) => {
   const [value, updateValue] = useState('Test');
   const onChange = (e) => {
@@ -65,6 +87,13 @@ export const InputWithStaticIcon = (args) => {
       value={value}
     />
   );
+};
+
+export const InputErrorWithStaticIcon = Template.bind({});
+InputErrorWithStaticIcon.args = {
+  icon: SageTokens.ICONS.INFO_CIRCLE,
+  hasError: true,
+  value: "Test",
 };
 
 export const InputWithPopover = (args) => {
@@ -100,6 +129,7 @@ Default.args = {
 InputWithStaticIcon.args = {
   icon: SageTokens.ICONS.INFO_CIRCLE,
 };
+
 
 InputWithPopover.args = {
   popover: (

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -15,6 +15,7 @@ export default {
     }),
   },
   args: {
+    id: 'input',
     disabled: false,
     label: 'First name',
     readonly: false

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -10,12 +10,14 @@ export default {
   argTypes: {
     ...selectArgs({
       icon: SageTokens.ICONS,
+      inputMode: Input.Mode,
+      type: Input.Type
     }),
   },
   args: {
     disabled: false,
     label: 'First name',
-    readyOnly: false
+    readonly: false
   }
 };
 
@@ -60,8 +62,53 @@ InputDisabled.args = {
 
 export const InputReadonly = Template.bind({});
 InputReadonly.args = {
-  readOnly: true,
+  readonly: true,
   value: "You can't change me"
+};
+
+export const InputEmail = Template.bind({});
+InputEmail.args = {
+  type: Input.Type.EMAIL,
+  label: "Email address"
+};
+
+export const InputPassword = Template.bind({});
+InputPassword.args = {
+  type: Input.Type.PASSWORD,
+  label: "Create a password",
+  maxLength: "128",
+  minLength: "8",
+};
+
+export const InputNumbers = Template.bind({});
+InputNumbers.args = {
+  inputMode: Input.Mode.NUMBERIC,
+  type: Input.Type.NUMBER,
+  label: "Enter quantity (max 48)",
+  max: "48",
+  maxLength: "2",
+  pattern: "[0-9]{2}",
+  required: true
+
+};
+
+export const InputNumbersIncremented = Template.bind({});
+InputNumbersIncremented.args = {
+  type: Input.Type.NUMBER,
+  label: "Enter quantity (max 5%)",
+  max: "5",
+  maxLength: "2",
+  min: "0",
+  pattern: "[0-9]{2}",
+  required: true,
+  step: "0.5"
+};
+
+export const InputCustomPlaceholderLabelVisible = Template.bind({});
+InputCustomPlaceholderLabelVisible.args = {
+  label: "Reply-to email",
+  placeholder: "Custom placeholder text",
+  hasPlaceholder: true
 };
 
 export const InputWithStaticIcon = (args) => {
@@ -129,7 +176,6 @@ Default.args = {
 InputWithStaticIcon.args = {
   icon: SageTokens.ICONS.INFO_CIRCLE,
 };
-
 
 InputWithPopover.args = {
   popover: (

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -46,8 +46,6 @@ export const Default = (args) => {
   );
 };
 
-
-
 const Template = (args) => <Input {...args} />;
 
 export const InputWithError = Template.bind({});
@@ -63,52 +61,52 @@ InputDisabled.args = {
 export const InputReadonly = Template.bind({});
 InputReadonly.args = {
   readonly: true,
-  value: "You can't change me"
+  value: 'You cannot change me'
 };
 
 export const InputEmail = Template.bind({});
 InputEmail.args = {
   type: Input.Type.EMAIL,
-  label: "Email address"
+  label: 'Email address'
 };
 
 export const InputPassword = Template.bind({});
 InputPassword.args = {
   type: Input.Type.PASSWORD,
-  label: "Create a password",
-  maxLength: "128",
-  minLength: "8",
+  label: 'Create a password',
+  maxLength: '128',
+  minLength: '8',
 };
 
 export const InputNumbers = Template.bind({});
 InputNumbers.args = {
   inputMode: Input.Mode.NUMBERIC,
   type: Input.Type.NUMBER,
-  label: "Enter quantity (max 48)",
-  max: "48",
-  maxLength: "2",
-  pattern: "[0-9]{2}",
-  required: true
+  label: 'Enter quantity (max 48)',
+  max: '48',
+  maxLength: '2',
+  pattern: '[0-9]{2}',
+  required: true,
 
 };
 
 export const InputNumbersIncremented = Template.bind({});
 InputNumbersIncremented.args = {
   type: Input.Type.NUMBER,
-  label: "Enter quantity (max 5%)",
-  max: "5",
-  maxLength: "2",
-  min: "0",
-  pattern: "[0-9]{2}",
+  label: 'Enter quantity (max 5%)',
+  max: '5',
+  maxLength: '2',
+  min: '0',
+  pattern: '[0-9]{2}',
   required: true,
-  step: "0.5"
+  step: '0.5',
 };
 
 export const InputCustomPlaceholderLabelVisible = Template.bind({});
 InputCustomPlaceholderLabelVisible.args = {
-  label: "Reply-to email",
-  placeholder: "Custom placeholder text",
-  hasPlaceholder: true
+  label: 'Reply-to email',
+  placeholder: 'Custom placeholder text',
+  hasPlaceholder: true,
 };
 
 export const InputWithStaticIcon = (args) => {

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -139,7 +139,7 @@ export const InputErrorWithStaticIcon = Template.bind({});
 InputErrorWithStaticIcon.args = {
   icon: SageTokens.ICONS.INFO_CIRCLE,
   hasError: true,
-  value: "Test",
+  value: 'Test',
 };
 
 export const InputWithPopover = (args) => {

--- a/packages/sage-react/lib/Input/configs.js
+++ b/packages/sage-react/lib/Input/configs.js
@@ -1,0 +1,13 @@
+export const INPUT_MODE = {
+  DEFAULT: null,
+  NUMBERIC: 'numeric',
+  TEXT: 'text',
+};
+
+export const INPUT_TYPE = {
+  DEFAULT: null,
+  EMAIL: 'email',
+  NUMBER: 'number',
+  PASSWORD: 'password',
+  TEXT: 'text',
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update conditional logic for the `placeholder` / `label`
- [ ] add missing props to the react version:
    - [x] autocomplete
    - [x] disabled
    - [x] hasPlaceholder
    - [x] inputMode
    - [x] inputType
    - [x] max
    - [x] maxLength
    - [x] min
    - [x] minLength
    - [x] name
    - [x] pattern
    - [x] placeholder
    - [ ] ~prefix~ [SAGE-315](https://kajabi.atlassian.net/browse/SAGE-315)
    - [x] readonly
    - [x] required
    - [x] step
    - [ ] ~suffix~ [SAGE-315](https://kajabi.atlassian.net/browse/SAGE-315)

## Known issues
- Clicking the number inputs don't work
- The prefix doesn't work properly
- The suffix doesn't work properly
To be handled in a followup: [SAGE-315](https://kajabi.atlassian.net/browse/SAGE-315)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-02-28 at 10 02 35 AM](https://user-images.githubusercontent.com/1241836/156016286-239d7615-07d3-4621-99e5-f27b44494481.png)|![Screen Shot 2022-02-28 at 10 02 22 AM](https://user-images.githubusercontent.com/1241836/156016321-15eee4f8-70f9-40c3-8597-249ded7c2ffb.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
View the Input story view and verify docs:
- [Input Default](http://localhost:4100/?path=/story/sage-input--default)
- [Input with Error](http://localhost:4100/?path=/story/sage-input--input-with-error)
- [Input Disabled](http://localhost:4100/?path=/story/sage-input--input-disabled)
- [Input Readonly](http://localhost:4100/?path=/story/sage-input--input-readonly)
- [Input Email](http://localhost:4100/?path=/story/sage-input--input-email)
- [Input Password](http://localhost:4100/?path=/story/sage-input--input-password)
- [Input Numbers](http://localhost:4100/?path=/story/sage-input--input-numbers)
- [Input Numbers Incremented](http://localhost:4100/?path=/story/sage-input--input-numbers-incremented)
- [Input Custom Placeholder Label Visible](http://localhost:4100/?path=/story/sage-input--input-custom-placeholder-label-visible)
- [Input with Static Icon](http://localhost:4100/?path=/story/sage-input--input-with-static-icon)
- [Input Error with Static Icon](http://localhost:4100/?path=/story/sage-input--input-error-with-static-icon)
- [Input with Popover](http://localhost:4100/?path=/story/sage-input--input-with-popover)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds new properties to the react only version of `FormInput`.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-303](https://kajabi.atlassian.net/browse/SAGE-303)