### PR TITLE
[SAGE-439] Button foundations update

### DIFF
--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -1,25 +1,5 @@
 <%
-demo_configs_standard = [
-  {
-    heading: "Primary",
-    label: "Primary",
-    style: "primary",
-  },
-  {
-    heading: "Neutral",
-    label: "Neutral",
-    style: "neutral",
-  },
-  {
-    heading: "Danger",
-    label: "Danger",
-    style: "danger",
-  }
-]
-%>
-
-<%
-demo_configs_subtle = [
+demo_configs = [
   {
     heading: "Primary",
     label: "Primary",
@@ -40,7 +20,7 @@ demo_configs_subtle = [
 
 <h3>Standard Buttons</h3>
 
-<% demo_configs_standard.each do | config | %>
+<% demo_configs.each do | config | %>
   <%= sage_component SageCardBlock, {} do %>
     <%= sage_component SageBadge, {
       color: "draft",
@@ -116,7 +96,7 @@ demo_configs_subtle = [
 <% end %>
 
 <h3>Subtle Buttons</h3>
-<% demo_configs_subtle.each do | config | %>
+<% demo_configs.each do | config | %>
   <%= sage_component SageCardBlock, {} do %>
     <%= sage_component SageBadge, {
       color: "draft",

--- a/docs/lib/sage_rails/app/sage_components/sage_button.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_button.rb
@@ -8,7 +8,7 @@ class SageButton < SageComponent
     icon: [:optional, { name: String, style: Set.new(["left", "right", "only"]) }],
     small: [:optional, NilClass, TrueClass],
     spinner_on_submit: [:optional, NilClass, String],
-    style: [:optional, NilClass, Set.new(["primary", "neutral", "secondary", "danger"])],
+    style: [:optional, NilClass, Set.new(["primary", "secondary", "danger"])],
     subtle: [:optional, NilClass, TrueClass],
     value: [:optional, String],
   })

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -21,7 +21,7 @@ $-btn-base-styles: (
   primary: (
     default: (
       color: sage-color(white),
-      background-color: sage-color(primary, 500),
+      background-color: sage-color(primary, 600),
       ring-color: sage-color(primary, 300),
     ),
     hover: (
@@ -33,27 +33,8 @@ $-btn-base-styles: (
       background-color: sage-color(primary, 600),
     ),
     disabled: (
-      color: sage-color(primary, 300),
+      color: sage-color(primary, 400),
       background-color: sage-color(primary, 100),
-    )
-  ),
-  neutral: (
-    default: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 800),
-      ring-color: sage-color(grey, 300),
-    ),
-    hover: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 900),
-    ),
-    focus: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 800),
-    ),
-    disabled: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 400),
     )
   ),
   secondary: (
@@ -64,22 +45,22 @@ $-btn-base-styles: (
     ),
     hover: (
       color: sage-color(grey, 800),
-      background-color: sage-color(grey, 100),
+      background-color: sage-color(grey, 50),
     ),
     focus: (
       color: sage-color(grey, 800),
       background-color: sage-color(white),
     ),
     disabled: (
-      color: sage-color(grey, 400),
-      background-color: sage-color(grey, 200),
+      color: sage-color(grey, 500),
+      background-color: sage-color(grey, 50),
     )
   ),
   danger: (
     default: (
       color: sage-color(white),
-      background-color: sage-color(red, 500),
-      ring-color: sage-color(red, 400),
+      background-color: sage-color(red, 600),
+      ring-color: sage-color(primary, 300),
     ),
     hover: (
       color: sage-color(white),
@@ -87,21 +68,14 @@ $-btn-base-styles: (
     ),
     focus: (
       color: sage-color(white),
-      background-color: sage-color(red, 500),
+      background-color: sage-color(red, 600),
     ),
     disabled: (
-      color: sage-color(red, 300),
+      color: sage-color(red, 400),
       background-color: sage-color(red, 100),
     )
   ),
 );
-
-$-btn-subtle-secondary-neutral-default: sage-color(grey, 600);
-$-btn-subtle-secondary-neutral-hover: sage-color(grey, 600);
-$-btn-subtle-secondary-neutral-hover-background: sage-color(grey, 200);
-$-btn-subtle-secondary-neutral-focus: sage-color(grey, 600);
-$-btn-subtle-secondary-neutral-focus-outline: sage-color(grey, 400);
-$-btn-subtle-secondary-neutral-disabled: sage-color(grey, 500);
 
 $-btn-subtle-styles: (
   primary: (
@@ -113,21 +87,12 @@ $-btn-subtle-styles: (
     disabled: sage-color(primary, 300),
   ),
   secondary: (
-    default: $-btn-subtle-secondary-neutral-default,
-    hover: $-btn-subtle-secondary-neutral-hover,
-    hover-background: $-btn-subtle-secondary-neutral-hover-background,
-    focus: $-btn-subtle-secondary-neutral-focus,
-    focus-outline: $-btn-subtle-secondary-neutral-focus-outline,
-    disabled: $-btn-subtle-secondary-neutral-disabled,
-  ),
-  // must be same as secondary
-  neutral: (
-    default: $-btn-subtle-secondary-neutral-default,
-    hover: $-btn-subtle-secondary-neutral-hover,
-    hover-background: $-btn-subtle-secondary-neutral-hover-background,
-    focus: $-btn-subtle-secondary-neutral-focus,
-    focus-outline: $-btn-subtle-secondary-neutral-focus-outline,
-    disabled: $-btn-subtle-secondary-neutral-disabled,
+    default: sage-color(grey, 800),
+    hover: sage-color(grey, 800),
+    hover-background: sage-color(grey, 100),
+    focus: sage-color(grey, 800),
+    focus-outline: sage-color(primary, 300),
+    disabled: sage-color(grey, 500),
   ),
   danger: (
     default: sage-color(red, 600),

--- a/packages/sage-react/lib/Button/configs.js
+++ b/packages/sage-react/lib/Button/configs.js
@@ -1,6 +1,5 @@
 export const BUTTON_COLORS = {
   PRIMARY: 'primary',
-  NEUTRAL: 'neutral',
   SECONDARY: 'secondary',
   DANGER: 'danger',
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove neutral variation
- [x] Aligning button styles with a Primary, Secondary, and Danger variation
- [x] Aligning subtle button styles with a Primary, Secondary, and Danger variation
- [ ] ~Aligning subtle button pseudo element padding with a Primary, Secondary, and Danger variation~ requires chat with @croswell that will need a followup PR

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="790" alt="Screen Shot 2022-04-12 at 7 34 55 PM" src="https://user-images.githubusercontent.com/1241836/163076316-411dcb42-4e22-4d96-8a00-aeca178e21b0.png">|<img width="786" alt="Screen Shot 2022-04-12 at 7 30 28 PM" src="https://user-images.githubusercontent.com/1241836/163076220-455af120-fd36-4ce8-a971-4041558f9f3d.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify that the Button views align with the latest sage spec:
- [Rails](http://localhost:4000/pages/component/button)
- [React](http://localhost:4100/?path=/story/sage-button--standard)

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-439](https://kajabi.atlassian.net/browse/SAGE-439)