### PR TITLE
[Sage-363] Link - Spot Check Updates

### DIFF
--- a/docs/app/views/examples/components/panel/_preview.html.erb
+++ b/docs/app/views/examples/components/panel/_preview.html.erb
@@ -229,7 +229,7 @@ Panels are rich containers that allow for grouping and organizing content detail
 <% end %>
 
 <%= sage_component SagePanelHeader, { title: "Panel Figure <code>.sage-panel__figure</code>".html_safe } %>
-<%= md("A Panel Figure contains an image that occupies a substantive space in the panel, typically filling edge to edge.See the #{link_to("Panel Figure component", pages_component_path("panel_figure"))} for more details.", use_sage_type: true) %>
+<%= md("A Panel Figure contains an image that occupies a substantive space in the panel, typically filling edge to edge.See the #{link_to("Panel Figure component", pages_component_path("panel_figure"), class: "sage-link")} for more details.", use_sage_type: true) %>
 
 <%= sage_component SagePanelHeader, { title: "Panel Grid Utility <code>.sage-panel-grid</code>".html_safe } %>
 <%= md("The `.sage-panel-grid` utility class can be added onto containers in order to enforce the Panel's internal grid settings.This is helpful in cases where a container of some sort is needed around contents but those contents should still recieve the standard Panel-scoped gaps.", use_sage_type: true) %>

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -16,7 +16,6 @@ $-link-subtext-color-hover: sage-color(grey, 800);
   position: relative;
   max-width: 100%;
   min-width: 0; /* the is needed so that truncation work when the link doesn't have an explicit width set  */
-  color: $-link-color;
 
   &:hover {
     color: $-link-color-hover;

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -4,6 +4,10 @@
 /// @group sage
 ////
 
+$-link-color: sage-color(primary, 500);
+$-link-color-hover: sage-color(primary, 700);
+$-link-subtext-color: sage-color(grey, 600);
+$-link-subtext-color-hover: sage-color(grey, 800);
 
 .sage-link {
   @extend %t-sage-body-med;
@@ -12,15 +16,14 @@
   position: relative;
   max-width: 100%;
   min-width: 0; /* the is needed so that truncation work when the link doesn't have an explicit width set  */
-  text-decoration: underline;
+  color: $-link-color;
 
   &:hover {
-    color: sage-color(primary, 700);
-    text-decoration: underline;
+    color: $-link-color-hover;
   }
 
   &:focus {
-    color: sage-color(primary, 300);
+    color: $-link-color;
   }
 
   @include sage-focus-outline(
@@ -77,7 +80,7 @@
 
 .sage-link--help-icon-only {
   @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 2px);
-  @include sage-focus-outline--update-color(sage-color(primary, 500));
+  @include sage-focus-outline--update-color($-link-color);
 }
 
 .sage-link--subtext {
@@ -86,17 +89,16 @@
   display: inline-block;
   position: relative;
   padding: 0 sage-spacing(2xs);
-  color: sage-color(grey, 600);
-  text-decoration: underline;
+  color: $-link-subtext-color;
   border-radius: sage-border(radius-small);
 
   &:hover {
-    color: sage-color(grey, 800);
+    color: $-link-subtext-color-hover;
     text-decoration: underline;
   }
 
   &:focus {
-    color: sage-color(grey, 800);
+    color: $-link-subtext-color-hover;
     text-decoration: none;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -16,9 +16,8 @@ $-table-max-width: none;
 // Text
 $-table-caption-font-size: "%t-sage-body-small";
 $-table-caption-alignment: center;
-$-table-cell-font-color: sage-color(grey, 600);
+$-table-cell-font-color: sage-color(grey, 800);
 $-table-cell-type-spec: "%t-sage-body";
-$-table-cell-font-color-strong: sage-color(grey, 800);
 $-table-cell-type-spec-strong: "%t-sage-body-med";
 $-table-heading-font-color: sage-color(grey, 900);
 $-table-heading-type-spec: "%t-sage-heading-6";
@@ -110,7 +109,7 @@ $-table-avatar-width: rem(32px);
     &.sage-table-cell--strong {
       @extend #{$-table-cell-type-spec-strong};
 
-      color: $-table-cell-font-color-strong;
+      color: $-table-cell-font-color;
     }
   }
 
@@ -352,7 +351,7 @@ $-table-avatar-width: rem(32px);
 }
 
 .sage-table-cell__link {
-  color: inherit;
+color: $-table-cell-font-color;
 
   &:focus,
   &:active {

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -351,7 +351,7 @@ $-table-avatar-width: rem(32px);
 }
 
 .sage-table-cell__link {
-color: $-table-cell-font-color;
+  color: $-table-cell-font-color;
 
   &:focus,
   &:active {

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -135,7 +135,6 @@ body:not(.sage-excluded),
   > a:not([class]),
   > a[class*="sage-link"] {
     color: sage-color(primary, 500);
-    text-decoration: underline;
 
     &:hover {
       color: sage-color(primary, 700);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Removes underline from Link component and fixes links in tables and panels.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="282" alt="Screen Shot 2022-03-24 at 9 35 49 AM" src="https://user-images.githubusercontent.com/14791307/159940345-ee7ab394-8f35-4f78-bb1f-eb2429f9cf73.png">|<img width="282" alt="Screen Shot 2022-03-24 at 9 34 50 AM" src="https://user-images.githubusercontent.com/14791307/159941122-8c29989c-427c-4424-972b-0c691e57fce1.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- Navigate to [Link](http://localhost:4000/pages/component/link) component
- Check that it matches Figma specs

### React
- Navigate to [Link](http://localhost:4100/?path=/docs/sage-link--primary) component
- Check that it matches Figma specs

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Removes underline from Link component and fixes links in tables and panels.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-363](https://kajabi.atlassian.net/browse/SAGE-363)