### PR TITLE
[SAGE-326] Hide code comments from production code

### DIFF
--- a/docs/app/views/mocks/payments_index/_banner.html.erb
+++ b/docs/app/views/mocks/payments_index/_banner.html.erb
@@ -1,4 +1,4 @@
-<!-- TODO: Hero: Need to add slot for icon at top -->
+<%# TODO: Hero: Need to add slot for icon at top %>
 <%= sage_component SageHero, {
     alt_text: "",
     # TODO: Hero: Should look into a slot for easier composition of this aspect

--- a/docs/app/views/mocks/payments_index/_comparison_selections_bar.html.erb
+++ b/docs/app/views/mocks/payments_index/_comparison_selections_bar.html.erb
@@ -1,5 +1,5 @@
 <%= sage_component SagePanelRow, { gap: :sm, grid_template: "st", spacer: { top: :lg, bottom: :lg }} do %>
-  <!-- TODO: Need to allow custom layouts within dropdown items -->
+  <%# TODO: Need to allow custom layouts within dropdown items %>
   <%= sage_component SageDropdown, {
     contained: true,
     items: [
@@ -22,7 +22,7 @@
   <p class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
     compared to
   </p>
-  
+
   <%= sage_component SageDropdown, {
     contained: true,
     items: [

--- a/docs/app/views/mocks/payments_index/_main.html.erb
+++ b/docs/app/views/mocks/payments_index/_main.html.erb
@@ -56,7 +56,7 @@
 
   <%= sage_component SageTabsPane, { id: "feature-5" } do %>
     <%= render "mocks/payments_index/page_heading", show_settings: true %>
-    <!-- TODO: Need to enable actions slot in small variation of alert -->
+    <%# TODO: Need to enable actions slot in small variation of alert %>
     <%= sage_component SageAlert, {
       color: "warning",
       desc: "Chip Skylark failed a payment for Cancle Making 101 on Dec 6, 2021.",

--- a/docs/app/views/mocks/payments_index/_payment_cards.html.erb
+++ b/docs/app/views/mocks/payments_index/_payment_cards.html.erb
@@ -1,6 +1,6 @@
 <%= sage_component SagePanelTiles, { tiles_in_row: 3 } do %>
   <% payments_index_cards(with_data: with_data, payments_adopted: payments_adopted).each do | card | %>
-    <!-- TODO: Need to enable a while background on stat box -->
+    <%# TODO: Need to enable a while background on stat box %>
     <%= sage_component SageStatBox, {
       # TODO: Need to allow nil for change when no change needed
       change: (card[:change] ? {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -19,7 +19,7 @@ trigger_configs = component.trigger.present? ? component.trigger : { type: trigg
   <%= component.generated_html_attributes.html_safe %>
 >
   <div aria-hidden="true" class="sage-dropdown__screen"></div>
-  
+
   <% if component.trigger.present? %>
     <%= sage_component SageDropdownTrigger, trigger_configs do %>
       <%= component.content %>
@@ -30,17 +30,17 @@ trigger_configs = component.trigger.present? ? component.trigger : { type: trigg
     <% end %>
   <% end %>
 
-  <!-- TODO: Deprecate use of `content` for the trigger.
+  <%# TODO: Deprecate use of `content` for the trigger.
   Use `trigger` or `sage_dropdown_trigger` instead,
   Then adjust so that `content` can instead be used for panel contents.
-  -->
+  %>
   <% if component.content.present? %>
     <%= sage_component SageDropdownTrigger, trigger_configs do %>
       <%= component.content %>
     <% end %>
   <% end %>
 
-  <div 
+  <div
     class="
       sage-dropdown__panel
       <%= "sage-dropdown__panel--custom-width" if component.panel_width %>


### PR DESCRIPTION
## Description
Cosmetic cleanup preventing internal developer comments from being exposed to customers. Replaces HTML comments in Rails components with non-rendered Rails comments.

Affected areas:
- Dropdown
- Payments Index Mocks


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![dropdown](https://user-images.githubusercontent.com/816579/156273244-487834bc-b364-4013-a896-965792e8244f.png)|![dropdown-after](https://user-images.githubusercontent.com/816579/156274715-62e521ed-d988-484e-9406-c0737b7867d1.png)|


## Testing in `sage-lib`
1. View the dropdown rails component preview page
2. Inspect one of the example dropdowns
3. Verify that developer comments are not rendering in markup


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Replaces HTML comments with Rails comments in dropdown component. No expected visual or functional impact.


## Related
[SAGE-326](https://kajabi.atlassian.net/browse/SAGE-326)
[SAGE-273](https://kajabi.atlassian.net/browse/SAGE-273)