### PR TITLE
[Sage-386] Containers update

### DIFF
--- a/docs/app/views/examples/components/container/_preview.html.erb
+++ b/docs/app/views/examples/components/container/_preview.html.erb
@@ -5,7 +5,7 @@
       <%= sage_component SageCardHeader, {
         title: md("#{c[:name]} (max `#{c[:max_size]}`)")
       } %>
-      <p><%= c[:usage] %></p>
+      <p>Usage: <code><%= c[:usage] %></code></p>
     <% end %>
   <% end %>
 <% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
@@ -62,50 +62,38 @@ module SageTokens
 
   COLOR_SLIDERS = SageTokens.color_sliders()
 
-  CONTAINER_SIZES = ["tiny", "xs", "sm", "md", "lg", "xl", "full"]
+  CONTAINER_SIZES = ["xs", "sm", "md", "lg", "full"]
 
   CONTAINER_SPECS = [
-    {
-      alias: "tiny",
-      max_size: "200px",
-      name: "Tiny",
-      usage: "For smaller dropdowns.",
-    },
     {
       alias: "xs",
       max_size: "240px",
       name: "Extra Small",
-      usage: "For standard dropdowns and smaller modal panels.",
+      usage: "sage-container(xs)",
     },
     {
       alias: "sm",
-      max_size: "352px",
+      max_size: "340px",
       name: "Small",
-      usage: "For one third of a trifold layout, the smaller portion of a side fold layout, standard modal panels, and narrow single-column layouts.",
+      usage: "sage-container(sm)",
     },
     {
       alias: "md",
-      max_size: "544px",
+      max_size: "520px",
       name: "Medium",
-      usage: "For one half of a bifold layout, medium-sized single column layouts, and larger modal panels.",
+      usage: "sage-container(md)",
     },
     {
       alias: "lg",
-      max_size: "736px",
+      max_size: "700px",
       name: "Large",
-      usage: "For the larger part of a side fold layout, larger single-column layouts, and largest for modal panels.",
-    },
-    {
-      alias: "xl",
-      max_size: "1120px",
-      name: "Large",
-      usage: "For single-column layouts that span full portion of stage yet stay at a maximum of 1120px wide.",
+      usage: "sage-container(lg)",
     },
     {
       alias: "full",
-      max_size: "1440px",
+      max_size: "1064px",
       name: "Full",
-      usage: "For widest possible panels and containing layout patterns.",
+      usage: "sage-container(full)",
     }
   ]
 

--- a/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tokens.rb
@@ -62,15 +62,9 @@ module SageTokens
 
   COLOR_SLIDERS = SageTokens.color_sliders()
 
-  CONTAINER_SIZES = ["xs", "sm", "md", "lg", "full"]
+  CONTAINER_SIZES = ["tiny", "xs", "sm", "md", "lg", "xl", "full"]
 
   CONTAINER_SPECS = [
-    {
-      alias: "xs",
-      max_size: "240px",
-      name: "Extra Small",
-      usage: "sage-container(xs)",
-    },
     {
       alias: "sm",
       max_size: "340px",

--- a/packages/sage-assets/lib/stylesheets/dictionary/_tokens.scss
+++ b/packages/sage-assets/lib/stylesheets/dictionary/_tokens.scss
@@ -3319,3 +3319,4 @@ $sd-sage-content-grid-template: (
   $value: map-get($value, $subkey);
   @return $value;
 }
+

--- a/packages/sage-assets/lib/stylesheets/dictionary/_tokens.scss
+++ b/packages/sage-assets/lib/stylesheets/dictionary/_tokens.scss
@@ -3319,4 +3319,3 @@ $sd-sage-content-grid-template: (
   $value: map-get($value, $subkey);
   @return $value;
 }
-

--- a/packages/sage-assets/lib/stylesheets/tokens/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_container.scss
@@ -9,13 +9,11 @@
 /// Sage containers token
 ///
 $sage-containers: (
-  tiny: rem(200px),
   xs: rem(240px),
-  sm: rem(352px),
-  md: rem(544px),
-  lg: rem(736px),
-  xl: rem(1120px),
-  full: rem(1440px),
+  sm: rem(340px),
+  md: rem(520px),
+  lg: rem(700px),
+  full: rem(1064px),
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/tokens/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_container.scss
@@ -9,10 +9,12 @@
 /// Sage containers token
 ///
 $sage-containers: (
+  tiny: rem(200px),
   xs: rem(240px),
   sm: rem(340px),
   md: rem(520px),
   lg: rem(700px),
+  xl: rem(798px),
   full: rem(1064px),
 );
 

--- a/packages/sage-react/lib/Grid/configs.js
+++ b/packages/sage-react/lib/Grid/configs.js
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types';
 
 export const CONTAINER_SIZES = {
-  TINY: 'tiny',
   XS: 'xs',
   SM: 'sm',
   MD: 'md',
   LG: 'lg',
-  XL: 'xl',
   FULL: 'full',
 };
 


### PR DESCRIPTION
## Description

Align container components with the updated sizes per design.

## Design specs
[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=3106%3A25649)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| ![before-containers](https://user-images.githubusercontent.com/24237393/163846602-364879fe-f17d-4cab-8708-32c3f83a91b9.png) | ![Screen Shot 2022-04-18 at 1 55 48 PM](https://user-images.githubusercontent.com/24237393/163860238-e8f30fef-74e0-43a5-9942-2973d32850b2.png) |

## Testing in `sage-lib`
**Rails**
1. Navigate to http://localhost:4000/pages/component/container
2. Verify the sizes match the design specs

**React**
1. Navigate to http://localhost:4100/?path=/story/sage-grid--containers
2. Verify the sizes match the design specs

## Related

- [SAGE-386](https://kajabi.atlassian.net/browse/SAGE-386)
- [Deprecation Follow-up SAGE-448](https://kajabi.atlassian.net/browse/SAGE-448)
