### PR TITLE
[Sage-394] Breadcrumbs updates

### DIFF
--- a/docs/app/views/examples/components/breadcrumbs/_preview.html.erb
+++ b/docs/app/views/examples/components/breadcrumbs/_preview.html.erb
@@ -47,16 +47,16 @@
   is_progressbar: true,
   items: [
     {
-      text: "Test 1",
+      text: "Step 1 of 3",
       url: "#"
     },
     {
-      text: "Test 2",
+      text: "Step 2 of 3",
       url: "#",
       is_current: true
     },
     {
-      text: "Test 3",
+      text: "Step 3 of 3",
       url: "#"
     }
   ]

--- a/packages/sage-assets/lib/stylesheets/components/_breadcrumbs.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_breadcrumbs.scss
@@ -4,9 +4,8 @@
 /// @group sage
 ////
 
-$-breadcrumb-current-color: sage-color(grey, 900);
+$-breadcrumb-current-color: sage-color(grey, 800);
 $-breadcrumb-interactive-color: sage-color(grey, 800);
-$-breadcrumb-interactive-bg: sage-color(grey, 100);
 $-breadcrumb-outline-color: sage-color(grey, 400);
 
 .sage-breadcrumbs {
@@ -34,7 +33,6 @@ $-breadcrumb-outline-color: sage-color(grey, 400);
   &:not(:last-child) {
     &::after {
       content: "/";
-      margin: 0 rem(12px);
       color: sage-color(grey, 600);
     }
 
@@ -91,7 +89,6 @@ $-breadcrumb-outline-color: sage-color(grey, 400);
     &:focus,
     &:active {
       color: $-breadcrumb-interactive-color;
-      background: $-breadcrumb-interactive-bg;
     }
 
     &[aria-disabled="true"],


### PR DESCRIPTION
## Description

Sync breadcrumbs with design changes


## Screenshots
|  Before  |  After  |
|--------|--------|
| ![before-breadcrumbs](https://user-images.githubusercontent.com/24237393/163879029-164be47d-eee8-4c0d-b35f-39c3d8547ec9.png) | ![after-breadcrumbs](https://user-images.githubusercontent.com/24237393/163878847-048fc2d3-8088-4ec0-b83f-1d4070c7bf50.png) |




## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/breadcrumbs
2. Verify styles are matching updated design specs

## Related
[SAGE-394](https://kajabi.atlassian.net/browse/SAGE-394)
