### PR TITLE
Patch dropdown border style within toolbar__group 

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -156,7 +156,8 @@ $-btn-loading-min-height: rem(36px);
   .sage-panel-controls__tabs-dropdown .sage-dropdown__trigger &,
   .sage-panel-controls__toolbar .sage-dropdown__trigger &,
   .sage-panel-controls__bulk-actions .sage-dropdown__trigger &,
-  .sage-toolbar .sage-dropdown__trigger & {
+  .sage-toolbar .sage-dropdown__trigger &,
+  .sage-toolbar__group .sage-dropdown__trigger & {
     @include sage-focus-outline--update-color(transparent);
 
     width: inherit;
@@ -304,7 +305,8 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group > &,
-  .sage-toolbar__group > & {
+  .sage-toolbar__group > &,
+  .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
     border-radius: 0;
 
     &:first-child {


### PR DESCRIPTION
## Description

Select Dropdowns are not catching the correct border styles when placed within the `.sage-toolbar__group`. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| <img width="349" alt="Screen Shot 2022-03-24 at 2 44 10 PM" src="https://user-images.githubusercontent.com/17955295/159988237-543f2a70-2c86-4f51-b13a-8b7654bd5500.png"> | ![Screen Shot 2022-03-24 at 2 14 40 PM](https://user-images.githubusercontent.com/17955295/159988050-809d3b78-3cc6-4229-987c-35df0d31e23f.png) |

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`

1. (**LOW**) Small style bug fix for select dropdown within toolbar group


## Related

https://github.com/Kajabi/kajabi-products/pull/22877