### PR TITLE
[SAGE-551]: Dropdown: divider spacing needs tweak (Next)

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_dropdown.scss
@@ -124,11 +124,13 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 .sage-dropdown__item--border-before {
   padding-top: sage-spacing(xs);
+  margin-top: sage-spacing(xs);
   border-top: 1px solid sage-color(grey, 300);
 }
 
 .sage-dropdown__item--border-after {
   padding-bottom: sage-spacing(xs);
+  margin-bottom: sage-spacing(xs);
   border-bottom: 1px solid sage-color(grey, 300);
 }
 


### PR DESCRIPTION
## Description
Adjusts spacing of dropdown divider to add spacing for when dropdown items are hovered.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
||  Before  |  After  |
|--------|--------|--------|
|sage_next|![Screen Shot 2022-05-09 at 10 56 41 AM](https://user-images.githubusercontent.com/1175111/167469164-d8aa133f-2603-49ce-90df-f2400bf38682.png)|![Screen Shot 2022-05-09 at 10 43 04 AM](https://user-images.githubusercontent.com/1175111/167468434-ecde258b-e157-4d2e-becb-c73d7a1fdfab.png)|
|kp|![Screen Shot 2022-05-09 at 10 58 28 AM](https://user-images.githubusercontent.com/1175111/167469575-0f367eea-7ef5-4ddb-ab22-d4b80c9d8179.png)|![Screen Shot 2022-05-09 at 10 44 21 AM](https://user-images.githubusercontent.com/1175111/167468486-f738cdff-694f-41f4-8d4c-1abe87d3f770.png)|


## Testing in `sage-lib`

- Navigate to dropdown (Next)
- Verify divider displays as expected


## Testing in `kajabi-products`

1. (**LOW**) Adjusts spacing of dropdown divider in sage_next theme. 
   - [ ] User dropdown (sage_next)


## Related
https://kajabi.atlassian.net/browse/SAGE-551
