### PR TITLE
[SAGE-306]: Rename `radius-input` to `radius-medium` (border-radius)

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -26,7 +26,7 @@
   @include sage-focus-outline(
     $outline-width: 4px,
     $outline-offset-inline: 4px,
-    $outline-border-radius: sage-border(radius-input),
+    $outline-border-radius: sage-border(radius-medium),
   );
   @include sage-focus-outline--update-color(sage-color(primary, 300));
 }

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -45,7 +45,7 @@ $-nav-subitem-border-width: rem(2px);
     $outline-width: 4px,
     $outline-offset-inline: -2,
     $outline-offset-block: -4,
-    $outline-border-radius: sage-border(radius-input),
+    $outline-border-radius: sage-border(radius-medium),
   );
   @include sage-focus-outline--update-color(sage-color(grey, 400));
 
@@ -54,7 +54,7 @@ $-nav-subitem-border-width: rem(2px);
   padding: sage-spacing(xs) sage-spacing(sm);
   margin-bottom: sage-spacing(2xs);
   color: $-nav-color-text;
-  border-radius: sage-border(radius-input);
+  border-radius: sage-border(radius-medium);
   transition: map-get($sage-transitions, default);
   transition-property: background, box-shadow;
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -355,7 +355,7 @@
   color: sage-color(grey, 800);
   appearance: none;
   border: rem(1px) solid sage-color(grey, 400);
-  border-radius: sage-border(radius-input);
+  border-radius: sage-border(radius-medium);
   background: transparent;
   transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 

--- a/packages/sage-assets/lib/stylesheets/tokens/_border.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_border.scss
@@ -13,7 +13,7 @@ $sage-borders: (
   default: rem(1px) solid sage-color(grey, 300),
   radius-small: rem(4px),
   radius: rem(8px),
-  radius-input: rem(10px),
+  radius-medium: rem(10px),
   radius-large: rem(16px),
   radius-x-large: rem(100px),
   radius-round: 50%,


### PR DESCRIPTION
## Description
Renames `radius-input` to `radius-medium` to reduce confusion around this new value for use with `border-radius`. After further investigation, it appears the value is used in more locations than just inputs/form elements.

## Screenshots
N/A

## Testing in `sage-lib`
Visit sidebar, link, and input pages and verify border-radius of elements still appears as expected.

## Testing in `kajabi-products`
N/A

## Related
https://kajabi.atlassian.net/browse/SAGE-306