### PR TITLE
[QEINBOX-340] - remove z index from select

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
@@ -53,7 +53,6 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
   @include sage-form-field();
   @include sage-focus-ring;
 
-  z-index: sage-z-index(default, 1);
   position: relative;
   height: $-select-height;
   padding: 0 $-select-padding-x 0;


### PR DESCRIPTION
## Description
Forrest found a bug when testing the sage bump, in Safari. It has been discovered that the `z-index` should NOT have been used in this case. 


## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/1633290/167729616-e9c8a384-6a96-4751-9ac4-88d785003b94.png)|![image](https://user-images.githubusercontent.com/1633290/167729650-4305a1c4-af22-4aa7-9ed5-68e83e566b2b.png)|


## Testing in `sage-lib`
Unable able to test.


## Testing in `kajabi-products`
1. In Sage-Lib
2. check out the branch `QEINBOX-340/remove-z-index-from-select`
3. turn on the bridge
4. In `KP`
5. start the webserver
6. Enable the creation wizard feature flag
7. Navigate to `https://www.kajabi.test/admin/sites/1/products#/create` in `SAFARI`
8.  Follow the steps in the Loom below once the page has been loaded.
https://www.loom.com/share/f35e0400b7694775ae4dcbf9cc9f4d3e

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
