### PR TITLE
SAGE-425: fix(input): add hasPlaceholder prop to react input

### DIFF
--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -7,6 +7,7 @@ import { SageTokens } from '../configs';
 export const Input = ({
   className,
   hasError,
+  hasPlaceholder,
   icon,
   id,
   label,
@@ -28,6 +29,7 @@ export const Input = ({
     className,
     {
       'sage-form-field--error': hasError,
+      'sage-form-field--showplaceholder': hasPlaceholder,
       'sage-input--prefixed': prefix,
       'sage-input--suffixed': suffix,
       'sage-input--standalone': standalone,
@@ -121,6 +123,7 @@ export const Input = ({
 Input.defaultProps = {
   className: null,
   hasError: false,
+  hasPlaceholder: false,
   icon: null,
   label: null,
   message: null,
@@ -137,6 +140,7 @@ Input.propTypes = {
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,
   hasError: PropTypes.bool,
+  hasPlaceholder: PropTypes.bool,
   label: PropTypes.string,
   message: PropTypes.string,
   onChange: PropTypes.func,

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -28,6 +28,7 @@ export const Default = (args) => {
       className={args.className}
       disabled={args.disabled}
       hasError={args.hasError}
+      hasPlaceholder={args.hasPlaceholder}
       icon={args.icon}
       id={args.id}
       label={args.label}
@@ -53,6 +54,7 @@ export const InputWithStaticIcon = (args) => {
       className={args.className}
       disabled={args.disabled}
       hasError={args.hasError}
+      hasPlaceholder={args.hasPlaceholder}
       icon={args.icon}
       id={args.id}
       label={args.label}
@@ -78,6 +80,7 @@ export const InputWithPopover = (args) => {
       className={args.className}
       disabled={args.disabled}
       hasError={args.hasError}
+      hasPlaceholder={args.hasPlaceholder}
       icon={args.icon}
       id={args.id}
       label={args.label}


### PR DESCRIPTION
## Description

Allow for React input fields to be disabled and still show the label. This aligns with the behavior Rails already has in place.


## Screenshots
|  Before - no label showing  |  After - label shows  |
|--------|--------|
| <img width="1792" alt="image (17)" src="https://user-images.githubusercontent.com/24237393/162834613-298d2ff4-a6ad-464d-b340-305a4ca34690.png"> | ![Screen Shot 2022-04-11 at 4 14 05 PM](https://user-images.githubusercontent.com/24237393/162834564-e3ded66c-c68c-42db-8504-849641c777c1.png) |

## Testing in `sage-lib`

1. Navigate to http://localhost:4100/?path=/docs/sage-input--default
2. Select "hasPlaceholder" and set to `true` 
3. Inspect the `input` and add `disabled` as a property
4. Verify the label still shows with a lower opacity (.5)


## Testing in `kajabi-products`
1. (**LOW**) New property to React input component. No testing in kp


## Related
[SAGE-425](https://kajabi.atlassian.net/browse/SAGE-425)
