### PR TITLE
[SAGE-344] choice tabs custom class

### DIFF
--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -317,6 +317,7 @@ document.addEventListener("sage.tabs.change", function(evt) {
         },
         {
           target: "item2",
+          custom_content_class: "custom-choice__content",
           content: %(
             #{sage_component(SageAvatar, { initials: 'JW' })}
             #{sage_component(SageCardBlock, { content: %(

--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -305,6 +305,7 @@ document.addEventListener("sage.tabs.change", function(evt) {
       items: [
         {
           target: "item1",
+          custom_content_class: "my-custom-tab-choice-class",
           content: %(
             #{sage_component(SageAvatar, { initials: 'PS' })}
             #{sage_component(SageCardBlock, { content: %(
@@ -317,7 +318,7 @@ document.addEventListener("sage.tabs.change", function(evt) {
         },
         {
           target: "item2",
-          custom_content_class: "custom-choice__content",
+          custom_content_class: "my-custom-tab-choice-class",
           content: %(
             #{sage_component(SageAvatar, { initials: 'JW' })}
             #{sage_component(SageCardBlock, { content: %(

--- a/packages/sage-react/lib/Choice/Choice.story.jsx
+++ b/packages/sage-react/lib/Choice/Choice.story.jsx
@@ -143,6 +143,7 @@ export const LinkText = () => (
 export const CustomContent = () => (
   <div style={{ maxWidth: '360px', display: 'flex' }}>
     <Choice
+      customContentClassName="my-test-class"
       href="https://example.com"
     >
       <Avatar initials="BH" />

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -55,12 +55,14 @@ export const Tabs = ({
           id,
           label,
           tabDetails,
+          tabChoiceCustomClass,
           tabChoiceIcon,
           tabChoiceIconAlignment,
           tabChoiceType,
           subtext
         }) => (
           <TabsItem
+            className={tabChoiceCustomClass}
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -62,7 +62,6 @@ export const Tabs = ({
           subtext
         }) => (
           <TabsItem
-            className={tabChoiceCustomClass}
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}
@@ -72,6 +71,7 @@ export const Tabs = ({
             panelId={id}
             label={label}
             subtext={subtext}
+            customContentClassName={tabChoiceCustomClass}
             type={tabChoiceType}
             verticalAlignIcon={tabChoiceIconAlignment}
           >

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -97,6 +97,8 @@ RichContent.args = {
   tabs: [
     {
       id: 'tab-1',
+      tabChoiceCustomClass: 'testing-this',
+      content: 'Content 1',
       tabDetails: (
         <>
           <h4>Tab 1 content.</h4>
@@ -106,6 +108,7 @@ RichContent.args = {
     },
     {
       id: 'tab-2',
+      content: 'Content 2',
       tabDetails: (
         <>
           <h4>Tab 2 content.</h4>
@@ -115,6 +118,7 @@ RichContent.args = {
     },
     {
       id: 'tab-3',
+      content: 'Content 3',
       tabDetails: (
         <>
           <h4>Tab 3 content.</h4>
@@ -128,6 +132,7 @@ RichContent.args = {
 
 export const IconAlignment = () => {
   const tabChoiceSettings = {
+    tabChoiceCustomClass: 'testing-this',
     tabChoiceType: Tabs.Item.CHOICE_TYPES.RADIO,
     tabChoiceIcon: null,
     tabChoiceIconAlignment: Tabs.Item.ICON_ALIGNMENTS.START,

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -97,8 +97,8 @@ RichContent.args = {
   tabs: [
     {
       id: 'tab-1',
-      tabChoiceCustomClass: 'testing-this',
       content: 'Content 1',
+      tabChoiceCustomClass: 'my-custom-tab-choice-class',
       tabDetails: (
         <>
           <h4>Tab 1 content.</h4>
@@ -109,6 +109,7 @@ RichContent.args = {
     {
       id: 'tab-2',
       content: 'Content 2',
+      tabChoiceCustomClass: 'my-custom-tab-choice-class',
       tabDetails: (
         <>
           <h4>Tab 2 content.</h4>
@@ -119,6 +120,7 @@ RichContent.args = {
     {
       id: 'tab-3',
       content: 'Content 3',
+      tabChoiceCustomClass: 'my-custom-tab-choice-class',
       tabDetails: (
         <>
           <h4>Tab 3 content.</h4>

--- a/packages/sage-react/lib/Tabs/TabsItem.jsx
+++ b/packages/sage-react/lib/Tabs/TabsItem.jsx
@@ -83,7 +83,7 @@ export const TabsItem = ({
               {graphic}
             </span>
           )}
-          <span className={`sage-choice__content ${children && 'sage-choice__content--custom'}`}>
+          <span className={`sage-choice__content ${className} ${children && 'sage-choice__content--custom'}`}>
             {label && (
               <em className="sage-choice__text">
                 {label}

--- a/packages/sage-react/lib/Tabs/TabsItem.jsx
+++ b/packages/sage-react/lib/Tabs/TabsItem.jsx
@@ -9,6 +9,7 @@ export const TabsItem = ({
   alignCenter,
   children,
   className,
+  customContentClassName,
   disabled,
   graphic,
   label,
@@ -83,7 +84,7 @@ export const TabsItem = ({
               {graphic}
             </span>
           )}
-          <span className={`sage-choice__content ${className} ${children && 'sage-choice__content--custom'}`}>
+          <span className={`sage-choice__content ${customContentClassName} ${children && 'sage-choice__content--custom'}`}>
             {label && (
               <em className="sage-choice__text">
                 {label}
@@ -115,6 +116,7 @@ TabsItem.defaultProps = {
   alignCenter: false,
   children: null,
   className: null,
+  customContentClassName: null,
   disabled: false,
   graphic: null,
   icon: null,
@@ -131,6 +133,7 @@ TabsItem.propTypes = {
   alignCenter: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
+  customContentClassName: PropTypes.string,
   disabled: PropTypes.bool,
   graphic: PropTypes.node,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),

--- a/packages/sage-react/lib/Tabs/configs.js
+++ b/packages/sage-react/lib/Tabs/configs.js
@@ -30,6 +30,7 @@ export const tabsItemsPropTypes = PropTypes.shape({
   disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   subtext: PropTypes.string,
+  tabChoiceCustomClass: PropTypes.string,
   tabChoiceIcon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   tabChoicIconAlignment: PropTypes.oneOf(Object.values(CHOICE_ICON_ALIGNMENTS)),
   tabChoiceType: PropTypes.oneOf(Object.values(CHOICE_TYPES)),


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] in the react version allow the ability to pass the `Choice`'s custom class to the parent `Tabs`
- [ ] ~add utility class for horizontal alignment~ [SAGE-343](https://kajabi.atlassian.net/browse/SAGE-343)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Rails  |  React  |
|--------|--------|
|![Screen_Shot_2022-03-07_at_3_18_10_PM](https://user-images.githubusercontent.com/1241836/157119701-c8aa5b50-5f52-4d0c-9c60-cdb951525f5a.png)|![Screen_Shot_2022-03-07_at_3_18_21_PM](https://user-images.githubusercontent.com/1241836/157119715-e1caa4ef-84c9-4639-8615-e7f307a96a97.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
In the respective demo verify that the added custom class appears in the DOM:
- [Rails](http://localhost:4000/pages/component/tabs)
- [React](http://localhost:4100/?path=/story/sage-tabs--rich-content)
The followup PR will address the alignment utility classes

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds new custom class prop for the Tabs component. Doesn't affect existing iterations


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-344](https://kajabi.atlassian.net/browse/SAGE-344)