### PR TITLE
[SAGE-411] Popover foundations update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -6,7 +6,7 @@
 
 
 $-popover-overlay-z-index: sage-z-index(modal);
-$-popover-panel-padding: sage-spacing(sm);
+$-popover-panel-padding: sage-spacing();
 $-popover-panel-min-size: sage-container(sm);
 $-popover-panel-contentmin-size: $-popover-panel-min-size - $-popover-panel-padding;
 $-popover-panel-max-size: rem(350px);
@@ -45,8 +45,8 @@ $-popover-panel-offset: sage-spacing(sm);
   padding: $-popover-panel-padding;
   background-color: sage-color(white);
   background-clip: padding-box;
-  box-shadow: sage-shadow();
-  border-radius: sage-border(radius);
+  box-shadow: sage-shadow(lg);
+  border-radius: sage-border(radius-large);
 
   .sage-popover--is-expanded & {
     visibility: visible;
@@ -91,7 +91,7 @@ $-popover-panel-offset: sage-spacing(sm);
   @extend %t-sage-body-small;
   @include sage-grid-stack();
 
-  color: sage-color(grey, 600);
+  color: sage-color(grey, 700);
 }
 
 .sage-popover__media {
@@ -117,5 +117,7 @@ $-popover-panel-offset: sage-spacing(sm);
 }
 
 .sage-popover__title {
-  @extend %t-sage-heading-6;
+  @extend %t-sage-heading-5;
+
+  color: sage-color(grey, 900);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_popover.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_popover.scss
@@ -39,6 +39,7 @@ $-popover-panel-offset: sage-spacing(sm);
   visibility: hidden;
   z-index: sage-z-index(modal);
   grid-template-columns: minmax(auto, $-popover-panel-max-size);
+  gap: rem(20px);
   position: absolute;
   width: auto;
   min-width: $-popover-panel-min-size;
@@ -91,6 +92,7 @@ $-popover-panel-offset: sage-spacing(sm);
   @extend %t-sage-body-small;
   @include sage-grid-stack();
 
+  gap: rem(20px);
   color: sage-color(grey, 700);
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update `box-shadow`, `border-radius`, `__title`, and `gap` styles to align with foundations spec

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-04-18 at 4 14 07 PM](https://user-images.githubusercontent.com/1241836/163879140-476d5a63-b771-4484-a89d-5dfe76ed3fd2.png)|![Screen Shot 2022-04-18 at 4 12 15 PM](https://user-images.githubusercontent.com/1241836/163879150-255feb5b-44cf-4ec3-9198-a4881b4be35d.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Popover views and verify alignment with the foundations spec:
- [Rails](http://localhost:4000/pages/component/popover)
- [React](http://localhost:4100/?path=/story/sage-popover--default)

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-411](https://kajabi.atlassian.net/browse/SAGE-411)