### PR TITLE
[SAGE-498]: SageSearch field border-radius

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_panel_controls.scss
@@ -19,6 +19,11 @@
     margin-left: -1 * sage-spacing(panel);
     border-top: 1px solid sage-color(grey, 400);
   }
+
+  .sage-search {
+    width: 100%;
+  }
+
 }
 
 .sage-panel-controls__tabs {
@@ -57,6 +62,10 @@
 
   .sage-panel-controls--show-pagination .sage-panel-controls__toolbar &:last-child {
     flex: 0 1;
+  }
+
+  .sage-search {
+    width: auto;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
@@ -78,14 +78,21 @@ $-search-icon: "::before";
     margin-right: sage-spacing(panel);
   }
 
-  .sage-panel-controls__toolbar .sage-search--contained:first-child &,
+  .sage-panel-controls__toolbar .sage-search--contained & {
+    border-radius: sage-border(radius-medium);
+  }
+
+  .sage-panel-controls__toolbar .sage-search--contained:first-child:not(:only-child) & {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
   .sage-toolbar__group .sage-search--contained:first-child & {
     border-radius: sage-border(radius-medium);
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
 
-  .sage-panel-controls__toolbar .sage-search--contained:last-child &,
   .sage-toolbar__group .sage-search--contained:last-child & {
     border-radius: sage-border(radius-medium);
     border-top-left-radius: 0;


### PR DESCRIPTION
## Description
Sage search within panel controls has incorrect border-radius and width when it's used as a stand-alone search. This is causing layout issues in KP as well when testing `sage_next`


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
||  Before  |  After  |
|--------|--------|--------|
|`sage-lib`|![Screen Shot 2022-05-02 at 3 22 35 PM](https://user-images.githubusercontent.com/1175111/166337088-e9a23c42-310d-44f3-ae4e-fe6b6f74d7ce.png)|![Screen Shot 2022-05-02 at 3 22 43 PM](https://user-images.githubusercontent.com/1175111/166337116-3dc0aefa-7255-4491-b8e8-c8115e68ed92.png)|
|`kp`|![Screen Shot 2022-05-02 at 3 35 11 PM](https://user-images.githubusercontent.com/1175111/166337724-08201fbc-957a-4ead-87ce-ed8140f9bd22.png)|![Screen Shot 2022-05-02 at 3 12 34 PM](https://user-images.githubusercontent.com/1175111/166337746-d6bc1913-9712-4c67-a9ef-26b117128f52.png)|


## Testing in `sage-lib`

- Navigate to Panel Controls http://localhost:4000/pages/component/panel_controls
- Verify stand-alone search has the correct radius and width. (see Tabs + Search section)
- Sanity check toolbar component just in case.


## Testing in `kajabi-products`
1. (**LOW**) Corrects styling of sage search within panel controls. Should be verified on the blog page, the podcasts page, and any pages that use panel controls.


## Related
https://kajabi.atlassian.net/browse/SAGE-498
