### PR TITLE
[QEINBOX-340] - Additional fixes for Sage Bump 4.63.2

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_form_select.scss
@@ -67,7 +67,6 @@ $-select-padding-label: sage-spacing(2xs);
 .sage-select__field {
   @include sage-form-field();
 
-  z-index: sage-z-index(default, 1);
   position: relative;
   height: $-select-height;
   padding: 0 $-select-padding-x 0;


### PR DESCRIPTION
## Description
I was bit by the `legacy` and `next` version. The previous PR only fixed `Next` and I was running `next` locally. This fixes legacy. 
* fix(creationwizard): in Safari, z-index affected the layering of Select dropdown (legacy)


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/1633290/167916071-1a9e79c6-8780-4489-a490-2571426f545c.png)|![image](https://user-images.githubusercontent.com/1633290/167915248-a7025762-dab1-49a9-89a8-b0467e4fe47f.png)|

## Testing in `sage-lib`
Unable able to test.


## Testing in `kajabi-products`
1. In Sage-Lib
2. check out the branch `QEINBOX-340/remove-z-index-from-select`
3. turn on the bridge
4. In `KP`
5. start the webserver
6. Enable the creation wizard feature flag
7. Navigate to `https://www.kajabi.test/admin/sites/1/products#/create` in `SAFARI`
8.  Follow the steps in the Loom below once the page has been loaded.
https://www.loom.com/share/f35e0400b7694775ae4dcbf9cc9f4d3e



## Related
Part 2 of #1397 