### PR TITLE
Next version bump (~4.53.0)

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -63,17 +63,13 @@ $-modal-fullscreen-top-spacing: rem(104px);
     background-image: none;
     pointer-events: none;
   }
-
 }
 
 .sage-modal__container {
-  display: grid;
   visibility: hidden;
-  grid-template-rows: auto 1fr auto;
   z-index: sage-z-index(modal);
   width: calc(100vw - #{sage-spacing(md)});
   max-width: sage-container(md);
-  max-height: 85vh;
   margin: 0;
   border-radius: sage-border(radius);
   background-color: sage-color(white);
@@ -81,13 +77,6 @@ $-modal-fullscreen-top-spacing: rem(104px);
   transition: opacity 0.1s ease-in 0.1s;
   pointer-events: none;
   opacity: 0;
-
-  // Used for modals with simpleform form element
-  > .simple_form {
-    display: grid;
-    grid-template-rows: auto 1fr auto;
-    overflow: auto;
-  }
 
   .sage-drawer & {
     height: 100vh;
@@ -211,7 +200,6 @@ $-modal-fullscreen-top-spacing: rem(104px);
 }
 
 .sage-modal__content {
-  overflow: auto;
   margin: $-modal-padding-y $-modal-padding-x;
 
   .sage-modal--fullscreen & {


### PR DESCRIPTION
1. Reverts Kajabi/sage-lib#1295 due to issues with Modals found during the QE testing process.
---
3. (**LOW**) - kajabi/sage-lib#1297 - Adds select all checkbox abilities in React Table (Rails requires manual construction using sage_table_for. See Docs site > Components > Table
4. (**LOW**) - kajabi/sage-lib#1304 - Adds a color combo for SageIcon that was not present before. No need to verify in kajabi-products.