### PR TITLE
SAGE-413 Dropdown preview fix

### DIFF
--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -1,4 +1,4 @@
-<%
+<%-
 menu_items = [
   {
     attributes: { "href": "#" },
@@ -60,7 +60,8 @@ custom_items = [
       graphic: { icon: "pen", card_color: "published" },
       name: "Subscription",
     },
-  }, {
+  },
+  {
     attributes: { "href": "#" },
     value: {
       description: "Require several...",
@@ -69,7 +70,7 @@ custom_items = [
     },
   },
 ]
-%>
+-%>
 
 <h3 class="t-sage-heading-6">Menu Dropdown</h3>
 <%= sage_component SageDropdown, { items: menu_items } do %>
@@ -194,40 +195,45 @@ custom_items = [
       selected: true,
       value: "Option 1",
     },
-  }],
+  ],
   contained: true
 } do %>
   <%= sage_component SageButton, {
     style: "secondary",
     value: "",
-  }
-} %>
+  } %>
+<% end %>
 
 <h3 class="t-sage-heading-6">Form Field</h3>
 <p>Note: This pattern is used with the SageReact implementation, please consult UXD before using this as SageRails.</p>
 <%= sage_component SageDropdown, {
   align: "right",
-  items: [{
+  items: [
+    {
     value: "-- None --"
-  }, {
-    value: "Option 1",
-   }, {
-    value: "Option 2",
-   }, {
-    value: "Option 3",
-  }, {
-    value: "Muted",
-    style: "muted"
-  }],
+    },
+    {
+      value: "Option 1",
+    },
+    {
+      value: "Option 2",
+    },
+    {
+      value: "Option 3",
+    },
+    {
+      value: "Muted",
+      style: "muted"
+    }
+  ],
   contained: true
 } do %>
   <%= sage_component SageButton, {
     style: "secondary",
     value: "",
     label: "Add an Element",
-  }
-} %>
-
+  } %>
+<% end %>
 <h3 class="t-sage-heading-6">Dropdown Field with full-width Custom Content and Footer</h3>
 <%= sage_component SageDropdown, {
   contained: true,


### PR DESCRIPTION
## Description
Addresses syntax errors with Rails dropdown in docs site preview page. Updates unclosed blocks and cleans up formatting.

![Screen Shot 2022-03-25 at 10 08 12 AM 10 12 24 AM](https://user-images.githubusercontent.com/816579/160170869-adc00c29-38bc-40ba-8f53-13be4b63e9ff.png)


## Testing in `sage-lib`
1. Navigate to the [dropdown component page](http://localhost:4000/pages/component/dropdown)
2. Verify that the preview renders as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**N/A**) Dropdown: addresses preview on docs site only. No effect on component use.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
