### PR TITLE
[SAGE-503] Alert - added margin-bottom

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_alert.scss
@@ -23,6 +23,7 @@ $-alert-colors: (
   position: relative;
   padding: sage-spacing();
   border-radius: sage-border(radius-large);
+  margin-bottom: sage-spacing();
 
   .sage-panel > & {
     margin-bottom: 0;
@@ -37,7 +38,7 @@ $-alert-colors: (
     @else {
       background-color: sage-color($color, 100);
     }
-    
+
     a:not([class]) {
       color: sage-color(charcoal, 400);
       text-decoration: underline;

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_alert.scss
@@ -22,8 +22,8 @@ $-alert-colors: (
   gap: sage-spacing(sm);
   position: relative;
   padding: sage-spacing();
-  border-radius: sage-border(radius-large);
   margin-bottom: sage-spacing();
+  border-radius: sage-border(radius-large);
 
   .sage-panel > & {
     margin-bottom: 0;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] added `margin-bottom`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2022-05-05_at_4_58_13_PM](https://user-images.githubusercontent.com/1241836/167032474-abe21706-7d40-4a2c-a259-bbd8c4e360ec.png)|![Screen_Shot_2022-05-05_at_4_57_47_PM](https://user-images.githubusercontent.com/1241836/167032490-09269b27-2b83-4666-b63f-b732f7de0c7e.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the alert views and verify that it now has a `margin-bottom`:
- [Rails](http://localhost:4000/pages/component/alert?sage_theme=sage_theme_next&tab=preview)
- [React](http://localhost:4110/?path=/docs/sage-alert--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Added `margin-bottom` to `Alert`.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-503](https://kajabi.atlassian.net/browse/SAGE-503)