### PR TITLE
[SAGE-352] add static width to grid columns

### DIFF
--- a/docs/app/views/pages/grid.html.erb
+++ b/docs/app/views/pages/grid.html.erb
@@ -207,6 +207,43 @@
     small: true
   } %>
 
+  <h4 class="t-sage-heading-6">Auto Width</h4>
+  <%= sage_component SageGridRow, {
+    html_attributes: {
+      "aria-hidden": true
+    }
+  } do %>
+    <%= sage_component SageGridCol, {
+      small: "12",
+      medium: "6",
+      large: "3",
+    } do %>
+      <div class="grid-item">1</div>
+    <% end %>
+    <%= sage_component SageGridCol, {
+      css_classes: "sage-col-auto"
+    } do %>
+      <div class="grid-item">auto</div>
+    <% end %>
+    <%= sage_component SageGridCol, {
+      small: "12",
+      medium: "6",
+      large: "3",
+    } do %>
+      <div class="grid-item">3</div>
+    <% end %>
+    <%= sage_component SageGridCol, {
+    } do %>
+      <div class="grid-item">4</div>
+    <% end %>
+  <% end %>
+
+  <%= sage_component SageAlert, {
+    color: "warning",
+    desc: "TODO - add code example for Multiple breakpoints.",
+    icon_name: "sage-icon-warning",
+    small: true
+  } %>
 
   <h3 class="t-sage-heading-5" id="grid-responsive-show-hide">Hiding and showing content</h3>
   <p>In cases where content will be hidden or shown at specific screen sizes, classes using breakpoint keywords are available. These classes use sizing from <code>sage-breakpoint()</code> to affect where content is displayed.</p>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/core/mixins/_sage.scss
@@ -230,9 +230,9 @@
 /// Adds automatic sizing to the grid columns. The sibling columns automatically resize accordingly if they don't have defined breakpoint widths
 ///
 @mixin sage-auto-col() {
+  flex: 0 0 auto;
   width: auto;
   max-width: none;
-  flex: 0 0 auto;
 }
 
 ///

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/core/mixins/_sage.scss
@@ -227,6 +227,15 @@
 }
 
 ///
+/// Adds automatic sizing to the grid columns. The sibling columns automatically resize accordingly if they don't have defined breakpoint widths
+///
+@mixin sage-auto-col() {
+  width: auto;
+  max-width: none;
+  flex: 0 0 auto;
+}
+
+///
 /// Sets up a grid stack that uses card-scoped spacing (16px)
 ///
 @mixin sage-grid-card() {

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_grid.scss
@@ -100,6 +100,10 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 
+.sage-col-auto {
+  @include sage-auto-col;
+}
+
 @for $i from 1 through $-grid-num-columns {
   .sage-col-#{$i},
   .sage-col--sm-#{$i},
@@ -135,6 +139,10 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
       max-width: percentage($i / $-grid-num-columns);
     }
   }
+
+  .sage-col--sm-auto {
+    @include sage-auto-col;
+  }
 }
 
 @media (max-width: $-grid-breakpoint-sm-max) {
@@ -155,6 +163,10 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
   .sage-col--sm-show {
     display: none;
+  }
+
+  .sage-col--md-auto {
+    @include sage-auto-col;
   }
 }
 
@@ -177,6 +189,10 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   .sage-col--md-show {
     display: none;
   }
+
+  .sage-col--lg-auto {
+    @include sage-auto-col;
+  }
 }
 
 @media (max-width: $-grid-breakpoint-lg-max) {
@@ -188,5 +204,9 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 @media (min-width: $-grid-breakpoint-xl) {
   .sage-col--lg-show {
     display: none;
+  }
+
+  .sage-col--xl-auto {
+    @include sage-auto-col;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -233,9 +233,9 @@
 /// Adds automatic sizing to the grid columns. The sibling columns automatically resize accordingly if they don't have defined breakpoint widths
 ///
 @mixin sage-auto-col() {
+  flex: 0 0 auto;
   width: auto;
   max-width: none;
-  flex: 0 0 auto;
 }
 
 ///

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -230,6 +230,15 @@
 }
 
 ///
+/// Adds automatic sizing to the grid columns. The sibling columns automatically resize accordingly if they don't have defined breakpoint widths
+///
+@mixin sage-auto-col() {
+  width: auto;
+  max-width: none;
+  flex: 0 0 auto;
+}
+
+///
 /// Adds the basic default card setup including grid, spacing, and border treatment
 ///
 @mixin sage-card($grid: true) {

--- a/packages/sage-assets/lib/stylesheets/themes/next/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/layout/_grid.scss
@@ -100,6 +100,10 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   padding: 0 calc(#{$-grid-gap} / 2);
 }
 
+.sage-col-auto {
+  @include sage-auto-col;
+}
+
 @for $i from 1 through $-grid-num-columns {
   .sage-col-#{$i},
   .sage-col--sm-#{$i},

--- a/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
@@ -206,3 +206,40 @@ EqualColumns.args = {
     </>
   )
 };
+
+export const AutoWidth = Template.bind({});
+AutoWidth.args = {
+  children: (
+    <>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column" className="sage-col-auto">
+          <GridDemo>
+            Auto width
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" className="sage-col--md-auto">
+          <GridDemo>
+            Auto width
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};

--- a/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
@@ -206,3 +206,40 @@ EqualColumns.args = {
     </>
   )
 };
+
+export const AutoWidth = Template.bind({});
+AutoWidth.args = {
+  children: (
+    <>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column" className="sage-col-auto">
+          <GridDemo>
+            Auto width
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" className="sage-col--md-auto">
+          <GridDemo>
+            Auto width
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column">
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add ability to have auto width columns that don't resize

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
![autoWidthCol](https://user-images.githubusercontent.com/1241836/166311837-1ab6a7ba-d574-442c-a2d0-ec59ed0e4a6a.gif)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the grid views and check the `Auto Width` version:
- [Rails](http://localhost:4000/pages/patterns/grid)
- [React](http://localhost:4100/?path=/story/sage-grid--auto-width)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Add new classes to the Grid component.  No current usage in the app.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-352](https://kajabi.atlassian.net/browse/SAGE-352)