### PR TITLE
[SAGE-459] Search: add option to hide label

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -414,7 +414,7 @@ module ComponentsHelper
       },
       {
         title: "search",
-        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+        description: "A self-contained search form that can be used in isolation and inside of menus.",
         scss: "doing",
         docs: "doing",
         rails: "todo",

--- a/docs/app/views/examples/components/themes/next/search/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/search/_preview.html.erb
@@ -14,3 +14,14 @@
   contained: true,
   label_text: "Search"
 } %>
+
+<h3 class="t-sage-heading-6">Hidden label</h3>
+<p>Please note that a label is still required and rendered, but will be hidden from visual display.</p>
+<%= sage_component SageSearch, {
+  id: "search-3",
+  placeholder: "Search Coupons",
+  value: nil,
+  contained: true,
+  hide_label: true,
+  label_text: "Search"
+} %>

--- a/docs/app/views/examples/components/themes/next/search/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/search/_preview.html.erb
@@ -15,8 +15,7 @@
   label_text: "Search"
 } %>
 
-<h3 class="t-sage-heading-6">Hidden label</h3>
-<p>Please note that a label is still required and rendered, but will be hidden from visual display.</p>
+<h3 class="t-sage-heading-6">Hidden label (label is visually hidden, but still accessible to screenreaders)</h3>
 <%= sage_component SageSearch, {
   id: "search-3",
   placeholder: "Search Coupons",

--- a/docs/app/views/examples/components/themes/next/search/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/search/_props.html.erb
@@ -5,13 +5,19 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`hide_label`') %></td>
+  <td><%= md('Visually hides the Search input\'s label') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('Unique identifier for the search. Should match the `for` attribute on the corresponding label.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
-  <td><%= md('`label_text`') %></td>
+  <td><%= md('`label_text`') %><%= sage_component SageBadge, { color: "published", value: "required" } %></td>
   <td><%= md('The value of the search label.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>

--- a/docs/app/views/examples/components/themes/next/search/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/search/_props.html.erb
@@ -1,36 +1,36 @@
 <tr>
   <td><%= md('`contained`') %></td>
-  <td><%= md('Is in the context of a "search toolbar" area.') %></td>
-  <td><%= md('Boolean') %></td>
-  <td><%= md('`nil`') %></td>
-</tr>
-<tr>
-  <td><%= md('`hide_label`') %></td>
-  <td><%= md('Visually hides the Search input\'s label') %></td>
+  <td><%= md('Set to `true` when in the context of a "search toolbar" area.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
-  <td><%= md('`id`') %></td>
-  <td><%= md('Unique identifier for the search. Should match the `for` attribute on the corresponding label.') %></td>
+  <td><%= md('`hide_label`') %></td>
+  <td><%= md('When set to `true`, hides the Search input\'s label') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`id`') %><%= sage_component SageBadge, { color: "published", value: "required" } %></td>
+  <td><%= md('A unique identifier for this component, used to associate with the label.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`label_text`') %><%= sage_component SageBadge, { color: "published", value: "required" } %></td>
-  <td><%= md('The value of the search label.') %></td>
+  <td><%= md('Text to display as a label/caption above the search field.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`placeholder`') %></td>
-  <td><%= md('Search null-state text.') %></td>
+  <td><%= md('Text displayed within the search field when empty.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`value`') %></td>
-  <td><%= md('The value of the search input.') %></td>
+  <td><%= md('Allows setting a predefined value of the search input.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_search.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_search.rb
@@ -2,6 +2,7 @@ class SageSearch < SageComponent
   set_attribute_schema({
     contained: [:optional, TrueClass],
     disabled: [:optional, TrueClass],
+    hide_label: [:optional, TrueClass],
     id: [:optional, String],
     label_text: [:optional, String],
     placeholder: [:optional, String],

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_search.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_search.html.erb
@@ -9,7 +9,7 @@
   <%= component.generated_html_attributes.html_safe %>
 >
 
-  <label for="<%= component.id %>" class="sage-search__label">
+  <label for="<%= component.id %>" class="sage-search__label<%= " visually-hidden" if component.hide_label %>">
     <%= component.label_text %>
   </label>
   <div class="sage-search__field-wrapper">
@@ -17,13 +17,12 @@
       id="<%= component.id %>"
       class="sage-search__input"
       <%# Prevents the default Kajabi-Products Search.js from binding to this input %>
-      data-kjb-disable-
-      search
+      data-kjb-disable-search
       type="search"
       <%= "disabled" if component.disabled %>
       placeholder="<%= component.placeholder.present? ? component.placeholder : "Search" %>"
       value="<%= component.value %>"
-    />
+    >
     <%= sage_component SageButton, {
       value: "Clear Search",
       style: "secondary",

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
@@ -5,6 +5,7 @@
 ////
 
 $-search-icon: "::before";
+$-search-input-height: rem(40px);
 
 .sage-search {
   display: flex;
@@ -44,7 +45,7 @@ $-search-icon: "::before";
   .sage-search--contained & {
     position: relative;
     z-index: sage-z-index(default);
-    border-radius: sage-border(radius);
+    border-radius: sage-border(radius-medium);
     box-shadow: map-get($sage-toolbar-button-borders, default);
     border: 0;
 
@@ -126,12 +127,10 @@ $-search-icon: "::before";
     outline: 0;
   }
 
-  .sage-panel-controls__toolbar & {
-    border-radius: sage-border(radius);
-  }
-
+  .sage-panel-controls__toolbar &,
   .sage-search--contained & {
-    border-radius: sage-border(radius);
+    border-radius: inherit;
+    height: $-search-input-height
   }
 
   .sage-search--contained &:focus,

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
@@ -129,8 +129,8 @@ $-search-input-height: rem(40px);
 
   .sage-panel-controls__toolbar &,
   .sage-search--contained & {
+    height: $-search-input-height;
     border-radius: inherit;
-    height: $-search-input-height
   }
 
   .sage-search--contained &:focus,

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
@@ -101,6 +101,8 @@ $-search-icon: "::before";
 
 .sage-search__label {
   @include sage-form-field-label;
+
+  margin-bottom: sage-spacing(2xs);
 }
 
 .sage-search__input {

--- a/packages/sage-react/lib/themes/next/Search/Search.jsx
+++ b/packages/sage-react/lib/themes/next/Search/Search.jsx
@@ -75,7 +75,6 @@ Search.defaultProps = {
   contained: false,
   disabled: false,
   hideLabel: false,
-  label: null,
   onClear: null,
   placeholder: 'Search',
 };

--- a/packages/sage-react/lib/themes/next/Search/Search.jsx
+++ b/packages/sage-react/lib/themes/next/Search/Search.jsx
@@ -8,6 +8,9 @@ export const Search = ({
   className,
   contained,
   disabled,
+  hideLabel,
+  id,
+  label,
   onClear,
   onChange,
   placeholder,
@@ -23,17 +26,27 @@ export const Search = ({
     }
   );
 
+  const labelClassnames = classnames(
+    'sage-search__label',
+    className,
+    {
+      'visually-hidden': hideLabel,
+    });
+
   return (
     <div className={classNames}>
-      <label className="sage-search__label">
-        {placeholder}
-      </label>
+      {label && (
+        <label htmlFor={id} className={labelClassnames}>
+          {label}
+        </label>
+      )}
       <div className="sage-search__field-wrapper">
         <input
           className="sage-search__input"
           type="search"
           onChange={onChange}
           disabled={disabled}
+          id={id}
           placeholder={`${placeholder}…`}
           value={value}
           // Prevents the default Kajabi-Products Search.js from binding to this input
@@ -61,6 +74,8 @@ Search.defaultProps = {
   className: null,
   contained: false,
   disabled: false,
+  hideLabel: false,
+  label: null,
   onClear: null,
   placeholder: 'Search',
 };
@@ -69,6 +84,9 @@ Search.propTypes = {
   className: PropTypes.string,
   contained: PropTypes.bool,
   disabled: PropTypes.bool,
+  hideLabel: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
   placeholder: PropTypes.string,

--- a/packages/sage-react/lib/themes/next/Search/Search.jsx
+++ b/packages/sage-react/lib/themes/next/Search/Search.jsx
@@ -86,7 +86,7 @@ Search.propTypes = {
   disabled: PropTypes.bool,
   hideLabel: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
   placeholder: PropTypes.string,

--- a/packages/sage-react/lib/themes/next/Search/Search.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Search/Search.spec.jsx
@@ -10,7 +10,6 @@ describe('Sage Search', () => {
 
   beforeEach(() => {
     defaultProps = {
-      label: 'Search',
       id: 'search-form-1',
       onChange: (data) => data,
       value: '',

--- a/packages/sage-react/lib/themes/next/Search/Search.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Search/Search.spec.jsx
@@ -10,6 +10,8 @@ describe('Sage Search', () => {
 
   beforeEach(() => {
     defaultProps = {
+      label: 'Search',
+      id: 'search-form-1',
       onChange: (data) => data,
       value: '',
     };

--- a/packages/sage-react/lib/themes/next/Search/Search.story.jsx
+++ b/packages/sage-react/lib/themes/next/Search/Search.story.jsx
@@ -10,11 +10,13 @@ const Template = (args) => <Search {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
+  label: 'Find',
+  id: 'search_default',
   placeholder: 'Find',
   value: ''
 };
 
-export const Contained = (args) => {
+export const ContainedWithLabelHidden = (args) => {
   const [value, setValue] = useState('');
 
   return (
@@ -28,15 +30,21 @@ export const Contained = (args) => {
     </>
   );
 };
-Contained.args = {
+ContainedWithLabelHidden.args = {
   contained: true,
-  placeholder: 'Search'
+  hideLabel: true,
+  label: 'Search',
+  id: 'search_contained',
+  placeholder: 'Search',
+  value: ''
 };
 
 export const Disabled = Template.bind({});
 Disabled.args = {
   contained: true,
   disabled: true,
+  label: 'Search',
+  id: 'search_disabled',
   placeholder: 'Search',
   value: ''
 };


### PR DESCRIPTION
## Description
Adds the ability to visually hide the label, necessary for vertical alignment of the [Toolbar component](https://kajabi.atlassian.net/browse/SAGE-410).

[Figma mockup](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/?node-id=3516%3A22970)

Notable changes for the React component (Sage Next only):
- A required `label` prop has been added to match behavior of the Rails component. Previously, the React version of Search reused the `placeholder` for the label.
- A required `id` prop has been added to be used in concert with `label`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![actual](https://user-images.githubusercontent.com/816579/164340560-b7885bd7-08f9-403f-8086-aa6d858dccca.png)|![Screen Shot 2022-04-20 at 4 23 51 PM](https://user-images.githubusercontent.com/816579/164340638-e0c0f0c8-4448-4bbe-80f3-12d043c3ce4d.png)|


## Testing in `sage-lib`
Rails
1. Navigate to the [Rails Search component](http://localhost:4000/pages/component/search)
2. Enable the "Use Next theme" switch in the top banner
3. Verify that the "Hidden label" example does not display its label

React
1. Navigate to the [Search component in storybook](http://localhost:4110/?path=/story/sage-search--contained-with-label-hidden&args=hideLabel:false)
3. Verify that the "Contained with label hidden" example does not display its label

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Search component: adds the ability to visually hide the label from view. Sage Next only; no expected impact on current use.



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
