### PR TITLE
[SAGE-381] fix responsive hide show classes in React

### DIFF
--- a/packages/sage-react/lib/Grid/Grid.jsx
+++ b/packages/sage-react/lib/Grid/Grid.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { GridCol } from './GridCol';
 import { GridRow } from './GridRow';
-import { CONTAINER_SIZES } from './configs';
+import { CONTAINER_SIZES, GRID_BREAKPOINT_TOGGLES } from './configs';
 
 export const Grid = ({
   children,
@@ -51,6 +51,7 @@ export const Grid = ({
 Grid.Row = GridRow;
 Grid.Col = GridCol;
 Grid.CONTAINER_SIZES = CONTAINER_SIZES;
+Grid.GRID_BREAKPOINT_TOGGLES = GRID_BREAKPOINT_TOGGLES;
 
 Grid.defaultProps = {
   children: null,

--- a/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
+++ b/packages/sage-react/lib/mocks/product-creation-wizard/components/Root.jsx
@@ -114,7 +114,7 @@ export const Root = () => {
             <Grid.Col size={4} small={12} medium={5} large={4}>
               {renderStep()}
             </Grid.Col>
-            <Grid.Col size={8} small={0} medium={7} large={8}>
+            <Grid.Col size={8} small={Grid.GRID_BREAKPOINT_TOGGLES.HIDE} medium={7} large={8}>
               {/* TODO: Dev to add actual graphic SVG here  with live edit synced */}
               <img
                 src="//source.unsplash.com/random/832x575"


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] fix responsive hide show classes in React

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1155" alt="Screen_Shot_2022-03-21_at_12_40_21_PM" src="https://user-images.githubusercontent.com/1241836/159332809-83d16a1b-040f-4297-92d3-e85ccc855671.png">|<img width="1239" alt="Screen_Shot_2022-03-21_at_12_40_48_PM" src="https://user-images.githubusercontent.com/1241836/159332851-7c836cbf-95a8-47f6-bde9-f71bc67d07cd.png">|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Creation Wizard React page and verify that the mobile class `.sage-col--sm-hide` is visible

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds new grid classes. Has no affect in the app.
   - [ ] Creation Wizard


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [#381](https://kajabi.atlassian.net/browse/SAGE-381)