### PR TITLE
[SAGE-558] Page Heading - update storybook examples and add help props

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_page_heading.html.erb
@@ -15,8 +15,10 @@
       <%= content_for :sage_page_heading_intro %>
     </div>
   <% end %>
-  <h1 class="sage-page-heading__title">
-    <%= component.title %>
+  <div class="sage-page-heading__title-wrapper">
+    <h1 class="sage-page-heading__title">
+      <%= component.title %>
+    </h1>
     <% if component.help_link.present? && component.help_html.blank? %>
       <a href="<%= component.help_link[:href] %>"
         class="sage-link--no-launch sage-link--help-icon-only"
@@ -39,7 +41,7 @@
         <%= component.help_html.html_safe %>
       <% end %>
     <% end %>
-  </h1>
+  </div>
   <% if content_for? :sage_page_heading_image %>
     <div class="sage-page-heading__image">
       <%= content_for :sage_page_heading_image %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_page_heading.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_page_heading.html.erb
@@ -15,8 +15,10 @@
       <%= content_for :sage_page_heading_intro %>
     </div>
   <% end %>
-  <h1 class="sage-page-heading__title">
-    <%= component.title %>
+  <div class="sage-page-heading__title-wrapper">
+    <h1 class="sage-page-heading__title">
+      <%= component.title %>
+    </h1>
     <% if component.help_link.present? && component.help_html.blank? %>
       <a href="<%= component.help_link[:href] %>"
         class="sage-link--no-launch sage-link--help-icon-only"
@@ -39,7 +41,7 @@
         <%= component.help_html.html_safe %>
       <% end %>
     <% end %>
-  </h1>
+  </div>
   <% if content_for? :sage_page_heading_image %>
     <div class="sage-page-heading__image">
       <%= content_for :sage_page_heading_image %>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_page_heading.scss
@@ -59,10 +59,18 @@ $-page-heading-image-height-mobile: rem(120px);
   }
 }
 
-.sage-page-heading__title {
-  @extend %t-sage-heading-1;
+.sage-page-heading__title-wrapper {
+  display: flex;
+  align-items: center;
   grid-area: title;
+  gap: sage-spacing(xs);
+  min-width: 0;
   margin-right: sage-spacing(sm);
+}
+
+.sage-page-heading__title {
+  @extend %t-sage-heading-2;
+  @include truncate;
 }
 
 .sage-page-heading__intro {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_page_heading.scss
@@ -59,10 +59,18 @@ $-page-heading-image-height-mobile: rem(120px);
   }
 }
 
