### PR TITLE
Adjust container sizes larger for xl and full

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_container.scss
@@ -14,8 +14,8 @@ $sage-containers: (
   sm: rem(340px),
   md: rem(520px),
   lg: rem(700px),
-  xl: rem(798px),
-  full: rem(1064px),
+  xl: rem(1064px),
+  full: rem(1440px),
 );
 
 ///


### PR DESCRIPTION
## Description

This PR adjusts the `xl` and `full` container tokens to larger sizes in order to reduce impact on `kp`. 

I added comments in Figma related to this discrepancy as well.


## Testing in `sage-lib`

See http://localhost:4000/pages/layout/container

## Testing in `kajabi-products`

1. (**MEDIUM**) Adjusts larger container sizes in `next` closer to sizes in `legacy` theme.


## Related

[SAGE-495](https://kajabi.atlassian.net/browse/SAGE-495)
