### PR TITLE
Add dependencies to re-render table row

### DIFF
--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -65,7 +65,7 @@ export const TableRow = ({
       };
     });
     setSelfCells(newCells);
-  }, []);
+  }, [cells, schema, typeRenderers]);
 
   const onChangeSelector = (value, checked) => {
     setSelfSelected(!checked);


### PR DESCRIPTION
## Description
This PR fixed a bug in React Table component where an `useEffect` was missing dependencies to listen for. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| https://www.loom.com/share/06caee6b27624528a38472e908636d45 | https://www.loom.com/share/d3d883ff484148f08e397837ef49bf0e |


## Testing in `sage-lib`
Need to bridge with this PR here (https://github.com/Kajabi/kajabi-products/pull/22833) in `kajabi-products` repo.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (MID) Adds a dependency to an useEffect in the TableRow component


## Related
Closes PR: https://kajabi.atlassian.net/browse/MAN-2572
