### PR TITLE
Dropdown trigger size

### DIFF
--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -81,8 +81,12 @@ custom_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Menu Button with Custom Panel Width</h3>
-<%= sage_component SageDropdown, { panel_width: "512px", items: menu_items } do %>
+<h3 class="t-sage-heading-6">Menu Button with Custom Trigger width and Custom Panel Width</h3>
+<%= sage_component SageDropdown, {
+  panel_width: "512px",
+  items: menu_items,
+  trigger: { width: "240px" },
+} do %>
   <% content_for :sage_dropdown_trigger, flush: true do %>
     <%= sage_component SageButton, {
       style: "primary",

--- a/docs/app/views/examples/components/dropdown/_props.html.erb
+++ b/docs/app/views/examples/components/dropdown/_props.html.erb
@@ -221,4 +221,10 @@
     <td><%= md('String') %></td>
     <td><%= md('`""`') %></td>
   </tr>
+  <tr>
+    <td><%= md('`width`') %></td>
+    <td><%= md('Sets a custom width for the trigger.') %></td>
+    <td><%= md('String') %></td>
+    <td><%= md('`nil`') %></td>
+  </tr>
 </tbody>

--- a/docs/app/views/examples/components/toolbar/_preview.html.erb
+++ b/docs/app/views/examples/components/toolbar/_preview.html.erb
@@ -1,6 +1,5 @@
 <%
 dropdown_configs = {
-  icon: { style: "right", name: "caret-down" },
   items: [
     {
       selected: true,
@@ -43,7 +42,11 @@ dropdown_configs = {
       modifiers: ["disabled"]
     }
   ],
-  trigger_type: "select",
+  trigger: {
+    type: "select",
+    label: "Add an Element",
+    value: "",
+  },
 }
 %>
 
@@ -78,16 +81,7 @@ dropdown_configs = {
     value: "Edit",
   } %>
 
-  <%= sage_component SageDropdown, dropdown_configs do %>
-    <%= sage_component SageButton, {
-      css_classes: "sage-dropdown__trigger-selected-value",
-      icon: { style: "right", name: "caret-down" },
-      raised: false,
-      style: "secondary",
-      value: "",
-    } %>
-    <label class="sage-dropdown__trigger-label">Add an Element</label>
-  <% end %>
+  <%= sage_component SageDropdown, dropdown_configs %>
 
   <p>Plain text</p>
 
@@ -99,16 +93,8 @@ dropdown_configs = {
       contained: true,
       label_text: "Search",
     } %>
-    <%= sage_component SageDropdown, dropdown_configs do %>
-      <%= sage_component SageButton, {
-        css_classes: "sage-dropdown__trigger-selected-value",
-        icon: { style: "right", name: "caret-down" },
-        raised: false,
-        style: "secondary",
-        value: "",
-      } %>
-      <label class="sage-dropdown__trigger-label">Add an Element</label>
-    <% end %>
+
+    <%= sage_component SageDropdown, dropdown_configs %>
 
     <%= sage_component SageButton, {
       value: "Edit",

--- a/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_schemas.rb
@@ -89,6 +89,7 @@ module SageSchemas
     label: [:optional, NilClass, String],
     type: DROPDOWN_TRIGGER_TYPE,
     value: [:optional, NilClass, String],
+    width: [:optional, NilClass, String],
   }
 
   DROPDOWN = {
@@ -104,7 +105,7 @@ module SageSchemas
     panel_type: [:optional, NilClass, Set.new(["custom", "dropdown", "choice", "checkbox", "status", "searchable"])],
     search: [:optional, NilClass, TrueClass],
     trigger: [:optional, NilClass, DROPDOWN_TRIGGER],
-    trigger_type: [:optional, NilClass, Set.new(["select", "select-labeled"])],
+    trigger_type: DROPDOWN_TRIGGER_TYPE,
     wrap_footer: [:optional, NilClass, TrueClass],
   }
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown.html.erb
@@ -1,6 +1,5 @@
 <%
-trigger_type = component.trigger_type.present? ? component.trigger_type : nil
-trigger_configs = component.trigger.present? ? component.trigger : { type: trigger_type }
+trigger_configs = component.trigger.present? ? component.trigger : {}
 %>
 <div
   class="sage-dropdown
@@ -20,13 +19,9 @@ trigger_configs = component.trigger.present? ? component.trigger : { type: trigg
 >
   <div aria-hidden="true" class="sage-dropdown__screen"></div>
 
-  <% if component.trigger.present? %>
-    <%= sage_component SageDropdownTrigger, trigger_configs do %>
-      <%= component.content %>
-    <% end %>
-  <% elsif content_for? :sage_dropdown_trigger %>
-    <%= sage_component SageDropdownTrigger, trigger_configs do %>
-      <%= content_for :sage_dropdown_trigger %>
+  <% if component.trigger.present? || content_for?(:sage_dropdown_trigger) %>
+    <%= sage_component SageDropdownTrigger, component.trigger.present? ? component.trigger : {} do %>
+      <%= content_for :sage_dropdown_trigger if content_for? :sage_dropdown_trigger %>
     <% end %>
   <% end %>
 
@@ -35,7 +30,7 @@ trigger_configs = component.trigger.present? ? component.trigger : { type: trigg
   Then adjust so that `content` can instead be used for panel contents.
   %>
   <% if component.content.present? %>
-    <%= sage_component SageDropdownTrigger, trigger_configs do %>
+    <%= sage_component SageDropdownTrigger, {} do %>
       <%= component.content %>
     <% end %>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown_trigger.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_dropdown_trigger.html.erb
@@ -3,13 +3,15 @@
   class="
     sage-dropdown__trigger
     <%= "sage-dropdown__trigger--#{component.type}" if component.type.present? %>
+    <%= "sage-dropdown__trigger--custom-width" if component.width.present? %>
     <%= component.generated_css_classes %>
   "
+  <% if component.width.present? %>
+    style="--sage-dropdown-trigger-width: <%= component.width %>"
+  <% end %>
   <%= component.generated_html_attributes %>
 >
-  <% if component.content.present? %>
-    <%= component.content %>
-  <% elsif component.type.present? && component.type == "select" %>
+  <% if component.type.present? && component.type == "select" %>
     <%= sage_component SageButton, {
       style: "secondary",
       raised: false,
@@ -20,5 +22,7 @@
     <label class="sage-dropdown__trigger-label">
       <%= component.label %>
     </label>
+  <% elsif component.content.present? %>
+    <%= component.content %>
   <% end %>
 </div>

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -204,6 +204,10 @@ $-btn-loading-min-height: rem(36px);
     line-height: sage-line-height(body);
   }
 
+  .sage-dropdown__trigger--custom-width > & {
+    width: 100%;
+  }
+
   .sage-dropdown__trigger--select & {
     font-weight: sage-font-weight(regular);
   }

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -309,8 +309,7 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group > &,
-  .sage-toolbar__group > &,
-  .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
+  .sage-toolbar__group > & {
     border-radius: 0;
 
     &:first-child {
@@ -322,6 +321,20 @@ $-btn-loading-min-height: rem(36px);
       border-top-right-radius: sage-border(radius);
       border-bottom-right-radius: sage-border(radius);
     }
+  }
+
+  .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
+    border-radius: 0;
+  }
+
+  .sage-toolbar__group > .sage-dropdown:first-child .sage-dropdown__trigger > & {
+    border-top-left-radius: sage-border(radius);
+    border-bottom-left-radius: sage-border(radius);
+  }
+
+  .sage-toolbar__group > .sage-dropdown:last-child .sage-dropdown__trigger > & {
+    border-top-right-radius: sage-border(radius);
+    border-bottom-right-radius: sage-border(radius);
   }
 
   .sage-panel-controls__toolbar-btn-group--expand-collapse > & {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -371,6 +371,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 }
 
+.sage-dropdown__trigger--custom-width {
+  width: var(--sage-dropdown-trigger-width, auto);
+}
+
 .sage-dropdown__trigger--select,
 .sage-dropdown__trigger--select-labeled {
   :not(.sage-dropdown--customized) > & {

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -34,6 +34,7 @@ export const Dropdown = ({
   panelType,
   triggerButtonSubtle,
   triggerModifier,
+  triggerWidth,
 }) => {
   const [isActive, setActive] = useState(false);
   const [coords, updateCoords] = useState(null);
@@ -145,6 +146,7 @@ export const Dropdown = ({
         modifier={triggerModifier}
         onClickTrigger={onClickTrigger}
         subtleButton={triggerButtonSubtle}
+        width={triggerWidth}
       >
         {customTrigger}
       </DropdownTrigger>
@@ -189,6 +191,7 @@ Dropdown.defaultProps = {
   icon: null,
   isLabelVisible: true,
   isPinned: false,
+  label: null,
   onEscapeHook: () => false,
   panelMaxWidth: null,
   panelModifier: 'default',
@@ -197,7 +200,7 @@ Dropdown.defaultProps = {
   panelType: null,
   triggerButtonSubtle: false,
   triggerModifier: 'default',
-  label: null
+  triggerWidth: null,
 };
 
 Dropdown.propTypes = {
@@ -223,4 +226,5 @@ Dropdown.propTypes = {
   panelStateToken: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
   triggerModifier: PropTypes.string,
+  triggerWidth: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
@@ -13,6 +13,7 @@ export const DropdownTrigger = ({
   onClickTrigger,
   raisedButton,
   subtleButton,
+  width,
 }) => {
   const onClick = () => {
     onClickTrigger();
@@ -22,11 +23,17 @@ export const DropdownTrigger = ({
     'sage-dropdown__trigger',
     {
       [`sage-dropdown__trigger--${modifier}`]: modifier,
+      [`sage-dropdown__trigger--custom-width`]: width,
     }
   );
 
+  const styles = {};
+  if (width) {
+    styles['--sage-dropdown-trigger-width'] = width;
+  }
+
   return (
-    <div className={classNames}>
+    <div className={classNames} style={{ ...styles }}>
       {children
         ? React.cloneElement(children, { onClick })
         : (
@@ -53,6 +60,7 @@ DropdownTrigger.defaultProps = {
   label: null,
   raisedButton: false,
   subtleButton: false,
+  width: null,
 };
 
 DropdownTrigger.propTypes = {
@@ -65,4 +73,5 @@ DropdownTrigger.propTypes = {
   onClickTrigger: PropTypes.func.isRequired,
   raisedButton: PropTypes.bool,
   subtleButton: PropTypes.bool,
+  width: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
@@ -23,7 +23,7 @@ export const DropdownTrigger = ({
     'sage-dropdown__trigger',
     {
       [`sage-dropdown__trigger--${modifier}`]: modifier,
-      [`sage-dropdown__trigger--custom-width`]: width,
+      'sage-dropdown__trigger--custom-width': width,
     }
   );
 

--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -36,6 +36,7 @@ export const SelectDropdown = ({
   searchPlaceholder,
   selectionBecomesLabel,
   showSelectionsAsLabels,
+  triggerWidth,
 }) => {
   const emptySelectedValue = (
     <>
@@ -211,6 +212,7 @@ export const SelectDropdown = ({
       panelModifier="select"
       panelSize={panelSize}
       triggerModifier="select"
+      triggerWidth={triggerWidth}
     >
       <Dropdown.ItemList
         allowMultiselect={allowMultiselect}
@@ -274,6 +276,7 @@ SelectDropdown.defaultProps = {
   searchPlaceholder: 'Find',
   selectionBecomesLabel: true,
   showSelectionsAsLabels: false,
+  triggerWidth: null,
 };
 
 SelectDropdown.propTypes = {
@@ -314,4 +317,5 @@ SelectDropdown.propTypes = {
   searchPlaceholder: PropTypes.string,
   selectionBecomesLabel: PropTypes.bool,
   showSelectionsAsLabels: PropTypes.bool,
+  triggerWidth: PropTypes.string,
 };


### PR DESCRIPTION
## Description

Adds ability to set a custom width for dropdown triggers. Particularly useful for dropdowns in toolbars that otherwise adjust to the size of the selected item.

## Screenshots

<img width="547" alt="Screen Shot 2022-03-25 at 4 02 21 PM" src="https://user-images.githubusercontent.com/17955295/160193098-b214e288-5692-4c2a-96b8-58a57d951feb.png">


## Testing in `sage-lib`
See [Components > Dropdown](http://localhost:4000/pages/component/dropdown) and [Storybook](http://localhost:4100/?path=/story/sage-dropdown--default)


## Testing in `kajabi-products`

1. (LOW) Adds ability to set custom width on Dropdown triggers


## Related

https://kajabi.atlassian.net/browse/SAGE-235
