### PR TITLE
Next version bump ~v4.56.0

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -1,5 +1,7 @@
 <%
   sample_body_text = "<p class='#{SageClassnames::TYPE::BODY}'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>".html_safe
+
+  long_sample_text = "<p class=' #{SageClassnames::TYPE::BODY}'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse urna leo, condimentum nec pellentesque finibus, ultricies pulvinar ante. Donec eu interdum ligula. Pellentesque aliquam ullamcorper orci, nec tempor libero tristique in. Aliquam vitae felis at leo condimentum placerat eget id libero. In dictum tortor ac accumsan aliquam. Donec sit amet tortor porttitor, tincidunt nisl at, egestas lacus. Integer metus augue, aliquet accumsan vulputate eget, tristique id erat. Donec a venenatis nibh, ac molestie risus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Vivamus in orci vitae ex tempor ultrices in a leo. Sed purus magna, vulputate aliquet ligula eget, consectetur sagittis nunc.</p>".html_safe
 %>
 <%= sage_component SagePanelBlock, {} do %>
   <%= sage_component SageButtonGroup, { wrap: true, gap: :sm, spacer: { bottom: :sm }} do %>
@@ -9,6 +11,14 @@
       value: "Modal",
       attributes: {
         "data-js-modaltrigger": "cool-modal",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Modal with Content Scrolling",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-scrolling",
       }
     } %>
     <%= sage_component SageButton, {
@@ -95,6 +105,65 @@
       <%= sample_body_text %>
 
       <%= sample_body_text %>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%# Standard Modal with Scrolling %>
+  <%= sage_component SageModal, { allow_scroll: true, id: "cool-modal-scrolling" } do %>
+    <%= sage_component SageModalContent, {
+      title: "Example Modal",
+      subheader: "Example Subheader",
+      help_content: "<p>Popover content</p>",
+      help_title: "Example Popover Title",
+      help_link: {
+        href: "#",
+        name: "Learn more about modals"
+      }
+    } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <% content_for :sage_header_indicator do %>
+        <%= sage_component SageIndicator, {
+          current_item: 2,
+          label: "Page",
+          num_items: 5,
+          show_text: true
+        } %>
+      <% end %>
+
+      <%= long_sample_text %>
+      <%= long_sample_text %>
+      <%= long_sample_text %>
+      <%= long_sample_text %>
 
       <% content_for :sage_footer do %>
         <% content_for :sage_footer_aside do %>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -1,6 +1,7 @@
 class SageModal < SageComponent
   set_attribute_schema({
     active: [:optional, NilClass, TrueClass],
+    allow_scroll: [:optional, NilClass, TrueClass],
     animate: [:optional, String, TrueClass, {
       direction: [:optional, String, Set.new(["bottom", "top", "left", "right"])]
     }],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -5,6 +5,7 @@
     <%= "sage-modal--fullscreen" if component.fullscreen -%>
     <%= "sage-modal--no-blur" if component.disable_background_blur -%>
     <%= "sage-modal--no-background-dismiss" if component.disable_background_dismiss -%>
+    <%= "sage-modal--scrollable" if component.allow_scroll %>
     <%= component.generated_css_classes %>
   "
   <%= "data-sage-animate" if component.animate.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -65,6 +65,10 @@ $-modal-fullscreen-top-spacing: rem(104px);
   }
 }
 
+.sage-modal--scrollable {
+  overflow-y: initial;
+}
+
 .sage-modal__container {
   visibility: hidden;
   z-index: sage-z-index(modal);
@@ -136,6 +140,18 @@ $-modal-fullscreen-top-spacing: rem(104px);
     border-radius: 0;
     opacity: 1;
   }
+
+  .sage-modal--scrollable &,
+  .sage-modal--scrollable & > .simple_form {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    max-height: 85vh;
+  }
+  
+  .sage-modal--scrollable & > .simple_form {
+    @include overflow-scroll(y);
+    padding: sage-spacing(xs) sage-spacing(3xs);
+  }
 }
 
 .sage-modal__header {
@@ -204,6 +220,17 @@ $-modal-fullscreen-top-spacing: rem(104px);
 
   .sage-modal--fullscreen & {
     margin-top: $-modal-fullscreen-top-spacing;
+  }
+
+  .sage-modal--scrollable & {
+    @include overflow-scroll(y);
+
+    margin-top: 0;
+    padding: sage-spacing(xs) sage-spacing(3xs);
+
+    > :first-child {
+      margin-top: sage-spacing(xs);
+    }
   }
 
   .sage-drawer & {

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -10,6 +10,7 @@ import { MODAL_ANIMATION_PRESETS, MODAL_ANIMATION_DIRECTIONS } from './configs';
 
 export const Modal = ({
   active,
+  allowScroll,
   animation,
   children,
   className,
@@ -27,6 +28,7 @@ export const Modal = ({
     className,
     {
       'sage-modal--active': active,
+      'sage-modal--scrollable': allowScroll,
       'sage-modal--large': large,
       'sage-modal--fullscreen': fullScreen,
       'sage-modal--no-blur': disableBackgroundBlur,
@@ -93,6 +95,7 @@ Modal.ANIMATION_DIRECTIONS = MODAL_ANIMATION_DIRECTIONS;
 
 Modal.defaultProps = {
   active: false,
+  allowScroll: false,
   animation: null,
   children: null,
   containerClassName: null,
@@ -107,6 +110,7 @@ Modal.defaultProps = {
 
 Modal.propTypes = {
   active: PropTypes.bool,
+  allowScroll: PropTypes.bool,
   animation: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.shape({

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -267,6 +267,8 @@ export const Table = ({
   const renderTableRow = (row) => {
     // Ensure there's a unique id for the row if one is not provided
     const rowId = row.id || uuid();
+    const disableSelect = row.disableSelect || false;
+    const hideSelect = row.hideSelect || false;
 
     // Transform the raw row data into a consistent structure
     const cells = TableRow.parseRowData(row, schema);
@@ -276,6 +278,8 @@ export const Table = ({
         key={rowId}
         id={rowId}
         cells={cells}
+        disableSelect={disableSelect}
+        hideSelect={hideSelect}
         schema={schema}
         selected={selfSelectedRows === SELECTION_TYPES.ALL || selfSelectedRows.includes(rowId)}
         selectable={selectable}

--- a/packages/sage-react/lib/Table/Table.story.jsx
+++ b/packages/sage-react/lib/Table/Table.story.jsx
@@ -68,6 +68,14 @@ Default.decorators = [
             If this table has paged data you should also
             set <code>hasDataBeyondCurrentRows: true</code>.
           </li>
+          <li>
+            If you want to disable the checkbox on an individual row,
+            add <code>disableSelect: true</code> to that row&rsquo;s data.
+          </li>
+          <li>
+            If you want to hide the checkbox on an individual row,
+            add <code>hideSelect: true</code> to that row&rsquo;s data.
+          </li>
         </ul>
       </div>
     </>

--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -10,6 +10,8 @@ import { Checkbox } from '../Toggle';
 export const TableRow = ({
   className,
   cells,
+  disableSelect,
+  hideSelect,
   id,
   onSelect,
   schema,
@@ -76,15 +78,18 @@ export const TableRow = ({
     <tr className={classNames} data-table-row-id={id}>
       {selectable && (
         <td className="sage-table-cell sage-table-cell--checkbox">
-          <Checkbox
-            checked={selfSelected}
-            id={`sage-table__row-selector-${id}`}
-            label="Select row"
-            name="sage-table-selections"
-            onChange={onChangeSelector}
-            standalone={true}
-            value={id.toString()}
-          />
+          {!hideSelect && (
+            <Checkbox
+              checked={selfSelected}
+              disabled={disableSelect}
+              id={`sage-table__row-selector-${id}`}
+              label="Select row"
+              name="sage-table-selections"
+              onChange={onChangeSelector}
+              standalone={true}
+              value={id.toString()}
+            />
+          )}
         </td>
       )}
       {selfCells.map((configs) => {
@@ -107,6 +112,8 @@ TableRow.parseRowData = parseRowData;
 TableRow.defaultProps = {
   className: null,
   cells: [],
+  disableSelect: false,
+  hideSelect: false,
   onSelect: (ev) => ev,
   selectable: false,
   selected: false,
@@ -116,6 +123,8 @@ TableRow.defaultProps = {
 TableRow.propTypes = {
   className: PropTypes.string,
   cells: PropTypes.arrayOf(PropTypes.shape(cellPropTypes)),
+  disableSelect: PropTypes.bool,
+  hideSelect: PropTypes.bool,
   id: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,

--- a/packages/sage-react/lib/Table/sample-data/contacts.js
+++ b/packages/sage-react/lib/Table/sample-data/contacts.js
@@ -18,6 +18,8 @@ export const dataCollection = [
     first: 'Rowan',
     email: 'rowan@example.com',
     phone: '555-111-1101',
+    disableSelect: true,
+    hideSelect: true,
   },
   {
     id: 3,


### PR DESCRIPTION
1. (LOW) - kajabi/sage-lib#1318 - Adds `allow_scroll`/`allowScroll` prop to Rails and React to allow modal content to scroll. Scrolling is guarded behind an opt-in prop, so modals across the app will not be affected.