### PR TITLE
[Sage-224] Choice - Specs Update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
@@ -38,11 +38,11 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   align-items: center;
   flex-grow: 1;
   flex-basis: 0;
-  padding: sage-spacing(sm);
+  padding: sage-spacing();
   text-decoration: none;
   color: $-choice-color-default;
   border: sage-border();
-  border-radius: sage-border(radius);
+  border-radius: sage-border(radius-large);
   transition: map-get($sage-transitions, default);
   transition-property: color, background-color, border-color, box-shadow;
 
@@ -52,7 +52,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     content: "";
     position: absolute;
     border: 1px solid transparent;
-    border-radius: sage-border(radius);
+    border-radius: sage-border(radius-large);
 
     @include position(-1px, -1px, -1px, -1px);
   }
@@ -235,5 +235,5 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   @extend %t-sage-body-xsmall;
 
   margin-top: sage-spacing(2xs);
-  color: sage-color(grey, 500);
+  color: sage-color(charcoal, 200);
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates the Choice component to match Figma design specs for Card component:
- Updates border radius and padding
- Fixes subtext color

[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=1667%3A23273)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="887" alt="Screen Shot 2022-04-21 at 4 52 31 PM" src="https://user-images.githubusercontent.com/14791307/164558065-487ffc7a-b38f-4c41-bba0-873974342f2d.png">|<img width="885" alt="Screen Shot 2022-04-21 at 4 48 17 PM" src="https://user-images.githubusercontent.com/14791307/164558074-e2ecaedc-459d-4d2a-992e-8e77941361ef.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Choice](http://localhost:4000/pages/component/choice)
- Check that it matches Card design specs in Figma

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Updates the Choice component to match Figma design specs for Card component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-224](https://kajabi.atlassian.net/browse/SAGE-224)