### PR TITLE
[Sage-438] Card Highlight - Border Fix

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_card_highlight.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card_highlight.scss
@@ -4,6 +4,9 @@
 /// @group sage
 ////
 
+$-card-highlight-border-radius: sage-border(radius-large);
+$-card-highlight-size: rem(12px);
+
 .sage-card-highlight {
   --color: #{sage-color(primary, 900)};
 
@@ -15,38 +18,38 @@
 .sage-card-highlight--left {
   top: 0;
   bottom: 0;
-  width: rem(4px);
+  width: $-card-highlight-size;
 }
 
 .sage-card-highlight--right {
   right: 0;
-  border-top-right-radius: sage-border(radius);
-  border-bottom-right-radius: sage-border(radius);
+  border-top-right-radius: $-card-highlight-border-radius;
+  border-bottom-right-radius: $-card-highlight-border-radius;
 }
 
 .sage-card-highlight--left {
   left: 0;
-  border-top-left-radius: sage-border(radius);
-  border-bottom-left-radius: sage-border(radius);
+  border-top-left-radius: $-card-highlight-border-radius;
+  border-bottom-left-radius: $-card-highlight-border-radius;
 }
 
 .sage-card-highlight--top,
 .sage-card-highlight--bottom {
   right: 0;
   left: 0;
-  height: rem(4px);
+  height: $-card-highlight-size;
 }
 
 .sage-card-highlight--top {
   top: 0;
-  border-top-left-radius: sage-border(radius);
-  border-top-right-radius: sage-border(radius);
+  border-top-left-radius: $-card-highlight-border-radius;
+  border-top-right-radius: $-card-highlight-border-radius;
 }
 
 .sage-card-highlight--bottom {
   bottom: 0;
-  border-bottom-left-radius: sage-border(radius);
-  border-bottom-right-radius: sage-border(radius);
+  border-bottom-left-radius: $-card-highlight-border-radius;
+  border-bottom-right-radius: $-card-highlight-border-radius;
 }
 
 @each $-color-name, $-color-sliders in $sage-colors {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes highlight size and border radius to match new Card specs in Foundations.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="424" alt="Screen Shot 2022-04-15 at 3 13 07 PM" src="https://user-images.githubusercontent.com/14791307/163627587-67f25e5a-edc9-4285-b969-06ad9d56402e.png">|<img width="419" alt="Screen Shot 2022-04-15 at 3 12 13 PM" src="https://user-images.githubusercontent.com/14791307/163627591-91cb04c3-fc85-4573-9e46-5aaddde422bf.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Card Highlight](http://localhost:4000/pages/component/card_highlight)
- Check that alignment is corrected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Fixes highlight size and border radius to match new Card specs in Foundations.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-438](https://kajabi.atlassian.net/browse/SAGE-438)