+.sage-page-heading__title-wrapper {
+  display: flex;
+  align-items: center;
+  grid-area: title;
+  gap: sage-spacing(xs);
+  min-width: 0;
+  margin-right: sage-spacing(sm);
+}
+
 .sage-page-heading__title {
   @extend %t-sage-heading-2;
-  grid-area: title;
-  margin-right: sage-spacing(sm);
+  @include truncate;
 }
 
 .sage-page-heading__intro {

--- a/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.jsx
@@ -5,14 +5,15 @@ import classnames from 'classnames';
 import { Breadcrumbs } from '../Breadcrumbs';
 
 export const PageHeading = ({
+  actionItems,
+  breadcrumbs,
   className,
   children,
+  help,
   image,
-  breadcrumbs,
-  actionItems,
+  introText,
   toolbarItems,
   secondaryText,
-  introText,
   ...rest
 }) => (
   <div
@@ -36,9 +37,16 @@ export const PageHeading = ({
         <p>{introText}</p>
       </div>
     )}
-    <h1 className="sage-page-heading__title">
-      {children}
-    </h1>
+    <div className="sage-page-heading__title-wrapper">
+      <h1 className="sage-page-heading__title">
+        {children}
+      </h1>
+      {help && (
+        <>
+          {help}
+        </>
+      )}
+    </div>
     {image.src && (
       <div className="sage-page-heading__image">
         <img alt={image.alt || ''} src={image.src} />
@@ -63,25 +71,27 @@ export const PageHeading = ({
 );
 
 PageHeading.defaultProps = {
-  className: '',
-  image: {},
   actionItems: null,
-  toolbarItems: null,
   breadcrumbs: null,
+  className: '',
+  help: null,
+  image: {},
   introText: null,
+  toolbarItems: null,
   secondaryText: null,
 };
 
 PageHeading.propTypes = {
+  actionItems: PropTypes.arrayOf(PropTypes.node),
+  breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
+  children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  help: PropTypes.arrayOf(PropTypes.node),
   image: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string,
   }),
-  children: PropTypes.node.isRequired,
-  actionItems: PropTypes.arrayOf(PropTypes.node),
-  toolbarItems: PropTypes.arrayOf(PropTypes.node),
-  breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   introText: PropTypes.string,
   secondaryText: PropTypes.string,
+  toolbarItems: PropTypes.arrayOf(PropTypes.node),
 };

--- a/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.jsx
@@ -86,7 +86,7 @@ PageHeading.propTypes = {
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  help: PropTypes.arrayOf(PropTypes.node),
+  help: PropTypes.node,
   image: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string,

--- a/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.story.jsx
@@ -53,6 +53,11 @@ PageHeadingWithHelpLink.args = {
   )
 };
 
+export const PageHeadingWithIntro = Template.bind({});
+PageHeadingWithIntro.args = {
+  introText: 'Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit.'
+};
+
 export const PageHeadingWithThumbnail = Template.bind({});
 PageHeadingWithThumbnail.args = {
   image: {
@@ -92,6 +97,7 @@ PageHeadingWithToolbarAndSecondaryText.args = {
 export const AllItems = Template.bind({});
 AllItems.args = {
   secondaryText: 'Secondary text here',
+  introText: 'Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit.',
   breadcrumbs: [
     {
       label: 'Back somewhere',

--- a/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { HelpLink } from '../HelpLink';
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
 import { PageHeading } from './PageHeading';
 
 export default {
@@ -9,24 +11,138 @@ export default {
     children: (
       <>
         Page heading goes here
-        <HelpLink href="//example.com" target="_blank" rel="noopener" />
       </>
     ),
-    breadcrumbs: [
-      {
-        label: 'Back somewhere',
-        href: '#back'
-      }
+    actionItems: [
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.PREVIEW_ON}
+        subtle={true}
+      >
+        Preview
+      </Button>,
+      <Button
+        color={Button.COLORS.PRIMARY}
+        icon={SageTokens.ICONS.CART}
+      >
+        Create
+      </Button>
     ],
-    actionItems: null,
-    secondaryText: 'Secondary text here',
     toolbarItems: null,
-    image: {
-      src: 'https://via.placeholder.com/132x74',
-      alt: 'Page heading demo image'
-    },
   }
 };
 const Template = (args) => <PageHeading {...args} />;
 
 export const Default = Template.bind({});
+
+export const PageHeadingWithBackLink = Template.bind({});
+PageHeadingWithBackLink.args = {
+  breadcrumbs: [
+    {
+      label: 'Back somewhere',
+      href: '#back'
+    }
+  ]
+};
+export const PageHeadingWithHelpLink = Template.bind({});
+PageHeadingWithHelpLink.args = {
+  help: (
+    <>
+      <HelpLink href="//example.com" target="_blank" rel="noopener" />
+    </>
+  )
+};
+
+export const PageHeadingWithThumbnail = Template.bind({});
+PageHeadingWithThumbnail.args = {
+  image: {
+    src: 'https://via.placeholder.com/132x74',
+    alt: 'Page heading demo image',
+  }
+};
+
+export const PageHeadingWithToolbarAndSecondaryText = Template.bind({});
+PageHeadingWithToolbarAndSecondaryText.args = {
+  secondaryText: 'Secondary text here',
+  toolbarItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CART}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Report
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Settings
+    </Button>
+  ],
+};
+
+export const AllItems = Template.bind({});
+AllItems.args = {
+  secondaryText: 'Secondary text here',
+  breadcrumbs: [
+    {
+      label: 'Back somewhere',
+      href: '#back'
+    }
+  ],
+  help: (
+    <>
+      <HelpLink href="//example.com" target="_blank" rel="noopener" />
+    </>
+  ),
+  actionItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.PREVIEW_ON}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.PRIMARY}
+      icon={SageTokens.ICONS.CART}
+    >
+      Create
+    </Button>
+  ],
+  image: {
+    src: 'https://via.placeholder.com/132x74',
+    alt: 'Page heading demo image',
+  },
+  toolbarItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CART}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Report
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Settings
+    </Button>
+  ],
+};

--- a/packages/sage-react/lib/themes/next/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/themes/next/PageHeading/PageHeading.jsx
@@ -5,14 +5,15 @@ import classnames from 'classnames';
 import { Breadcrumbs } from '../Breadcrumbs';
 
 export const PageHeading = ({
+  actionItems,
+  breadcrumbs,
   className,
   children,
+  help,
   image,
-  breadcrumbs,
-  actionItems,
+  introText,
   toolbarItems,
   secondaryText,
-  introText,
   ...rest
 }) => (
   <div
@@ -36,9 +37,16 @@ export const PageHeading = ({
         <p>{introText}</p>
       </div>
     )}
-    <h1 className="sage-page-heading__title">
-      {children}
-    </h1>
+    <div className="sage-page-heading__title-wrapper">
+      <h1 className="sage-page-heading__title">
+        {children}
+      </h1>
+      {help && (
+        <>
+          {help}
+        </>
+      )}
+    </div>
     {image.src && (
       <div className="sage-page-heading__image">
         <img alt={image.alt || ''} src={image.src} />
@@ -63,25 +71,27 @@ export const PageHeading = ({
 );
 
 PageHeading.defaultProps = {
-  className: '',
-  image: {},
   actionItems: null,
-  toolbarItems: null,
   breadcrumbs: null,
+  className: '',
+  help: null,
+  image: {},
   introText: null,
+  toolbarItems: null,
   secondaryText: null,
 };
 
 PageHeading.propTypes = {
+  actionItems: PropTypes.arrayOf(PropTypes.node),
+  breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
+  children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  help: PropTypes.arrayOf(PropTypes.node),
   image: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string,
   }),
-  children: PropTypes.node.isRequired,
-  actionItems: PropTypes.arrayOf(PropTypes.node),
-  toolbarItems: PropTypes.arrayOf(PropTypes.node),
-  breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   introText: PropTypes.string,
   secondaryText: PropTypes.string,
+  toolbarItems: PropTypes.arrayOf(PropTypes.node),
 };

--- a/packages/sage-react/lib/themes/next/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/themes/next/PageHeading/PageHeading.jsx
@@ -86,7 +86,7 @@ PageHeading.propTypes = {
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  help: PropTypes.arrayOf(PropTypes.node),
+  help: PropTypes.node,
   image: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string,

--- a/packages/sage-react/lib/themes/next/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/themes/next/PageHeading/PageHeading.story.jsx
@@ -53,6 +53,11 @@ PageHeadingWithHelpLink.args = {
   )
 };
 
+export const PageHeadingWithIntro = Template.bind({});
+PageHeadingWithIntro.args = {
+  introText: 'Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit.'
+};
+
 export const PageHeadingWithThumbnail = Template.bind({});
 PageHeadingWithThumbnail.args = {
   image: {
@@ -91,6 +96,7 @@ PageHeadingWithToolbarAndSecondaryText.args = {
 
 export const AllItems = Template.bind({});
 AllItems.args = {
+  introText: 'Intro - Lorem ipsum, dolor sit amet consectetur adipisicing elit.',
   secondaryText: 'Secondary text here',
   breadcrumbs: [
     {

--- a/packages/sage-react/lib/themes/next/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/themes/next/PageHeading/PageHeading.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { HelpLink } from '../HelpLink';
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
 import { PageHeading } from './PageHeading';
 
 export default {
@@ -9,24 +11,138 @@ export default {
     children: (
       <>
         Page heading goes here
-        <HelpLink href="//example.com" target="_blank" rel="noopener" />
       </>
     ),
-    breadcrumbs: [
-      {
-        label: 'Back somewhere',
-        href: '#back'
-      }
+    actionItems: [
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.PREVIEW_ON}
+        subtle={true}
+      >
+        Preview
+      </Button>,
+      <Button
+        color={Button.COLORS.PRIMARY}
+        icon={SageTokens.ICONS.CART}
+      >
+        Create
+      </Button>
     ],
-    actionItems: null,
-    secondaryText: 'Secondary text here',
     toolbarItems: null,
-    image: {
-      src: 'https://via.placeholder.com/132x74',
-      alt: 'Page heading demo image'
-    },
   }
 };
 const Template = (args) => <PageHeading {...args} />;
 
 export const Default = Template.bind({});
+
+export const PageHeadingWithBackLink = Template.bind({});
+PageHeadingWithBackLink.args = {
+  breadcrumbs: [
+    {
+      label: 'Back somewhere',
+      href: '#back'
+    }
+  ]
+};
+export const PageHeadingWithHelpLink = Template.bind({});
+PageHeadingWithHelpLink.args = {
+  help: (
+    <>
+      <HelpLink href="//example.com" target="_blank" rel="noopener" />
+    </>
+  )
+};
+
+export const PageHeadingWithThumbnail = Template.bind({});
+PageHeadingWithThumbnail.args = {
+  image: {
+    src: 'https://via.placeholder.com/132x74',
+    alt: 'Page heading demo image',
+  }
+};
+
+export const PageHeadingWithToolbarAndSecondaryText = Template.bind({});
+PageHeadingWithToolbarAndSecondaryText.args = {
+  secondaryText: 'Secondary text here',
+  toolbarItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CART}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Report
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Settings
+    </Button>
+  ],
+};
+
+export const AllItems = Template.bind({});
+AllItems.args = {
+  secondaryText: 'Secondary text here',
+  breadcrumbs: [
+    {
+      label: 'Back somewhere',
+      href: '#back'
+    }
+  ],
+  help: (
+    <>
+      <HelpLink href="//example.com" target="_blank" rel="noopener" />
+    </>
+  ),
+  actionItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.PREVIEW_ON}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.PRIMARY}
+      icon={SageTokens.ICONS.CART}
+    >
+      Create
+    </Button>
+  ],
+  image: {
+    src: 'https://via.placeholder.com/132x74',
+    alt: 'Page heading demo image',
+  },
+  toolbarItems: [
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CART}
+      subtle={true}
+    >
+      Preview
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Report
+    </Button>,
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.GEAR}
+      subtle={true}
+    >
+      Settings
+    </Button>
+  ],
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update storybook demos to show all variations
- [x] remove help content to outside of the `<h1>` element


####  Breaking Change:
**Notes for implementation**
To remove the help or `Popover` content from the `<h1>`, a new `help` prop exists.
For the following React pages, you'll need to:
- move the `<Popover>` from the `Pageheading`s `children`
- place that content into the `help` prop
```
app/javascript/apps/click_report/views/ClickReport/ClickReport.jsx
app/javascript/apps/click_report/views/LinkReport/LinkReport.jsx
app/javascript/apps/dns_settings/DnsSettings.jsx
app/javascript/apps/imports/views/BulkActions/BulkActionsContainer.jsx
app/javascript/apps/imports/views/Confirm/ConfirmContainer.jsx
app/javascript/apps/imports/views/ImportContacts/ImportContacts.jsx
app/javascript/apps/imports/views/MapColumns/MapColumnsContainer.jsx
app/javascript/apps/manage/insights/InsightsContainer.jsx
app/javascript/apps/manage/peoples/contacts/ContactsHeader.jsx
app/javascript/apps/manage/pipelines/PipelineBlueprintsContainer.jsx
app/javascript/apps/manage/pipelines/PipelinesContainer.jsx
app/javascript/apps/products/PostContainer/components/PostHeader/PostHeader.jsx
app/javascript/apps/products/ProductContainer/components/ProductHeader/ProductHeader.jsx
app/javascript/apps/quizzes/admin/components/QuizHeader/QuizHeader.jsx
app/javascript/apps/reporting/components/BaseReport/BaseReportContainer.jsx
app/javascript/apps/reporting/reports/MemberProductProgressReport/MemberProductProgressReport.jsx
app/javascript/stories/mocks/coaching/DashboardPageMock.jsx
app/javascript/stories/mocks/coaching/OAuthPageMock.jsx
app/javascript/stories/mocks/crm/CRMEngagementWidget.jsx
app/javascript/stories/mocks/crm/CRMStatBox.jsx
app/javascript/stories/mocks/domains/GetADomainPage.jsx
app/javascript/stories/mocks/domains/OrderSummary.jsx
```
## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1277" alt="Screen_Shot_2022-05-06_at_9_57_42_AM" src="https://user-images.githubusercontent.com/1241836/167159114-d114e610-7ff6-4c3c-8273-248273a1611c.png">|<img width="1187" alt="Screen_Shot_2022-05-06_at_9_57_34_AM" src="https://user-images.githubusercontent.com/1241836/167159132-3f1789f2-a209-499d-b0a2-60f12fd34a70.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
No visual difference
Visit the Page Heading view and verify that the example match the designs:
- [React](http://localhost:4100/?path=/docs/sage-pageheading--default)

In both views verify that the help content exists outside of the `<h1>` element:
- [Rails](http://localhost:4000/pages/component/page_heading?sage_theme=sage_theme_next)
- [React](http://localhost:4100/?path=/docs/sage-pageheading--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**BREAKING**) Added new property to `Pageheading`. Requires implementation to not introduce visual breaking change.
   - [ ] Product Index
   - [ ] Commerce Index


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-558](https://kajabi.atlassian.net/browse/SAGE-558)