### PR TITLE
[Nav] added back no underline after rebase

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -54,6 +54,7 @@ $-nav-subitem-border-width: rem(2px);
   align-items: center;
   padding: rem(10px) rem(12px);
   margin-bottom: sage-spacing(2xs);
+  text-decoration: none;
   color: $-nav-color-text;
   border-radius: sage-border(radius-medium);
   transition: map-get($sage-transitions, default);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add back removed line after rebase

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-04-18 at 5 08 06 PM](https://user-images.githubusercontent.com/1241836/163885522-41484e90-46af-4b02-a71f-b2b15aa06303.png)|![Screen Shot 2022-04-18 at 5 08 32 PM](https://user-images.githubusercontent.com/1241836/163885565-7bf04a7e-bacc-4636-9fe8-06d92d6c2553.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify that the sidebar link don't show underlines
