### PR TITLE
[SAGE-393] Foundations Sidebar updates

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -47,7 +47,7 @@ $-nav-subitem-border-width: rem(2px);
     $outline-offset-block: -4,
     $outline-border-radius: sage-border(radius-medium),
   );
-  @include sage-focus-outline--update-color(sage-color(grey, 400));
+  @include sage-focus-outline--update-color(sage-color(primary, 300));
 
   display: flex;
   align-items: center;
@@ -58,16 +58,13 @@ $-nav-subitem-border-width: rem(2px);
   transition: map-get($sage-transitions, default);
   transition-property: background, box-shadow;
 
-  &:active,
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: $-nav-color-background-hover;
   }
 }
 
 .sage-nav__link--active::after {
   transform: translate3d(-50%, -50%, 0) scale(1);
-  border-color: sage-color(grey, 400);
   opacity: 1;
 }
 


### PR DESCRIPTION
## Description
Minor revisions to `focus` and `active` nav link states. No change to default and `hover` states, though the background color on a focused link will now display only when hovered.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
| | Before  |  After  |
|---|-----|--------|
|Nav links|![nav-before](https://user-images.githubusercontent.com/816579/163437113-61a6cb9d-9459-4f0b-a28c-7ed6f9516ab4.png)|![nav-after](https://user-images.githubusercontent.com/816579/163437131-0e8d238a-f26e-4a9b-abac-155932c29cf9.png)|
| Focus|![focus-before](https://user-images.githubusercontent.com/816579/163297057-0e83adb5-1596-4d64-99a0-fb56defa530a.png)|![focus-after](https://user-images.githubusercontent.com/816579/163297078-4033a8a4-6005-4177-a070-df3cbcbb4a47.png)|
|Active|![active-before](https://user-images.githubusercontent.com/816579/163297105-314e1d79-2a39-4da9-8382-87b0b89858bc.png)|![active-after](https://user-images.githubusercontent.com/816579/163297120-574a0d0b-fc9e-40b0-9f92-749c10a306ee.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Nav link `focus` and `active` states. No expected impact on current use.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
