### PR TITLE
[SAGE-405] Nav icon active style

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -18,7 +18,7 @@ $-nav-icon-size: rem(20px);
   color: sage-color(charcoal, 200);
 
   .sage-nav__link--active & {
-    color: sage-color(primary);
+    color: inherit;
   }
 }
 


### PR DESCRIPTION
## Description
Updates sidebar/nav icon to match [current Figma comp](https://www.figma.com/file/9Km09NjlZHYWsMP7EGT8tI/Sage-3-for-Admin?node-id=6999%3A22305). Icons will inherit color values from the parent link.

Impacts work in [SAGE-272](https://github.com/Kajabi/kajabi-products/pull/22475).


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/159987003-cd578433-52a0-44a7-b38b-de0bbcd2ed19.png)|![after](https://user-images.githubusercontent.com/816579/159987026-cd5d1ede-f7e0-4019-8f76-c08678aeb3ec.png)|


With Sage bridge on
|  Before   |  After  |
|--------|--------|
|![before](https://user-images.githubusercontent.com/816579/159992194-2e12673c-0e50-417d-8e62-b21175baec02.png)|![after](https://user-images.githubusercontent.com/816579/159992217-3765f4e4-bb3e-4e15-8701-0c0763cd6a11.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Sidebar/nav: Active link icons updated to match parent link's text color
   - [ ] No expected change. Sage sidebar with icons are not in use within the app, and a single mention of `sage-nav__icon` overrides component styling: `app/assets/stylesheets/page_specific/_coaching.scss`


## Related
- closes SAGE-405
- [SAGE-272](https://github.com/Kajabi/kajabi-products/pull/22475)
