### PR TITLE
Sync sage-system with `next` modifications

### DIFF
--- a/packages/sage-system/lib/inputaffixes.js
+++ b/packages/sage-system/lib/inputaffixes.js
@@ -1,3 +1,5 @@
+import { isNextTheme } from './utils';
+
 Sage.inputaffixes = (() => {
 
   // ==================================================
@@ -9,6 +11,7 @@ Sage.inputaffixes = (() => {
   const suffixRootClass = "sage-input--suffixed";
   const fieldClass = "sage-input__field";
   const valueClass = "sage-input__affix-value";
+  const wrapperClass = "sage-input__field-wrapper";
   const valueElement = "span";
   const inputPaddingOffset = 16;
 
@@ -20,6 +23,7 @@ Sage.inputaffixes = (() => {
   // Adds affix content to an element
   const addAffixes = (el) => {
     const elRoot = el;
+    const elWrapper = el.querySelector(`.${wrapperClass}`);
     const elInput = el.querySelector(`.${fieldClass}`);
 
     // Toggle off the affixed class
@@ -27,14 +31,23 @@ Sage.inputaffixes = (() => {
 
     if (elRoot.dataset.jsInputPrefix) {
       const elLabel = makeLabel(elRoot.dataset.jsInputPrefix, 'prefix');
-      elRoot.appendChild(elLabel);
+
+      if (isNextTheme()) {
+        elWrapper.appendChild(elLabel);
+      } else {
+        elRoot.appendChild(elLabel);
+      }
       elRoot.classList.add(prefixRootClass);
       elInput.style.paddingLeft = `${elLabel.offsetWidth + inputPaddingOffset}px`;
     }
 
     if (elRoot.dataset.jsInputSuffix) {
       const elLabel = makeLabel(elRoot.dataset.jsInputSuffix, 'suffix');
-      elRoot.appendChild(elLabel);
+      if (isNextTheme()) {
+        elWrapper.appendChild(elLabel);
+      } else {
+        elRoot.appendChild(elLabel);
+      }
       elRoot.classList.add(suffixRootClass);
       elInput.style.paddingRight = `${elLabel.offsetWidth + inputPaddingOffset}px`;
     }

--- a/packages/sage-system/lib/inputaffixes.js
+++ b/packages/sage-system/lib/inputaffixes.js
@@ -37,17 +37,20 @@ Sage.inputaffixes = (() => {
       } else {
         elRoot.appendChild(elLabel);
       }
+
       elRoot.classList.add(prefixRootClass);
       elInput.style.paddingLeft = `${elLabel.offsetWidth + inputPaddingOffset}px`;
     }
 
     if (elRoot.dataset.jsInputSuffix) {
       const elLabel = makeLabel(elRoot.dataset.jsInputSuffix, 'suffix');
+
       if (isNextTheme()) {
         elWrapper.appendChild(elLabel);
       } else {
         elRoot.appendChild(elLabel);
       }
+
       elRoot.classList.add(suffixRootClass);
       elInput.style.paddingRight = `${elLabel.offsetWidth + inputPaddingOffset}px`;
     }

--- a/packages/sage-system/lib/select.js
+++ b/packages/sage-system/lib/select.js
@@ -1,11 +1,14 @@
+import { isNextTheme } from './utils';
+
 Sage.select = (function() {
 
   // ==================================================
   // Variables
   // ==================================================
   var elSelectClass = '.sage-select',
-      classActive   = 'sage-select--value-selected',
-      htmlArrow     = '<i class="sage-select__arrow" aria-hidden="true"></i>';
+      elSelectWrapperClass = '.sage-select__field-wrapper',
+      classActive = 'sage-select--value-selected',
+      htmlArrow = '<i class="sage-select__arrow" aria-hidden="true"></i>';
 
   // ==================================================
   // Functions
@@ -38,7 +41,13 @@ Sage.select = (function() {
   function init(el) {
     var elSelect = el.querySelector('select');
 
-    el.insertAdjacentHTML('beforeEnd', htmlArrow);
+    if (isNextTheme()) {
+      var elWrapper = el.querySelector(elSelectWrapperClass);
+      elWrapper.insertAdjacentHTML('beforeEnd', htmlArrow);
+    } else {
+      el.insertAdjacentHTML('beforeEnd', htmlArrow);
+    }
+
     disableSelectPromptOptions(elSelect);
     updateValueSelectedState(elSelect.value, el);
 

--- a/packages/sage-system/lib/toast/toast.config.js
+++ b/packages/sage-system/lib/toast/toast.config.js
@@ -1,3 +1,5 @@
+import { isNextTheme } from "../utils";
+
 export const ID_TOAST_CONTAINER = 'SageToastContainer';
 export const DATA_ATTR = 'data-js-toast';
 export const DATA_ATTR_CLOSE_BUTTON = 'data-js-toast-close';
@@ -7,7 +9,7 @@ export const EVENT_CLOSE = "sage.toast.close";
 export const EVENT_DISMISS = "sage.toast.dismiss";
 
 export const DEFAULT_CONFIG = {
-  icon: 'check',
+  icon: isNextTheme() ? 'check-circle-filled' : 'check',
   type: 'notice',
   timer: 4500,
 };

--- a/packages/sage-system/lib/toast/toast.template.js
+++ b/packages/sage-system/lib/toast/toast.template.js
@@ -1,5 +1,6 @@
 import {
   objectToHtmlAttributes,
+  isNextTheme,
 } from '../utils/index';
 
 import {
@@ -26,7 +27,10 @@ export const toastTemplate = ({id, type, icon, text, link, testId = null}) => (`
     </output>
     ${linkTemplate(link)}
     <button
-      class="sage-toast__button sage-toast__button--close"
+      class="
+        sage-toast__button sage-toast__button--close
+        ${isNextTheme() && 'sage-btn sage-btn--subtle sage-btn--secondary sage-btn--icon-only-remove'}
+      "
       type="button"
       ${DATA_ATTR_CLOSE_BUTTON}
     >

--- a/packages/sage-system/lib/utils/index.js
+++ b/packages/sage-system/lib/utils/index.js
@@ -13,3 +13,7 @@ export function objectToHtmlAttributes(object) {
     return `${key}="${value}"`;
   }).join(' ');
 };
+
+export const isNextTheme = () => {
+  return window.SAGE_THEME === 'sage_theme_next';
+};


### PR DESCRIPTION
## Description

This PR adds the modifications to `sage-system` that were added in [SAGE-19_EPIC-foundations](https://github.com/Kajabi/sage-lib/pull/1185/files?file-filters%5B%5D=.js&show-deleted-files=true&show-viewed-files=true) so that both "themes" Rails components use most appropriate JS.

See the `.js` files within `sage-system` [here](https://github.com/Kajabi/sage-lib/pull/1185/files?file-filters%5B%5D=.js&show-deleted-files=true&show-viewed-files=true)

## Testing in `sage-lib`

In both themes validate that:

- [Toast](http://localhost:4000/pages/component/form_select) looks as expected in both themes (secondary close button and check icon)
- [Select](http://localhost:4000/pages/component/form_select) gets the dropdown arrow on the right
- [Input](http://localhost:4000/pages/component/form_input) gets appropriately style suffix and prefix


## Testing in `kajabi-products`

1. (LOW) Patches Rails JS for Next theme

NOTE: This is set to merge to `main` so as to trigger a patch version that can be used in currently running version bump.