### PR TITLE
Next Version Bump ~4.52.0

### DIFF
--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -81,8 +81,12 @@ custom_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Menu Button with Custom Panel Width</h3>
-<%= sage_component SageDropdown, { panel_width: "512px", items: menu_items } do %>
+<h3 class="t-sage-heading-6">Menu Button with Custom Trigger width and Custom Panel Width</h3>
+<%= sage_component SageDropdown, {
+  panel_width: "512px",
+  items: menu_items,
+  trigger: { width: "240px" },
+} do %>
   <% content_for :sage_dropdown_trigger, flush: true do %>
     <%= sage_component SageButton, {
       style: "primary",

--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -221,4 +221,10 @@
     <td><%= md('String') %></td>
     <td><%= md('`""`') %></td>
   </tr>
+  <tr>
+    <td><%= md('`width`') %></td>
+    <td><%= md('Sets a custom width for the trigger.') %></td>
+    <td><%= md('String') %></td>
+    <td><%= md('`nil`') %></td>
+  </tr>
 </tbody>

--- a/docs/app/views/examples/components/search/_preview.html.erb
+++ b/docs/app/views/examples/components/search/_preview.html.erb
@@ -11,6 +11,7 @@
   id: "search-2",
   placeholder: "Search Products",
   value: nil,
+  disabled: true,
   contained: true,
   label_text: "Search"
 } %>

