### PR TITLE
[Sage-229] ProgressBar - Foundations Update

### DIFF
--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -5,6 +5,14 @@
   label: "Cloning product"
 } %>
 
+<h2 class="t-sage-heading-6">Default with Disabled Tooltip</h2>
+<%= sage_component SageProgressBar, {
+  color: SageTokens::COLOR_PALETTE[:PRIMARY_500],
+  disable_tooltip: true,
+  percent: 70,
+  label: "Cloning product"
+} %>
+
 <h2 class="t-sage-heading-6">Default with Percentage</h2>
 <%= sage_component SageProgressBar, {
   color: SageTokens::COLOR_PALETTE[:PRIMARY_500],

--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -5,6 +5,14 @@
   label: "Cloning product"
 } %>
 
+<h2 class="t-sage-heading-6">Default with Percentage</h2>
+<%= sage_component SageProgressBar, {
+  color: SageTokens::COLOR_PALETTE[:PRIMARY_500],
+  display_percent: true,
+  percent: 70,
+  label: "Cloning product"
+} %>
+
 <h2 class="t-sage-heading-6">Custom color</h2>
 <%= sage_component SageProgressBar, {
   color: "#4edbe6",

--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -1,12 +1,13 @@
 <h2 class="t-sage-heading-6">Default</h2>
 <%= sage_component SageProgressBar, {
+  color: SageTokens::COLOR_PALETTE[:PRIMARY_500],
   percent: 70,
   label: "Cloning product"
 } %>
 
 <h2 class="t-sage-heading-6">Custom color</h2>
 <%= sage_component SageProgressBar, {
-  color: SageTokens::COLOR_PALETTE[:ORANGE_500],
+  color: "#4edbe6",
   percent: 47,
   label: "Reached limit"
 } %>

--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -7,6 +7,6 @@
 <h2 class="t-sage-heading-6">Custom color</h2>
 <%= sage_component SageProgressBar, {
   color: SageTokens::COLOR_PALETTE[:ORANGE_500],
-  percent: 100,
+  percent: 47,
   label: "Reached limit"
 } %>

--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -5,25 +5,33 @@
   label: "Cloning product"
 } %>
 
-<h2 class="t-sage-heading-6">Default with Disabled Tooltip</h2>
-<%= sage_component SageProgressBar, {
-  color: SageTokens::COLOR_PALETTE[:PRIMARY_500],
-  disable_tooltip: true,
-  percent: 70,
-  label: "Cloning product"
-} %>
-
 <h2 class="t-sage-heading-6">Default with Percentage</h2>
 <%= sage_component SageProgressBar, {
-  color: SageTokens::COLOR_PALETTE[:PRIMARY_500],
+  color: SageTokens::COLOR_PALETTE[:SAGE_500],
   display_percent: true,
   percent: 70,
   label: "Cloning product"
 } %>
 
+<h2 class="t-sage-heading-6">Default with Disabled Tooltip</h2>
+<%= sage_component SageProgressBar, {
+  color: SageTokens::COLOR_PALETTE[:ORANGE_500],
+  disable_tooltip: true,
+  percent: 17,
+  label: "Cloning product"
+} %>
+
+<h2 class="t-sage-heading-6">Tooltip Position - Bottom</h2>
+<%= sage_component SageProgressBar, {
+  color: SageTokens::COLOR_PALETTE[:YELLOW_500],
+  percent: 32,
+  label: "Cloning product",
+  tooltip_position: "bottom",
+} %>
+
 <h2 class="t-sage-heading-6">Custom color</h2>
 <%= sage_component SageProgressBar, {
   color: "#4edbe6",
-  percent: 47,
+  percent: 86,
   label: "Reached limit"
 } %>

--- a/docs/app/views/examples/components/progress_bar/_props.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_props.html.erb
@@ -5,6 +5,18 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`disable_tooltip`') %></td>
+  <td><%= md('Option to disable the default tooltip.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`display_percent`') %></td>
+  <td><%= md('If true, displays the percentage to the right of the progress bar.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`label`') %><%= sage_component SageLabel, { color: "published", value: "required" } %></td>
   <td><%= md('Sets `aria-valuetext` and content text for `<progress>` element.') %></td>
   <td><%= md('String') %></td>
