### PR TITLE
Add tabs subitems to storybook docs

### DIFF
--- a/packages/sage-react/lib/themes/legacy/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Tabs/Tabs.story.jsx
@@ -17,7 +17,11 @@ export default {
   args: {
     tabStyle: Tabs.STYLES.TAB,
     tabLayout: Tabs.LAYOUTS.DEFAULT
-  }
+  },
+  subcomponents: {
+    'Tabs.Item': Tabs.Item,
+    'Tabs.Pane': Tabs.Pane,
+  },
 };
 
 export const Default = (args) => {


### PR DESCRIPTION
## Description

This PR adds Storybook documentation of the Tabs subcomponents Item and Pane.


## Screenshots

![Screen Shot 2022-05-10 at 1 04 30 PM](https://user-images.githubusercontent.com/17955295/167684462-2b8f22a3-4fca-4466-8bf5-cd3259d4d596.png)

## Testing in `sage-lib`

See http://localhost:4100/?path=/docs/sage-tabs--default

## Testing in `kajabi-products`

1. (N/A) Add additional React Tabs documentation details.