### PR TITLE
SAGE-302 - Restore Creation Wizard mocks

### DIFF
--- a/docs/app/helpers/mocks_helper.rb
+++ b/docs/app/helpers/mocks_helper.rb
@@ -37,61 +37,18 @@ module MocksHelper
 
   def sage_mocks
     [
+      # DOING
       {
-        alias: "test",
-        name: "Test",
-        status: ARCHIVED,
-        team: "UXD",
-      },
-      {
-        alias: "contact_profile",
-        milestone_id: 21,
-        name: "Contact Profile",
+        alias: "product_creation_wizard",
+        jira_epic: "SAGE-39",
+        name: "Product Creation Wizard",
         no_custom_styles: true,
         no_rails_js: true,
+        no_rails_partials: true,
+        no_rails_helper: true,
         status: DOING,
-        storybook_path: '/story/mocks-contact-profile--default',
-        team: "Manage",
-      },
-      {
-        alias: "upsell_downsell",
-        milestone_id: 25,
-        name: "Upsell Downsell",
-        no_rails_js: true,
-        status: DONE,
-        team: "Commerce",
-      },
-      {
-        alias: "new_plans_upgrade",
-        milestone_id: 23,
-        name: "New Plans and Upgrade",
-        no_rails_js: true,
-        status: DOING,
-        team: "Growth",
-      },
-      {
-        alias: "creation_wizard",
-        milestone_id: nil,
-        name: "Creation Wizard",
-        no_rails_js: true,
-        status: DOING,
-        team: "Build/Commerce",
-      },
-      {
-        alias: "payments_index",
-        jira_epic: "SAGE-172",
-        name: "Payments Index",
-        no_rails_js: true,
-        status: DOING,
-        team: "Commerce",
-      },
-      {
-        alias: "customize_columns",
-        jira_epic: "SAGE-180",
-        name: "Table Settings Modal",
-        no_rails_js: true,
-        status: DOING,
-        team: "Commerce",
+        storybook_path: '/story/mocks-product-creation-wizard--default',
+        team: "Build",
       },
       {
         alias: "get_started",
@@ -101,6 +58,66 @@ module MocksHelper
         status: DOING,
         team: "Growth",
       }
+
+      # DONE
+      {
+        alias: "contact_profile",
+        milestone_id: 21,
+        name: "Contact Profile",
+        no_custom_styles: true,
+        no_rails_js: true,
+        status: DONE,
+        storybook_path: '/story/mocks-contact-profile--default',
+        team: "Manage",
+      },
+      {
+        alias: "customize_columns",
+        jira_epic: "SAGE-180",
+        name: "Table Settings Modal",
+        no_rails_js: true,
+        status: DONE,
+        team: "Commerce",
+      },
+      {
+        alias: "payments_index",
+        jira_epic: "SAGE-172",
+        name: "Payments Index",
+        no_rails_js: true,
+        status: DONE,
+        team: "Commerce",
+      },
+
+      # ARCHIVE
+      {
+        alias: "test",
+        name: "Test",
+        status: ARCHIVED,
+        team: "UXD",
+      },
+      {
+        alias: "upsell_downsell",
+        milestone_id: 25,
+        name: "Upsell Downsell",
+        no_rails_js: true,
+        status: ARCHIVED,
+        team: "Commerce",
+      },
+      {
+        alias: "new_plans_upgrade",
+        milestone_id: 23,
+        name: "New Plans and Upgrade",
+        no_rails_js: true,
+        status: ARCHIVED,
+        team: "Growth",
+      },
+      {
+        alias: "creation_wizard",
+        milestone_id: nil,
+        name: "Creation Wizard",
+        no_rails_js: true,
+        status: ARCHIVED,
+        team: "Build/Commerce",
+      },
     ]
   end
 

--- a/docs/app/helpers/mocks_helper.rb
+++ b/docs/app/helpers/mocks_helper.rb
@@ -37,7 +37,6 @@ module MocksHelper
 
   def sage_mocks
     [
-      # DOING
       {
         alias: "product_creation_wizard",
         jira_epic: "SAGE-39",
@@ -57,9 +56,7 @@ module MocksHelper
         no_rails_js: true,
         status: DOING,
         team: "Growth",
-      }
-
-      # DONE
+      },
       {
         alias: "contact_profile",
         milestone_id: 21,
@@ -86,8 +83,6 @@ module MocksHelper
         status: DONE,
         team: "Commerce",
       },
-
-      # ARCHIVE
       {
         alias: "test",
         name: "Test",

--- a/docs/app/views/mocks/product-creation-wizard/ProductCreationWizard.story.jsx.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/ProductCreationWizard.story.jsx.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Root } from './components';
+
+export default {
+  title: 'Mocks/Product Creation Wizard',
+  argTypes: {},
+  args: {}
+};
+const Template = () => (
+  <Root />
+);
+
+export const Default = Template.bind({});

