### PR TITLE
[SAGE-491] Empty state - add max-width

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_empty_state.scss
@@ -8,11 +8,12 @@ $-empty-state-graphic-feature-width: rem(220px);
 $-empty-state-graphic-feature-height: rem(124px);
 $-empty-state-graphic-page-width: rem(512px);
 $-empty-state-graphic-page-height: rem(384px);
+$-empty-state-page-max-width: rem(1064);
 
 .sage-empty-state {
   margin-left: auto;
   margin-right: auto;
-  
+
   &:not(.sage-empty-state--page) {
     @include sage-grid-panel();
 
@@ -56,6 +57,7 @@ $-empty-state-graphic-page-height: rem(384px);
 
   @media screen and (min-width: sage-breakpoint(xl-min)) {
     flex-direction: row;
+    max-width: $-empty-state-page-max-width;
   }
 }
 
@@ -66,7 +68,7 @@ $-empty-state-graphic-page-height: rem(384px);
 .sage-empty-state__content {
   .sage-empty-state--page & {
     max-width: $-empty-state-graphic-page-width;
-    
+
     @media screen and (max-width: sage-breakpoint(lg-max)) {
       width: 100%;
     }
@@ -96,7 +98,7 @@ $-empty-state-graphic-page-height: rem(384px);
   .sage-empty-state--page & {
     max-width: $-empty-state-graphic-page-width;
     height: $-empty-state-graphic-page-height;
-    
+
     @media screen and (max-width: sage-breakpoint(lg-max)) {
       width: 100%;
     }
@@ -115,10 +117,10 @@ $-empty-state-graphic-page-height: rem(384px);
 
 .sage-empty-state__title {
   @extend %t-sage-heading-4;
-  
+
   color: sage-color(charcoal, 500);
   word-wrap: break-word;
-  
+
   .sage-empty-state--page & {
     @extend %t-sage-heading-1;
   }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_empty_state.scss
@@ -8,6 +8,7 @@ $-empty-state-graphic-feature-width: 100%;
 $-empty-state-graphic-feature-height: rem(142px);
 $-empty-state-graphic-page-width: 100%;
 $-empty-state-graphic-page-height: rem(336px);
+$-empty-state-page-max-width: rem(1064);
 
 .sage-empty-state {
   margin-left: auto;
@@ -57,6 +58,7 @@ $-empty-state-graphic-page-height: rem(336px);
 
   @media screen and (min-width: sage-breakpoint(xl-min)) {
     flex-direction: row;
+    max-width: $-empty-state-page-max-width;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_empty_state.scss
@@ -8,7 +8,7 @@ $-empty-state-graphic-feature-width: 100%;
 $-empty-state-graphic-feature-height: rem(142px);
 $-empty-state-graphic-page-width: 100%;
 $-empty-state-graphic-page-height: rem(336px);
-$-empty-state-page-max-width: rem(1064);
+$-empty-state-page-max-width: rem(1064px);
 
 .sage-empty-state {
   margin-left: auto;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `max-width` to empty state component

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-05-02 at 3 14 07 PM](https://user-images.githubusercontent.com/1241836/166319638-10cb6b3c-3805-4343-9ade-fba6850cc370.png)|![Screen Shot 2022-05-02 at 3 14 19 PM](https://user-images.githubusercontent.com/1241836/166319653-af1a3d7e-8ce2-48a4-9d1e-1cf0e3215b71.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify that the empty state component has a `max-width` on `xxl` displays:
- [Rails](http://localhost:4000/pages/component/empty_state)
- [React](http://localhost:4100/?path=/story/sage-emptystate--page-scope)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Updates `max-width` on Empty State component. Used on various pages throughout the app.
   - [ ] Empty Newsletters view


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[SAGE-491](https://kajabi.atlassian.net/browse/SAGE-491)