### PR TITLE
[SAGE-493] Add generic `.sage-col` when only no column size is specified

### DIFF
--- a/docs/app/views/pages/grid.html.erb
+++ b/docs/app/views/pages/grid.html.erb
@@ -195,9 +195,6 @@
       <div class="grid-item">3</div>
     <% end %>
     <%= sage_component SageGridCol, {
-      small: "12",
-      medium: "6",
-      large: "3",
     } do %>
       <div class="grid-item">4</div>
     <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
@@ -3,7 +3,7 @@
 <div class="
   <%= "sage-col" if !has_infix -%>
   <%= "sage-col-#{component.size}" if component.size -%>
-  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint -%>
+  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint && component.size -%>
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
@@ -1,10 +1,14 @@
+<% has_infix = component.breakpoint || component.size || component.small || component.medium || component.large %>
+
+
 <div class="
-  <%= "sage-col" if !component.size %>
-  <%= "sage-col-#{component.size}" if component.size %>
-  sage-col--<%= component.breakpoint %>-<%= component.size %> <%= component.generated_css_classes %>
+  <%= "sage-col" if !has_infix -%>
+  <%= "sage-col-#{component.size}" if component.size -%>
+  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint -%>
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
+  <%= component.generated_css_classes %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
@@ -1,6 +1,5 @@
 <% has_infix = component.breakpoint || component.size || component.small || component.medium || component.large %>
 
-
 <div class="
   <%= "sage-col" if !has_infix -%>
   <%= "sage-col-#{component.size}" if component.size -%>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
@@ -3,7 +3,7 @@
 <div class="
   <%= "sage-col" if !has_infix -%>
   <%= "sage-col-#{component.size}" if component.size -%>
-  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint -%>
+  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint && component.size -%>
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
@@ -1,10 +1,13 @@
+<% has_infix = component.breakpoint || component.size || component.small || component.medium || component.large %>
+
 <div class="
-  <%= "sage-col" if !component.size %>
-  <%= "sage-col-#{component.size}" if component.size %>
-  sage-col--<%= component.breakpoint %>-<%= component.size %> <%= component.generated_css_classes %>
+  <%= "sage-col" if !has_infix -%>
+  <%= "sage-col-#{component.size}" if component.size -%>
+  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint -%>
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
+  <%= component.generated_css_classes %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>
 </div>

--- a/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
@@ -152,7 +152,7 @@ export const EqualColumns = Template.bind({});
 EqualColumns.args = {
   children: (
     <>
-       <Grid.Row spacerBelow="sm">
+      <Grid.Row spacerBelow="sm">
         <Grid.Col aria-label="Single column">
           <GridDemo>
             Equal Width Column

--- a/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
@@ -147,3 +147,62 @@ Containers.args = {
     </>
   )
 };
+
+export const EqualColumns = Template.bind({});
+EqualColumns.args = {
+  children: (
+    <>
+       <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col size="6" aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};

--- a/packages/sage-react/lib/themes/legacy/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/GridCol.jsx
@@ -15,6 +15,7 @@ export const GridCol = ({
   ...rest
 }) => {
   const hasInfix = size || small || medium || large;
+
   const classNames = classnames(
     className,
     {

--- a/packages/sage-react/lib/themes/legacy/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/GridCol.jsx
@@ -14,10 +14,11 @@ export const GridCol = ({
   small,
   ...rest
 }) => {
+  const hasInfix = size || small || medium || large;
   const classNames = classnames(
     className,
     {
-      'sage-col': !size,
+      'sage-col': !hasInfix,
       [`sage-col-${size}`]: size,
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,

--- a/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
@@ -147,3 +147,62 @@ Containers.args = {
     </>
   )
 };
+
+export const EqualColumns = Template.bind({});
+EqualColumns.args = {
+  children: (
+    <>
+       <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};

--- a/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
@@ -152,7 +152,7 @@ export const EqualColumns = Template.bind({});
 EqualColumns.args = {
   children: (
     <>
-       <Grid.Row spacerBelow="sm">
+      <Grid.Row spacerBelow="sm">
         <Grid.Col aria-label="Single column">
           <GridDemo>
             Equal Width Column

--- a/packages/sage-react/lib/themes/next/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/themes/next/Grid/GridCol.jsx
@@ -14,10 +14,12 @@ export const GridCol = ({
   small,
   ...rest
 }) => {
+  const hasInfix = size || small || medium || large;
+
   const classNames = classnames(
     className,
     {
-      'sage-col': !size,
+      'sage-col': !hasInfix,
       [`sage-col-${size}`]: size,
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] Add generic `.sage-col` when no column size is specified

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-04-27 at 8 51 43 AM](https://user-images.githubusercontent.com/1241836/165616979-0dc39eaf-e1de-4607-945c-b6e094f12b0b.png)|![Screen Shot 2022-04-27 at 1 42 21 PM](https://user-images.githubusercontent.com/1241836/165617100-511f8d28-4075-4d53-b07b-e93115892133.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
**No visual regression**
Go the the Grid views:
- verify that the `.sage-col` class only shows when no `size`, `small`, `medium`, or `large` prop is set

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Updates classes on the Grid component. Requires QA as this is a high usage component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-493](https://kajabi.atlassian.net/browse/SAGE-493)