### PR TITLE
[SAGE-217] switch foundations update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -6,13 +6,13 @@
 
 
 // Colors
-$-switch-color-default: sage-color(grey, 400);
+$-switch-color-default: sage-color(grey, 300);
 $-switch-color-default-text: sage-color(grey, 700);
 $-switch-color-checked: sage-color(primary, 600);
 $-switch-color-checked-hover: sage-color(primary, 700);
 $-switch-color-disabled: sage-color(grey, 200);
-$-switch-color-disabled-text: sage-color(grey, 400);
-$-switch-color-disabled-checked: sage-color(primary, 300);
+$-switch-color-disabled-text: sage-color(grey, 700);
+$-switch-color-disabled-checked: sage-color(primary, 50);
 $-switch-color-disabled-checked-text: sage-color(grey, 500);
 
 // Switch
@@ -24,10 +24,6 @@ $-switch-width: rem(36px);
 // Toggle
 $-switch-toggle-size: rem(16px);
 
-// Focus state
-$-switch-focus-outline-spacing: sage-spacing(2xs);
-$-switch-focus-outline-width: 4;
-$-switch-focus-outline-color: sage-color(primary, 300);
 $-switch-focus-outline-error-color: sage-color(red, 300);
 
 
@@ -79,6 +75,7 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
 
 .sage-switch__input {
   @include sage-form-toggle-input;
+  @include sage-focus-ring;
 
   z-index: sage-z-index(default, 1);
   transform: translateY(2px);
@@ -88,7 +85,6 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
   background: $-switch-color-default;
   border: 0;
   border-radius: $-switch-border-radius;
-  outline: none !important; /* stylelint-disable-line declaration-no-important */
   transition: background 0.3s ease-out;
 
   .sage-switch--has-border & {
@@ -118,24 +114,12 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     }
   }
 
-  &::before,
   &::after {
     content: "";
     display: block;
     position: absolute;
     left: 50%;
     top: 50%;
-  }
-
-  &::before { // switch background
-    transform: translate3d(-50%, -50%, 0) scale(0.94);
-    width: calc(100% + (#{$-switch-focus-outline-spacing}));
-    height: calc(100% + (#{$-switch-focus-outline-spacing}));
-    border: ($-switch-focus-outline-width * 1px) solid $-switch-focus-outline-color;
-    border-radius: $-switch-border-radius;
-    transition: opacity 0.15s ease-out 0.05s, transform 0.2s ease-in-out;
-    pointer-events: none;
-    opacity: 0;
   }
 
   &::after {  // switch toggle
@@ -150,6 +134,8 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
 
   .sage-switch--error &,
   &:invalid {
+    @include sage-focus-ring(sage-color(red, 300));
+
     background-color: sage-color(red, 500);
     ~ .sage-switch__label,
     ~ .sage-switch__message {
@@ -160,9 +146,6 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     }
     &:checked:hover {
       background-color: sage-color(red, 500);
-    }
-    &::before {
-      border-color: sage-color(red, 500);
     }
   }
 
@@ -205,14 +188,6 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     &:checked ~ .sage-switch__label,
     &:checked ~ .sage-switch__message {
       color: $-switch-color-disabled-checked-text;
-    }
-  }
-
-  &:focus:not(:disabled),
-  &:active:not(:disabled) {
-    &::before {
-      transform: translate3d(-50%, -50%, 0);
-      opacity: 1;
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -28,7 +28,7 @@ $-switch-toggle-size: rem(16px);
 $-switch-focus-outline-spacing: sage-spacing(2xs);
 $-switch-focus-outline-width: 4;
 $-switch-focus-outline-color: sage-color(primary, 300);
-$-switch-focus-outline-error-color: sage-color(red, 500);
+$-switch-focus-outline-error-color: sage-color(red, 300);
 
 
 .sage-switch {

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -8,7 +8,7 @@
 // Colors
 $-switch-color-default: sage-color(grey, 400);
 $-switch-color-default-text: sage-color(grey, 700);
-$-switch-color-checked: sage-color(primary, 500);
+$-switch-color-checked: sage-color(primary, 600);
 $-switch-color-checked-hover: sage-color(primary, 700);
 $-switch-color-disabled: sage-color(grey, 200);
 $-switch-color-disabled-text: sage-color(grey, 400);
@@ -26,8 +26,8 @@ $-switch-toggle-size: rem(16px);
 
 // Focus state
 $-switch-focus-outline-spacing: sage-spacing(2xs);
-$-switch-focus-outline-width: 3;
-$-switch-focus-outline-color: sage-color(primary, 700);
+$-switch-focus-outline-width: 4;
+$-switch-focus-outline-color: sage-color(primary, 300);
 $-switch-focus-outline-error-color: sage-color(red, 500);
 
 

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -105,6 +105,7 @@ $-switch-focus-outline-error-color: sage-color(red, 300);
     }
 
     .sage-switch--has-border & {
+      margin-left: ($-switch-width + $-switch-label-left-spacing);
       color: sage-color(grey, 800);
       font-weight: sage-font-weight(semibold);
     }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -540,11 +540,11 @@
 }
 
 @mixin sage-form-toggle-label() {
-  @extend %t-sage-body-med;
+  @extend %t-sage-body-semi;
 
   display: inline-block;
   flex: 1;
-  margin-left: rem(12px);
+  margin-left: rem(8px);
   vertical-align: top;
   cursor: pointer;
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -540,7 +540,7 @@
 }
 
 @mixin sage-form-toggle-label() {
-  @extend %t-sage-body-semi;
+  @extend %t-sage-body-med;
 
   display: inline-block;
   flex: 1;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] align switch with foundations designs

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-02-28 at 9 51 59 AM](https://user-images.githubusercontent.com/1241836/156014604-b61fa2fe-9ed5-4b65-a51b-eb4fba4bbe10.png)|![Screen Shot 2022-02-28 at 9 51 24 AM](https://user-images.githubusercontent.com/1241836/156014635-9e4420ea-001b-4ee3-adcb-9deece0b7970.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Check the Switch component:
- [Rails](http://localhost:4000/pages/component/switch)
- [React](http://localhost:4100/?path=/docs/sage-switch--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Visual style updates to the Switch component. No new functionality.
   - [ ] Toggle in Edit detail forms


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-217](https://kajabi.atlassian.net/browse/SAGE-217)