### PR TITLE
[SAGE-352] Grid add fixed column width

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.50.3](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@4.50.2...@kajabi/sage@4.50.3) (2022-03-14)
+
+
+### Bug Fixes
+
+* **tabs:** add custom class to choice variation ([42b1eec](https://github.com/Kajabi/sage-lib/commit/42b1eecb7a65762fc5f3961b96599a01b4147503))
+* **tabs:** classname update ([064f332](https://github.com/Kajabi/sage-lib/commit/064f33246c18b06e59b0112c618037fd2ab89ff8))
+
+
+
+
+
 ## [4.50.2](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@4.50.1...@kajabi/sage@4.50.2) (2022-03-09)
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.50.2](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@4.50.1...@kajabi/sage@4.50.2) (2022-03-09)
+
+
+### Bug Fixes
+
+* **icons:** add new names to sage_tokens.rb (rails) ([dcc4427](https://github.com/Kajabi/sage-lib/commit/dcc4427842ab02e5a635e4f7e183801e372abc96))
+
+
+
+
+
 ## [4.50.1](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@4.50.0...@kajabi/sage@4.50.1) (2022-03-07)
 
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (4.50.2)
+    sage_rails (4.50.3)
       classy_hash
       rails
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (4.50.1)
+    sage_rails (4.50.2)
       classy_hash
       rails
 

--- a/docs/app/views/pages/grid.html.erb
+++ b/docs/app/views/pages/grid.html.erb
@@ -76,9 +76,46 @@
   <p>In the example below, each <code>.sage-col</code> example is named with the number of columns it represents. Generally, a single column (<code>.sage-col-1</code>) is too small for content, so <code>.sage-col-2</code> is the smallest width recommended for use.</p>
   <% 1.upto(9) do |num| %>
     <div class="sage-row">
-      <div class="sage-col--md-<%= num + 1%>"><div class="grid-item"><%= num + 1%><span class="visually-hidden"> columns wide</span></div></div>
-      <div class="sage-col--md-<%= 11 - num%>"><div class="grid-item"><%= 11 - num%><span class="visually-hidden"> columns wide</span></div></div>
+      <div class="sage-col-<%= num + 1%>"><div class="grid-item"><%= num + 1%><span class="visually-hidden"> columns wide</span></div></div>
+      <div class="sage-col-<%= 11 - num%>"><div class="grid-item"><%= 11 - num%><span class="visually-hidden"> columns wide</span></div></div>
     </div>
+  <% end %>
+
+  <h3 class="t-sage-heading-5" id="grid-spacing">Variable Width</h3>
+  <p>Doesn't set a width on the column. The width is determined by the width of the children.</p>
+
+  <%= sage_component SageGridRow, {} do %>
+    <%= sage_component(SageGridCol, {
+      variableWidth: true
+    }) do %>
+      <div class="grid-item">
+        Variable Width Container
+      </div>
+    <% end %>
+    <%= sage_component(SageGridCol, {}) do %>
+      <div class="grid-item">
+        Auto Width
+      </div>
+    <% end %>
+  <% end %>
+  <%= sage_component SageGridRow, {} do %>
+    <%= sage_component(SageGridCol, {}) do %>
+      <div class="grid-item">
+        Auto Width
+      </div>
+    <% end %>
+    <%= sage_component(SageGridCol, {
+      variableWidth: true
+    }) do %>
+      <div class="grid-item">
+        Variable Width Container
+      </div>
+    <% end %>
+    <%= sage_component(SageGridCol, {}) do %>
+      <div class="grid-item">
+        Auto Width
+      </div>
+    <% end %>
   <% end %>
 
   <h3 class="t-sage-heading-5" id="grid-spacing">Column spacing</h3>

--- a/docs/app/views/pages/grid.html.erb
+++ b/docs/app/views/pages/grid.html.erb
@@ -81,15 +81,15 @@
     </div>
   <% end %>
 
-  <h3 class="t-sage-heading-5" id="grid-spacing">Variable Width</h3>
+  <h3 class="t-sage-heading-5" id="grid-spacing">Fixed Width</h3>
   <p>Doesn't set a width on the column. The width is determined by the width of the children.</p>
 
   <%= sage_component SageGridRow, {} do %>
     <%= sage_component(SageGridCol, {
-      variableWidth: true
+      fixed_width: true
     }) do %>
       <div class="grid-item">
-        Variable Width Container
+        Fixed Width Container
       </div>
     <% end %>
     <%= sage_component(SageGridCol, {}) do %>
@@ -105,10 +105,10 @@
       </div>
     <% end %>
     <%= sage_component(SageGridCol, {
-      variableWidth: true
+      fixed_width: true
     }) do %>
       <div class="grid-item">
-        Variable Width Container
+        Fixed Width Container
       </div>
     <% end %>
     <%= sage_component(SageGridCol, {}) do %>

--- a/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
@@ -5,6 +5,6 @@ class SageGridCol < SageComponent
     medium: [:optional, String, Integer],
     size: [:optional, String, Integer],
     small: [:optional, String, Integer],
-    variableWidth: [:optional, TrueClass]
+    fixed_width: [:optional, TrueClass]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
@@ -5,5 +5,6 @@ class SageGridCol < SageComponent
     medium: [:optional, String, Integer],
     size: [:optional, String, Integer],
     small: [:optional, String, Integer],
+    variableWidth: [:optional, TrueClass]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
@@ -5,7 +5,7 @@
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
-  <%= "sage-col--auto" if component.variableWidth %>
+  <%= "sage-col--auto" if component.fixed_width %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
@@ -5,6 +5,7 @@
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
+  <%= "sage-col--auto" if component.variableWidth %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>
 </div>

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "4.50.1"
+  VERSION = "4.50.2"
 end

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "4.50.2"
+  VERSION = "4.50.3"
 end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "4.50.1",
+  "version": "4.50.2",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^0.1.114",
+    "@kajabi/sage-packs": "^0.1.115",
     "@rails/webpacker": "5.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "4.50.2",
+  "version": "4.50.3",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^0.1.115",
+    "@kajabi/sage-packs": "^0.1.116",
     "@rails/webpacker": "5.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/packages/sage-assets/CHANGELOG.md
+++ b/packages/sage-assets/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.72.1](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-assets@0.72.0...@kajabi/sage-assets@0.72.1) (2022-03-09)
+
+
+### Bug Fixes
+
+* **icons:** add new unicodes to tokens stylesheet ([8b70289](https://github.com/Kajabi/sage-lib/commit/8b70289715d6fcde40e265a70286cd569f14f49f))
+* **icons:** update CDN version to match new directory ([a97e23b](https://github.com/Kajabi/sage-lib/commit/a97e23b2b6955b8121d79966f2c688e0f9694560))
+
+
+
+
+
 # [0.72.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-assets@0.71.1...@kajabi/sage-assets@0.72.0) (2022-03-07)
 
 

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -100,9 +100,9 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 }
 
 .sage-col {
-  max-width: 100%;
   flex-grow: 1;
   flex-basis: 0;
+  max-width: 100%;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 
@@ -146,6 +146,12 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
       width: percentage($i / $-grid-num-columns);
     }
   }
+
+  .sage-col-sm-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: none;
+  }
 }
 
 @media (max-width: $-grid-breakpoint-sm-max) {
@@ -166,6 +172,12 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   .sage-col--sm-show {
     display: none;
   }
+
+  .sage-col-md-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: none;
+  }
 }
 
 @media (max-width: $-grid-breakpoint-md-max) {
@@ -185,6 +197,12 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
   .sage-col--md-show {
     display: none;
+  }
+
+  .sage-col--lg-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: none;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -98,6 +98,13 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 
+.sage-col {
+  max-width: 100%;
+  flex-grow: 1;
+  flex-basis: 0;
+  padding: 0 calc(#{$-grid-gap} / 2);
+}
+
 @for $i from 1 through $-grid-num-columns {
   .sage-col-#{$i},
   .sage-col--sm-#{$i},

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -87,6 +87,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
 @mixin sage-col {
   flex: 0 0 100%;
+  width: 100%;
   max-width: 100%;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
@@ -102,6 +103,13 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   max-width: 100%;
   flex-grow: 1;
   flex-basis: 0;
+  padding: 0 calc(#{$-grid-gap} / 2);
+}
+
+.sage-col--auto {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: none;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 

--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-assets",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Assets",
   "main": "dist/main.css",
   "repository": {

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.115](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.1.114...@kajabi/sage-packs@0.1.115) (2022-03-09)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [0.1.114](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.1.113...@kajabi/sage-packs@0.1.114) (2022-03-07)
 
 

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.116](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.1.115...@kajabi/sage-packs@0.1.116) (2022-03-14)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [0.1.115](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@0.1.114...@kajabi/sage-packs@0.1.115) (2022-03-09)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -32,8 +32,8 @@
     "url": "https://github.com/Kajabi/sage-lib/issues"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^0.72.0",
-    "@kajabi/sage-react": "^0.83.1",
+    "@kajabi/sage-assets": "^0.72.1",
+    "@kajabi/sage-react": "^0.83.2",
     "@kajabi/sage-system": "^0.18.1"
   },
   "devDependencies": {

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@kajabi/sage-assets": "^0.72.1",
-    "@kajabi/sage-react": "^0.83.2",
+    "@kajabi/sage-react": "^0.83.3",
     "@kajabi/sage-system": "^0.18.1"
   },
   "devDependencies": {

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.83.2](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.83.1...@kajabi/sage-react@0.83.2) (2022-03-09)
+
+
+### Bug Fixes
+
+* **icons:** add new names to icons.js (react) ([87ae0e4](https://github.com/Kajabi/sage-lib/commit/87ae0e4b1c124c0d8c7bd02cb103062e6487005e))
+
+
+
+
+
 ## [0.83.1](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.83.0...@kajabi/sage-react@0.83.1) (2022-03-07)
 
 

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.83.3](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.83.2...@kajabi/sage-react@0.83.3) (2022-03-14)
+
+
+### Bug Fixes
+
+* **grid:** update react props to resolve error ([698dc71](https://github.com/Kajabi/sage-lib/commit/698dc71812932d84b87d0cb6193e1f15ae89bb45))
+* **progress-bar:** add progress bar to react ([072d6cf](https://github.com/Kajabi/sage-lib/commit/072d6cf8a623dc0939a34bace19dcd97e4b67be7))
+* **progress-bar:** add spec ([586b509](https://github.com/Kajabi/sage-lib/commit/586b509a7ac05d1383110505ba74d37692a43d88))
+* **progress-bar:** typo ([7b08a76](https://github.com/Kajabi/sage-lib/commit/7b08a76230fb737654cb322628bceac52fb4fcd8))
+* **progress-bar:** updates to react progress bar ([add07d7](https://github.com/Kajabi/sage-lib/commit/add07d703ec030bbed7c1ca2d7f2ec04b04bd209))
+* **progress-bar:** updates to react side ([db4ea2a](https://github.com/Kajabi/sage-lib/commit/db4ea2ac961c02fc375777358b6531339f32a2c6))
+* **tabs:** add custom class to choice variation ([42b1eec](https://github.com/Kajabi/sage-lib/commit/42b1eecb7a65762fc5f3961b96599a01b4147503))
+* **tabs:** updates to custom class ([10cf870](https://github.com/Kajabi/sage-lib/commit/10cf870463376dea40ea6a6447f7be6b745cf8c7))
+
+
+
+
+
 ## [0.83.2](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@0.83.1...@kajabi/sage-react@0.83.2) (2022-03-09)
 
 

--- a/packages/sage-react/lib/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/Grid/Grid.story.jsx
@@ -147,3 +147,28 @@ Containers.args = {
     </>
   )
 };
+
+export const VariableWidth = Template.bind({});
+VariableWidth.args = {
+  children: (
+    <>
+      <Grid.Row>
+        <Grid.Col>
+          <GridDemo>
+            Auto width
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col variableWidth={true}>
+          <GridDemo>
+            Variable Width Container
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col>
+          <GridDemo>
+            Auto width
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};

--- a/packages/sage-react/lib/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/Grid/Grid.story.jsx
@@ -148,8 +148,8 @@ Containers.args = {
   )
 };
 
-export const VariableWidth = Template.bind({});
-VariableWidth.args = {
+export const fixedWidth = Template.bind({});
+fixedWidth.args = {
   children: (
     <>
       <Grid.Row>
@@ -158,9 +158,9 @@ VariableWidth.args = {
             Auto width
           </GridDemo>
         </Grid.Col>
-        <Grid.Col variableWidth={true}>
+        <Grid.Col fixedWidth={true}>
           <GridDemo>
-            Variable Width Container
+            Fixed Width Container
           </GridDemo>
         </Grid.Col>
         <Grid.Col>

--- a/packages/sage-react/lib/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/Grid/GridCol.jsx
@@ -12,14 +12,14 @@ export const GridCol = ({
   sageType,
   size,
   small,
-  variableWidth,
+  fixedWidth,
   ...rest
 }) => {
   const classNames = classnames(
     className,
     {
-      'sage-col--auto': variableWidth,
-      'sage-col': !size && !variableWidth,
+      'sage-col--auto': fixedWidth,
+      'sage-col': !size && !fixedWidth,
       [`sage-col-${size}`]: size,
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,
@@ -43,7 +43,7 @@ GridCol.defaultProps = {
   sageType: false,
   small: null,
   size: null,
-  variableWidth: null
+  fixedWidth: null
 };
 
 GridCol.propTypes = {
@@ -54,5 +54,5 @@ GridCol.propTypes = {
   large: validBreakpoint,
   sageType: PropTypes.bool,
   size: validNumberWithinGrid,
-  variableWidth: PropTypes.string
+  fixedWidth: PropTypes.string
 };

--- a/packages/sage-react/lib/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/Grid/GridCol.jsx
@@ -12,12 +12,14 @@ export const GridCol = ({
   sageType,
   size,
   small,
+  variableWidth,
   ...rest
 }) => {
   const classNames = classnames(
     className,
     {
-      'sage-col': !size,
+      'sage-col--auto': variableWidth,
+      'sage-col': !size && !variableWidth,
       [`sage-col-${size}`]: size,
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,
@@ -41,6 +43,7 @@ GridCol.defaultProps = {
   sageType: false,
   small: null,
   size: null,
+  variableWidth: null
 };
 
 GridCol.propTypes = {
@@ -50,5 +53,6 @@ GridCol.propTypes = {
   medium: validBreakpoint,
   large: validBreakpoint,
   sageType: PropTypes.bool,
-  size: validNumberWithinGrid
+  size: validNumberWithinGrid,
+  variableWidth: PropTypes.string
 };

--- a/packages/sage-react/lib/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/Grid/GridCol.jsx
@@ -54,5 +54,5 @@ GridCol.propTypes = {
   large: validBreakpoint,
   sageType: PropTypes.bool,
   size: validNumberWithinGrid,
-  fixedWidth: PropTypes.string
+  fixedWidth: PropTypes.bool
 };

--- a/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
+++ b/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
@@ -5,6 +5,8 @@ import {
   Modal,
   SageTokens,
 } from '../../..';
+import { ProgressBar } from '../../../ProgressBar';
+import { GRID_BREAKPOINT_TOGGLES } from '../../../Grid/configs';
 import {
   CoachingAppearance,
   CoachingBooking,
@@ -98,12 +100,13 @@ export const Root = () => {
               Close
             </Button>
           )}
-        >
-          {/*
-            TODO: Need to determine what/how the "progress bar" can be added here
-            https://kajabi.atlassian.net/browse/SAGE-328
-          */}
-        </Modal.Header>
+          headerProgressBar={(
+            <ProgressBar
+              label="Cloning product"
+              percent="44"
+            />
+          )}
+        />
         <Modal.Body>
           {/*
             TODO: Need to allow column panel to fill space
@@ -111,10 +114,12 @@ export const Root = () => {
             https://kajabi.atlassian.net/browse/SAGE-329
           */}
           <Grid.Row>
-            <Grid.Col size={4} small={12} medium={5} large={4}>
-              {renderStep()}
+            <Grid.Col className="sage-col-sm-auto">
+              <div style={{ width: '540px' }}>
+                {renderStep()}
+              </div>
             </Grid.Col>
-            <Grid.Col fixedWidth={true}>
+            <Grid.Col small={GRID_BREAKPOINT_TOGGLES.HIDE}>
               {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
               <img
                 src="//source.unsplash.com/random/832x575"

--- a/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
+++ b/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
@@ -114,7 +114,7 @@ export const Root = () => {
             <Grid.Col size={4} small={12} medium={5} large={4}>
               {renderStep()}
             </Grid.Col>
-            <Grid.Col variableWidth='225px'>
+            <Grid.Col variableWidth="225px">
               {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
               <img
                 src="//source.unsplash.com/random/832x575"

--- a/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
+++ b/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
@@ -114,7 +114,7 @@ export const Root = () => {
             <Grid.Col size={4} small={12} medium={5} large={4}>
               {renderStep()}
             </Grid.Col>
-            <Grid.Col variableWidth="225px">
+            <Grid.Col fixedWidth={true}>
               {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
               <img
                 src="//source.unsplash.com/random/832x575"

--- a/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
+++ b/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
@@ -114,7 +114,7 @@ export const Root = () => {
             <Grid.Col size={4} small={12} medium={5} large={4}>
               {renderStep()}
             </Grid.Col>
-            <Grid.Col size={8} small={0} medium={7} large={8}>
+            <Grid.Col variableWidth='225px'>
               {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
               <img
                 src="//source.unsplash.com/random/832x575"

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "description": "React Components",
   "keywords": [
     "react",
@@ -81,7 +81,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^0.72.0",
+    "@kajabi/sage-assets": "^0.72.1",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "focus-trap": "^6.2.2",

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "description": "React Components",
   "keywords": [
     "react",


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add ability for the Grid to have a fixed width column. The parent grid should allow for the natural width of the children to determine the width

## Screenshots

![variableWidth](https://user-images.githubusercontent.com/1241836/158205648-454ec296-9e1b-4e17-bffd-8906ef9f7bb0.gif)

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Go the Grid views and resize the browser to verify that `Variable Width` variation works as expected:
- [Rails](http://localhost:4000/pages/patterns/grid)
- [React](http://localhost:4100/?path=/story/sage-grid--fixed-width)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds new `Grid` property. Has no affect in the app


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-352](https://kajabi.atlassian.net/browse/SAGE-352)