### PR TITLE
[Sage-412] Empty State - Foundations Sync Update

### DIFF
--- a/docs/app/views/examples/components/empty_state/_preview.html.erb
+++ b/docs/app/views/examples/components/empty_state/_preview.html.erb
@@ -41,19 +41,17 @@
     </p>
   <% end %>
   <% content_for :sage_empty_state_actions do %>
-    <%= sage_component SageButtonGroup, { gap: :md } do %>
-      <%= sage_component SageButton, {
-        attributes: { href: "#" },
-        style: "primary",
-        value: "Create Email Campaigns",
-      } %>
-      <%= sage_component SageButton, {
-        attributes: { href: "#" },
-        style: "secondary",
-        subtle: true,
-        value: "Learn More",
-      } %>
-    <% end %>
+    <%= sage_component SageButton, {
+      attributes: { href: "#" },
+      style: "primary",
+      value: "Create Email Campaigns",
+    } %>
+    <%= sage_component SageButton, {
+      attributes: { href: "#" },
+      style: "secondary",
+      subtle: true,
+      value: "Learn More",
+    } %>
   <% end %>
 <% end %>
 
@@ -71,18 +69,16 @@
     </p>
   <% end %>
   <% content_for :sage_empty_state_actions do %>
-    <%= sage_component SageButtonGroup, { gap: :md } do %>
-      <%= sage_component SageButton, {
-        attributes: { href: "#" },
-        style: "primary",
-        value: "Create Email Campaigns",
-      } %>
-      <%= sage_component SageButton, {
-        attributes: { href: "#" },
-        style: "secondary",
-        subtle: true,
-        value: "Learn More",
-      } %>
-    <% end %>
+    <%= sage_component SageButton, {
+      attributes: { href: "#" },
+      style: "primary",
+      value: "Create Email Campaigns",
+    } %>
+    <%= sage_component SageButton, {
+      attributes: { href: "#" },
+      style: "secondary",
+      subtle: true,
+      value: "Learn More",
+    } %>
   <% end %>
 <% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_empty_state.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_empty_state.rb
@@ -8,6 +8,7 @@ class SageEmptyState < SageComponent
     text: [:optional, String],
     title: [:optional, String],
     title_tag: [:optional, Set.new(["h1", "h2", "h3", "h4", "h5", "h5", "h6"])],
+    video: [:optional, Hash],
   })
   def sections
     %w(empty_state_actions empty_state_text empty_state_video)

--- a/docs/lib/sage_rails/app/sage_components/sage_empty_state.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_empty_state.rb
@@ -8,7 +8,6 @@ class SageEmptyState < SageComponent
     text: [:optional, String],
     title: [:optional, String],
     title_tag: [:optional, Set.new(["h1", "h2", "h3", "h4", "h5", "h5", "h6"])],
-    video: [:optional, Hash],
   })
   def sections
     %w(empty_state_actions empty_state_text empty_state_video)

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
@@ -50,7 +50,9 @@ end
 
     <% if content_for? :sage_empty_state_actions %>
       <div class="sage-empty-state__actions">
-        <%= content_for :sage_empty_state_actions %>
+        <%= sage_component SageButtonGroup, { gap: :sm } do %>
+          <%= content_for :sage_empty_state_actions %>
+        <% end %>
       </div>
     <% end %>
 

--- a/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
@@ -22,6 +22,7 @@ $-empty-state-graphic-page-height: rem(336px);
   }
 
   &:not(.sage-empty-state--compact):not(.sage-empty-state--page) {
+    gap: sage-spacing();
     padding: sage-spacing(2xl) sage-spacing();
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
@@ -60,7 +60,8 @@ $-empty-state-graphic-page-height: rem(336px);
 }
 
 .sage-empty-state__actions,
-.sage-empty-state__custom-content {
+.sage-empty-state__custom-content,
+.sage-empty-state__video {
   margin-top: sage-spacing();
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
@@ -46,7 +46,7 @@ $-empty-state-graphic-page-height: rem(336px);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: sage-spacing(lg);
+  gap: sage-spacing();
   width: 100%;
   padding: sage-spacing(lg);
 

--- a/packages/sage-react/lib/EmptyState/EmptyState.jsx
+++ b/packages/sage-react/lib/EmptyState/EmptyState.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageTokens } from '../configs';
+import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { EMPTY_STATE_SCOPES } from './configs';
 
@@ -60,7 +61,9 @@ export const EmptyState = ({
         )}
         {actions && (
           <div className="sage-empty-state__actions">
-            {actions}
+            <Button.Group gap={Button.Group.GAP_OPTIONS.SM}>
+              {actions}
+            </Button.Group>
           </div>
         )}
         {video && (

--- a/packages/sage-react/lib/EmptyState/EmptyState.story.jsx
+++ b/packages/sage-react/lib/EmptyState/EmptyState.story.jsx
@@ -46,6 +46,9 @@ PageScope.args = {
   titleTag: 'h1',
   children: null,
   actions: (
-    <Button>Add Email Campaign</Button>
+    <>
+      <Button>Add Email Campaign</Button>
+      <Button subtle={true} color={Button.COLORS.SECONDARY}>Link</Button>
+    </>
   )
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates spacing to new Foundation specs:
- Gaps changed to `24px`
- Adds margin to `video` slot

[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=2522%3A24021)

### Implementation Changes
N/A

### Follow-up Items
- [Build default video card](https://kajabi.atlassian.net/browse/SAGE-444)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1247" alt="Screen Shot 2022-04-13 at 2 55 46 PM" src="https://user-images.githubusercontent.com/14791307/163259859-b36a2c3b-1b00-4207-a67a-13b17fe4452d.png">|<img width="1253" alt="Screen Shot 2022-04-13 at 2 52 45 PM" src="https://user-images.githubusercontent.com/14791307/163259871-f353e949-8c0c-40f6-ad71-4d3b9fdcad1d.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- [View component](http://localhost:4000/pages/component/empty_state)
- Check that spacing is updated

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates Empty State spacing to new Foundation design specs.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-412](https://kajabi.atlassian.net/browse/SAGE-412)