--- a/docs/app/views/mocks/product-creation-wizard/components/PaidPricingOptions.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/PaidPricingOptions.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import {
+  Card,
+  Checkbox,
+  Icon,
+  Input,
+  Select,
+  SageClassnames,
+  SageTokens,
+} from '../../..';
+import { PricingOptionsDropdown } from './PricingOptionsDropdown';
+
+export const PaidPricingOptions = () => {
+  const [selectedPaymentType, setSelectedPaymentType] = React.useState('once');
+  const initialLabel = 'Select a product';
+
+  // TODO: Need updated icon set to include these three
+  // - `money`
+  // - `subscription`
+  // - `multi-pay`
+  // https://kajabi.atlassian.net/browse/SAGE-327
+  const items = [
+    {
+      id: 1,
+      label: 'One-time',
+      alias: 'once',
+      subtext: 'Customer pays once for access to the product.',
+      icon: SageTokens.ICONS.ROUND_DOLLAR, // TODO: Dev needs to correct icon once available
+      color: Icon.CARD_COLORS.INFO,
+    },
+    {
+      id: 2,
+      label: 'Subscription',
+      alias: 'subscription',
+      subtext: 'Customer pays once for access to the product.',
+      icon: SageTokens.ICONS.ROUND_DOLLAR, // TODO: Dev needs to correct icon once available
+      color: Icon.CARD_COLORS.PUBLISHED,
+    },
+    {
+      id: 3,
+      label: 'Multi-pay',
+      alias: 'multi',
+      subtext: 'Customer pays once for access to the product.',
+      icon: SageTokens.ICONS.ROUND_DOLLAR, // TODO: Dev needs to correct icon once available
+      color: Icon.CARD_COLORS.LOCKED,
+    },
+  ];
+
+  const renderDetailsFields = () => {
+    let detailsFields = null;
+    switch (selectedPaymentType) {
+      case 'subscription':
+        detailsFields = (
+          <Card.Row gridTemplate={SageTokens.GRID_TEMPLATES.TE}>
+            <Input
+              id="course-price-subscription-frequency"
+              type="number"
+              label="Bill every"
+            />
+            <Select
+              id="course-price-subscription-interval"
+              label="Interval"
+              value="Monthly"
+              options={[
+                'Weekly',
+                'Monthly',
+                'Annually',
+              ]}
+            />
+          </Card.Row>
+        );
+        break;
+      case 'multi':
+        detailsFields = (
+          <Input
+            id="course-price-multi-count"
+            type="number"
+            label="Number of monthly payments"
+          />
+        );
+        break;
+      case 'once':
+      default:
+        detailsFields = null;
+        break;
+    }
+
+    return detailsFields;
+  };
+
+  const onSelectItem = (data) => {
+    const newSelectedPaymentType = items.find((item) => item.id === data.id);
+    if (!newSelectedPaymentType) {
+      setSelectedPaymentType('once');
+    } else {
+      setSelectedPaymentType(newSelectedPaymentType.alias);
+    }
+  };
+
+  return (
+    <div className={SageClassnames.PANEL_GRID}>
+      <PricingOptionsDropdown
+        initialLabel={initialLabel}
+        items={items}
+        onSelectItem={onSelectItem}
+      />
+      <Input
+        id="course-price"
+        prefix="$"
+        type="number"
+      />
+      {renderDetailsFields()}
+      <div className={SageClassnames.CARD_GRID}>
+        <h6 className={SageClassnames.TYPE.HEADING_6}>
+          Preferred payment methods
+        </h6>
+        <ul className="sage-list">
+          <Checkbox
+            id="course-payment-method-stripe"
+            name="course-payment-method"
+            itemInList={true}
+            label={(<p>[Stripe logo]</p>)}
+          />
+          <Checkbox
+            id="course-payment-method-paypal"
+            name="course-payment-method"
+            itemInList={true}
+            label={(<p>[Paypal logo]</p>)}
+          />
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/PricingOptionsDropdown.jsx.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/PricingOptionsDropdown.jsx.jsx
@@ -1,0 +1,103 @@
+/* eslint-disable no-unused-vars */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  Icon,
+  Dropdown,
+  SageTokens
+} from '../../..';
+
+const PricingOptionsDropdownCard = ({
+  color,
+  icon,
+  label,
+  subtext,
+}) => (
+  <Card.Row gridTemplate={SageTokens.GRID_TEMPLATES.ET}>
+    <Icon icon={icon} cardColor={color} />
+    <Card.Block>
+      <h4>{label}</h4>
+      <p>{subtext}</p>
+    </Card.Block>
+  </Card.Row>
+);
+
+PricingOptionsDropdownCard.defaultProps = {
+  color: Icon.CARD_COLORS.DRAFT,
+  icon: SageTokens.ICONS.QUESTION,
+  label: 'Default label',
+  subtext: 'Default subtext',
+};
+
+PricingOptionsDropdownCard.propTypes = {
+  color: Icon.propTypes.cardColor,
+  icon: Icon.propTypes.icon,
+  label: PropTypes.string,
+  subtext: PropTypes.string,
+};
+
+export const PricingOptionsDropdown = ({
+  initialLabel,
+  items,
+  onSelectItem,
+}) => {
+  const [label, setLabel] = useState(initialLabel);
+  const [selectedContent, setSelectedContent] = useState(null);
+
+  const handleClickItem = (data) => {
+    const item = items.find((obj) => obj.id === data.id);
+
+    if (item) {
+      setSelectedContent((
+        <PricingOptionsDropdownCard {...item} />
+      ));
+      setLabel('');
+    } else {
+      setSelectedContent(null);
+      setLabel(initialLabel);
+    }
+
+    onSelectItem(data);
+  };
+
+  return (
+    <Dropdown
+      contained={true}
+      customTrigger={(
+        <Dropdown.TriggerSelect
+          label={label}
+          selectedValue={selectedContent}
+        />
+      )}
+      label="Select..."
+      panelModifier="select"
+      triggerModifier="select"
+      exitPanelHandler={handleClickItem}
+    >
+      <Dropdown.ItemList
+        items={items.map((item) => ({
+          customComponent: PricingOptionsDropdownCard,
+          id: item.id,
+          label: item.label,
+          payload: { ...item },
+        }))}
+      />
+    </Dropdown>
+  );
+};
+
+PricingOptionsDropdown.defaultProps = {
+  initialLabel: '',
+  items: [],
+  onSelectItem: (data) => null,
+};
+
+PricingOptionsDropdown.propTypes = {
+  initialLabel: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string,
+    label: PropTypes.string,
+  })),
+  onSelectItem: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/ProductChoice.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/ProductChoice.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Choice,
+  Card,
+  Icon,
+  SageClassnames,
+  SageTokens
+} from '../../..';
+
+export const ProductChoice = ({
+  active,
+  icon,
+  iconColor,
+  onClick,
+  title,
+}) => (
+  <Choice isActive={active} onClick={onClick}>
+    <Card.Row gridTemplate={SageTokens.GRID_TEMPLATES.ET}>
+      {/* TODO: Dev to switch out Icon here for graphic from design comp */}
+      <Icon
+        icon={icon}
+        cardColor={iconColor}
+      />
+      <p className={`${SageClassnames.TYPE.HEADING_5} t-sage--truncate`}>
+        {title}
+      </p>
+    </Card.Row>
+  </Choice>
+);
+
+ProductChoice.defaultProps = {
+  active: false,
+  icon: Icon.ICONS.BAN,
+  iconColor: Icon.CARD_COLORS.INFO,
+  onClick: () => null,
+  title: '',
+};
+
+ProductChoice.propTypes = {
+  active: PropTypes.bool,
+  icon: PropTypes.oneOf(Object.values(Icon.ICONS)),
+  iconColor: PropTypes.oneOf(Object.values(Icon.CARD_COLORS)),
+  onClick: PropTypes.func,
+  title: PropTypes.string,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/ProductChoiceDetails.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/ProductChoiceDetails.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  Property,
+  SageClassnames,
+  SageTokens
+} from '../../..';
+
+export const ProductChoiceDetails = ({
+  body,
+  leftFeatures,
+  rightFeatures,
+  title,
+}) => (
+  <>
+    <Card.Stack>
+      <h5 className={SageClassnames.TYPE.HEADING_5}>
+        {title}
+      </h5>
+      <p className={`${SageClassnames.TYPE.BODY} ${SageClassnames.TYPE_COLORS.CHARCOAL_200}`}>
+        {body}
+      </p>
+    </Card.Stack>
+    <Card.Stack>
+      <h6 className={SageClassnames.TYPE.HEADING_6}>
+        Features
+      </h6>
+      <Card.Row
+        gridTemplate={SageTokens.GRID_TEMPLATES.M}
+        style={{ width: '100%' }}
+        verticalAlign={Card.Row.ALIGNMENT_OPTIONS.START}
+      >
+        <Card.Stack>
+          {leftFeatures.map(({ icon, label }) => (
+            <Property key={icon} icon={icon}>{label}</Property>
+          ))}
+        </Card.Stack>
+        <Card.Stack>
+          {rightFeatures.map(({ icon, label }) => (
+            <Property key={icon} icon={icon}>{label}</Property>
+          ))}
+        </Card.Stack>
+      </Card.Row>
+    </Card.Stack>
+  </>
+);
+
+ProductChoiceDetails.defaultProps = {
+  body: '',
+  leftFeatures: [],
+  rightFeatures: [],
+  title: '',
+};
+
+ProductChoiceDetails.propTypes = {
+  body: PropTypes.string,
+  leftFeatures: PropTypes.arrayOf(PropTypes.shape({
+    icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
+    label: PropTypes.string,
+  })),
+  rightFeatures: PropTypes.arrayOf(PropTypes.shape({
+    icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
+    label: PropTypes.string,
+  })),
+  title: PropTypes.string,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/ProductColorPickerCard.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/ProductColorPickerCard.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  SageClassnames,
+  SageTokens
+} from '../../..';
+
+export const ProductColorPickerCard = ({
+  subtext,
+  title,
+}) => (
+  <Card>
+    <Card.Row gridTemplate={SageTokens.GRID_TEMPLATES.TE}>
+      <Card.Stack>
+        <h6 className={`${SageClassnames.TYPE.HEADING_6}`}>
+          {title}
+        </h6>
+        <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+          {subtext}
+        </p>
+      </Card.Stack>
+      {/*
+        TODO: Dev to put color picker here and sync changes
+        with SVG graphic through `onChangeColor`
+      */}
+    </Card.Row>
+  </Card>
+);
+
+ProductColorPickerCard.defaultProps = {
+  subtext: '',
+  title: '',
+};
+
+ProductColorPickerCard.propTypes = {
+  subtext: PropTypes.string,
+  title: PropTypes.string,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/Root.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/Root.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import {
+  Button,
+  Grid,
+  Modal,
+  SageTokens,
+} from '../../..';
+import {
+  CoachingAppearance,
+  CoachingBooking,
+  CoachingDetails,
+  CoachingPricing,
+  CourseAppearance,
+  CourseDetails,
+  CoursePricing,
+  Main,
+} from './panels';
+
+export const Root = () => {
+  const initialModalTitle = 'New Product';
+  const initialStep = null;
+  const [modalActive, setModalActive] = React.useState(true);
+  const [modalTitle, setModalTitle] = React.useState(initialModalTitle);
+  const [step, setStep] = React.useState(initialStep);
+
+  const handleClickStart = (productChoice) => {
+    const { title, alias } = productChoice;
+    setModalTitle(`New ${title}`);
+    setStep(`${alias}-1`);
+  };
+
+  const handleChangeStep = (step) => {
+    if (!step) {
+      setStep(initialStep);
+      setModalTitle(initialModalTitle);
+    }
+
+    setStep(step);
+  };
+
+  const renderStep = () => {
+    if (!step) {
+      return <Main onClickStart={handleClickStart} />;
+    }
+
+    let stepComponent = null;
+
+    switch (step) {
+      case 'course-1':
+        stepComponent = <CourseDetails onChangeStep={handleChangeStep} />;
+        break;
+      case 'course-2':
+        stepComponent = <CourseAppearance onChangeStep={handleChangeStep} />;
+        break;
+      case 'course-3':
+        stepComponent = <CoursePricing onChangeStep={handleChangeStep} />;
+        break;
+      case 'coaching-1':
+        stepComponent = <CoachingDetails onChangeStep={handleChangeStep} />;
+        break;
+      case 'coaching-2':
+        stepComponent = <CoachingBooking onChangeStep={handleChangeStep} />;
+        break;
+      case 'coaching-3':
+        stepComponent = <CoachingAppearance onChangeStep={handleChangeStep} />;
+        break;
+      case 'coaching-4':
+        stepComponent = <CoachingPricing onChangeStep={handleChangeStep} />;
+        break;
+      default:
+        // stepComponent stays null
+        break;
+    }
+
+    return stepComponent;
+  };
+
+  return (
+    <Grid>
+      <Button color={Button.COLORS.PRIMARY} onClick={() => setModalActive(true)}>
+        Add product
+      </Button>
+      <Modal active={modalActive} fullScreen={true}>
+        {/*
+          TODO: Build dismiss into modal header
+          https://kajabi.atlassian.net/browse/SAGE-312
+        */}
+        <Modal.Header
+          title={modalTitle}
+          aside={(
+            <Button
+              color={Button.COLORS.SECONDARY}
+              icon={SageTokens.ICONS.REMOVE}
+              iconOnly={true}
+              subtle={true}
+              onClick={() => setModalActive(false)}
+            >
+              Close
+            </Button>
+          )}
+        >
+          {/*
+            TODO: Need to determine what/how the "progress bar" can be added here
+            https://kajabi.atlassian.net/browse/SAGE-328
+          */}
+        </Modal.Header>
+        <Modal.Body>
+          {/*
+            TODO: Need to allow column panel to fill space
+            with a footer at bottom and scroll in middle
+            https://kajabi.atlassian.net/browse/SAGE-329
+          */}
+          <Grid.Row>
+            <Grid.Col size={4}>
+              {renderStep()}
+            </Grid.Col>
+            <Grid.Col size={8}>
+              {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
+              <img
+                src="//source.unsplash.com/random/832x575"
+                style={{ margin: '0 auto', display: 'block', maxWidth: '100%' }}
+                alt=""
+              />
+            </Grid.Col>
+          </Grid.Row>
+        </Modal.Body>
+      </Modal>
+    </Grid>
+  );
+};
+
+export default Root;

--- a/docs/app/views/mocks/product-creation-wizard/components/index.js
+++ b/docs/app/views/mocks/product-creation-wizard/components/index.js
@@ -1,0 +1,6 @@
+export { PaidPricingOptions } from './PaidPricingOptions';
+export { PricingOptionsDropdown } from './PricingOptionsDropdown';
+export { ProductChoice } from './ProductChoice';
+export { ProductChoiceDetails } from './ProductChoiceDetails';
+export { ProductColorPickerCard } from './ProductColorPickerCard';
+export { Root } from './Root';

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/Main.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/Main.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Panel,
+  SageClassnames,
+} from '../../../..';
+import { productChoices, productChoiceDetails } from '../../content';
+import { ProductChoice, ProductChoiceDetails } from '..';
+
+export const Main = ({ onClickStart }) => {
+  const [selectedProduct, setSelectedProduct] = React.useState('course');
+
+  const handleClickStart = () => onClickStart(
+    productChoices.find((choice) => choice.alias === selectedProduct)
+  );
+
+  return (
+    <div className={SageClassnames.PANEL_GRID}>
+      <h5 className={`${SageClassnames.TYPE.HEADING_5}`}>
+        What do you want to create?
+      </h5>
+      <Panel.Tiles tilesInRow={2} className={SageClassnames.SPACERS.XS_BOTTOM}>
+        {productChoices.map(({ alias, icon, iconColor, title, }) => (
+          <ProductChoice
+            active={selectedProduct === alias}
+            icon={icon}
+            iconColor={iconColor}
+            key={alias}
+            onClick={() => setSelectedProduct(alias)}
+            title={title}
+          />
+        ))}
+      </Panel.Tiles>
+      <ProductChoiceDetails {...productChoiceDetails[selectedProduct]} />
+      <Button.Group>
+        <Button
+          color={Button.COLORS.PRIMARY}
+          fullWidth={true}
+          onClick={handleClickStart}
+        >
+          Get started
+        </Button>
+      </Button.Group>
+    </div>
+  );
+};
+
+Main.defaultProps = {
+  onClickStart: (step) => step,
+};
+
+Main.propTypes = {
+  onClickStart: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingAppearance.jsx.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingAppearance.jsx.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ProductColorPickerCard } from '../..';
+import {
+  Button,
+  Card,
+  SageClassnames,
+} from '../../../../..';
+
+export const CoachingAppearance = ({ onChangeStep }) => (
+  <div className={SageClassnames.PANEL_GRID}>
+    <Card.Stack>
+      <h5 className={`${SageClassnames.TYPE.HEADING_5}`}>
+        Customize your course&rsquo;s appearance
+      </h5>
+      <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+        Choose a color and image to help brand your course.
+        These will be shown at checkout and throughout the member experience.
+      </p>
+    </Card.Stack>
+    <ProductColorPickerCard
+      title="Primary color"
+      subtext="Applies to the buttons and icons."
+    />
+    <ProductColorPickerCard
+      title="Secondary color"
+      subtext="Applies to the hero section background."
+    />
+    {/* TODO: Dev to add image uploader and sync changes with SVG graphic */}
+    [image upload]
+    <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        raised={false}
+        onClick={() => onChangeStep('coaching-2')}
+      >
+        Go back
+      </Button>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        fullWidth={true}
+        onClick={() => onChangeStep('coaching-4')}
+      >
+        Continue
+      </Button>
+    </Button.Group>
+  </div>
+);
+
+CoachingAppearance.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CoachingAppearance.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingBooking.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingBooking.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  // Alert,
+  Button,
+  Dot,
+  Icon,
+  Input,
+  Panel,
+  SageClassnames,
+  Tabs,
+} from '../../../../..';
+import { CoachingCalendlyDropdown } from './CoachingCalendlyDropdown';
+
+export const CoachingBooking = ({ onChangeStep }) => {
+  // TODO: Dev to add the following in final implementation:
+  // - Add state/story management for input data to persist
+  // - Use field state to toggle disabled button
+  // - Sync changes to fields with SVG graphic
+
+  const tabChoiceSettings = {
+    tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+  };
+
+  return (
+    <div className={SageClassnames.PANEL_GRID}>
+      <Panel.Stack>
+        <h5 className={`${SageClassnames.TYPE.HEADING_5}`}>
+          How should clients book your sessions?
+        </h5>
+        <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+          You control whether your sessions are scheduled
+          with Kajabi Calendar, Calendly, or custom links.
+        </p>
+      </Panel.Stack>
+
+      {/*
+        TODO: Dev to wire logic to check for connection to Calendly
+        <Alert
+          color={Alert.COLORS.INFO}
+          title="Connect Calendly to your Kajabi account"
+          description="Automatically add sessions to your calendar when you connect with Calendly."
+          actions={(
+            <Link href="#TODO-dev-url-or-action">
+              Connect with Calendly
+            </Link>
+          )}
+        />
+      */}
+
+      <Tabs
+        useSeparator={true}
+        tabs={[
+          {
+            id: 'tab-1',
+            label: 'Calendly',
+            tabChoiceIcon: null,
+            tabChoiceType: Tabs.Item.CHOICE_TYPES.GRAPHIC,
+            content: (
+              <Panel.Stack>
+                <CoachingCalendlyDropdown
+                  items={[
+                    {
+                      color: Dot.COLORS.PURPLE,
+                      label: 'Flow & Let Go - 1:1 Yoga Class',
+                      subtext: '45 minutes, One-on-One with Aditi Shah',
+                    },
+                    {
+                      color: Dot.COLORS.SAGE,
+                      label: 'Beginner Strength Class',
+                      subtext: '1 hour, One-on-One with Olivia Amato',
+                    },
+                    {
+                      color: Dot.COLORS.ORANGE,
+                      label: 'Free Consultation',
+                      subtext: '30 minutes, One-on-One with Olivia Amato',
+                    }
+                  ]}
+                  initialLabel="Event type"
+                />
+                <p className={`${SageClassnames.TYPE.BODY_XSMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+                  Clients will schedule through this event’s booking page.
+                </p>
+              </Panel.Stack>
+            ),
+            // TODO: Add `children` to `Tabs` items processing
+            // so this can be passed down successfully
+            // https://kajabi.atlassian.net/browse/SAGE-330
+            children: (
+              <>
+                [calendly icon]
+                <p className={SageClassnames.TYPE.BODY_SMALL_MED}>Calendly</p>
+              </>
+            ),
+            ...tabChoiceSettings,
+          },
+          {
+            id: 'tab-2',
+            label: 'Custom link',
+            tabChoiceIcon: Icon.ICONS.URL,
+            tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+            content: (
+              <div className={SageClassnames.GRID_CARD}>
+                <Input
+                  id="coaching-booking-custom-link"
+                  label="Custom link"
+                  message="You can use a link from Calendly, Acuity, Google Calendar, etc."
+                />
+              </div>
+            ),
+            children: (
+              <>
+                <Icon name={Icon.ICONS.URL} />
+                <p className={SageClassnames.TYPE.BODY_SMALL_MED}>
+                  Calendly
+                </p>
+              </>
+            ),
+            ...tabChoiceSettings,
+          },
+          {
+            id: 'tab-3',
+            label: 'Manual booking',
+            tabChoiceIcon: Icon.ICONS.CALENDAR_SIMPLE,
+            tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+            content: (
+              <div className={SageClassnames.GRID_CARD}>
+                <Input
+                  id="coaching-booking-custom-address"
+                  label="Address"
+                  placeholder="e.g., 123 Main St., https://zoom.us*"
+                />
+                <Input
+                  id="coaching-booking-duration"
+                  label="Duration"
+                  message="Set the duration of your booking."
+                />
+              </div>
+            ),
+            children: (
+              <>
+                <Icon name={Icon.ICONS.CALENDAR_SIMPLE} />
+                <p className={SageClassnames.TYPE.BODY_SMALL_MED}>Calendly</p>
+              </>
+            ),
+            ...tabChoiceSettings,
+          },
+        ]}
+        tabStyle={Tabs.STYLES.CHOICE}
+      />
+      <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+        <Button
+          color={Button.COLORS.SECONDARY}
+          raised={false}
+          onClick={() => onChangeStep('coaching-1')}
+        >
+          Go back
+        </Button>
+        <Button
+          color={Button.COLORS.PRIMARY}
+          fullWidth={true}
+          onClick={() => onChangeStep('coaching-3')}
+        >
+          Continue
+        </Button>
+      </Button.Group>
+    </div>
+  );
+};
+
+CoachingBooking.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CoachingBooking.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingCalendlyDropdown.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingCalendlyDropdown.jsx
@@ -1,0 +1,109 @@
+/* eslint-disable no-unused-vars */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  Dot,
+  Icon,
+  Dropdown,
+  SageTokens,
+  SageClassnames
+} from '../../../../..';
+
+const CoachingCalendlyDropdownCard = ({
+  color,
+  label,
+  subtext,
+}) => (
+  <Card.Row verticalAlign="start" gridTemplate={SageTokens.GRID_TEMPLATES.ET}>
+    <Card.Block>
+      <h4 className={`${SageClassnames.TYPE.BODY_MED} t-sage--truncate`}>
+        <Dot color={color} />{' '}
+        {label}
+      </h4>
+      <p
+        className={`${SageClassnames.TYPE.BODY_MED} ${SageClassnames.TYPE_COLORS.CHARCOAL_200}`}
+        style={{ marginLeft: '12px' }}
+      >
+        {subtext}
+      </p>
+    </Card.Block>
+  </Card.Row>
+);
+
+CoachingCalendlyDropdownCard.defaultProps = {
+  color: Icon.CARD_COLORS.DRAFT,
+  label: 'Default label',
+  subtext: 'Default subtext',
+};
+
+CoachingCalendlyDropdownCard.propTypes = {
+  color: Icon.propTypes.cardColor,
+  label: PropTypes.string,
+  subtext: PropTypes.string,
+};
+
+export const CoachingCalendlyDropdown = ({
+  initialLabel,
+  items,
+  onSelectItem,
+}) => {
+  const [label, setLabel] = useState(initialLabel);
+  const [selectedContent, setSelectedContent] = useState(null);
+
+  const handleClickItem = (data) => {
+    const item = items.find((obj) => obj.id === data.id);
+
+    if (item) {
+      setSelectedContent((
+        <CoachingCalendlyDropdownCard {...item} />
+      ));
+      setLabel('');
+    } else {
+      setSelectedContent(null);
+      setLabel(initialLabel);
+    }
+
+    onSelectItem(data);
+  };
+
+  return (
+    <Dropdown
+      contained={true}
+      customTrigger={(
+        <Dropdown.TriggerSelect
+          label={label}
+          selectedValue={selectedContent}
+        />
+      )}
+      label="Event type"
+      panelModifier="select"
+      triggerModifier="select"
+      exitPanelHandler={handleClickItem}
+    >
+      <Dropdown.ItemList
+        items={items.map((item) => ({
+          customComponent: CoachingCalendlyDropdownCard,
+          id: item.id,
+          label: item.label,
+          payload: { ...item },
+        }))}
+      />
+    </Dropdown>
+  );
+};
+
+CoachingCalendlyDropdown.defaultProps = {
+  initialLabel: '',
+  items: [],
+  onSelectItem: (data) => null,
+};
+
+CoachingCalendlyDropdown.propTypes = {
+  initialLabel: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string,
+    label: PropTypes.string,
+  })),
+  onSelectItem: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingDetails.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingDetails.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Input,
+  SageClassnames,
+  Tabs,
+  Textarea,
+} from '../../../../..';
+
+export const CoachingDetails = ({ onChangeStep }) => {
+  // TODO: Dev to add the following in final implementation:
+  // - Add state/story management for input data to persist
+  // - Use field state to toggle disabled button
+  // - Sync changes to fields with SVG graphic
+
+  const tabChoiceSettings = {
+    tabChoiceType: Tabs.Item.CHOICE_TYPES.RADIO,
+    tabChoiceIcon: null,
+    tabChoiceIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,
+  };
+
+  return (
+    <div className={SageClassnames.GRID_PANEL}>
+      <h5 className={`${SageClassnames.TYPE.HEADING_5} ${SageClassnames.SPACERS.MD_BOTTOM}`}>
+        Choose your program
+      </h5>
+      <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+        Pick a program length that best fits for your coaching topic.
+      </p>
+
+      <Tabs
+        useSeparator={true}
+        tabs={[
+          {
+            id: 'tab-1',
+            label: 'Single session',
+            subtext: 'Create a standalone coaching session.',
+            content: (
+              <div className={SageClassnames.PANEL_GRID}>
+                <Input
+                  id="coaching-details-title"
+                  label="Title"
+                />
+                <Input
+                  id="coaching-details-coach-name"
+                  label="Coach name"
+                />
+                <Textarea
+                  id="coaching-details-description"
+                  label="Description (optional)"
+                />
+              </div>
+            ),
+            ...tabChoiceSettings,
+          },
+          {
+            id: 'tab-2',
+            label: 'Package',
+            subtext: 'Build a program with multiple coaching sessions.',
+            content: (
+              <div className={SageClassnames.PANEL_GRID}>
+                <Input
+                  id="coaching-details-title"
+                  label="Title"
+                />
+                <Input
+                  id="coaching-details-coach-name"
+                  label="Coach name"
+                />
+                <Textarea
+                  id="coaching-details-description"
+                  label="Description (optional)"
+                />
+                <Input
+                  id="coaching-details-session-count"
+                  label="Total sessions"
+                  type="number"
+                />
+              </div>
+            ),
+            ...tabChoiceSettings,
+          },
+        ]}
+        tabLayout={Tabs.LAYOUTS.STACKED}
+        tabStyle={Tabs.STYLES.CHOICE}
+      />
+      <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+        <Button
+          color={Button.COLORS.SECONDARY}
+          raised={false}
+          onClick={() => onChangeStep(null)}
+        >
+          Go back
+        </Button>
+        <Button
+          color={Button.COLORS.PRIMARY}
+          fullWidth={true}
+          onClick={() => onChangeStep('coaching-2')}
+        >
+          Save and continue
+        </Button>
+      </Button.Group>
+    </div>
+  );
+};
+
+CoachingDetails.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CoachingDetails.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingPricing.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/CoachingPricing.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Card,
+  SageClassnames,
+  SageTokens,
+  Tabs,
+} from '../../../../..';
+import { PaidPricingOptions } from '../..';
+
+export const CoachingPricing = ({ onChangeStep }) => (
+  <div className={SageClassnames.PANEL_GRID}>
+    <Card.Stack>
+      <h5 className={`${SageClassnames.TYPE.HEADING_5}`}>
+        Price your program
+      </h5>
+      <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+        Choose whether this coaching program is paid or free.
+        If it&rsquo;s paid, set its price and payment preferences.
+      </p>
+    </Card.Stack>
+
+    <Tabs
+      initialActiveId="pricing-paid"
+      tabStyle={Tabs.STYLES.CHOICE}
+      tabs={[
+        {
+          // TODO: Need alignCenter added to options on tabItems
+          // https://kajabi.atlassian.net/browse/SAGE-331
+          id: 'pricing-paid',
+          tabChoiceIcon: SageTokens.ICONS.ROUND_DOLLAR,
+          tabChoicIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,
+          tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+          label: 'Paid',
+          content: <PaidPricingOptions />
+        },
+        {
+          id: 'pricing-free',
+          tabChoiceIcon: SageTokens.ICONS.BAN,
+          tabChoicIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,
+          tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+          label: 'Free',
+          content: null,
+        }
+      ]}
+    />
+    <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        raised={false}
+        onClick={() => onChangeStep('coaching-3')}
+      >
+        Go back
+      </Button>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        fullWidth={true}
+        onClick={() => onChangeStep('coaching-fin')}
+      >
+        Finish
+      </Button>
+    </Button.Group>
+  </div>
+);
+
+CoachingPricing.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CoachingPricing.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/index.js
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/coaching/index.js
@@ -1,0 +1,4 @@
+export { CoachingAppearance } from './CoachingAppearance';
+export { CoachingBooking } from './CoachingBooking';
+export { CoachingDetails } from './CoachingDetails';
+export { CoachingPricing } from './CoachingPricing';

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/course/CourseAppearance.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/course/CourseAppearance.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ProductColorPickerCard } from '../..';
+import {
+  Button,
+  Card,
+  SageClassnames,
+} from '../../../../..';
+
+export const CourseAppearance = ({ onChangeStep }) => (
+  <div className={SageClassnames.PANEL_GRID}>
+    <Card.Stack>
+      <h5 className={`${SageClassnames.TYPE.HEADING_5}`}>
+        Customize your course&rsquo;s appearance
+      </h5>
+      <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+        Choose a color and image to help brand your course.
+        These will be shown at checkout and throughout the member experience.
+      </p>
+    </Card.Stack>
+    <ProductColorPickerCard
+      title="Primary color"
+      subtext="Applies to the audio player and page buttons."
+    />
+    {/* TODO: dev to add image uploader and sync changes with SVG graphic */}
+    [image upload]
+    <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        raised={false}
+        onClick={() => onChangeStep('course-1')}
+      >
+        Go back
+      </Button>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        fullWidth={true}
+        onClick={() => onChangeStep('course-3')}
+      >
+        Continue
+      </Button>
+    </Button.Group>
+  </div>
+);
+
+CourseAppearance.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CourseAppearance.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/course/CourseDetails.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/course/CourseDetails.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Input,
+  SageClassnames,
+  Textarea,
+} from '../../../../..';
+
+// TODO: Dev to add the following in final implementation:
+// - Add state/story management for input data to persist
+// - Use field state to toggle disabled button
+// - Sync changes to fields with SVG graphic
+export const CourseDetails = ({ onChangeStep }) => (
+  <div className={SageClassnames.GRID_PANEL}>
+    <h5 className={`${SageClassnames.TYPE.HEADING_5} ${SageClassnames.SPACERS.MD_BOTTOM}`}>
+      Course details
+    </h5>
+    <Input
+      id="course-details-title"
+      label="Course title"
+    />
+    <Textarea
+      id="course-details-description"
+      label="Brief description"
+    />
+    <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        raised={false}
+        onClick={() => onChangeStep(null)}
+      >
+        Go back
+      </Button>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        fullWidth={true}
+        onClick={() => onChangeStep('course-2')}
+      >
+        Continue
+      </Button>
+    </Button.Group>
+  </div>
+);
+
+CourseDetails.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CourseDetails.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/course/CoursePricing.jsx
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/course/CoursePricing.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { PaidPricingOptions } from '../..';
+import {
+  Button,
+  Card,
+  SageClassnames,
+  SageTokens,
+  Tabs,
+} from '../../../../..';
+
+export const CoursePricing = ({ onChangeStep }) => (
+  <div className={SageClassnames.PANEL_GRID}>
+    <Card.Stack>
+      <h5 className={`${SageClassnames.TYPE.HEADING_5}`}>
+        Price your course
+      </h5>
+      <p className={`${SageClassnames.TYPE.BODY_SMALL} ${SageClassnames.TYPE_COLORS.CHARCOAL_100}`}>
+        Choose whether this course is paid or free.
+        If it&rsquo;s paid, set its price and payment preferences.
+      </p>
+    </Card.Stack>
+
+    <Tabs
+      initialActiveId="pricing-paid"
+      tabStyle={Tabs.STYLES.CHOICE}
+      tabs={[
+        {
+          // TODO: Need alignCenter added to options on tabItems
+          // https://kajabi.atlassian.net/browse/SAGE-331
+          id: 'pricing-paid',
+          tabChoiceIcon: SageTokens.ICONS.ROUND_DOLLAR,
+          tabChoiceIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,
+          tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+          label: 'Paid',
+          content: <PaidPricingOptions />
+        },
+        {
+          id: 'pricing-free',
+          tabChoiceIcon: SageTokens.ICONS.BAN,
+          tabChoiceIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,
+          tabChoiceType: Tabs.Item.CHOICE_TYPES.ICON,
+          label: 'Free',
+          content: null,
+        }
+      ]}
+    />
+
+    <Button.Group gap={Button.Group.GAP_OPTIONS.MD}>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        raised={false}
+        onClick={() => onChangeStep('course-2')}
+      >
+        Go back
+      </Button>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        fullWidth={true}
+        onClick={() => onChangeStep('course-fin')}
+      >
+        Finish
+      </Button>
+    </Button.Group>
+  </div>
+);
+
+CoursePricing.defaultProps = {
+  onChangeStep: (step) => step,
+};
+
+CoursePricing.propTypes = {
+  onChangeStep: PropTypes.func,
+};

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/course/index.js
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/course/index.js
@@ -1,0 +1,3 @@
+export { CourseAppearance } from './CourseAppearance';
+export { CourseDetails } from './CourseDetails';
+export { CoursePricing } from './CoursePricing';

--- a/docs/app/views/mocks/product-creation-wizard/components/panels/index.js
+++ b/docs/app/views/mocks/product-creation-wizard/components/panels/index.js
@@ -1,0 +1,12 @@
+export { Main } from './Main';
+export {
+  CoachingAppearance,
+  CoachingBooking,
+  CoachingDetails,
+  CoachingPricing,
+} from './coaching';
+export {
+  CourseAppearance,
+  CourseDetails,
+  CoursePricing,
+} from './course';

--- a/docs/app/views/mocks/product-creation-wizard/content/index.js
+++ b/docs/app/views/mocks/product-creation-wizard/content/index.js
@@ -1,0 +1,1 @@
+export { productChoices, productChoiceDetails } from './product-choices';

--- a/docs/app/views/mocks/product-creation-wizard/content/product-choices.js
+++ b/docs/app/views/mocks/product-creation-wizard/content/product-choices.js
@@ -1,0 +1,166 @@
+import { Icon, SageTokens } from '../../..';
+
+export const productChoices = [
+  {
+    alias: 'course',
+    icon: SageTokens.ICONS.PEN,
+    iconColor: Icon.CARD_COLORS.INFO,
+    title: 'Course',
+  },
+  {
+    alias: 'podcast',
+    title: 'Podcast',
+    icon: SageTokens.ICONS.PEN,
+    iconColor: Icon.CARD_COLORS.DRAFT,
+  },
+  {
+    alias: 'community',
+    icon: SageTokens.ICONS.PEN,
+    iconColor: Icon.CARD_COLORS.PUBLISHED,
+    title: 'Community',
+  },
+  {
+    alias: 'coaching',
+    icon: SageTokens.ICONS.PEN,
+    iconColor: Icon.CARD_COLORS.DANGER,
+    title: 'Coaching',
+  }
+];
+
+export const productChoiceDetails = {
+  coaching: {
+    title: 'Coaching program',
+    body: `
+      Share your knowledge to help others achieve their goals.
+      Book one-on-one sessions with clients, track their progress, and more.  
+    `,
+    leftFeatures: [
+      {
+        icon: SageTokens.ICONS.SCREEN_SHARE_ON,
+        label: 'Live video conferencing'
+      },
+      {
+        icon: SageTokens.ICONS.CALENDAR_DATE,
+        label: 'Calendar integrations'
+      },
+      {
+        icon: SageTokens.ICONS.VIDEO_ON,
+        label: 'Video content'
+      },
+      {
+        icon: SageTokens.ICONS.MICROPHONE,
+        label: 'Audio content'
+      },
+    ],
+    rightFeatures: [
+      {
+        icon: SageTokens.ICONS.DOWNLOAD,
+        label: 'Exclusive downloads'
+      },
+      {
+        icon: SageTokens.ICONS.FILE,
+        label: 'Shared notes'
+      },
+    ]
+  },
+  community: {
+    title: 'Community',
+    body: `
+      Build an online space for your audience to share common interests and interact with each other.  
+    `,
+    leftFeatures: [
+      {
+        icon: SageTokens.ICONS.COMMENT,
+        label: 'Discussion topics'
+      },
+      {
+        icon: SageTokens.ICONS.URL,
+        label: 'Links and resources'
+      },
+      {
+        icon: SageTokens.ICONS.USERS,
+        label: 'Membership area'
+      },
+      {
+        icon: SageTokens.ICONS.BELL,
+        label: 'Member activity notifications'
+      },
+    ],
+    rightFeatures: [
+      {
+        icon: SageTokens.ICONS.ROUND_DOLLAR,
+        label: 'Paid access'
+      },
+    ]
+  },
+  course: {
+    title: 'Course',
+    body: `
+      Turn your knowledge into a world-class learning experience.
+      Build a course that helps you connect with your audience and grow your business.
+    `,
+    leftFeatures: [
+      {
+        icon: SageTokens.ICONS.VIDEO_ON,
+        label: 'Video content'
+      },
+      {
+        icon: SageTokens.ICONS.MICROPHONE,
+        label: 'Audio content'
+      },
+      {
+        icon: SageTokens.ICONS.FILE,
+        label: 'Text posts'
+      },
+      {
+        icon: SageTokens.ICONS.ASSESSMENT,
+        label: 'Quizzes and surveys'
+      },
+    ],
+    rightFeatures: [
+      {
+        icon: SageTokens.ICONS.USER_STAR,
+        label: 'Membership data'
+      },
+      {
+        icon: SageTokens.ICONS.DOWNLOAD,
+        label: 'Exclusive downloads'
+      },
+    ]
+  },
+  podcast: {
+    title: 'Podcast',
+    body: `
+      Create and publish episodes, distribute to all major listening apps,
+      and monetize your podcast — all from your dashboard.  
+    `,
+    leftFeatures: [
+      {
+        icon: SageTokens.ICONS.UPLOAD,
+        label: 'Import podcasts'
+      },
+      {
+        icon: SageTokens.ICONS.MICROPHONE,
+        label: 'Audio content'
+      },
+      {
+        icon: SageTokens.ICONS.WORLD,
+        label: 'Podcast distribution'
+      },
+      {
+        icon: SageTokens.ICONS.HOME,
+        label: 'Podcast homepage'
+      },
+    ],
+    rightFeatures: [
+      {
+        icon: SageTokens.ICONS.CHART,
+        label: 'Analytics'
+      },
+      {
+        icon: SageTokens.ICONS.ROUND_DOLLAR,
+        label: 'Paid feeds'
+      },
+    ]
+  },
+};


### PR DESCRIPTION
# Restore PR

This PR is to restore work from #1234 that was reverted due to causing the Rails docs site to error and not display.

# From original PR:

## Description

Adds first round of mocks for Course portion of Product Creation Wizard.

## Screenshots

![Screen Shot 2022-02-25 at 2 00 21 PM](https://user-images.githubusercontent.com/17955295/155772564-bf3014df-9784-46e5-bfa3-de8bc806563e.png)

## Testing in `sage-lib`

- http://localhost:4000/pages/mock/product_creation_wizard
- http://localhost:4100/?path=/story/mocks-product-creation-wizard--default

## Testing in `kajabi-products`

N/A Mocks only

