### PR TITLE
Ensure consumables don't export CSS

### DIFF
--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -332,7 +332,7 @@ module SageTokens
     "body-xsmall", "body-xsmall-med", "body-xsmall-semi", "body-xsmall-bold",
   ]
 
-  # Aliasses for responsive pairings of size and leading.
+  # Aliases for responsive pairings of size and leading.
   # Keep in sync with `line-height` custom props set in `sage-assets/.../core/_typography.scss`
   RESPONSIVE_TYPE_SPECS = [
     "h1", "h2", "h3", "h4", "h5", "h6",

--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -332,7 +332,8 @@ module SageTokens
     "body-xsmall", "body-xsmall-med", "body-xsmall-semi", "body-xsmall-bold",
   ]
 
-  # Aliasses for responsive pairings of size and leading. Keep in sync with `sage-font-size` token as an example.
+  # Aliasses for responsive pairings of size and leading.
+  # Keep in sync with `line-height` custom props set in `sage-assets/.../core/_typography.scss`
   RESPONSIVE_TYPE_SPECS = [
     "h1", "h2", "h3", "h4", "h5", "h6",
     "body", "body-sm", "body-xs",

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_icon.scss
@@ -8,7 +8,8 @@ $-icon-font-cdn-version: "4";
 $-icon-font-path: "#{$sage-font-cdn-root}/sage/v#{$-icon-font-cdn-version}" !default;
 $-icon-font-version: 4;
 
-// NOTE: These should be kept in sync with line-height pairings from `packages/sage-assets/lib/stylesheets/tokens/_line_height.scss`
+// NOTE: These should be kept in sync with line-height pairings.
+// See `core/_typography.scss`
 $-icon-beside-type: (
   "h1",
   "h2",
@@ -21,7 +22,8 @@ $-icon-beside-type: (
   "body-xs",
 );
 
-// NOTE: These should be kept in sync with line-height pairings from `packages/sage-assets/lib/stylesheets/tokens/_line_height.scss`
+// NOTE: These should be kept in sync with line-height pairings.
+// See `core/_typography.scss`
 $-icon-beside-type: (
   "h1",
   "h2",

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/core/_typography.scss
@@ -10,6 +10,64 @@ $-body-font-stack: "Inter", -apple-system, "BlinkMacSystemFont", "Segoe UI", "Ro
 $-body-margin-bottom: sage-spacing(xs);
 $-headings-margin-bottom: sage-spacing(sm);
 
+///
+/// Sage responsive font sizes and line heights custom props
+///
+/// Responsive font sizes and line heights use CSS custom properties to apply a raw font size for a given breakpoint range.
+/// NOTE: Changes to these configurations should also be synced up in the following places:
+///   - `components/_icon.scss`
+///   - Sage Rails tokens definition
+///   - React Icon configurations
+///
+:root {
+  // Font sizes
+  --sage-font-size-body-xs: #{map-get($sage-font-sizes, 2xs)};
+  --sage-font-size-body-sm: #{map-get($sage-font-sizes, sm)};
+  --sage-font-size-body: #{map-get($sage-font-sizes, md)};
+  --sage-font-size-h6: #{map-get($sage-font-sizes, md)};
+  --sage-font-size-h5: #{map-get($sage-font-sizes, md)};
+  --sage-font-size-h4: #{map-get($sage-font-sizes, lg)};
+  --sage-font-size-h3: #{map-get($sage-font-sizes, xl)};
+  --sage-font-size-h2: #{map-get($sage-font-sizes, 2xl)};
+  --sage-font-size-h1: #{map-get($sage-font-sizes, 3xl)};
+
+  // Line heights
+  --sage-line-height-body-xs: #{map-get($sage-line-heights, xs)};
+  --sage-line-height-body-sm: #{map-get($sage-line-heights, sm)};
+  --sage-line-height-body: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h6: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h5: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h4: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h3: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h2: #{map-get($sage-line-heights, lg)};
+  --sage-line-height-h1: #{map-get($sage-line-heights, lg)};
+}
+
+@media screen and (min-width: sage-breakpoint(lg-min)) {
+  :root {
+    // Font sizes
+    // --sage-font-size-body-xs is same
+    --sage-font-size-body-sm: #{map-get($sage-font-sizes, xs)};
+    --sage-font-size-body: #{map-get($sage-font-sizes, sm)};
+    --sage-font-size-h6: #{map-get($sage-font-sizes, sm)};
+    --sage-font-size-h5: #{map-get($sage-font-sizes, lg)};
+    --sage-font-size-h4: #{map-get($sage-font-sizes, xl)};
+    --sage-font-size-h3: #{map-get($sage-font-sizes, 2xl)};
+    --sage-font-size-h2: #{map-get($sage-font-sizes, 3xl)};
+    --sage-font-size-h1: #{map-get($sage-font-sizes, 4xl)};
+
+    // Line heights
+    // --sage-line-height-body-xs: same
+    // --sage-line-height-body-sm: same
+    --sage-line-height-body: #{map-get($sage-line-heights, sm)};
+    --sage-line-height-h6: #{map-get($sage-line-heights, sm)};
+    // --sage-line-height-h5: same
+    // --sage-line-height-h4: same
+    --sage-line-height-h3: #{map-get($sage-line-heights, lg)};
+    // --sage-line-height-h2: same
+    --sage-line-height-h1: #{map-get($sage-line-heights, xl)};
+  }
+}
 
 body:not(.sage-excluded) {
   @include sage-font-family();

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/tokens/_font_size.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/tokens/_font_size.scss
@@ -7,7 +7,8 @@
 ///
 /// Sage raw font sizes token (non-responsive)
 ///
-/// Sage allows for responsive typography, that uses these raw font sizes as the source of truth for its possible sizes.
+/// Sage allows for responsive typography which use these raw font sizes as the source of truth for its possible sizes.
+/// See core/_typography.scss for where these are primarily implemented.
 ///
 $sage-font-sizes: (
   2xs: rem(12px),
@@ -20,37 +21,6 @@ $sage-font-sizes: (
   3xl: rem(26px),
   4xl: rem(29px)
 );
-
-///
-/// Sage responsive font sizes custom props
-///
-/// Responsive font sizes use CSS custom properties to apply a raw font size for a given breakpoint range.
-///
-:root {
-  --sage-font-size-body-xs: #{map-get($sage-font-sizes, 2xs)};
-  --sage-font-size-body-sm: #{map-get($sage-font-sizes, sm)};
-  --sage-font-size-body: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h6: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h5: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h4: #{map-get($sage-font-sizes, lg)};
-  --sage-font-size-h3: #{map-get($sage-font-sizes, xl)};
-  --sage-font-size-h2: #{map-get($sage-font-sizes, 2xl)};
-  --sage-font-size-h1: #{map-get($sage-font-sizes, 3xl)};
-}
-
-@media screen and (min-width: sage-breakpoint(lg-min)) {
-  :root {
-    // --sage-font-size-body-xs is same
-    --sage-font-size-body-sm: #{map-get($sage-font-sizes, xs)};
-    --sage-font-size-body: #{map-get($sage-font-sizes, sm)};
-    --sage-font-size-h6: #{map-get($sage-font-sizes, sm)};
-    --sage-font-size-h5: #{map-get($sage-font-sizes, lg)};
-    --sage-font-size-h4: #{map-get($sage-font-sizes, xl)};
-    --sage-font-size-h3: #{map-get($sage-font-sizes, 2xl)};
-    --sage-font-size-h2: #{map-get($sage-font-sizes, 3xl)};
-    --sage-font-size-h1: #{map-get($sage-font-sizes, 4xl)};
-  }
-}
 
 ///
 /// Sage font size token utility (responsive)

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/tokens/_line_height.scss
@@ -7,6 +7,7 @@
 
 ///
 /// Sage raw line height/leading token (non-responsive)
+/// See core/_typography.scss for where these are primarily implemented.
 ///
 $sage-line-heights: (
   xs: sage-baseline(5), // 20
@@ -15,39 +16,6 @@ $sage-line-heights: (
   lg: sage-baseline(8), // 32
   xl: sage-baseline(9), // 36
 );
-
-///
-/// Sage responsive line height/leading custom props
-///
-/// NOTE: Changes to these configurations should also be synced up in the following know places:
-///   - `docs/lib/sage_rails/app/sage_components/sage_tokens.rb`
-///   - `packages/sage-assets/lib/stylesheets/components/_icon.scss`
-///   - `packages/sage-react/lib/Icon/configs.js`
-:root {
-  --sage-line-height-body-xs: #{map-get($sage-line-heights, xs)};
-  --sage-line-height-body-sm: #{map-get($sage-line-heights, sm)};
-  --sage-line-height-body: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h6: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h5: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h4: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h3: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h2: #{map-get($sage-line-heights, lg)};
-  --sage-line-height-h1: #{map-get($sage-line-heights, lg)};
-}
-
-@media screen and (min-width: sage-breakpoint(lg-min)) {
-  :root {
-    // --sage-line-height-body-xs: same
-    // --sage-line-height-body-sm: same
-    --sage-line-height-body: #{map-get($sage-line-heights, sm)};
-    --sage-line-height-h6: #{map-get($sage-line-heights, sm)};
-    // --sage-line-height-h5: same
-    // --sage-line-height-h4: same
-    --sage-line-height-h3: #{map-get($sage-line-heights, lg)};
-    // --sage-line-height-h2: same
-    --sage-line-height-h1: #{map-get($sage-line-heights, xl)};
-  }
-}
 
 ///
 /// Sage line height token utility

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_icon.scss
@@ -8,7 +8,8 @@ $-icon-font-cdn-version: "4";
 $-icon-font-path: "#{$sage-font-cdn-root}/sage/v#{$-icon-font-cdn-version}" !default;
 $-icon-font-version: 4;
 
-// NOTE: These should be kept in sync with line-height pairings from `packages/sage-assets/lib/stylesheets/tokens/_line_height.scss`
+// NOTE: These should be kept in sync with line-height pairings.
+// See `core/_typography.scss`
 $-icon-beside-type: (
   "h1",
   "h2",
@@ -21,7 +22,8 @@ $-icon-beside-type: (
   "body-xs",
 );
 
-// NOTE: These should be kept in sync with line-height pairings from `packages/sage-assets/lib/stylesheets/tokens/_line_height.scss`
+// NOTE: These should be kept in sync with line-height pairings.
+// See `core/_typography.scss`
 $-icon-beside-type: (
   "h1",
   "h2",

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_typography.scss
@@ -10,6 +10,65 @@ $-body-font-stack: "Circular", -apple-system, "BlinkMacSystemFont", "Segoe UI", 
 $-body-margin-bottom: sage-spacing(xs);
 $-headings-margin-bottom: sage-spacing(sm);
 
+///
+/// Sage responsive font sizes and line heights custom props
+///
+/// Responsive font sizes and line heights use CSS custom properties to apply a raw font size for a given breakpoint range.
+/// NOTE: Changes to these configurations should also be synced up in the following places:
+///   - `components/_icon.scss`
+///   - Sage Rails tokens definition
+///   - React Icon configurations
+///
+:root {
+  // Font sizes
+  --sage-font-size-body-xs: #{map-get($sage-font-sizes, xs)};
+  --sage-font-size-body-sm: #{map-get($sage-font-sizes, sm)};
+  --sage-font-size-body: #{map-get($sage-font-sizes, md)};
+  --sage-font-size-h6: #{map-get($sage-font-sizes, md)};
+  --sage-font-size-h5: #{map-get($sage-font-sizes, lg)};
+  --sage-font-size-h4: #{map-get($sage-font-sizes, xl)};
+  --sage-font-size-h3: #{map-get($sage-font-sizes, 2xl)};
+  --sage-font-size-h2: #{map-get($sage-font-sizes, 3xl)};
+  --sage-font-size-h1: #{map-get($sage-font-sizes, 4xl)};
+
+  // Line heights
+  --sage-line-height-body-xs: #{map-get($sage-line-heights, xs)};
+  --sage-line-height-body-sm: #{map-get($sage-line-heights, sm)};
+  --sage-line-height-body: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h6: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h5: #{map-get($sage-line-heights, lg)};
+  --sage-line-height-h4: #{map-get($sage-line-heights, xl)};
+  --sage-line-height-h3: #{map-get($sage-line-heights, 2xl)};
+  --sage-line-height-h2: #{map-get($sage-line-heights, 3xl)};
+  --sage-line-height-h1: #{map-get($sage-line-heights, 4xl)};
+}
+
+// Responsive adjustments are currently TBD
+// @media screen and (min-width: sage-breakpoint(lg-min)) {
+//   :root {
+//     // Font sizes
+//     // --sage-font-size-body-xs: same
+//     // --sage-font-size-body-sm: same
+//     // --sage-font-size-body: same
+//     // --sage-font-size-h6: same
+//     // --sage-font-size-h5: same
+//     // --sage-font-size-h4: same
+//     // --sage-font-size-h3: same
+//     // --sage-font-size-h2: same
+//     // --sage-font-size-h1: same
+//
+//     // Line heights
+//     // --sage-line-height-body-xs: same
+//     // --sage-line-height-body-sm: same
+//     // --sage-line-height-body: same
+//     // --sage-line-height-h6: same
+//     // --sage-line-height-h5: same
+//     // --sage-line-height-h4: same
+//     // --sage-line-height-h3: same
+//     // --sage-line-height-h2: same
+//     // --sage-line-height-h1: same
+//   }
+// }
 
 body:not(.sage-excluded) {
   @include sage-font-family();

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_font_size.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_font_size.scss
@@ -7,7 +7,8 @@
 ///
 /// Sage raw font sizes token (non-responsive)
 ///
-/// Sage allows for responsive typography, that uses these raw font sizes as the source of truth for its possible sizes.
+/// Sage allows for responsive typography which use these raw font sizes as the source of truth for its possible sizes.
+/// See core/_typography.scss for where these are primarily implemented.
 ///
 $sage-font-sizes: (
   xs: rem(12px),
@@ -19,37 +20,6 @@ $sage-font-sizes: (
   3xl: rem(32px),
   4xl: rem(40px)
 );
-
-///
-/// Sage responsive font sizes custom props
-///
-/// Responsive font sizes use CSS custom properties to apply a raw font size for a given breakpoint range.
-///
-:root {
-  --sage-font-size-body-xs: #{map-get($sage-font-sizes, xs)};
-  --sage-font-size-body-sm: #{map-get($sage-font-sizes, sm)};
-  --sage-font-size-body: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h6: #{map-get($sage-font-sizes, md)};
-  --sage-font-size-h5: #{map-get($sage-font-sizes, lg)};
-  --sage-font-size-h4: #{map-get($sage-font-sizes, xl)};
-  --sage-font-size-h3: #{map-get($sage-font-sizes, 2xl)};
-  --sage-font-size-h2: #{map-get($sage-font-sizes, 3xl)};
-  --sage-font-size-h1: #{map-get($sage-font-sizes, 4xl)};
-}
-
-@media screen and (min-width: sage-breakpoint(lg-min)) {
-  :root {
-    // --sage-font-size-body-xs is same
-    // --sage-font-size-body-sm: same
-    // --sage-font-size-body: same
-    // --sage-font-size-h6: same
-    // --sage-font-size-h5: same
-    // --sage-font-size-h4: same
-    // --sage-font-size-h3: same
-    // --sage-font-size-h2: same
-    // --sage-font-size-h1: same
-  }
-}
 
 ///
 /// Sage font size token utility (responsive)

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_line_height.scss
@@ -7,6 +7,7 @@
 
 ///
 /// Sage raw line height/leading token (non-responsive)
+/// See core/_typography.scss for where these are primarily implemented.
 ///
 $sage-line-heights: (
   xs: sage-baseline(4), // 16
@@ -18,39 +19,6 @@ $sage-line-heights: (
   3xl: sage-baseline(12), // 48
   4xl: sage-baseline(15), // 60
 );
-
-///
-/// Sage responsive line height/leading custom props
-///
-/// NOTE: Changes to these configurations should also be synced up in the following know places:
-///   - `docs/lib/sage_rails/app/sage_components/sage_tokens.rb`
-///   - `packages/sage-assets/lib/stylesheets/components/_icon.scss`
-///   - `packages/sage-react/lib/Icon/configs.js`
-:root {
-  --sage-line-height-body-xs: #{map-get($sage-line-heights, xs)};
-  --sage-line-height-body-sm: #{map-get($sage-line-heights, sm)};
-  --sage-line-height-body: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h6: #{map-get($sage-line-heights, md)};
-  --sage-line-height-h5: #{map-get($sage-line-heights, lg)};
-  --sage-line-height-h4: #{map-get($sage-line-heights, xl)};
-  --sage-line-height-h3: #{map-get($sage-line-heights, 2xl)};
-  --sage-line-height-h2: #{map-get($sage-line-heights, 3xl)};
-  --sage-line-height-h1: #{map-get($sage-line-heights, 4xl)};
-}
-
-@media screen and (min-width: sage-breakpoint(lg-min)) {
-  :root {
-    // --sage-line-height-body-xs: same
-    // --sage-line-height-body-sm: same
-    // --sage-line-height-body: same
-    // --sage-line-height-h6: same
-    // --sage-line-height-h5: same
-    // --sage-line-height-h4: same
-    // --sage-line-height-h3: same
-    // --sage-line-height-h2: same
-    // --sage-line-height-h1: same
-  }
-}
 
 ///
 /// Sage line height token utility


### PR DESCRIPTION
## Description

This PR moves the font size and line height css custom props that were being declared and output in `tokens` files that are included in the `consumables` exports into more appropriate spots. The result is that `consumables` no longer has any output CSS.

This resolves an issue in `kp` where multiples settings for styles were colliding due to unexpected output from `consumables`. 

## Screenshots

CSS output in developer tools:

| Before | After |
|---|---|
| CSS Props output every time consumables are used in addition to initial use with correct theme. | CSS Props only output once for initiaul use in theme. |
| ![Screen Shot 2022-05-09 at 4 50 30 PM](https://user-images.githubusercontent.com/17955295/167496226-854c2ff1-c339-434f-979d-e85921a8015d.png)  | ![Screen Shot 2022-05-09 at 4 48 39 PM](https://user-images.githubusercontent.com/17955295/167496271-494a87b9-052a-4a80-8232-80cc48fea8d9.png) |

## Testing in `sage-lib`

See that docs site show now change to font size settings.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Change to where font size and line height CSS props are declared to reduce unexpected output from uses of `_consumables.scss`

## Related

[SAGE-549](https://kajabi.atlassian.net/browse/SAGE-549)