--- a/docs/app/views/examples/components/toolbar/_preview.html.erb
+++ b/docs/app/views/examples/components/toolbar/_preview.html.erb
@@ -1,6 +1,5 @@
 <%
 dropdown_configs = {
-  icon: { style: "right", name: "caret-down" },
   items: [
     {
       selected: true,
@@ -43,7 +42,11 @@ dropdown_configs = {
       modifiers: ["disabled"]
     }
   ],
-  trigger_type: "select",
+  trigger: {
+    type: "select",
+    label: "Add an Element",
+    value: "",
+  },
 }
 %>
 
@@ -78,16 +81,7 @@ dropdown_configs = {
     value: "Edit",
   } %>
 
-  <%= sage_component SageDropdown, dropdown_configs do %>
-    <%= sage_component SageButton, {
-      css_classes: "sage-dropdown__trigger-selected-value",
-      icon: { style: "right", name: "caret-down" },
-      raised: false,
-      style: "secondary",
-      value: "",
-    } %>
-    <label class="sage-dropdown__trigger-label">Add an Element</label>
-  <% end %>
+  <%= sage_component SageDropdown, dropdown_configs %>
 
   <p>Plain text</p>
 
@@ -99,16 +93,8 @@ dropdown_configs = {
       contained: true,
       label_text: "Search",
     } %>
-    <%= sage_component SageDropdown, dropdown_configs do %>
-      <%= sage_component SageButton, {
-        css_classes: "sage-dropdown__trigger-selected-value",
-        icon: { style: "right", name: "caret-down" },
-        raised: false,
-        style: "secondary",
-        value: "",
-      } %>
-      <label class="sage-dropdown__trigger-label">Add an Element</label>
-    <% end %>
+
+    <%= sage_component SageDropdown, dropdown_configs %>
 
     <%= sage_component SageButton, {
       value: "Edit",

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -89,6 +89,7 @@ module SageSchemas
     label: [:optional, NilClass, String],
     type: DROPDOWN_TRIGGER_TYPE,
     value: [:optional, NilClass, String],
+    width: [:optional, NilClass, String],
   }
 
   DROPDOWN = {
@@ -104,7 +105,7 @@ module SageSchemas
     panel_type: [:optional, NilClass, Set.new(["custom", "dropdown", "choice", "checkbox", "status", "searchable"])],
     search: [:optional, NilClass, TrueClass],
     trigger: [:optional, NilClass, DROPDOWN_TRIGGER],
-    trigger_type: [:optional, NilClass, Set.new(["select", "select-labeled"])],
+    trigger_type: DROPDOWN_TRIGGER_TYPE,
     wrap_footer: [:optional, NilClass, TrueClass],
   }
 

--- a/docs/lib/sage_rails/app/sage_components/sage_search.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_search.rb
@@ -1,6 +1,7 @@
 class SageSearch < SageComponent
   set_attribute_schema({
     contained: [:optional, TrueClass],
+    disabled: [:optional, TrueClass],
     id: [:optional, String],
     label_text: [:optional, String],
     placeholder: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -1,6 +1,5 @@
 <%
-trigger_type = component.trigger_type.present? ? component.trigger_type : nil
-trigger_configs = component.trigger.present? ? component.trigger : { type: trigger_type }
+trigger_configs = component.trigger.present? ? component.trigger : {}
 %>
 <div
   class="sage-dropdown
@@ -20,13 +19,9 @@ trigger_configs = component.trigger.present? ? component.trigger : { type: trigg
 >
   <div aria-hidden="true" class="sage-dropdown__screen"></div>
 
-  <% if component.trigger.present? %>
-    <%= sage_component SageDropdownTrigger, trigger_configs do %>
-      <%= component.content %>
-    <% end %>
-  <% elsif content_for? :sage_dropdown_trigger %>
-    <%= sage_component SageDropdownTrigger, trigger_configs do %>
-      <%= content_for :sage_dropdown_trigger %>
+  <% if component.trigger.present? || content_for?(:sage_dropdown_trigger) %>
+    <%= sage_component SageDropdownTrigger, component.trigger.present? ? component.trigger : {} do %>
+      <%= content_for :sage_dropdown_trigger if content_for? :sage_dropdown_trigger %>
     <% end %>
   <% end %>
 
@@ -35,7 +30,7 @@ trigger_configs = component.trigger.present? ? component.trigger : { type: trigg
   Then adjust so that `content` can instead be used for panel contents.
   %>
   <% if component.content.present? %>
-    <%= sage_component SageDropdownTrigger, trigger_configs do %>
+    <%= sage_component SageDropdownTrigger, {} do %>
       <%= component.content %>
     <% end %>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown_trigger.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown_trigger.html.erb
@@ -3,13 +3,15 @@
   class="
     sage-dropdown__trigger
     <%= "sage-dropdown__trigger--#{component.type}" if component.type.present? %>
+    <%= "sage-dropdown__trigger--custom-width" if component.width.present? %>
     <%= component.generated_css_classes %>
   "
+  <% if component.width.present? %>
+    style="--sage-dropdown-trigger-width: <%= component.width %>"
+  <% end %>
   <%= component.generated_html_attributes %>
 >
-  <% if component.content.present? %>
-    <%= component.content %>
-  <% elsif component.type.present? && component.type == "select" %>
+  <% if component.type.present? && component.type == "select" %>
     <%= sage_component SageButton, {
       style: "secondary",
       raised: false,
@@ -20,5 +22,7 @@
     <label class="sage-dropdown__trigger-label">
       <%= component.label %>
     </label>
+  <% elsif component.content.present? %>
+    <%= component.content %>
   <% end %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_search.html.erb
@@ -14,6 +14,7 @@
     <%# Prevents the default Kajabi-Products Search.js from binding to this input %>
     data-kjb-disable-search
     type="search"
+    <%= "disabled" if component.disabled %>
     placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
     value="<%= component.value %>"
   />

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -204,6 +204,10 @@ $-btn-loading-min-height: rem(36px);
     line-height: sage-line-height(body);
   }
 
+  .sage-dropdown__trigger--custom-width > & {
+    width: 100%;
+  }
+
   .sage-dropdown__trigger--select & {
     font-weight: sage-font-weight(regular);
   }
@@ -305,8 +309,7 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group > &,
-  .sage-toolbar__group > &,
-  .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
+  .sage-toolbar__group > & {
     border-radius: 0;
 
     &:first-child {
@@ -318,6 +321,20 @@ $-btn-loading-min-height: rem(36px);
       border-top-right-radius: sage-border(radius);
       border-bottom-right-radius: sage-border(radius);
     }
+  }
+
+  .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
+    border-radius: 0;
+  }
+
+  .sage-toolbar__group > .sage-dropdown:first-child .sage-dropdown__trigger > & {
+    border-top-left-radius: sage-border(radius);
+    border-bottom-left-radius: sage-border(radius);
+  }
+
+  .sage-toolbar__group > .sage-dropdown:last-child .sage-dropdown__trigger > & {
+    border-top-right-radius: sage-border(radius);
+    border-bottom-right-radius: sage-border(radius);
   }
 
   .sage-panel-controls__toolbar-btn-group--expand-collapse > & {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -156,7 +156,8 @@ $-btn-loading-min-height: rem(36px);
   .sage-panel-controls__tabs-dropdown .sage-dropdown__trigger &,
   .sage-panel-controls__toolbar .sage-dropdown__trigger &,
   .sage-panel-controls__bulk-actions .sage-dropdown__trigger &,
-  .sage-toolbar .sage-dropdown__trigger & {
+  .sage-toolbar .sage-dropdown__trigger &,
+  .sage-toolbar__group .sage-dropdown__trigger & {
     @include sage-focus-outline--update-color(transparent);
 
     width: inherit;
@@ -304,7 +305,8 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group > &,
-  .sage-toolbar__group > & {
+  .sage-toolbar__group > &,
+  .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
     border-radius: 0;
 
     &:first-child {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -371,6 +371,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 }
 
+.sage-dropdown__trigger--custom-width {
+  width: var(--sage-dropdown-trigger-width, auto);
+}
+
 .sage-dropdown__trigger--select,
 .sage-dropdown__trigger--select-labeled {
   :not(.sage-dropdown--customized) > & {

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -18,7 +18,7 @@ $-nav-icon-size: rem(20px);
   color: sage-color(charcoal, 200);
 
   .sage-nav__link--active & {
-    color: sage-color(primary);
+    color: inherit;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -106,6 +106,8 @@ $-search-icon: "::before";
 }
 
 .sage-search__input {
+  @include sage-form-field;
+
   position: relative;
   z-index: 1;
   flex: 1;
@@ -123,6 +125,12 @@ $-search-icon: "::before";
     outline: 0;
   }
 
+  &:focus:not(:disabled),
+  &:active:not(:disabled),
+  &:valid:not(:placeholder-shown) {
+    box-shadow: none;
+  }
+
   .sage-panel-controls__toolbar & {
     border-radius: sage-border(radius);
   }
@@ -135,15 +143,38 @@ $-search-icon: "::before";
       opacity: 0;
     }
 
-    ~ .sage-search__label {
-      @include sage-form-field-floating-label();
-      color: sage-color(primary);
+    &:focus:not(:disabled),
+    &:active:not(:disabled) {
+      /* stylelint-disable max-nesting-depth */
+      ~ .sage-search__label {
+        @include sage-form-field-floating-label();
+        @include placeholder {
+          opacity: 1;
+        }
+
+        color: sage-color(primary);
+      }
+      /* stylelint-enable max-nesting-depth */
     }
+
+    /* stylelint-disable max-nesting-depth */
+    &:disabled,
+    &:disabled:placeholder-shown {
+      @include placeholder {
+        opacity: 1;
+      }
+    }
+    /* stylelint-enable max-nesting-depth */
   }
 
   .sage-search--has-text & {
-    ~ .sage-search__label {
-      @include sage-form-field-floating-label();
+    &:focus:not(:disabled),
+    &:active:not(:disabled) {
+      /* stylelint-disable max-nesting-depth */
+      ~ .sage-search__label {
+        @include sage-form-field-floating-label();
+      }
+      /* stylelint-enable max-nesting-depth */
     }
   }
 
@@ -158,6 +189,9 @@ $-search-icon: "::before";
 
 .sage-search__reset-button {
   visibility: hidden;
+  position: absolute;
+  right: 0;
+  z-index: sage-z-index(default, 1);
 
   :not(.sage-search--contained) & {
     margin-right: sage-spacing(xs);

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -34,6 +34,7 @@ export const Dropdown = ({
   panelType,
   triggerButtonSubtle,
   triggerModifier,
+  triggerWidth,
 }) => {
   const [isActive, setActive] = useState(false);
   const [coords, updateCoords] = useState(null);
@@ -145,6 +146,7 @@ export const Dropdown = ({
         modifier={triggerModifier}
         onClickTrigger={onClickTrigger}
         subtleButton={triggerButtonSubtle}
+        width={triggerWidth}
       >
         {customTrigger}
       </DropdownTrigger>
@@ -189,6 +191,7 @@ Dropdown.defaultProps = {
   icon: null,
   isLabelVisible: true,
   isPinned: false,
+  label: null,
   onEscapeHook: () => false,
   panelMaxWidth: null,
   panelModifier: 'default',
@@ -197,7 +200,7 @@ Dropdown.defaultProps = {
   panelType: null,
   triggerButtonSubtle: false,
   triggerModifier: 'default',
-  label: null
+  triggerWidth: null,
 };
 
 Dropdown.propTypes = {
@@ -223,4 +226,5 @@ Dropdown.propTypes = {
   panelStateToken: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,
+  triggerWidth: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
@@ -13,6 +13,7 @@ export const DropdownTrigger = ({
   onClickTrigger,
   raisedButton,
   subtleButton,
+  width,
 }) => {
   const onClick = () => {
     onClickTrigger();
@@ -22,11 +23,17 @@ export const DropdownTrigger = ({
     'sage-dropdown__trigger',
     {
       [`sage-dropdown__trigger--${modifier}`]: modifier,
+      'sage-dropdown__trigger--custom-width': width,
     }
   );
 
+  const styles = {};
+  if (width) {
+    styles['--sage-dropdown-trigger-width'] = width;
+  }
+
   return (
-    <div className={classNames}>
+    <div className={classNames} style={{ ...styles }}>
       {children
         ? React.cloneElement(children, { onClick })
         : (
@@ -53,6 +60,7 @@ DropdownTrigger.defaultProps = {
   label: null,
   raisedButton: false,
   subtleButton: false,
+  width: null,
 };
 
 DropdownTrigger.propTypes = {
@@ -65,4 +73,5 @@ DropdownTrigger.propTypes = {
   onClickTrigger: PropTypes.func.isRequired,
   raisedButton: PropTypes.bool,
   subtleButton: PropTypes.bool,
+  width: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -36,6 +36,7 @@ export const SelectDropdown = ({
   searchPlaceholder,
   selectionBecomesLabel,
   showSelectionsAsLabels,
+  triggerWidth,
 }) => {
   const emptySelectedValue = (
     <>
@@ -211,6 +212,7 @@ export const SelectDropdown = ({
       panelModifier="select"
       panelSize={panelSize}
       triggerModifier="select"
+      triggerWidth={triggerWidth}
     >
       <Dropdown.ItemList
         allowMultiselect={allowMultiselect}
@@ -274,6 +276,7 @@ SelectDropdown.defaultProps = {
   searchPlaceholder: 'Find',
   selectionBecomesLabel: true,
   showSelectionsAsLabels: false,
+  triggerWidth: null,
 };
 
 SelectDropdown.propTypes = {
@@ -314,4 +317,5 @@ SelectDropdown.propTypes = {
   searchPlaceholder: PropTypes.string,
   selectionBecomesLabel: PropTypes.bool,
   showSelectionsAsLabels: PropTypes.bool,
+  triggerWidth: PropTypes.string,
 };

--- a/packages/sage-react/lib/Search/Search.jsx
+++ b/packages/sage-react/lib/Search/Search.jsx
@@ -7,6 +7,7 @@ import { SageTokens } from '../configs';
 export const Search = ({
   className,
   contained,
+  disabled,
   onClear,
   onChange,
   placeholder,
@@ -28,6 +29,7 @@ export const Search = ({
         className="sage-search__input"
         type="search"
         onChange={onChange}
+        disabled={disabled}
         placeholder={`${placeholder}…`}
         value={value}
         // Prevents the default Kajabi-Products Search.js from binding to this input
@@ -56,6 +58,7 @@ export const Search = ({
 Search.defaultProps = {
   className: null,
   contained: false,
+  disabled: false,
   onClear: null,
   placeholder: 'Search',
 };
@@ -63,6 +66,7 @@ Search.defaultProps = {
 Search.propTypes = {
   className: PropTypes.string,
   contained: PropTypes.bool,
+  disabled: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
   placeholder: PropTypes.string,

--- a/packages/sage-react/lib/Search/Search.story.jsx
+++ b/packages/sage-react/lib/Search/Search.story.jsx
@@ -32,3 +32,11 @@ Contained.args = {
   contained: true,
   placeholder: 'Search'
 };
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  contained: true,
+  disabled: true,
+  placeholder: 'Search',
+  value: ''
+};

--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -65,7 +65,7 @@ export const TableRow = ({
       };
     });
     setSelfCells(newCells);
-  }, []);
+  }, [cells, schema, typeRenderers]);
 
   const onChangeSelector = (value, checked) => {
     setSelfSelected(!checked);


### PR DESCRIPTION
1. (**MEDIUM**) #1279 (MEDIUM) Adding a new property to the Search component and style update. No existing use in the app, but Search is a core component so QE is recommended
   - Spot check of domains with search in use in `kajabi-products` to ensure functionality is intact
---
3. (**LOW**) kajabi/sage-lib#1283 Small style bug fix for select dropdown within toolbar group
4. (**LOW**) kajabi/sage-lib#1282 (LOW) Sidebar/nav: Active link icons updated to match parent link's text color
     - No expected in-app impact. One mention of `.sage-nav__icon` that overrides component styling in app/assets/stylesheets/page_specific/_coaching.scss
5. (**LOW**) kajabi/sage-lib#1290  Adds ability to set custom width on Dropdown triggers
6. (**LOW**) kajabi/sage-lib#1289 Adds a dependency to an useEffect in the TableRow component