### PR TITLE
[Sage-430] Next Best Action - Title Refactor + Full-bleed Image

### DIFF
--- a/docs/app/views/examples/components/carousel/_preview.html.erb
+++ b/docs/app/views/examples/components/carousel/_preview.html.erb
@@ -18,8 +18,10 @@
         graphic: {
           element: image_tag("next_best_action_graphic.png", alt: ""),
         },
-        title: "Offer an additional buy with Upsell",
       } do %>
+        <%= content_for :sage_next_best_action_title %>
+          <h3>Offer an additional buy with Upsell</h3>
+        <% end %>
         <%= content_for :sage_next_best_action_description do %>
           <p>Maximize your profit by adding an Upsell to your order flow. This section might wrap to two lines.</p>
         <% end %>

--- a/docs/app/views/examples/components/next_best_action/_preview.html.erb
+++ b/docs/app/views/examples/components/next_best_action/_preview.html.erb
@@ -8,8 +8,10 @@
   graphic: {
     element: image_tag("next_best_action_graphic.png", alt: ""),
   },
-  title: "Offer an additional buy with Upsell",
 } do %>
+  <%= content_for :sage_next_best_action_title do %>
+    <h3>Offer an additional buy with Upsell</h3>
+  <% end %>
   <%= content_for :sage_next_best_action_description do %>
     <p>Maximize your profit by adding an Upsell to your order flow. This section might wrap to two lines.</p>
     <p>Here is the second line. It has some text also.</p>
@@ -33,8 +35,10 @@
     element: image_tag("next_best_action_graphic.png", alt: ""),
     on_right: true,
   },
-  title: "Offer an additional buy with Upsell",
 } do %>
+	<%= content_for :sage_next_best_action_title do %>
+    <h3>Offer an additional buy with Upsell</h3>
+  <% end %>
   <%= content_for :sage_next_best_action_description do %>
     <p>Maximize your profit by adding an Upsell to your order flow. This section might wrap to two lines.</p>
     <p>Here is the second line. It has some text also.</p>

--- a/docs/app/views/examples/components/next_best_action/_props.html.erb
+++ b/docs/app/views/examples/components/next_best_action/_props.html.erb
@@ -31,14 +31,13 @@ graphic: {
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`title`') %></td>
-  <td><%= md('Sets the title text to be displayed.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
   <td colspan="2"><%= md('**Sections**') %></td>
   <td colspan="2"><%= md('**`Element`**') %></td>
+</tr>
+<tr>
+  <td><%= md('`sage_next_best_action_title`') %></td>
+  <td><%= md('Allows for descriptive HTML content.') %></td>
+   <td colspan="2"><%= md('Restricted to text elements.') %></td>
 </tr>
 <tr>
   <td><%= md('`sage_next_best_action_description`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_next_best_action.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_next_best_action.rb
@@ -7,10 +7,9 @@ class SageNextBestAction < SageComponent
       element: [:optional, String],
       on_right: [:optional, TrueClass],
     }],
-    title: [:optional, String],
   })
 
   def sections
-    %w(next_best_action_actions next_best_action_description)
+    %w(next_best_action_title next_best_action_actions next_best_action_description)
   end
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_next_best_action.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_next_best_action.html.erb
@@ -11,8 +11,10 @@
     </div>
   <% end %>
   <div class="sage-next-best-action__text">
-    <% if component.title %>
-      <h3 class="sage-next-best-action__title"><%= component.title %></h3>
+    <% if content_for? :sage_next_best_action_title %>
+    	<div class="sage-next-best-action__title">
+        <%= content_for :sage_next_best_action_title %>
+      </div>
     <% end %>
     <% if content_for? :sage_next_best_action_description %>
       <div class="sage-next-best-action__description">

--- a/packages/sage-react/lib/NextBestAction/NextBestAction.jsx
+++ b/packages/sage-react/lib/NextBestAction/NextBestAction.jsx
@@ -34,7 +34,9 @@ export const NextBestAction = ({
       )}
       <div className="sage-next-best-action__text">
         {title && (
-          <h3 className="sage-next-best-action__title">{title}</h3>
+          <div className="sage-next-best-action__title">
+            {title}
+          </div>
         )}
         {description && (
           <div className="sage-next-best-action__description">
@@ -71,7 +73,7 @@ NextBestAction.defaultProps = {
     onRight: false,
   },
   onClickDismiss: null,
-  title: '',
+  title: null,
 };
 
 NextBestAction.propTypes = {
@@ -85,5 +87,5 @@ NextBestAction.propTypes = {
     onRight: PropTypes.bool,
   }),
   onClickDismiss: PropTypes.func,
-  title: PropTypes.string,
+  title: PropTypes.node,
 };

--- a/packages/sage-react/lib/NextBestAction/NextBestAction.story.jsx
+++ b/packages/sage-react/lib/NextBestAction/NextBestAction.story.jsx
@@ -30,7 +30,9 @@ export default {
     },
     // eslint-disable-next-line no-console
     onClickDismiss: () => { console.log('Add your own dismiss functionality here!'); },
-    title: 'Offer an additional buy with Upsell',
+    title: (
+      <h3>Offer an additional buy with Upsell</h3>
+    ),
   },
   argTypes: {
     ...selectArgs({


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates the Next Best Action component to refactor the title prop into a custom slot, and adds new prop to make the image full-bleed.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
WIP|WIP


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
WIP

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
WIP


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-430](https://kajabi.atlassian.net/browse/SAGE-430)