### PR TITLE
[SAGE-379]:  Page Heading Image & Intro Text Support (React)

### DIFF
--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -7,6 +7,7 @@ import { Breadcrumbs } from '../Breadcrumbs';
 export const PageHeading = ({
   className,
   children,
+  image,
   breadcrumbs,
   actionItems,
   toolbarItems,
@@ -17,7 +18,10 @@ export const PageHeading = ({
     className={classnames(
       'sage-page-heading',
       className,
-      { 'sage-page-heading--no-secondary-text': !secondaryText }
+      {
+        'sage-page-heading--no-secondary-text': !secondaryText,
+        'sage-page-heading--has-image': image.src,
+      }
     )}
     {...rest}
   >
@@ -29,6 +33,11 @@ export const PageHeading = ({
     <h1 className="sage-page-heading__title">
       {children}
     </h1>
+    {image.src && (
+      <div className="sage-page-heading__image">
+        <img alt={image.alt || ''} src={image.src} />
+      </div>
+    )}
     {toolbarItems && (
       <div className="sage-page-heading__toolbar">
         {toolbarItems.map((tool) => <React.Fragment key={uuid()}>{tool}</React.Fragment>)}
@@ -49,6 +58,7 @@ export const PageHeading = ({
 
 PageHeading.defaultProps = {
   className: '',
+  image: {},
   actionItems: null,
   toolbarItems: null,
   breadcrumbs: null,
@@ -57,6 +67,10 @@ PageHeading.defaultProps = {
 
 PageHeading.propTypes = {
   className: PropTypes.string,
+  image: PropTypes.shape({
+    alt: PropTypes.string,
+    src: PropTypes.string,
+  }),
   children: PropTypes.node.isRequired,
   actionItems: PropTypes.arrayOf(PropTypes.node),
   toolbarItems: PropTypes.arrayOf(PropTypes.node),

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -12,6 +12,7 @@ export const PageHeading = ({
   actionItems,
   toolbarItems,
   secondaryText,
+  introText,
   ...rest
 }) => (
   <div
@@ -28,6 +29,11 @@ export const PageHeading = ({
     {breadcrumbs && (
       <div className="sage-page-heading__crumbs">
         <Breadcrumbs items={breadcrumbs} className="sage-page-heading__back" />
+      </div>
+    )}
+    {introText && (
+      <div className="sage-page-heading__intro">
+        <p>{introText}</p>
       </div>
     )}
     <h1 className="sage-page-heading__title">
@@ -62,6 +68,7 @@ PageHeading.defaultProps = {
   actionItems: null,
   toolbarItems: null,
   breadcrumbs: null,
+  introText: null,
   secondaryText: null,
 };
 
@@ -75,5 +82,6 @@ PageHeading.propTypes = {
   actionItems: PropTypes.arrayOf(PropTypes.node),
   toolbarItems: PropTypes.arrayOf(PropTypes.node),
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
+  introText: PropTypes.string,
   secondaryText: PropTypes.string,
 };

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -20,7 +20,11 @@ export default {
     ],
     actionItems: null,
     secondaryText: 'Secondary text here',
-    toolbarItems: null
+    toolbarItems: null,
+    image: {
+      src: "https://via.placeholder.com/132x74",
+      alt: "Page heading demo image"
+    },
   }
 };
 const Template = (args) => <PageHeading {...args} />;

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -22,8 +22,8 @@ export default {
     secondaryText: 'Secondary text here',
     toolbarItems: null,
     image: {
-      src: "https://via.placeholder.com/132x74",
-      alt: "Page heading demo image"
+      src: 'https://via.placeholder.com/132x74',
+      alt: 'Page heading demo image'
     },
   }
 };


### PR DESCRIPTION
## Description
Adds the following missing sections to the react page heading:

- Image
- Intro Text

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Image  |  Intro Text  |
|--------|--------|
|![Screen Shot 2022-03-18 at 2 07 43 PM](https://user-images.githubusercontent.com/1175111/159083455-70eccf5c-6c28-4703-9657-36917ad399bb.png)|![Screen Shot 2022-03-18 at 2 07 43 PM copy](https://user-images.githubusercontent.com/1175111/159083494-c8ebaca8-f233-4751-8c81-14a535b6f36d.png)|


## Testing in `sage-lib`
- Navigate to http://localhost:4100/?path=/story/sage-pageheading--default
- Add image `src` and `alt` - verify the image is displayed.
- Add intro text - verify text displays

## Testing in `kajabi-products`
1. (**LOW**) Adds image and intro text to react page heading. No expected effect in kp.

## Related
https://kajabi.atlassian.net/browse/SAGE-379