### PR TITLE
[SAGE-349] Grid - update react props to resolve error

### DIFF
--- a/packages/sage-react/lib/Grid/configs.js
+++ b/packages/sage-react/lib/Grid/configs.js
@@ -28,7 +28,7 @@ export const validNumberWithinGrid = (props, propName, componentName) => {
   return null;
 };
 
-export const validBreakpoint = PropTypes.oneOf([
+export const validBreakpoint = PropTypes.oneOfType([
   PropTypes.oneOf(Object.values(GRID_BREAKPOINT_TOGGLES)),
   validNumberWithinGrid,
 ]);

--- a/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
+++ b/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
@@ -111,10 +111,10 @@ export const Root = () => {
             https://kajabi.atlassian.net/browse/SAGE-329
           */}
           <Grid.Row>
-            <Grid.Col size={4}>
+            <Grid.Col size={4} small={12} medium={5} large={4}>
               {renderStep()}
             </Grid.Col>
-            <Grid.Col size={8}>
+            <Grid.Col size={8} small={0} medium={7} large={8}>
               {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
               <img
                 src="//source.unsplash.com/random/832x575"


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] resolve error when using `small`, `medium`, or `large` in `<Grid>`

## Screenshots
![Screen Shot 2022-03-11 at 9 03 49 AM](https://user-images.githubusercontent.com/1241836/157894841-047f6ec9-3216-49e5-8ba0-f5dcf414dab9.png)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the [Creation Wizard Mock](http://localhost:4100/?path=/story/mocks-product-creation-wizard--default) and verify that not console errors appear when responsive grid props are used

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Updates responsive property for the Grid react component.
   - [ ] Podcast Report
   - [ ] Quiz Builder
   - [ ] Product Post


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-349](https://kajabi.atlassian.net/browse/SAGE-349)