### PR TITLE
fix(grid): add width property along side max-width

### DIFF
--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -87,6 +87,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
 @mixin sage-col {
   flex: 0 0 100%;
+  width: 100%;
   max-width: 100%;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
@@ -94,6 +95,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 .sage-col {
   flex-grow: 1;
   flex-basis: 0;
+  width: 100%;
   max-width: 100%;
   padding: 0 calc(#{$-grid-gap} / 2);
 }
@@ -120,6 +122,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
   .sage-col-#{$i} {
     flex: 0 0 percentage($i / $-grid-num-columns);
+    width: percentage($i / $-grid-num-columns);
     max-width: percentage($i / $-grid-num-columns);
   }
 }
@@ -129,6 +132,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
     .sage-col--sm-#{$i} {
       flex: 0 1 auto;
       width: percentage($i / $-grid-num-columns);
+      max-width: percentage($i / $-grid-num-columns);
     }
   }
 }
@@ -144,6 +148,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   @for $i from 1 through $-grid-num-columns {
     .sage-col--md-#{$i} {
       flex: 0 0 auto;
+      width: percentage($i / $-grid-num-columns);
       max-width: percentage($i / $-grid-num-columns);
     }
   }
@@ -165,6 +170,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
     .sage-col--lg-#{$i} {
       flex: 0 1 auto;
       width: percentage($i / $-grid-num-columns);
+      max-width: percentage($i / $-grid-num-columns);
     }
   }
 


### PR DESCRIPTION
## Description

Grid columns are breaking width when a single item is used in a row

## Screenshots

### Icon grid
|  Before  |  After  |
|--------|--------|
| ![before-icons](https://user-images.githubusercontent.com/24237393/159520436-097392cd-8d89-4950-ba6d-6fe8e931d45b.png) | ![after-icons](https://user-images.githubusercontent.com/24237393/159520495-17511346-ced1-4e7c-9ac8-6f8762fff787.png) |


### KP Pages - Landing
|  Before  |  After  |
|--------|--------|
| ![before-landing](https://user-images.githubusercontent.com/24237393/159520588-2b809f77-0597-4ee8-9663-967060389d9a.png) | ![after-landing](https://user-images.githubusercontent.com/24237393/159520653-a34b1b73-6688-4d20-9f53-deb62cb16abb.png) |

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`

1. (**MEDIUM**) Modified grid width property to fix incorrect single column item not fitting set size
   - [ ] Verify in Websites / Pages / Landing / New Landing Page


## Related
[SAGE-382](https://kajabi.atlassian.net/browse/SAGE-382)