@@ -14,5 +26,11 @@
   <td><%= md('`percent`') %><%= sage_component SageLabel, { color: "published", value: "required" } %></td>
   <td><%= md('Sets `value`, `aria-valuenow` and inline `width` style of progress bar.') %></td>
   <td><%= md('Integer') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`tooltip_position`') %></td>
+  <td><%= md('Sets the tooltip position to either above or below the progress bar.') %></td>
+  <td><%= md('String: ["top", "bottom"]') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
@@ -1,6 +1,7 @@
 class SageProgressBar < SageComponent
   set_attribute_schema({
     color: [:optional, String],
+    disable_tooltip: [:optional, TrueClass],
     display_percent: [:optional, TrueClass],
     label: String,
     percent: 0..100,

--- a/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
@@ -1,6 +1,7 @@
 class SageProgressBar < SageComponent
   set_attribute_schema({
     color: [:optional, String],
+    display_percent: [:optional, TrueClass],
     label: String,
     percent: 0..100,
   })

--- a/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
@@ -5,5 +5,6 @@ class SageProgressBar < SageComponent
     display_percent: [:optional, TrueClass],
     label: String,
     percent: 0..100,
+    tooltip_position: [:optional, Set.new(["top", "bottom"])]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -9,16 +9,21 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_500]
   data-js-tooltip="<%= content %>"
   <%= component.generated_html_attributes.html_safe %>
 >
-  <progress
-    class="sage-progress-bar__element"
-    aria-valuemax="100"
-    max="100"
-    aria-valuemin="0"
-    value="<%= component.percent %>"
-    aria-valuenow="<%= component.percent %>"
-    aria-valuetext="<%= content %>"
-  >
-    <%= content %>
-  </progress>
-  <div class="sage-progress-bar__value" style="--progress-bar-value-color: <%= color %>; width: <%= component.percent %>%;"></div>
+  <div class="sage-progress-bar__background">
+    <progress
+      class="sage-progress-bar__element"
+      aria-valuemax="100"
+      max="100"
+      aria-valuemin="0"
+      value="<%= component.percent %>"
+      aria-valuenow="<%= component.percent %>"
+      aria-valuetext="<%= content %>"
+    >
+      <%= content %>
+    </progress>
+    <div class="sage-progress-bar__value" style="--progress-bar-value-color: <%= color %>; width: <%= component.percent %>%;"></div>
+  </div>
+  <% if component.display_percent %>
+    <span><%= component.percent %></span>
+  <% end %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -11,6 +11,7 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_500]
   "
   <% if !component.disable_tooltip %>
     data-js-tooltip="<%= content %>"
+    data-js-tooltip-position="<%= component.tooltip_position %>"
   <% end %>
   <%= component.generated_html_attributes.html_safe %>
 >

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -5,11 +5,14 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_500]
 %>
 
 <div
-  class="sage-progress-bar <%= component.generated_css_classes %>"
+  class="
+    sage-progress-bar <%= component.generated_css_classes %>
+    <%= "sage-progress-bar--has-percentage" if component.display_percent %>
+  "
   data-js-tooltip="<%= content %>"
   <%= component.generated_html_attributes.html_safe %>
 >
-  <div class="sage-progress-bar__background">
+	<div class="sage-progress-bar__background">
     <progress
       class="sage-progress-bar__element"
       aria-valuemax="100"
@@ -24,6 +27,6 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_500]
     <div class="sage-progress-bar__value" style="--progress-bar-value-color: <%= color %>; width: <%= component.percent %>%;"></div>
   </div>
   <% if component.display_percent %>
-    <span><%= component.percent %></span>
+    <span class="sage-progress-bar__percent"><%= component.percent %>%</span>
   <% end %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -11,7 +11,7 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_500]
   "
   <% if !component.disable_tooltip %>
     data-js-tooltip="<%= content %>"
