### PR TITLE
[SAGE-449] - feat(breadcrumb): focus update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_breadcrumbs.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_breadcrumbs.scss
@@ -6,7 +6,7 @@
 
 $-breadcrumb-current-color: sage-color(charcoal, 400);
 $-breadcrumb-interactive-color: sage-color(charcoal, 400);
-$-breadcrumb-outline-color: sage-color(grey, 500);
+$-breadcrumb-outline-color: sage-color(primary, 400);
 
 .sage-breadcrumbs {
   display: flex;
@@ -81,8 +81,9 @@ $-breadcrumb-outline-color: sage-color(grey, 500);
     border-radius: rem(6px);
     @include sage-focus-outline(
       $outline-width: 4px,
-      $outline-offset-block: -1,
-      $outline-border-radius: sage-border(radius)
+      $outline-offset-block: -4,
+      $outline-offset-inline: -6,
+      $outline-border-radius: rem(6px)
     );
     @include sage-focus-outline--update-color($-breadcrumb-outline-color);
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_breadcrumbs.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_breadcrumbs.scss
@@ -6,7 +6,7 @@
 
 $-breadcrumb-current-color: sage-color(charcoal, 400);
 $-breadcrumb-interactive-color: sage-color(charcoal, 400);
-$-breadcrumb-outline-color: sage-color(primary, 400);
+$-breadcrumb-outline-color: sage-color(primary, 200);
 
 .sage-breadcrumbs {
   display: flex;


### PR DESCRIPTION
## Description

Align focus states more closely with Next designs

## Designs
[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=351%3A5692)

## Screenshots

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2022-04-19 at 12 12 11 PM](https://user-images.githubusercontent.com/24237393/164058709-f8390f87-4371-40b3-854b-8f5803516a94.png) | ![Screen Shot 2022-04-19 at 12 09 07 PM](https://user-images.githubusercontent.com/24237393/164058646-97d07745-bf4f-4886-8315-a5d9dc85d611.png) |

## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/breadcrumbs?sage_theme=sage_theme_next
2. Tab through Breadcrumbs
3. Verify they align with [design files](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=351%3A5692)

## Testing in `kajabi-products`
1. (**LOW**) Focus state update to breadcrumb should not impact `kp`

## Related
[SAGE-449](https://kajabi.atlassian.net/browse/SAGE-449)
