### PR TITLE
[Sage-464] Tokens - Breakpoints Update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_breakpoints.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_breakpoints.scss
@@ -9,14 +9,16 @@
 /// Sage breakpoints token
 ///
 $sage-breakpoints: (
-  xs-max: 544px,
-  sm-min: 545px,
-  sm-max: 767px,
-  md-min: 768px,
-  md-max: 991px,
-  lg-min: 992px,
-  lg-max: 1199px,
-  xl-min: 1200px,
+  xxs-max: 699px,
+  xs-min: 700px,
+  xs-max: 799px,
+  sm-min: 800px,
+  sm-max: 989px,
+  md-min: 990px,
+  md-max: 1119px,
+  lg-min: 1120px,
+  lg-max: 1279px,
+  xl-max: 1280px,
   xxl-min: 1440px,
 );
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_breakpoints.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_breakpoints.scss
@@ -9,15 +9,27 @@
 /// Sage breakpoints token
 ///
 $sage-breakpoints: (
-  xs-max: 699px,
-  sm-min: 700px,
-  sm-max: 989px,
-  md-min: 990px,
+  xs-max: 544px,
+  sm-min: 545px,
+  sm-max: 767px,
+  md-min: 768px,
+  md-max: 991px,
+  lg-min: 992px,
+  lg-max: 1199px,
+  xl-min: 1200px,
+  xxl-min: 1440px,
+);
+
+$sage-next-breakpoints: (
+  xs-max: 767px,
+  sm-min: 768px,
+  sm-max: 991px,
+  md-min: 992px,
   md-max: 1119px,
   lg-min: 1120px,
   lg-max: 1279px,
-  xl-max: 1280px,
-  xxl-min: 1440px,
+  xl-min: 1280px,
+  xl-max: 1439px,
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_breakpoints.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_breakpoints.scss
@@ -9,10 +9,8 @@
 /// Sage breakpoints token
 ///
 $sage-breakpoints: (
-  xxs-max: 699px,
-  xs-min: 700px,
-  xs-max: 799px,
-  sm-min: 800px,
+  xs-max: 699px,
+  sm-min: 700px,
   sm-max: 989px,
   md-min: 990px,
   md-max: 1119px,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds map for new Sage Next layout breakpoints. The breakpoints used fall in line with some current breakpoints in `kp` and Sage Legacy styles while adhering to new, future container size updates.


Breakpoints before:
```
xs-max: 544px,
sm-min: 545px,
sm-max: 767px,
md-min: 768px,
md-max: 991px,
lg-min: 992px,
lg-max: 1199px,
xl-min: 1200px,
xxl-min: 1440px,
```

Updates breakpoints to the following values:
```
xs-max: 767px,
sm-min: 768px,
sm-max: 991px,
md-min: 992px,
md-max: 1119px,
lg-min: 1120px,
lg-max: 1279px,
xl-min: 1280px,
xl-max: 1439px,
```


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Change `sage-breakpoint` function to use `sage-next-breakpoints` variable
- Check all current Sage components
- Check pages in `kp`
- Ensure there are no breaking layout changes.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) Adds map for new Sage Next layout breakpoints.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-464](https://kajabi.atlassian.net/browse/SAGE-464)