-    data-js-tooltip-position="<%= component.tooltip_position %>"
+    <%= "data-js-tooltip-position=#{component.tooltip_position}" if component.tooltip_position %>
   <% end %>
   <%= component.generated_html_attributes.html_safe %>
 >

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -9,7 +9,9 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_500]
     sage-progress-bar <%= component.generated_css_classes %>
     <%= "sage-progress-bar--has-percentage" if component.display_percent %>
   "
-  data-js-tooltip="<%= content %>"
+  <% if !component.disable_tooltip %>
+    data-js-tooltip="<%= content %>"
+  <% end %>
   <%= component.generated_html_attributes.html_safe %>
 >
 	<div class="sage-progress-bar__background">

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -16,6 +16,9 @@
 
 .sage-progress-bar {
   height: sage-spacing(xs);
+}
+
+.sage-progress-bar__background {
   border-radius: sage-border(radius-small);
   background-color: sage-color(grey, 200);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -49,3 +49,4 @@ $-progress-bar-height: sage-spacing(xs);
 
   margin-left: rem(12px);
 }
+

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -16,8 +16,8 @@
 
 
 .sage-progress-bar {
-  height: rem(6px);
-  border-radius: sage-border(radius-large);
+  height: sage-spacing(xs);
+  border-radius: sage-border(radius-small);
   background-color: sage-color(grey, 300);
 }
 
@@ -25,7 +25,7 @@
   transform-origin: center left;
   height: 100%;
   background-color: var(--progress-bar-value-color, sage-color(sage, 500));
-  border-radius: sage-border(radius-large);
+  border-radius: sage-border(radius-small);
   animation: 3s sage-progress-bar--slide ease;
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -14,11 +14,10 @@
   }
 }
 
-
 .sage-progress-bar {
   height: sage-spacing(xs);
   border-radius: sage-border(radius-small);
-  background-color: sage-color(grey, 300);
+  background-color: sage-color(grey, 200);
 }
 
 .sage-progress-bar__value {

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -4,6 +4,7 @@
 /// @group sage
 ////
 
+$-progress-bar-height: sage-spacing(xs);
 
 @keyframes sage-progress-bar--slide {
   from {
@@ -15,10 +16,17 @@
 }
 
 .sage-progress-bar {
-  height: sage-spacing(xs);
+  height: $-progress-bar-height;
+}
+
+.sage-progress-bar--has-percentage {
+  display: flex;
+  align-items: center;
 }
 
 .sage-progress-bar__background {
+  height: $-progress-bar-height;
+  width: 100%;
   border-radius: sage-border(radius-small);
   background-color: sage-color(grey, 200);
 }
@@ -34,4 +42,10 @@
 .sage-progress-bar__element {
   @include visually-hidden;
   height: 0;
+}
+
+.sage-progress-bar__percent {
+  @extend %t-sage-body-small-semi;
+
+  margin-left: rem(12px);
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates Progress Bar component:
- Updates `height` to `8px`
- Updates `border-radius` to `4px`
- Adds new `display_percent` prop to show percentage to right of bar
- Adds new `disable_tooltip` prop to disable default tooltip
- Adds new `tooltip_position` prop to allow positioning of the tooltip either above or below the bar

[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/%E2%9A%A0%EF%B8%8F-%5BDO-NOT-USE-WIP%5D-Sage-Update?node-id=823%3A30602)

### Implementation Updates
- None for this ticket

### Follow-Up Items
- [Allow tooltip to be positioned at end of filled portion of bar](https://kajabi.atlassian.net/browse/SAGE-340)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1257" alt="Screen Shot 2022-03-07 at 3 09 29 PM" src="https://user-images.githubusercontent.com/14791307/157118234-37ef776f-9c29-4ef6-b274-1b8338e50df8.png">|<img width="1258" alt="Screen Shot 2022-03-07 at 3 08 58 PM" src="https://user-images.githubusercontent.com/14791307/157118240-f20ce498-b902-4c50-8596-37ccab44b912.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Progress Bar](http://localhost:4000/pages/component/progress_bar)
- Check that style updates are present
- Check that new props work as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates with minor UI changes and adds new props. There should be no effect on Kajabi Products work.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-229](https://kajabi.atlassian.net/browse/SAGE-229)