### PR TITLE
[SAGE-351] Grid - add generic col class when no size is specified

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
@@ -1,4 +1,5 @@
 <div class="
+  <%= "sage-col" if !component.size %>
   <%= "sage-col-#{component.size}" if component.size %>
   sage-col--<%= component.breakpoint %>-<%= component.size %> <%= component.generated_css_classes %>
   <%= "sage-col--sm-#{component.small}" if component.small%>

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -92,9 +92,9 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 }
 
 .sage-col {
-  max-width: 100%;
   flex-grow: 1;
   flex-basis: 0;
+  max-width: 100%;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -86,8 +86,15 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 ///
 
 @mixin sage-col {
-  flex: 1 1 auto;
+  flex: 0 0 100%;
   max-width: 100%;
+  padding: 0 calc(#{$-grid-gap} / 2);
+}
+
+.sage-col {
+  max-width: 100%;
+  flex-grow: 1;
+  flex-basis: 0;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 
@@ -97,7 +104,6 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   .sage-col--md-#{$i},
   .sage-col--lg-#{$i} {
     @include sage-col();
-    flex: 0 0 100%;
 
     .sage-row--stage > & {
       padding: 0 (sage-spacing(stage) / 2);
@@ -113,8 +119,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   }
 
   .sage-col-#{$i} {
-    flex: 0 1 auto;
-    width: percentage($i / $-grid-num-columns);
+    flex: 0 0 percentage($i / $-grid-num-columns);
+    max-width: percentage($i / $-grid-num-columns);
   }
 }
 
@@ -137,8 +143,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 @media (min-width: $-grid-breakpoint-md) {
   @for $i from 1 through $-grid-num-columns {
     .sage-col--md-#{$i} {
-      flex: 0 1 auto;
-      width: percentage($i / $-grid-num-columns);
+      flex: 0 0 auto;
+      max-width: percentage($i / $-grid-num-columns);
     }
   }
 

--- a/packages/sage-react/lib/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/Grid/GridCol.jsx
@@ -17,7 +17,7 @@ export const GridCol = ({
   const classNames = classnames(
     className,
     {
-      [`sage-col`]: !size,
+      'sage-col': !size,
       [`sage-col-${size}`]: size,
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,

--- a/packages/sage-react/lib/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/Grid/GridCol.jsx
@@ -17,6 +17,7 @@ export const GridCol = ({
   const classNames = classnames(
     className,
     {
+      [`sage-col`]: !size,
       [`sage-col-${size}`]: size,
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add generic col class when `size` not specified show that row item has a `width`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-03-11 at 2 41 14 PM](https://user-images.githubusercontent.com/1241836/157959797-0b453664-1681-478d-8c00-36a7abf85142.png)|![Screen Shot 2022-03-11 at 2 08 11 PM](https://user-images.githubusercontent.com/1241836/157959834-5d14aa52-668a-4e61-a9bd-309be7d5034f.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
In the react Grid story, remove a `size` from one of the grid columns and verify that the grid doesn't break due to weird wrapping

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds generic grid column for responsive grid


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-332](https://kajabi.atlassian.net/browse/SAGE-332)