### PR TITLE
Mw fix release deploy workflow

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Unsafe Perm set
         run: npm config set unsafe-perm true
 
+      - name: Add safe directory
+      run: git config --global --add safe.directory /__w/sage-lib/sage-lib
+
       - name: Clone Sage-Lib Repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Description

Failing workflow with error:
```
Initializing the repository
  /usr/bin/git init /__w/sage-lib/sage-lib
  hint: Using 'master' as the name for the initial branch. This default branch name
  hint: is subject to change. To configure the initial branch name to use in all
  hint: of your new repositories, which will suppress this warning, call:
  hint: 
  hint: 	git config --global init.defaultBranch <name>
  hint: 
  hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
  hint: 'development'. The just-created branch can be renamed via this command:
  hint: 
  hint: 	git branch -m <name>
  Initialized empty Git repository in /__w/sage-lib/sage-lib/.git/
  /usr/bin/git remote add origin https://github.com/Kajabi/sage-lib
  Error: fatal: unsafe repository ('/__w/sage-lib/sage-lib' is owned by someone else)
  To add an exception for this directory, call:
  
  	git config --global --add safe.directory /__w/sage-lib/sage-lib
  Error: The process '/usr/bin/git' failed with exit code 128
```


## Screenshots

![Screen Shot 2022-04-13 at 9 08 30 AM](https://user-images.githubusercontent.com/24237393/163199260-0204732f-1f94-4db8-a187-0a826fff30e6.png)

## KP testing
N/A - sage-lib repo workflow update