### PR TITLE
[Sage-369] Modal - Content Scrolling Prop

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -1,5 +1,7 @@
 <%
   sample_body_text = "<p class='#{SageClassnames::TYPE::BODY}'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>".html_safe
+
+  long_sample_text = "<p class=' #{SageClassnames::TYPE::BODY}'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse urna leo, condimentum nec pellentesque finibus, ultricies pulvinar ante. Donec eu interdum ligula. Pellentesque aliquam ullamcorper orci, nec tempor libero tristique in. Aliquam vitae felis at leo condimentum placerat eget id libero. In dictum tortor ac accumsan aliquam. Donec sit amet tortor porttitor, tincidunt nisl at, egestas lacus. Integer metus augue, aliquet accumsan vulputate eget, tristique id erat. Donec a venenatis nibh, ac molestie risus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Vivamus in orci vitae ex tempor ultrices in a leo. Sed purus magna, vulputate aliquet ligula eget, consectetur sagittis nunc.</p>".html_safe
 %>
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageButtonGroup, { wrap: true, gap: :sm, spacer: { bottom: :sm }} do %>
@@ -9,6 +11,14 @@
       value: "Modal",
       attributes: {
         "data-js-modaltrigger": "cool-modal",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Modal with Content Scrolling",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-scrolling",
       }
     } %>
     <%= sage_component SageButton, {
@@ -95,6 +105,65 @@
       <%= sample_body_text %>
 
       <%= sample_body_text %>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%# Standard Modal with Scrolling %>
+  <%= sage_component SageModal, { allow_scroll: true, id: "cool-modal-scrolling" } do %>
+    <%= sage_component SageModalContent, {
+      title: "Example Modal",
+      subheader: "Example Subheader",
+      help_content: "<p>Popover content</p>",
+      help_title: "Example Popover Title",
+      help_link: {
+        href: "#",
+        name: "Learn more about modals"
+      }
+    } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <% content_for :sage_header_indicator do %>
+        <%= sage_component SageIndicator, {
+          current_item: 2,
+          label: "Page",
+          num_items: 5,
+          show_text: true
+        } %>
+      <% end %>
+
+      <%= long_sample_text %>
+      <%= long_sample_text %>
+      <%= long_sample_text %>
+      <%= long_sample_text %>
 
       <% content_for :sage_footer do %>
         <% content_for :sage_footer_aside do %>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -1,6 +1,7 @@
 class SageModal < SageComponent
   set_attribute_schema({
     active: [:optional, NilClass, TrueClass],
+    allow_scroll: [:optional, NilClass, TrueClass],
     animate: [:optional, String, TrueClass, {
       direction: [:optional, String, Set.new(["bottom", "top", "left", "right"])]
     }],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -5,6 +5,7 @@
     <%= "sage-modal--fullscreen" if component.fullscreen -%>
     <%= "sage-modal--no-blur" if component.disable_background_blur -%>
     <%= "sage-modal--no-background-dismiss" if component.disable_background_dismiss -%>
+    <%= "sage-modal--scrollable" if component.allow_scroll %>
     <%= component.generated_css_classes %>
   "
   <%= "data-sage-animate" if component.animate.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -67,19 +67,6 @@ $-modal-fullscreen-top-spacing: rem(104px);
 
 .sage-modal--scrollable {
   overflow-y: initial;
-
-  .sage-modal__container,
-  .sage-modal__container > .simple_form {
-    display: grid;
-    grid-template-rows: auto 1fr auto;
-    max-height: 85vh;
-  }
-
-  .sage-modal__container .sage-modal__content,
-  .sage-modal__container > .simple_form {
-    overflow: auto;
-    padding: sage-spacing(xs) sage-spacing(3xs);
-  }
 }
 
 .sage-modal__container {
@@ -153,6 +140,18 @@ $-modal-fullscreen-top-spacing: rem(104px);
     border-radius: 0;
     opacity: 1;
   }
+
+  .sage-modal--scrollable &,
+  .sage-modal--scrollable & > .simple_form {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    max-height: 85vh;
+  }
+  
+  .sage-modal--scrollable & > .simple_form {
+    @include overflow-scroll(y);
+    padding: sage-spacing(xs) sage-spacing(3xs);
+  }
 }
 
 .sage-modal__header {
@@ -221,6 +220,11 @@ $-modal-fullscreen-top-spacing: rem(104px);
 
   .sage-modal--fullscreen & {
     margin-top: $-modal-fullscreen-top-spacing;
+  }
+
+  .sage-modal--scrollable & {
+    @include overflow-scroll(y);
+    padding: sage-spacing(xs) sage-spacing(3xs);
   }
 
   .sage-drawer & {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -78,7 +78,7 @@ $-modal-fullscreen-top-spacing: rem(104px);
   .sage-modal__container .sage-modal__content,
   .sage-modal__container > .simple_form {
     overflow: auto;
-    padding: 8px 2px;
+    padding: sage-spacing(xs) sage-spacing(3xs);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -65,6 +65,23 @@ $-modal-fullscreen-top-spacing: rem(104px);
   }
 }
 
+.sage-modal--scrollable {
+  overflow-y: initial;
+
+  .sage-modal__container,
+  .sage-modal__container > .simple_form {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    max-height: 85vh;
+  }
+
+  .sage-modal__container .sage-modal__content,
+  .sage-modal__container > .simple_form {
+    overflow: auto;
+    padding: 8px 2px;
+  }
+}
+
 .sage-modal__container {
   visibility: hidden;
   z-index: sage-z-index(modal);

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -224,7 +224,13 @@ $-modal-fullscreen-top-spacing: rem(104px);
 
   .sage-modal--scrollable & {
     @include overflow-scroll(y);
+
+    margin-top: 0;
     padding: sage-spacing(xs) sage-spacing(3xs);
+
+    > :first-child {
+      margin-top: sage-spacing(xs);
+    }
   }
 
   .sage-drawer & {

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -10,6 +10,7 @@ import { MODAL_ANIMATION_PRESETS, MODAL_ANIMATION_DIRECTIONS } from './configs';
 
 export const Modal = ({
   active,
+  allowScroll,
   animation,
   children,
   className,
@@ -27,6 +28,7 @@ export const Modal = ({
     className,
     {
       'sage-modal--active': active,
+      'sage-modal--scrollable': allowScroll,
       'sage-modal--large': large,
       'sage-modal--fullscreen': fullScreen,
       'sage-modal--no-blur': disableBackgroundBlur,
@@ -93,6 +95,7 @@ Modal.ANIMATION_DIRECTIONS = MODAL_ANIMATION_DIRECTIONS;
 
 Modal.defaultProps = {
   active: false,
+  allowScroll: false,
   animation: null,
   children: null,
   containerClassName: null,
@@ -107,6 +110,7 @@ Modal.defaultProps = {
 
 Modal.propTypes = {
   active: PropTypes.bool,
+  allowScroll: PropTypes.bool,
   animation: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.shape({


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds `allow_scroll`/`allowScroll` prop to Rails and React to allow modal content to scroll.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->

https://user-images.githubusercontent.com/14791307/162787300-1eab1d3c-316d-4f04-90e2-5623957995b8.mov



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Modal](http://localhost:4000/pages/component/modal)
- Add extra body content and `allow_scroll` prop
- Check that body content scrolls as necessary.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds `allow_scroll`/`allowScroll` prop to Rails and React to allow modal content to scroll. Scrolling is guarded behind an opt-in prop, so modals across the app will not be affected.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-369](https://kajabi.atlassian.net/browse/SAGE-369)