### PR TITLE
[SAGE-78] - docs(tabs): allows selected tab to be bookmarked

### DIFF
--- a/docs/app/views/examples/components/_component.html.erb
+++ b/docs/app/views/examples/components/_component.html.erb
@@ -49,7 +49,8 @@ dont_content = render partial: "#{partial_path_root}/#{theme_folder}/#{@title}/r
     <%= sage_component SagePanelRow, { grid_template: "te" } do %>
       <%= sage_component SageTabs, {
         id: "code-example-tabs",
-        items: tabs
+        items: tabs,
+        permalink: true,
       } %>
       <%= sage_component SageButton, {
         value: "#{image_tag("logo-react.svg", height: "20px")} React Component",

--- a/docs/app/views/examples/components/themes/legacy/tabs/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/tabs/_props.html.erb
@@ -42,6 +42,14 @@ Array<{
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
+<!-- Currently for Docs site only
+<tr>
+  <td><%= md('`permalink`') %></td>
+  <td><%= md('Whether or not the tab will update the url.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+-->
 <tr>
   <td><%= md('`progressbar`') %></td>
   <td><%= md('Whether or not to display tabs in a Progress bar layoutu with carets separating each.') %></td>

--- a/docs/app/views/examples/components/themes/next/tabs/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/tabs/_props.html.erb
@@ -42,6 +42,14 @@ Array<{
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
+<!-- Currently for Docs site only
+<tr>
+  <td><%= md('`permalink`') %></td>
+  <td><%= md('Whether or not the tab will update the url.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+-->
 <tr>
   <td><%= md('`progressbar`') %></td>
   <td><%= md('Whether or not to display tabs in a Progress bar layoutu with carets separating each.') %></td>

--- a/docs/lib/sage-frontend/javascript/docs/index.js
+++ b/docs/lib/sage-frontend/javascript/docs/index.js
@@ -9,6 +9,8 @@ require('./scroll-to-active-nav-item')
 
 require('./mocks')
 
+import SageDocsTabs from './tabs';
+
 // Conditional routing
 // NOTE: modules must be imported above to be initialized below
 if (document.querySelector('.sage-docs') !== null) {
@@ -27,6 +29,11 @@ if (document.querySelector('.sage-docs') !== null) {
 
   if (document.querySelector('.example__code') !== null && document.querySelector('.example__expand-btn') !== null) {
     Sage.docs.example.init();
+  }
+
+  if (document.querySelector('[data-js-tabs=code-example-tabs]')) {
+    let tabs = new SageDocsTabs(document.querySelector('[data-js-tabs=code-example-tabs]'))
+    tabs.init();
   }
 
   window.addEventListener("load", Sage.docs.scrollToActiveNavItem.init);

--- a/docs/lib/sage-frontend/javascript/docs/tabs.js
+++ b/docs/lib/sage-frontend/javascript/docs/tabs.js
@@ -1,0 +1,46 @@
+export default class SageDocsTab {
+  constructor (el) {
+    this.PERMALINK_ATTRIBUTE = 'jsTabsPermalink';
+    this.TABS_CHANGE_EVENT_NAME = 'sage.tabs.change';
+    this.TABS_INITIAL_EVENT_NAME = 'sage.tabs.initial';
+
+    this.tabs = el;
+    this.permalinkEnabled = false;
+  }
+
+  init() {
+    this.permalinkEnabled = Boolean(this.tabs.dataset[this.PERMALINK_ATTRIBUTE])
+    if (this.permalinkEnabled) this.bindEvents();
+  }
+
+  bindEvents() {
+    window.addEventListener('popstate', event => {
+      let tabsId, paneId;
+      const detail = { tabsId, paneId } = event.state;
+      document.dispatchEvent(new CustomEvent(this.TABS_CHANGE_EVENT_NAME, { detail }));
+    });
+
+    this.tabs.addEventListener(this.TABS_INITIAL_EVENT_NAME, e => {
+      if (this.permalinkEnabled == true) {
+        this.updateHistory(e.type, e.detail);
+      }
+    });
+
+    this.tabs.addEventListener(this.TABS_CHANGE_EVENT_NAME, e => {
+      if (this.permalinkEnabled == true) {
+        this.updateHistory(e.type, e.detail);
+      }
+    })
+  }
+
+  updateHistory(eventType, state) {
+    const { location: { search: queryString } } = window;
+    const params = new URLSearchParams(queryString);
+
+    params.set('tab', state.paneId);
+
+    (eventType !== this.TABS_INITIAL_EVENT_NAME)
+      ? history.pushState(state, '', [location.origin, location.pathname, '?', params.toString()].join(''))
+      : history.replaceState(state, '', [location.origin, location.pathname, '?', params.toString()].join(''));
+  }
+}

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -4,6 +4,7 @@ class SageTabs < SageComponent
     id: [:optional, String],
     items: [:optional, [[SageSchemas::CHOICE]], [[SageSchemas::TAB]]],
     navigational: [:optional, TrueClass],
+    permalink: [:optional, TrueClass], # For Docs site use only.
     progressbar: [:optional, TrueClass],
     stacked: [:optional, TrueClass],
     style: [:optional, Set.new(["choice"])],

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_tabs.html.erb
@@ -1,5 +1,6 @@
 <nav
   <%= "data-js-tabs=#{component.id}" if !component.navigational && component.id.present? %>
+  <%= "data-js-tabs-permalink=#{component.permalink}" if component.permalink.present? -%>
   class="sage-tabs
     <%= component.stacked.present? ? "sage-tabs--layout-stacked" : "sage-tabs--layout-default" %>
     <%= "sage-tabs--with-background" if component.with_background %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_tabs.html.erb
@@ -1,5 +1,6 @@
 <nav
   <%= "data-js-tabs=#{component.id}" if !component.navigational && component.id.present? %>
+  <%= "data-js-tabs-permalink=#{component.permalink}" if component.permalink.present? -%>
   class="sage-tabs
     <%= component.stacked.present? ? "sage-tabs--layout-stacked" : "sage-tabs--layout-default" %>
     <%= "sage-tabs--with-background" if component.with_background %>

--- a/packages/sage-system/lib/tabs.js
+++ b/packages/sage-system/lib/tabs.js
@@ -54,13 +54,13 @@ Sage.tabs = (function() {
     let selectedTarget
 
     if (target) {
-      switch(evt.keyCode) {
+      switch (evt.keyCode) {
         case 37: // Left arrow key
           selectedTarget = evt.target.previousElementSibling || evt.target.parentElement.lastElementChild
-        break
+          break
         case 39: // Right arrow key
           selectedTarget = evt.target.nextElementSibling || evt.target.parentElement.firstElementChild
-        break
+          break
       }
     }
 
@@ -74,7 +74,7 @@ Sage.tabs = (function() {
 
     let elTabsParent = document.querySelector(`[${SELECTOR_TABS}="${tabsId}"]`);
     let elTab = elTabsParent.querySelector(`[${SELECTOR_TAB_ITEM}="${paneId}"]`);
-    let tabsArray = Sage.util.nodelistToArray( elTabsParent.querySelectorAll(`[${SELECTOR_TAB_ITEM}]`) );
+    let tabsArray = Sage.util.nodelistToArray(elTabsParent.querySelectorAll(`[${SELECTOR_TAB_ITEM}]`));
 
     tabsArray.forEach((el) => {
       el.classList.remove(el.getAttribute(ACTIVE_CLASS_ATTRIBUTE));
@@ -90,12 +90,12 @@ Sage.tabs = (function() {
     }
 
     let elPane = document.querySelector(`[${SELECTOR_TAB_PANE}="${paneId}"]`);
-    // Ensure there is a matching pane 
+    // Ensure there is a matching pane
     if (!elPane) {
       return;
     }
 
-    let panesArray = Sage.util.nodelistToArray( elPane.parentElement.querySelectorAll(`[${SELECTOR_TAB_PANE}]`) );
+    let panesArray = Sage.util.nodelistToArray(elPane.parentElement.querySelectorAll(`[${SELECTOR_TAB_PANE}]`));
 
     panesArray.forEach((el) => el.classList.remove(CLASS_TAB_PANE_ACTIVE));
     elPane.classList.add(CLASS_TAB_PANE_ACTIVE);
@@ -104,7 +104,18 @@ Sage.tabs = (function() {
   function dispatchChange(tabsId, paneId, evType) {
     let eventDetail = { tabsId, paneId };
     evType = evType || EVENT_SELECT;
-    document.dispatchEvent(new CustomEvent(evType, { detail: eventDetail }));
+
+    let tabComponent = document.querySelector(`[${SELECTOR_TABS}="${tabsId}"]`);
+
+    dispatchChangeEvent(tabComponent, evType, eventDetail)
+  }
+
+  function dispatchChangeEvent(el, evType, eventDetail) {
+    evType = evType || EVENT_SELECT
+    const customEvent = new CustomEvent(evType, { detail: eventDetail })
+    document.dispatchEvent(customEvent);
+
+    el.dispatchEvent(customEvent)
   }
 
   return {
@@ -112,5 +123,4 @@ Sage.tabs = (function() {
     unbind: unbind,
     eventHandlerChange: eventHandlerChange
   }
-
 })();

--- a/packages/sage-system/lib/tabs.js
+++ b/packages/sage-system/lib/tabs.js
@@ -32,7 +32,16 @@ Sage.tabs = (function() {
     }
 
     if (elInitialActiveItem) {
-      dispatchChange(el.getAttribute(SELECTOR_TABS), elInitialActiveItem.getAttribute(SELECTOR_TAB_ITEM), EVENT_INITIAL_SELECT);
+      const { location: { search: queryString } } = window;
+      const params = new URLSearchParams(queryString);
+
+      if (params.has('tab')) {
+        const activeTab = params.get('tab');
+        dispatchChange(el.getAttribute(SELECTOR_TABS), activeTab, EVENT_INITIAL_SELECT);
+      }
+      else {
+        dispatchChange(el.getAttribute(SELECTOR_TABS), elInitialActiveItem.getAttribute(SELECTOR_TAB_ITEM), EVENT_INITIAL_SELECT);
+      }
     }
   }
 


### PR DESCRIPTION
## JIRA Ticket
[SAGE-78](https://kajabi.atlassian.net/browse/SAGE-78)

## Description
Allows the customer to the ability to bookmark a page with the current active tab. 


## Video
https://www.loom.com/share/aed605f88b94480bb5a7eceed1b09587

## Testing in `sage-lib`
1. Open up `sage-lib doc site`
2. Click `Components`
3. Notice that the url now contains a querystring `tab=preview`
4. Click on a tab or two
5. Click back, should navigate back to the previous tab. 
6. Copy the link in the address bar. Open a new tab and paste. It should open the the specific component and the correct tab. 


## Testing in `kajabi-products`
N/A

