### PR TITLE
[SAGE-520] Grid add xl breakpoint

### DIFF
--- a/docs/app/views/pages/grid.html.erb
+++ b/docs/app/views/pages/grid.html.erb
@@ -177,6 +177,7 @@
       small: "12",
       medium: "6",
       large: "3",
+      xlarge: "3",
     } do %>
       <div class="grid-item">1</div>
     <% end %>
@@ -184,6 +185,7 @@
       small: "12",
       medium: "6",
       large: "3",
+      xlarge: "3",
     } do %>
       <div class="grid-item">2</div>
     <% end %>
@@ -191,6 +193,7 @@
       small: "12",
       medium: "6",
       large: "3",
+      xlarge: "3",
     } do %>
       <div class="grid-item">3</div>
     <% end %>

--- a/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_grid_col.rb
@@ -5,5 +5,6 @@ class SageGridCol < SageComponent
     medium: [:optional, String, Integer],
     size: [:optional, String, Integer],
     small: [:optional, String, Integer],
+    xlarge: [:optional, String, Integer],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_grid_col.html.erb
@@ -7,6 +7,7 @@
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
+  <%= "sage-col--xl-#{component.xlarge}" if component.xlarge%>
   <%= component.generated_css_classes %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
@@ -7,6 +7,7 @@
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
+  <%= "sage-col--lg-#{component.xlarge}" if component.xlarge%>
   <%= component.generated_css_classes %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_grid_col.html.erb
@@ -7,7 +7,7 @@
   <%= "sage-col--sm-#{component.small}" if component.small%>
   <%= "sage-col--md-#{component.medium}" if component.medium%>
   <%= "sage-col--lg-#{component.large}" if component.large%>
-  <%= "sage-col--lg-#{component.xlarge}" if component.xlarge%>
+  <%= "sage-col--xl-#{component.xlarge}" if component.xlarge%>
   <%= component.generated_css_classes %>
 " <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_grid.scss
@@ -108,7 +108,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   .sage-col-#{$i},
   .sage-col--sm-#{$i},
   .sage-col--md-#{$i},
-  .sage-col--lg-#{$i} {
+  .sage-col--lg-#{$i},
+  .sage-col--xl-#{$i} {
     @include sage-col();
 
     .sage-row--stage > & {

--- a/packages/sage-assets/lib/stylesheets/themes/next/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/layout/_grid.scss
@@ -108,7 +108,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   .sage-col-#{$i},
   .sage-col--sm-#{$i},
   .sage-col--md-#{$i},
-  .sage-col--lg-#{$i} {
+  .sage-col--lg-#{$i},
+  .sage-col--xl-#{$i} {
     @include sage-col();
 
     .sage-row--stage > & {

--- a/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/Grid.story.jsx
@@ -243,3 +243,33 @@ AutoWidth.args = {
     </>
   )
 };
+
+export const MultipleBreakpoints = Template.bind({});
+MultipleBreakpoints.args = {
+  children: (
+    <>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};

--- a/packages/sage-react/lib/themes/legacy/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/themes/legacy/Grid/GridCol.jsx
@@ -12,9 +12,10 @@ export const GridCol = ({
   sageType,
   size,
   small,
+  xlarge,
   ...rest
 }) => {
-  const hasInfix = size || small || medium || large;
+  const hasInfix = size || small || medium || large || xlarge;
 
   const classNames = classnames(
     className,
@@ -24,6 +25,7 @@ export const GridCol = ({
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,
       [`sage-col--lg-${large}`]: large,
+      [`sage-col--xl-${xlarge}`]: xlarge,
       [`${SageClassnames.TYPE_BLOCK}`]: sageType
     }
   );
@@ -43,6 +45,7 @@ GridCol.defaultProps = {
   sageType: false,
   small: null,
   size: null,
+  xlarge: null,
 };
 
 GridCol.propTypes = {
@@ -52,5 +55,6 @@ GridCol.propTypes = {
   medium: validBreakpoint,
   large: validBreakpoint,
   sageType: PropTypes.bool,
-  size: validNumberWithinGrid
+  size: validNumberWithinGrid,
+  xlarge: validBreakpoint,
 };

--- a/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
+++ b/packages/sage-react/lib/themes/next/Grid/Grid.story.jsx
@@ -243,3 +243,33 @@ AutoWidth.args = {
     </>
   )
 };
+
+export const MultipleBreakpoints = Template.bind({});
+MultipleBreakpoints.args = {
+  children: (
+    <>
+      <Grid.Row spacerBelow="sm">
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+        <Grid.Col aria-label="Single column" small={12} medium={6} large={3} xlarge={3}>
+          <GridDemo>
+            Equal Width Column
+          </GridDemo>
+        </Grid.Col>
+      </Grid.Row>
+    </>
+  )
+};

--- a/packages/sage-react/lib/themes/next/Grid/GridCol.jsx
+++ b/packages/sage-react/lib/themes/next/Grid/GridCol.jsx
@@ -12,9 +12,10 @@ export const GridCol = ({
   sageType,
   size,
   small,
+  xlarge,
   ...rest
 }) => {
-  const hasInfix = size || small || medium || large;
+  const hasInfix = size || small || medium || large || xlarge;
 
   const classNames = classnames(
     className,
@@ -24,6 +25,7 @@ export const GridCol = ({
       [`sage-col--sm-${small}`]: small,
       [`sage-col--md-${medium}`]: medium,
       [`sage-col--lg-${large}`]: large,
+      [`sage-col--xl-${xlarge}`]: xlarge,
       [`${SageClassnames.TYPE_BLOCK}`]: sageType
     }
   );
@@ -43,6 +45,7 @@ GridCol.defaultProps = {
   sageType: false,
   small: null,
   size: null,
+  xlarge: null,
 };
 
 GridCol.propTypes = {
@@ -52,5 +55,6 @@ GridCol.propTypes = {
   medium: validBreakpoint,
   large: validBreakpoint,
   sageType: PropTypes.bool,
-  size: validNumberWithinGrid
+  size: validNumberWithinGrid,
+  xlarge: validBreakpoint,
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `xl` breakpoint

## Screenshots
![Screen Shot 2022-05-05 at 3 07 33 PM](https://user-images.githubusercontent.com/1241836/167017511-f4e3cefd-51c9-4265-959b-f90a522f03c2.png)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Grid views and verify the `-xl` classes are showing when `xlarge` prop is present:
- [Rails](http://localhost:4000/pages/patterns/grid?sage_theme=sage_theme_legacy) -> Multiple breakpoints
- [React](http://localhost:4100/?path=/story/sage-grid--multiple-breakpoints)


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Adds new class to Grid component. Requesting QA due to high usage.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-520](https://kajabi.atlassian.net/browse/SAGE-520)