### PR TITLE
Table: Disable row selectable

### DIFF
--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -267,6 +267,7 @@ export const Table = ({
   const renderTableRow = (row) => {
     // Ensure there's a unique id for the row if one is not provided
     const rowId = row.id || uuid();
+    const disableSelect = row.disableSelect || false;
 
     // Transform the raw row data into a consistent structure
     const cells = TableRow.parseRowData(row, schema);
@@ -276,6 +277,7 @@ export const Table = ({
         key={rowId}
         id={rowId}
         cells={cells}
+        disableSelect={disableSelect}
         schema={schema}
         selected={selfSelectedRows === SELECTION_TYPES.ALL || selfSelectedRows.includes(rowId)}
         selectable={selectable}

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -268,6 +268,7 @@ export const Table = ({
     // Ensure there's a unique id for the row if one is not provided
     const rowId = row.id || uuid();
     const disableSelect = row.disableSelect || false;
+    const hideSelect = row.hideSelect || false;
 
     // Transform the raw row data into a consistent structure
     const cells = TableRow.parseRowData(row, schema);
@@ -278,6 +279,7 @@ export const Table = ({
         id={rowId}
         cells={cells}
         disableSelect={disableSelect}
+        hideSelect={hideSelect}
         schema={schema}
         selected={selfSelectedRows === SELECTION_TYPES.ALL || selfSelectedRows.includes(rowId)}
         selectable={selectable}

--- a/packages/sage-react/lib/Table/Table.story.jsx
+++ b/packages/sage-react/lib/Table/Table.story.jsx
@@ -68,6 +68,14 @@ Default.decorators = [
             If this table has paged data you should also
             set <code>hasDataBeyondCurrentRows: true</code>.
           </li>
+          <li>
+            If you want to disable the checkbox on an individual row,
+            add <code>disableSelect: true</code> to that row's data.
+          </li>
+          <li>
+            If you want to hide the checkbox on an individual row,
+            add <code>hideSelect: true</code> to that row's data.
+          </li>
         </ul>
       </div>
     </>

--- a/packages/sage-react/lib/Table/Table.story.jsx
+++ b/packages/sage-react/lib/Table/Table.story.jsx
@@ -70,11 +70,11 @@ Default.decorators = [
           </li>
           <li>
             If you want to disable the checkbox on an individual row,
-            add <code>disableSelect: true</code> to that row's data.
+            add <code>disableSelect: true</code> to that row&rsquo;s data.
           </li>
           <li>
             If you want to hide the checkbox on an individual row,
-            add <code>hideSelect: true</code> to that row's data.
+            add <code>hideSelect: true</code> to that row&rsquo;s data.
           </li>
         </ul>
       </div>

--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -10,6 +10,7 @@ import { Checkbox } from '../Toggle';
 export const TableRow = ({
   className,
   cells,
+  disableSelect,
   id,
   onSelect,
   schema,
@@ -78,6 +79,7 @@ export const TableRow = ({
         <td className="sage-table-cell sage-table-cell--checkbox">
           <Checkbox
             checked={selfSelected}
+            disabled={disableSelect}
             id={`sage-table__row-selector-${id}`}
             label="Select row"
             name="sage-table-selections"
@@ -107,6 +109,7 @@ TableRow.parseRowData = parseRowData;
 TableRow.defaultProps = {
   className: null,
   cells: [],
+  disableSelect: false,
   onSelect: (ev) => ev,
   selectable: false,
   selected: false,
@@ -116,6 +119,7 @@ TableRow.defaultProps = {
 TableRow.propTypes = {
   className: PropTypes.string,
   cells: PropTypes.arrayOf(PropTypes.shape(cellPropTypes)),
+  disableSelect: PropTypes.bool,
   id: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,

--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -11,6 +11,7 @@ export const TableRow = ({
   className,
   cells,
   disableSelect,
+  hideSelect,
   id,
   onSelect,
   schema,
@@ -77,16 +78,18 @@ export const TableRow = ({
     <tr className={classNames} data-table-row-id={id}>
       {selectable && (
         <td className="sage-table-cell sage-table-cell--checkbox">
-          <Checkbox
-            checked={selfSelected}
-            disabled={disableSelect}
-            id={`sage-table__row-selector-${id}`}
-            label="Select row"
-            name="sage-table-selections"
-            onChange={onChangeSelector}
-            standalone={true}
-            value={id.toString()}
-          />
+          {!hideSelect && (
+            <Checkbox
+              checked={selfSelected}
+              disabled={disableSelect}
+              id={`sage-table__row-selector-${id}`}
+              label="Select row"
+              name="sage-table-selections"
+              onChange={onChangeSelector}
+              standalone={true}
+              value={id.toString()}
+            />
+          )}
         </td>
       )}
       {selfCells.map((configs) => {
@@ -110,6 +113,7 @@ TableRow.defaultProps = {
   className: null,
   cells: [],
   disableSelect: false,
+  hideSelect: false,
   onSelect: (ev) => ev,
   selectable: false,
   selected: false,
@@ -120,6 +124,7 @@ TableRow.propTypes = {
   className: PropTypes.string,
   cells: PropTypes.arrayOf(PropTypes.shape(cellPropTypes)),
   disableSelect: PropTypes.bool,
+  hideSelect: PropTypes.bool,
   id: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,

--- a/packages/sage-react/lib/Table/sample-data/contacts.js
+++ b/packages/sage-react/lib/Table/sample-data/contacts.js
@@ -19,6 +19,7 @@ export const dataCollection = [
     email: 'rowan@example.com',
     phone: '555-111-1101',
     disableSelect: true,
+    hideSelect: true,
   },
   {
     id: 3,

--- a/packages/sage-react/lib/Table/sample-data/contacts.js
+++ b/packages/sage-react/lib/Table/sample-data/contacts.js
@@ -18,6 +18,7 @@ export const dataCollection = [
     first: 'Rowan',
     email: 'rowan@example.com',
     phone: '555-111-1101',
+    disableSelect: true,
   },
   {
     id: 3,


### PR DESCRIPTION
## Description

This PR adds ability to disable selection on individual rows within a Sage Table (React). 

## Screenshots

<img width="884" alt="Screen Shot 2022-04-12 at 3 09 09 PM" src="https://user-images.githubusercontent.com/17955295/163036974-01a14acd-1f91-4967-b70b-4d9b393a3f52.png">



## Testing in `sage-lib`

See http://localhost:4100/?path=/story/sage-table--default

## Testing in `kajabi-products`

1. (LOW) New props added to TableRow to allow hiding and disabling checkbox on individual rows.

