### PR TITLE
[SAGE-387] Description List foundations update

### DIFF
--- a/docs/app/views/examples/components/themes/next/description/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/description/_preview.html.erb
@@ -59,6 +59,10 @@
     {
       title: "Wrapping item",
       data: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dignissim fringilla eros, at faucibus mauris aliquam at.",
+      action: {
+        value: "Details",
+        attributes: { href: "#" }
+      }
     },
     {
       title: "Item with hidden title",
@@ -83,6 +87,10 @@
           #{sage_component(SageBadge, { value: "eros", color: "draft" })}
         ).html_safe,
       }),
+      action: {
+        value: "View all tags",
+        attributes: { href: "#" }
+      }
     }
   ],
 } %>
@@ -96,7 +104,7 @@
   use_sage_type: true
 ) %>
 <%= sage_component SageDescription, {
-  action_width: "108px",
+  action_width: "50%",
   items: [
     {
       title: "No action",

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_description.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_description.html.erb
@@ -38,7 +38,7 @@ end
       end
     end
     %>
-    <div 
+    <div
       class="
         sage-description__term-group
         <%= "sage-description__term-group--hide-title" if item[:hide_title] %>
@@ -50,22 +50,25 @@ end
         <dt class="sage-description__title <%= "visually-hidden" if item[:hide_title] %>"><%= item[:title] %></dt>
       <% end %>
       <% if item[:data] %>
-        <dd class="sage-description__data"><%= item[:data] %></dd>
-      <% end %>
-      <% if item[:action] %>
-        <div class="sage-description__action">
-          <%= sage_component SageButton, {
-            value: item[:action][:value] || "View more",
-            style: "primary",
-            subtle: true,
-            icon: {
-              name: "caret-right",
-              style: icon_only ? "only" : "right",
-            },
-            test_id: item[:action][:test_id],
-            attributes: item[:action][:attributes],
-          } %>
-        </div>
+        <dd class="sage-description__data">
+          <%= item[:data] %>
+
+          <% if item[:action] %>
+            <span class="sage-description__action">
+              <%= sage_component SageButton, {
+                value: item[:action][:value] || "View more",
+                style: "primary",
+                subtle: true,
+                icon: {
+                  name: "caret-right",
+                  style: icon_only ? "only" : "right",
+                },
+                test_id: item[:action][:test_id],
+                attributes: item[:action][:attributes],
+              } %>
+            </span>
+          <% end %>
+        </dd>
       <% end %>
     </div>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_description.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_description.html.erb
@@ -54,7 +54,7 @@ end
           <%= item[:data] %>
 
           <% if item[:action] %>
-            <span class="sage-description__action">
+            <dd class="sage-description__action">
               <%= sage_component SageButton, {
                 value: item[:action][:value] || "View more",
                 style: "primary",
@@ -66,7 +66,7 @@ end
                 test_id: item[:action][:test_id],
                 attributes: item[:action][:attributes],
               } %>
-            </span>
+            </dd>
           <% end %>
         </dd>
       <% end %>

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_description.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_description.scss
@@ -4,10 +4,10 @@
 /// @group sage
 ////
 
-$-description-action-size: rem(16px);
-$-description-action-var: var(--sage-description-action-width, #{$-description-action-size});
-$-description-title-size: calc(50% - #{$-description-action-var});
-$-description-title-var: var(--sage-description-title-width, #{$-description-title-size});
+$-description-size: 1fr;
+$-description-action-var: var(--sage-description-action-width, #{$-description-size});
+$-description-title-var: var(--sage-description-title-width, #{$-description-size});
+$-description-spacing: sage-spacing(sm);
 
 .sage-description {
   display: flex;
@@ -17,14 +17,14 @@ $-description-title-var: var(--sage-description-title-width, #{$-description-tit
 }
 
 .sage-description--no-dividers {
-  gap: sage-spacing(sm);
+  gap: $-description-spacing;
 }
 
 .sage-description__term-group {
   display: grid;
-  grid-template-columns: #{$-description-title-var} 1fr #{$-description-action-var};
-  grid-template-areas: "title data action";
-  gap: sage-spacing(sm);
+  grid-template-columns: #{$-description-title-var} #{$-description-action-var};
+  grid-template-areas: "title data";
+  gap: $-description-spacing;
   width: 100%;
 
   &:not(:last-child) {
@@ -39,29 +39,30 @@ $-description-title-var: var(--sage-description-title-width, #{$-description-tit
 
   .sage-description--stacked & {
     grid-template-areas:
-      "title title action"
-      "data  data  action";
+      "title"
+      "data";
     align-items: center;
-    row-gap: sage-spacing(2xs);
+    grid-template-columns: 1fr;
+    row-gap: $-description-spacing;
   }
 }
 
 .sage-description__term-group--no-action {
-  grid-template-areas: "title data data";
+  grid-template-areas: "title data";
 
   .sage-description--stacked & {
     grid-template-areas:
-      "title title title"
-      "data  data  data";
+      "title"
+      "data";
   }
 }
 
 .sage-description__term-group--hide-title {
-  grid-template-areas: "data data action";
+  grid-template-areas: "data data";
 
   &.sage-description__term-group--no-action,
   .sage-description--stacked & {
-    grid-template-areas: "data data data";
+    grid-template-areas: "data data";
   }
 }
 
@@ -69,7 +70,7 @@ $-description-title-var: var(--sage-description-title-width, #{$-description-tit
   @extend %t-sage-body;
 
   grid-area: title;
-  color: sage-color(charcoal, 100);
+  color: sage-color(charcoal, 200);
 }
 
 .sage-description__data {
@@ -80,5 +81,6 @@ $-description-title-var: var(--sage-description-title-width, #{$-description-tit
 }
 
 .sage-description__action {
-  grid-area: action;
+  display: block;
+  margin-top: $-description-spacing;
 }

--- a/packages/sage-react/lib/themes/next/Description/Description.jsx
+++ b/packages/sage-react/lib/themes/next/Description/Description.jsx
@@ -46,21 +46,22 @@ export const Description = ({
         {data && (
           <dd className="sage-description__data">
             {data}
+
+            {action && (
+              <div className="sage-description__action">
+                <Button
+                  color={Button.COLORS.PRIMARY}
+                  subtle={true}
+                  icon={SageTokens.ICONS.CARET_RIGHT}
+                  iconPosition={!iconOnly && Button.ICON_POSITIONS.RIGHT}
+                  iconOnly={iconOnly}
+                  {...action.attributes}
+                >
+                  {action.value || 'View more'}
+                </Button>
+              </div>
+            )}
           </dd>
-        )}
-        {action && (
-          <div className="sage-description__action">
-            <Button
-              color={Button.COLORS.PRIMARY}
-              subtle={true}
-              icon={SageTokens.ICONS.CARET_RIGHT}
-              iconPosition={!iconOnly && Button.ICON_POSITIONS.RIGHT}
-              iconOnly={iconOnly}
-              {...action.attributes}
-            >
-              {action.value || 'View more'}
-            </Button>
-          </div>
         )}
       </>
     );

--- a/packages/sage-react/lib/themes/next/Description/Description.jsx
+++ b/packages/sage-react/lib/themes/next/Description/Description.jsx
@@ -48,7 +48,7 @@ export const Description = ({
             {data}
 
             {action && (
-              <div className="sage-description__action">
+              <dd className="sage-description__action">
                 <Button
                   color={Button.COLORS.PRIMARY}
                   subtle={true}
@@ -59,7 +59,7 @@ export const Description = ({
                 >
                   {action.value || 'View more'}
                 </Button>
-              </div>
+              </dd>
             )}
           </dd>
         )}

--- a/packages/sage-react/lib/themes/next/Description/Description.story.jsx
+++ b/packages/sage-react/lib/themes/next/Description/Description.story.jsx
@@ -66,7 +66,6 @@ MultipleItems.args = {
 
 export const MultipleItemsWithActionButton = Template.bind({});
 MultipleItemsWithActionButton.args = {
-  actionWidth: '108px',
   items: [
     {
       title: 'No action',
@@ -115,10 +114,10 @@ StackedLayout.args = {
       title: 'Short item',
       data: 'John Doe',
     },
-    null,
     {
       title: 'Wrapping item',
       data: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dignissim fringilla eros, at faucibus mauris aliquam at.',
+      action: { value: 'More' },
     },
     {
       title: 'Item with hidden title',
@@ -143,6 +142,7 @@ StackedLayout.args = {
           <Badge value="eros" color="draft" />
         </Label.Group>
       ),
+      action: { value: 'More tags' },
     }
   ]
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update position of the actions
- [x] update `grid-template-columns` and vars to account for going from 3 columns to 2, related to custom title and action widths

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="743" alt="Screen Shot 2022-04-19 at 6 05 22 PM" src="https://user-images.githubusercontent.com/1241836/164116133-5e367a7e-67eb-4311-92cb-80f670a43688.png">|<img width="744" alt="Screen Shot 2022-04-19 at 6 12 16 PM" src="https://user-images.githubusercontent.com/1241836/164116141-b3879c28-6359-49da-a8bc-d41a1d67a1a2.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the description list view and verify alignment with the foundations spec:
- [Rails](http://localhost:4000/pages/component/description)
- [React](http://localhost:4100/?path=/story/sage-description--multiple-items-with-action-button)

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-387](https://kajabi.atlassian.net/browse/SAGE-387)