### PR TITLE
[Sage-291] Modal - Foundations Update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -5,8 +5,8 @@
 ////
 
 
-$-modal-padding-x: sage-spacing(md);
-$-modal-padding-y: sage-spacing(md);
+$-modal-padding-x: rem(36px);
+$-modal-padding-y: rem(36px);
 $-modal-margin-lg: 6vh;
 $-modal-margin-xl: 8vh;
 $-modal-header-image-size: rem(28px);

--- a/packages/sage-assets/lib/stylesheets/tokens/_shadow.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_shadow.scss
@@ -12,7 +12,7 @@ $sage-shadows: (
   sm: (0 2px 4px rgba(sage-color(black), 0.12), 0 0 2px rgba(sage-color(black), 0.08)),
   md: (0 8px 14px rgba(sage-color(black), 0.16), 0 0 4px rgba(sage-color(black), 0.08)),
   lg: (0 8px 40px rgba(sage-color(black), 0.24)),
-  modal: (0 8px 40px rgba(sage-color(black), 0.2), 0 0 4px rgba(sage-color(black), 0.1)),
+  modal: (0 8px 40px rgba(sage-color(black), 0.24), 0 0 4px rgba(sage-color(black), 0.1)),
 );
 
 ///


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates Modal component:
- Updates content margins to `36px`
- Updates `box-shadow` token for modals

### Implementation Updates
N/A

### Follow-Up Items
N/A


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="608" alt="Screen Shot 2022-03-22 at 2 24 16 PM" src="https://user-images.githubusercontent.com/14791307/159559681-528f0851-2fcf-4e8f-a901-51f60370680f.png">|<img width="627" alt="Screen Shot 2022-03-22 at 1 27 14 PM" src="https://user-images.githubusercontent.com/14791307/159559701-f73c030e-e595-4696-9e65-04be3ac5457c.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- Navigate to [Modal](http://localhost:4000/pages/component/modal) component
- Check that it matches Figma specs

### React
- Navigate to [Modal](http://localhost:4100/?path=/docs/sage-modal--default) component
- Check that it matches Figma specs

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates Modal component to match Figma design specs. No effect on Kajabi Products.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-291](https://kajabi.atlassian.net/browse/SAGE-291)