### PR TITLE
[SAGE-316] Banner react variant

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -61,7 +61,7 @@ module ComponentsHelper
         scss: "done",
         docs: "done",
         rails: "done",
-        react: "doing",
+        react: "done",
         a11y: "done",
         figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F9Km09NjlZHYWsMP7EGT8tI%2F%255BWIP%255D-Sage-3-%25E2%2580%2594-Admin-Components%3Fnode-id%3D6999%253A21606",
       },

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_banner.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_banner.html.erb
@@ -1,4 +1,4 @@
-  <% if component.banner_context.present? %>
+<% if component.banner_context.present? %>
   <div class="
     sage-banner-wrapper
     <%= "sage-banner-wrapper--context-#{component.banner_context}" if component.banner_context.present? %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_banner.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_banner.html.erb
@@ -1,4 +1,4 @@
-  <% if component.banner_context.present? %>
+<% if component.banner_context.present? %>
   <div class="
     sage-banner-wrapper
     <%= "sage-banner-wrapper--context-#{component.banner_context}" if component.banner_context.present? %>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
@@ -635,6 +635,27 @@ $-alert-colors: (
       }
     }
   }
+
+  // react only styles as primary classes are added by default
+  &.sage-banner__link.sage-btn--primary,
+  &.sage-banner__close.sage-btn--primary {
+    color: sage-color(white);
+
+    &:focus,
+    &:active {
+      color: sage-color(white);
+
+      &::after {
+        border-color: sage-color(white);
+      }
+    }
+
+    &:not(:focus):hover,
+    &:not(:focus):hover::after {
+      background-color: transparent;
+      color: sage-color(white);
+    }
+  }
 }
 
 .sage-btn--small {

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
@@ -653,7 +653,6 @@ $-alert-colors: (
     &:not(:focus):hover,
     &:not(:focus):hover::after {
       background-color: transparent;
-      // color: sage-color(white);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
@@ -639,21 +639,21 @@ $-alert-colors: (
   // react only styles as primary classes are added by default
   &.sage-banner__link.sage-btn--primary,
   &.sage-banner__close.sage-btn--primary {
-    color: sage-color(white);
+    color: inherit;
 
     &:focus,
     &:active {
-      color: sage-color(white);
+      color: inherit;
 
       &::after {
-        border-color: sage-color(white);
+        border-color: inherit;
       }
     }
 
     &:not(:focus):hover,
     &:not(:focus):hover::after {
       background-color: transparent;
-      color: sage-color(white);
+      // color: sage-color(white);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -682,25 +682,24 @@ $-alert-colors: (
       }
     }
   }
-}
-
-// react only styles as primary classes are added by default
-&.sage-banner__link.sage-btn--primary,
-&.sage-banner__close.sage-btn--primary {
-  color: inherit;
-
-  &:focus,
-  &:active {
+  // react only styles as primary classes are added by default
+  &.sage-banner__link.sage-btn--primary,
+  &.sage-banner__close.sage-btn--primary {
     color: inherit;
 
-    &::after {
-      border-color: inherit;
-    }
-  }
+    &:focus,
+    &:active {
+      color: inherit;
 
-  &:not(:focus):hover,
-  &:not(:focus):hover::after {
-    background-color: transparent;
+      &::after {
+        border-color: inherit;
+      }
+    }
+
+    &:not(:focus):hover,
+    &:not(:focus):hover::after {
+      background-color: transparent;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -574,7 +574,7 @@ $-alert-colors: (
           z-index: 0;
           background-color: map-get($-styles, hover-background);
           opacity: 1;
-  
+
           .sage-alert & {
             background-color: transparent;
           }
@@ -681,6 +681,26 @@ $-alert-colors: (
         @include sage-focus-outline--update-color(sage-color($color, 400));
       }
     }
+  }
+}
+
+// react only styles as primary classes are added by default
+&.sage-banner__link.sage-btn--primary,
+&.sage-banner__close.sage-btn--primary {
+  color: inherit;
+
+  &:focus,
+  &:active {
+    color: inherit;
+
+    &::after {
+      border-color: inherit;
+    }
+  }
+
+  &:not(:focus):hover,
+  &:not(:focus):hover::after {
+    background-color: transparent;
   }
 }
 

--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -5,6 +5,7 @@ export const {
   Alert,
   Avatar,
   AvatarGroup,
+  Banner,
   Breadcrumbs,
   Button,
   Card,

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -1,36 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import BannerContent from './BannerContent';
-import BannerWrapper from './BannerWrapper'
+import { BannerContent } from './BannerContent';
+import { BannerWrapper } from './BannerWrapper';
 
 export const Banner = (props) => {
-  const {
-    active,
-    bannerContext,
-    className,
-    type,
-  } = props;
-  const classNames = classnames(
-    'sage-banner',
-    className,
-    {
-      [`sage-banner--${type}`]: type,
-      [`sage-banner--active`]: active,
-    }
-  );
-
-  const wrapperClassNames = classnames(
-    'sage-banner-wrapper',
-    {
-      [`sage-banner-wrapper--context-${bannerContext}`]: props.bannerContext,
-    }
-  );
-
+  const { bannerContext } = props;
+  console.log("bannercontext: ", bannerContext);
   return (
-    <>
-      (bannerContext ? <BannerWrapper {...props} /> : <BannerContent {...props} />)
-    </>
+    (bannerContext != "")
+      ? <BannerWrapper {...props} />
+      : <BannerContent {...props} />
   );
 };
 

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -3,15 +3,18 @@ import PropTypes from 'prop-types';
 import { BannerContent } from './BannerContent';
 import { BannerWrapper } from './BannerWrapper';
 
+import { BANNER_TYPES } from './configs';
+
 export const Banner = (props) => {
   const { bannerContext } = props;
-  console.log("bannercontext: ", bannerContext);
   return (
-    (bannerContext != "")
+    (bannerContext !== '')
       ? <BannerWrapper {...props} />
       : <BannerContent {...props} />
   );
 };
+
+Banner.TYPES = BANNER_TYPES;
 
 Banner.defaultProps = {
   active: null,
@@ -32,8 +35,7 @@ Banner.propTypes = {
   className: PropTypes.string,
   dismissable: PropTypes.bool,
   id: PropTypes.string,
-  label: PropTypes.string,
-  // link: ,
+  link: PropTypes.string,
   text: PropTypes.string,
-  type: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
 };

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -3,30 +3,43 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 export const Banner = ({
+  active,
+  bannerContext,
   children,
   className,
-  color,
-  label,
+  dismissable,
+  id,
+  link,
+  text,
+  type,
   ...rest
 }) => {
   const classNames = classnames(
     'sage-banner',
     className,
     {
+      [`sage-banner--${type}`]: type,
+      [`sage-banner--active`]: active,
+    }
+  );
 
+  const wrapperClassNames = classnames(
+    'sage-banner-wrapper',
+    {
+      [`sage-banner-wrapper--context-${bannerContext}`]: bannerContext,
     }
   );
 
   return (
-    // <span className={classNames} style={style} {...attrs} {...rest}>
-    //   {children}
-    // </span>
+    <div className={classNames} {...rest}>
+      {children}
+    </div>
   );
 };
 
 Banner.defaultProps = {
   active: null,
-  bannerContext,
+  bannerContext: null,
   children: null,
   className: null,
   dismissable: null,

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -15,27 +15,3 @@ export const Banner = (props) => {
 };
 
 Banner.TYPES = BANNER_TYPES;
-
-Banner.defaultProps = {
-  active: null,
-  bannerContext: null,
-  children: null,
-  className: null,
-  dismissable: null,
-  id: null,
-  link: null,
-  text: null,
-  type: null
-};
-
-Banner.propTypes = {
-  active: PropTypes.bool,
-  bannerContext: PropTypes.string,
-  children: PropTypes.node,
-  className: PropTypes.string,
-  dismissable: PropTypes.bool,
-  id: PropTypes.string,
-  link: PropTypes.string,
-  text: PropTypes.string,
-  type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
-};

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+export const Banner = ({
+  children,
+  className,
+  color,
+  label,
+  ...rest
+}) => {
+  const classNames = classnames(
+    'sage-banner',
+    className,
+    {
+
+    }
+  );
+
+  return (
+    // <span className={classNames} style={style} {...attrs} {...rest}>
+    //   {children}
+    // </span>
+  );
+};
+
+Banner.defaultProps = {
+  active: null,
+  bannerContext,
+  children: null,
+  className: null,
+  dismissable: null,
+  id: null,
+  link: null,
+  text: null,
+  type: null
+};
+
+Banner.propTypes = {
+  active: PropTypes.bool,
+  bannerContext: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  dismissable: PropTypes.bool,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  // link: ,
+  text: PropTypes.string,
+  type: PropTypes.string,
+};

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -8,13 +8,11 @@ import { BANNER_TYPES } from './configs';
 export const Banner = ({
   bannerContext,
   ...rest
-}) => {
-  return (
-    (bannerContext !== null)
-      ? <BannerWrapper bannerContext={bannerContext} {...rest} />
-      : <BannerContent bannerContext={bannerContext} {...rest} />
-  );
-};
+}) => (
+  (bannerContext !== null)
+    ? <BannerWrapper bannerContext={bannerContext} {...rest} />
+    : <BannerContent bannerContext={bannerContext} {...rest} />
+);
 
 Banner.TYPES = BANNER_TYPES;
 

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.jsx
@@ -5,13 +5,23 @@ import { BannerWrapper } from './BannerWrapper';
 
 import { BANNER_TYPES } from './configs';
 
-export const Banner = (props) => {
-  const { bannerContext } = props;
+export const Banner = ({
+  bannerContext,
+  ...rest
+}) => {
   return (
-    (bannerContext !== '')
-      ? <BannerWrapper {...props} />
-      : <BannerContent {...props} />
+    (bannerContext !== null)
+      ? <BannerWrapper bannerContext={bannerContext} {...rest} />
+      : <BannerContent bannerContext={bannerContext} {...rest} />
   );
 };
 
 Banner.TYPES = BANNER_TYPES;
+
+Banner.defaultProps = {
+  bannerContext: null
+};
+
+Banner.propTypes = {
+  bannerContext: PropTypes.string
+};

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.spec.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.spec.jsx
@@ -1,0 +1,24 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Banner } from './Banner';
+
+describe('Sage Banner', () => {
+  let component,
+    defaultProps;
+
+  beforeEach(() => {
+    defaultProps = {};
+
+    component = shallow(
+      <Banner {...defaultProps} />
+    );
+  });
+
+  describe('construction', () => {
+    it('renders the component', () => {
+      expect(component).toHaveLength(1);
+    });
+  });
+});

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.spec.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.spec.jsx
@@ -1,7 +1,7 @@
 require('../test/testHelper');
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Banner } from './Banner';
 
 describe('Sage Banner', () => {

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.spec.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.spec.jsx
@@ -1,7 +1,7 @@
 require('../test/testHelper');
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Banner } from './Banner';
 
 describe('Sage Banner', () => {
@@ -9,16 +9,32 @@ describe('Sage Banner', () => {
     defaultProps;
 
   beforeEach(() => {
-    defaultProps = {};
-
-    component = shallow(
+    component = mount(
       <Banner {...defaultProps} />
     );
   });
 
-  describe('construction', () => {
-    it('renders the component', () => {
-      expect(component).toHaveLength(1);
-    });
+  it('renders the component', () => {
+    defaultProps = {};
+    expect(component).toHaveLength(1);
+  });
+
+  it('renders the BannerWrapper when BannerContext is present', () => {
+    defaultProps = {
+      bannerContext: 'sage-demo'
+    };
+
+    component = mount(
+      <Banner {...defaultProps} />
+    );
+    const bannerWrapperFound = component.find('BannerWrapper').exists();
+    expect(bannerWrapperFound).toBeTruthy();
+  });
+
+  it('renders the BannerContent when bannerContext is NOT present', () => {
+    defaultProps = {};
+
+    const bannerFound = component.find('BannerContent').exists();
+    expect(bannerFound).toBeTruthy();
   });
 });

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
@@ -12,7 +12,6 @@ export default {
   },
   args: {
     active: true,
-    bannerContext: 'sage-demo',
     dismissable: true,
     link: '#',
     text: 'Alert description text',
@@ -22,3 +21,8 @@ export default {
 
 const Template = (args) => <Banner {...args} />;
 export const Default = Template.bind({});
+
+export const InlineBanner = Template.bind({});
+InlineBanner.args = {
+  bannerContext: 'sage-demo'
+};

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
@@ -5,10 +5,18 @@ import { Banner } from './Banner';
 export default {
   title: 'Sage/Banner',
   component: Banner,
+  argTypes: {
+    ...selectArgs({
+      type: Banner.TYPES
+    }),
+  },
   args: {
     active: true,
-    bannerContext: "This is text",
-    text: "This is text"
+    bannerContext: 'sage-demo',
+    dismissable: true,
+    link: '#',
+    text: "Alert description text",
+    type: Banner.TYPES.DEFAULT
   },
 };
 

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
@@ -15,7 +15,7 @@ export default {
     bannerContext: 'sage-demo',
     dismissable: true,
     link: '#',
-    text: "Alert description text",
+    text: 'Alert description text',
     type: Banner.TYPES.DEFAULT
   },
 };

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { Banner } from './Banner';
+
+export default {
+  title: 'Sage/Banner',
+  component: Banner,
+  args: {
+    active: true,
+    text: "This is text"
+  },
+};
+
+const Template = (args) => <Banner {...args} />;
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/Banner.story.jsx
@@ -7,6 +7,7 @@ export default {
   component: Banner,
   args: {
     active: true,
+    bannerContext: "This is text",
     text: "This is text"
   },
 };

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
@@ -29,7 +29,8 @@ export const BannerContent = ({
 
   return (
     <div
-      className={classNames} {...rest}
+      className={classNames}
+      {...rest}
       id={id}
     >
       {text && (
@@ -38,23 +39,25 @@ export const BannerContent = ({
 
       {link && (
         <Button
-          children="Hey there"
           className="sage-banner__link"
           subtle={true}
           href="#"
-        />
+        >
+          banner link
+        </Button>
       )}
 
       {children}
 
       {dismissable && (
         <Button
-          children="Dismiss"
           className="sage-banner__close"
           icon={SageTokens.ICONS.REMOVE}
           iconOnly={true}
           subtle={true}
-        />
+        >
+          Dismiss
+        </Button>
       )}
     </div>
   );

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import BannerContent from './BannerContent';
-import BannerWrapper from './BannerWrapper'
 
-export const Banner = (props) => {
-  const {
-    active,
-    bannerContext,
-    className,
-    type,
-  } = props;
+export const Banner = ({
+  active,
+  bannerContext,
+  children,
+  className,
+  dismissable,
+  id,
+  link,
+  text,
+  type,
+  ...rest
+}) => {
   const classNames = classnames(
     'sage-banner',
     className,
@@ -23,14 +26,16 @@ export const Banner = (props) => {
   const wrapperClassNames = classnames(
     'sage-banner-wrapper',
     {
-      [`sage-banner-wrapper--context-${bannerContext}`]: props.bannerContext,
+      [`sage-banner-wrapper--context-${bannerContext}`]: bannerContext,
     }
   );
 
   return (
-    <>
-      (bannerContext ? <BannerWrapper {...props} /> : <BannerContent {...props} />)
-    </>
+    <div className={`bannerContext && ${wrapperClassNames}`}>
+      <div className={classNames} {...rest}>
+        {children}
+      </div>
+    </div>
   );
 };
 

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-export const Banner = ({
+export const BannerContent = ({
   active,
-  bannerContext,
   children,
   className,
   dismissable,
@@ -23,23 +22,14 @@ export const Banner = ({
     }
   );
 
-  const wrapperClassNames = classnames(
-    'sage-banner-wrapper',
-    {
-      [`sage-banner-wrapper--context-${bannerContext}`]: bannerContext,
-    }
-  );
-
   return (
-    <div className={`bannerContext && ${wrapperClassNames}`}>
-      <div className={classNames} {...rest}>
-        {children}
-      </div>
+    <div className={classNames} {...rest}>
+      {children}
     </div>
   );
 };
 
-Banner.defaultProps = {
+BannerContent.defaultProps = {
   active: null,
   bannerContext: null,
   children: null,
@@ -51,7 +41,7 @@ Banner.defaultProps = {
   type: null
 };
 
-Banner.propTypes = {
+BannerContent.propTypes = {
   active: PropTypes.bool,
   bannerContext: PropTypes.string,
   children: PropTypes.node,

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerContent.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
+
+import { BANNER_TYPES } from './configs';
 
 export const BannerContent = ({
   active,
+  bannerContext,
   children,
   className,
   dismissable,
@@ -18,16 +23,44 @@ export const BannerContent = ({
     className,
     {
       [`sage-banner--${type}`]: type,
-      [`sage-banner--active`]: active,
+      'sage-banner--active': active,
     }
   );
 
   return (
-    <div className={classNames} {...rest}>
+    <div
+      className={classNames} {...rest}
+      id={id}
+    >
+      {text && (
+        <p className="sage-banner__text">{text}</p>
+      )}
+
+      {link && (
+        <Button
+          children="Hey there"
+          className="sage-banner__link"
+          subtle={true}
+          href="#"
+        />
+      )}
+
       {children}
+
+      {dismissable && (
+        <Button
+          children="Dismiss"
+          className="sage-banner__close"
+          icon={SageTokens.ICONS.REMOVE}
+          iconOnly={true}
+          subtle={true}
+        />
+      )}
     </div>
   );
 };
+
+BannerContent.TYPES = BANNER_TYPES;
 
 BannerContent.defaultProps = {
   active: null,
@@ -48,8 +81,7 @@ BannerContent.propTypes = {
   className: PropTypes.string,
   dismissable: PropTypes.bool,
   id: PropTypes.string,
-  label: PropTypes.string,
-  // link: ,
+  link: PropTypes.string,
   text: PropTypes.string,
-  type: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
 };

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerWrapper.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerWrapper.jsx
@@ -1,31 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { BannerContent } from './BannerContent';
 
 export const BannerWrapper = ({
-  active,
   bannerContext,
-  children,
-  className,
-  dismissable,
-  id,
-  link,
-  text,
-  type,
   ...rest
 }) => {
   const classNames = classnames(
     'sage-banner-wrapper',
-    className,
     {
-      [`sage-banner--${type}`]: type,
-      [`sage-banner--active`]: active,
+      [`sage-banner-wrapper--context-${bannerContext}`]: bannerContext,
     }
   );
 
   return (
-    <div className={classNames} {...rest}>
-      <Banner />
+    <div className={classNames}>
+      <BannerContent {...rest} />
     </div>
   );
 };

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerWrapper.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerWrapper.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import BannerContent from './BannerContent';
-import BannerWrapper from './BannerWrapper'
 
-export const Banner = (props) => {
-  const {
-    active,
-    bannerContext,
-    className,
-    type,
-  } = props;
+export const BannerWrapper = ({
+  active,
+  bannerContext,
+  children,
+  className,
+  dismissable,
+  id,
+  link,
+  text,
+  type,
+  ...rest
+}) => {
   const classNames = classnames(
-    'sage-banner',
+    'sage-banner-wrapper',
     className,
     {
       [`sage-banner--${type}`]: type,
@@ -20,21 +23,14 @@ export const Banner = (props) => {
     }
   );
 
-  const wrapperClassNames = classnames(
-    'sage-banner-wrapper',
-    {
-      [`sage-banner-wrapper--context-${bannerContext}`]: props.bannerContext,
-    }
-  );
-
   return (
-    <>
-      (bannerContext ? <BannerWrapper {...props} /> : <BannerContent {...props} />)
-    </>
+    <div className={classNames} {...rest}>
+      <Banner />
+    </div>
   );
 };
 
-Banner.defaultProps = {
+BannerWrapper.defaultProps = {
   active: null,
   bannerContext: null,
   children: null,
@@ -46,7 +42,7 @@ Banner.defaultProps = {
   type: null
 };
 
-Banner.propTypes = {
+BannerWrapper.propTypes = {
   active: PropTypes.bool,
   bannerContext: PropTypes.string,
   children: PropTypes.node,

--- a/packages/sage-react/lib/themes/legacy/Banner/BannerWrapper.jsx
+++ b/packages/sage-react/lib/themes/legacy/Banner/BannerWrapper.jsx
@@ -40,8 +40,7 @@ BannerWrapper.propTypes = {
   className: PropTypes.string,
   dismissable: PropTypes.bool,
   id: PropTypes.string,
-  label: PropTypes.string,
-  // link: ,
+  link: PropTypes.string,
   text: PropTypes.string,
   type: PropTypes.string,
 };

--- a/packages/sage-react/lib/themes/legacy/Banner/configs.js
+++ b/packages/sage-react/lib/themes/legacy/Banner/configs.js
@@ -1,0 +1,6 @@
+export const BANNER_TYPES = {
+  DEFAULT: 'default',
+  SECONDARY: 'secondary',
+  WARNING: 'warning',
+  DANGER: 'danger'
+};

--- a/packages/sage-react/lib/themes/legacy/Banner/index.js
+++ b/packages/sage-react/lib/themes/legacy/Banner/index.js
@@ -1,0 +1,1 @@
+export { Banner } from './Banner';

--- a/packages/sage-react/lib/themes/legacy/index.js
+++ b/packages/sage-react/lib/themes/legacy/index.js
@@ -1,6 +1,7 @@
 export { Alert } from './Alert';
 export { Avatar } from './Avatar';
 export { AvatarGroup } from './AvatarGroup';
+export { Banner } from './Banner';
 export { Breadcrumbs } from './Breadcrumbs';
 export { Button } from './Button';
 export { Card } from './Card';

--- a/packages/sage-react/lib/themes/next/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.jsx
@@ -15,27 +15,3 @@ export const Banner = (props) => {
 };
 
 Banner.TYPES = BANNER_TYPES;
-
-Banner.defaultProps = {
-  active: null,
-  bannerContext: null,
-  children: null,
-  className: null,
-  dismissable: null,
-  id: null,
-  link: null,
-  text: null,
-  type: null
-};
-
-Banner.propTypes = {
-  active: PropTypes.bool,
-  bannerContext: PropTypes.string,
-  children: PropTypes.node,
-  className: PropTypes.string,
-  dismissable: PropTypes.bool,
-  id: PropTypes.string,
-  link: PropTypes.string,
-  text: PropTypes.string,
-  type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
-};

--- a/packages/sage-react/lib/themes/next/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.jsx
@@ -8,13 +8,11 @@ import { BANNER_TYPES } from './configs';
 export const Banner = ({
   bannerContext,
   ...rest
-}) => {
-  return (
-    (bannerContext !== null)
-      ? <BannerWrapper bannerContext={bannerContext} {...rest} />
-      : <BannerContent bannerContext={bannerContext} {...rest} />
-  );
-};
+}) => (
+  (bannerContext !== null)
+    ? <BannerWrapper bannerContext={bannerContext} {...rest} />
+    : <BannerContent bannerContext={bannerContext} {...rest} />
+);
 
 Banner.TYPES = BANNER_TYPES;
 

--- a/packages/sage-react/lib/themes/next/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.jsx
@@ -5,13 +5,23 @@ import { BannerWrapper } from './BannerWrapper';
 
 import { BANNER_TYPES } from './configs';
 
-export const Banner = (props) => {
-  const { bannerContext } = props;
+export const Banner = ({
+  bannerContext,
+  ...rest
+}) => {
   return (
-    (bannerContext !== '')
-      ? <BannerWrapper {...props} />
-      : <BannerContent {...props} />
+    (bannerContext !== null)
+      ? <BannerWrapper bannerContext={bannerContext} {...rest} />
+      : <BannerContent bannerContext={bannerContext} {...rest} />
   );
 };
 
 Banner.TYPES = BANNER_TYPES;
+
+Banner.defaultProps = {
+  bannerContext: null
+};
+
+Banner.propTypes = {
+  bannerContext: PropTypes.string
+};

--- a/packages/sage-react/lib/themes/next/Banner/Banner.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { BannerContent } from './BannerContent';
+import { BannerWrapper } from './BannerWrapper';
+
+import { BANNER_TYPES } from './configs';
+
+export const Banner = (props) => {
+  const { bannerContext } = props;
+  return (
+    (bannerContext !== '')
+      ? <BannerWrapper {...props} />
+      : <BannerContent {...props} />
+  );
+};
+
+Banner.TYPES = BANNER_TYPES;
+
+Banner.defaultProps = {
+  active: null,
+  bannerContext: null,
+  children: null,
+  className: null,
+  dismissable: null,
+  id: null,
+  link: null,
+  text: null,
+  type: null
+};
+
+Banner.propTypes = {
+  active: PropTypes.bool,
+  bannerContext: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  dismissable: PropTypes.bool,
+  id: PropTypes.string,
+  link: PropTypes.string,
+  text: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
+};

--- a/packages/sage-react/lib/themes/next/Banner/Banner.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.spec.jsx
@@ -1,0 +1,24 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Banner } from './Banner';
+
+describe('Sage Banner', () => {
+  let component,
+    defaultProps;
+
+  beforeEach(() => {
+    defaultProps = {};
+
+    component = shallow(
+      <Banner {...defaultProps} />
+    );
+  });
+
+  describe('construction', () => {
+    it('renders the component', () => {
+      expect(component).toHaveLength(1);
+    });
+  });
+});

--- a/packages/sage-react/lib/themes/next/Banner/Banner.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.spec.jsx
@@ -1,7 +1,7 @@
 require('../test/testHelper');
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Banner } from './Banner';
 
 describe('Sage Banner', () => {

--- a/packages/sage-react/lib/themes/next/Banner/Banner.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.spec.jsx
@@ -1,7 +1,7 @@
 require('../test/testHelper');
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Banner } from './Banner';
 
 describe('Sage Banner', () => {
@@ -9,16 +9,32 @@ describe('Sage Banner', () => {
     defaultProps;
 
   beforeEach(() => {
-    defaultProps = {};
-
-    component = shallow(
+    component = mount(
       <Banner {...defaultProps} />
     );
   });
 
-  describe('construction', () => {
-    it('renders the component', () => {
-      expect(component).toHaveLength(1);
-    });
+  it('renders the component', () => {
+    defaultProps = {};
+    expect(component).toHaveLength(1);
+  });
+
+  it('renders the BannerWrapper when BannerContext is present', () => {
+    defaultProps = {
+      bannerContext: 'sage-demo'
+    };
+
+    component = mount(
+      <Banner {...defaultProps} />
+    );
+    const bannerWrapperFound = component.find('BannerWrapper').exists();
+    expect(bannerWrapperFound).toBeTruthy();
+  });
+
+  it('renders the BannerContent when bannerContext is NOT present', () => {
+    defaultProps = {};
+
+    const bannerFound = component.find('BannerContent').exists();
+    expect(bannerFound).toBeTruthy();
   });
 });

--- a/packages/sage-react/lib/themes/next/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.story.jsx
@@ -12,7 +12,6 @@ export default {
   },
   args: {
     active: true,
-    bannerContext: 'sage-demo',
     dismissable: true,
     link: '#',
     text: 'Alert description text',
@@ -22,3 +21,8 @@ export default {
 
 const Template = (args) => <Banner {...args} />;
 export const Default = Template.bind({});
+
+export const InlineBanner = Template.bind({});
+InlineBanner.args = {
+  bannerContext: 'sage-demo'
+};

--- a/packages/sage-react/lib/themes/next/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/Banner.story.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { Banner } from './Banner';
+
+export default {
+  title: 'Sage/Banner',
+  component: Banner,
+  argTypes: {
+    ...selectArgs({
+      type: Banner.TYPES
+    }),
+  },
+  args: {
+    active: true,
+    bannerContext: 'sage-demo',
+    dismissable: true,
+    link: '#',
+    text: 'Alert description text',
+    type: Banner.TYPES.DEFAULT
+  },
+};
+
+const Template = (args) => <Banner {...args} />;
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/themes/next/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/BannerContent.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
+
+import { BANNER_TYPES } from './configs';
+
+export const BannerContent = ({
+  active,
+  bannerContext,
+  children,
+  className,
+  dismissable,
+  id,
+  link,
+  text,
+  type,
+  ...rest
+}) => {
+  const classNames = classnames(
+    'sage-banner',
+    className,
+    {
+      [`sage-banner--${type}`]: type,
+      'sage-banner--active': active,
+    }
+  );
+
+  return (
+    <div
+      className={classNames}
+      {...rest}
+      id={id}
+    >
+      {text && (
+        <p className="sage-banner__text">{text}</p>
+      )}
+
+      {link && (
+        <Button
+          className="sage-banner__link"
+          subtle={true}
+          href="#"
+        >
+          banner link
+        </Button>
+      )}
+
+      {children}
+
+      {dismissable && (
+        <Button
+          className="sage-banner__close"
+          icon={SageTokens.ICONS.REMOVE}
+          iconOnly={true}
+          subtle={true}
+        >
+          Dismiss
+        </Button>
+      )}
+    </div>
+  );
+};
+
+BannerContent.TYPES = BANNER_TYPES;
+
+BannerContent.defaultProps = {
+  active: null,
+  bannerContext: null,
+  children: null,
+  className: null,
+  dismissable: null,
+  id: null,
+  link: null,
+  text: null,
+  type: null
+};
+
+BannerContent.propTypes = {
+  active: PropTypes.bool,
+  bannerContext: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  dismissable: PropTypes.bool,
+  id: PropTypes.string,
+  link: PropTypes.string,
+  text: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
+};

--- a/packages/sage-react/lib/themes/next/Banner/BannerWrapper.jsx
+++ b/packages/sage-react/lib/themes/next/Banner/BannerWrapper.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { BannerContent } from './BannerContent';
+
+export const BannerWrapper = ({
+  bannerContext,
+  ...rest
+}) => {
+  const classNames = classnames(
+    'sage-banner-wrapper',
+    {
+      [`sage-banner-wrapper--context-${bannerContext}`]: bannerContext,
+    }
+  );
+
+  return (
+    <div className={classNames}>
+      <BannerContent {...rest} />
+    </div>
+  );
+};
+
+BannerWrapper.defaultProps = {
+  active: null,
+  bannerContext: null,
+  children: null,
+  className: null,
+  dismissable: null,
+  id: null,
+  link: null,
+  text: null,
+  type: null
+};
+
+BannerWrapper.propTypes = {
+  active: PropTypes.bool,
+  bannerContext: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  dismissable: PropTypes.bool,
+  id: PropTypes.string,
+  link: PropTypes.string,
+  text: PropTypes.string,
+  type: PropTypes.string,
+};

--- a/packages/sage-react/lib/themes/next/Banner/configs.js
+++ b/packages/sage-react/lib/themes/next/Banner/configs.js
@@ -1,0 +1,6 @@
+export const BANNER_TYPES = {
+  DEFAULT: 'default',
+  SECONDARY: 'secondary',
+  WARNING: 'warning',
+  DANGER: 'danger'
+};

--- a/packages/sage-react/lib/themes/next/Banner/index.js
+++ b/packages/sage-react/lib/themes/next/Banner/index.js
@@ -1,0 +1,1 @@
+export { Banner } from './Banner';


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] added react banner version

## Screenshots
![Screen Shot 2022-05-03 at 7 03 21 PM](https://user-images.githubusercontent.com/1241836/166605045-9983120a-4c7e-43f4-953a-7ac8e375b218.png)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the banner react page and verify that the component is aligned with the rails version
- [React](http://localhost:4100/?path=/docs/sage-banner--default)
- [Rails](http://localhost:4000/pages/component/banner?tab=preview)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds a new react component. Has no affect in the app

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-316](https://kajabi.atlassian.net/browse/SAGE-316)