### PR TITLE
[SAGE-303] Input - Rails / React parity

### DIFF
--- a/packages/sage-react/lib/themes/legacy/Input/Input.jsx
+++ b/packages/sage-react/lib/themes/legacy/Input/Input.jsx
@@ -3,20 +3,38 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Icon } from '../Icon';
 import { SageTokens } from '../configs';
+import {
+  INPUT_MODE,
+  INPUT_TYPE
+} from './configs';
 
 export const Input = ({
+  autocomplete,
   className,
+  disabled,
   hasError,
   hasPlaceholder,
   icon,
   id,
+  inputMode,
   label,
+  max,
+  maxLength,
   message,
+  min,
+  minLength,
+  name,
   onChange,
+  pattern,
+  placeholder,
   popover,
   prefix,
+  readonly,
+  required,
   standalone,
+  step,
   suffix,
+  type,
   value,
   ...rest
 }) => {
@@ -49,6 +67,13 @@ export const Input = ({
     }
   };
 
+  const setPlaceholder = () => {
+    if (placeholder) {
+      return placeholder;
+    }
+    return label;
+  };
+
   useEffect(() => {
     const newInputStyles = {
       ...inputStyles,
@@ -76,11 +101,24 @@ export const Input = ({
   return (
     <div className={classNames}>
       <input
+        autoComplete={autocomplete}
         className="sage-form-field sage-input__field"
+        disabled={disabled}
         id={id}
+        inputMode={inputMode}
+        max={max}
+        maxLength={maxLength}
+        min={min}
+        minLength={minLength}
+        name={name}
         onChange={handleChange}
-        placeholder={label}
+        pattern={pattern}
+        placeholder={setPlaceholder()}
+        readOnly={readonly}
+        required={required}
+        step={step}
         style={inputStyles}
+        type={type}
         value={fieldValue || value}
         {...rest}
       />
@@ -120,33 +158,64 @@ export const Input = ({
   );
 };
 
+Input.Mode = INPUT_MODE;
+Input.Type = INPUT_TYPE;
+
 Input.defaultProps = {
+  autocomplete: null,
   className: null,
+  disabled: false,
   hasError: false,
   hasPlaceholder: false,
   icon: null,
+  inputMode: null,
   label: null,
+  max: null,
+  maxLength: null,
   message: null,
+  min: null,
+  minLength: null,
+  name: null,
   onChange: null,
+  pattern: null,
+  placeholder: null,
   popover: null,
   prefix: null,
+  readonly: false,
+  required: false,
   standalone: false,
+  step: null,
   suffix: null,
+  type: null,
   value: '',
 };
 
 Input.propTypes = {
+  autocomplete: PropTypes.string,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,
   hasError: PropTypes.bool,
   hasPlaceholder: PropTypes.bool,
+  inputMode: PropTypes.oneOf(Object.values(Input.Mode)),
   label: PropTypes.string,
+  max: PropTypes.string,
+  maxLength: PropTypes.string,
+  min: PropTypes.string,
+  minLength: PropTypes.string,
   message: PropTypes.string,
+  name: PropTypes.string,
   onChange: PropTypes.func,
+  pattern: PropTypes.string,
+  placeholder: PropTypes.string,
   popover: PropTypes.node,
   prefix: PropTypes.string,
+  readonly: PropTypes.bool,
+  required: PropTypes.bool,
   standalone: PropTypes.bool,
+  step: PropTypes.string,
   suffix: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(Input.Type)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/sage-react/lib/themes/legacy/Input/Input.jsx
+++ b/packages/sage-react/lib/themes/legacy/Input/Input.jsx
@@ -17,6 +17,7 @@ export const Input = ({
   icon,
   id,
   inputMode,
+  inputType,
   label,
   max,
   maxLength,
@@ -34,7 +35,6 @@ export const Input = ({
   standalone,
   step,
   suffix,
-  type,
   value,
   ...rest
 }) => {
@@ -106,6 +106,7 @@ export const Input = ({
         disabled={disabled}
         id={id}
         inputMode={inputMode}
+        inputType={inputType}
         max={max}
         maxLength={maxLength}
         min={min}
@@ -118,7 +119,6 @@ export const Input = ({
         required={required}
         step={step}
         style={inputStyles}
-        type={type}
         value={fieldValue || value}
         {...rest}
       />
@@ -169,6 +169,7 @@ Input.defaultProps = {
   hasPlaceholder: false,
   icon: null,
   inputMode: null,
+  inputType: null,
   label: null,
   max: null,
   maxLength: null,
@@ -186,7 +187,6 @@ Input.defaultProps = {
   standalone: false,
   step: null,
   suffix: null,
-  type: null,
   value: '',
 };
 
@@ -199,6 +199,7 @@ Input.propTypes = {
   hasError: PropTypes.bool,
   hasPlaceholder: PropTypes.bool,
   inputMode: PropTypes.oneOf(Object.values(Input.Mode)),
+  inputType: PropTypes.oneOf(Object.values(Input.Type)),
   label: PropTypes.string,
   max: PropTypes.string,
   maxLength: PropTypes.string,
@@ -216,6 +217,5 @@ Input.propTypes = {
   standalone: PropTypes.bool,
   step: PropTypes.string,
   suffix: PropTypes.string,
-  type: PropTypes.oneOf(Object.values(Input.Type)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/sage-react/lib/themes/legacy/Input/Input.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Input/Input.story.jsx
@@ -11,11 +11,11 @@ export default {
     ...selectArgs({
       icon: SageTokens.ICONS,
       inputMode: Input.Mode,
-      type: Input.Type
+      inputType: Input.Type
     }),
   },
   args: {
-    ind: 'test-input',
+    id: 'test-input',
     disabled: false,
     label: 'First name',
     readonly: false
@@ -67,7 +67,7 @@ InputReadonly.args = {
 
 export const InputEmail = Template.bind({});
 InputEmail.args = {
-  type: Input.Type.EMAIL,
+  inputType: Input.Type.EMAIL,
   label: 'Email address'
 };
 

--- a/packages/sage-react/lib/themes/legacy/Input/Input.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Input/Input.story.jsx
@@ -10,10 +10,15 @@ export default {
   argTypes: {
     ...selectArgs({
       icon: SageTokens.ICONS,
+      inputMode: Input.Mode,
+      type: Input.Type
     }),
   },
   args: {
+    ind: 'test-input',
+    disabled: false,
     label: 'First name',
+    readonly: false
   }
 };
 
@@ -41,6 +46,29 @@ export const Default = (args) => {
       value={value}
     />
   );
+};
+
+const Template = (args) => <Input {...args} />;
+export const InputWithError = Template.bind({});
+InputWithError.args = {
+  hasError: true
+};
+
+export const InputDisabled = Template.bind({});
+InputDisabled.args = {
+  disabled: true
+};
+
+export const InputReadonly = Template.bind({});
+InputReadonly.args = {
+  readonly: true,
+  value: 'You cannot change me'
+};
+
+export const InputEmail = Template.bind({});
+InputEmail.args = {
+  type: Input.Type.EMAIL,
+  label: 'Email address'
 };
 
 export const InputWithStaticIcon = (args) => {

--- a/packages/sage-react/lib/themes/legacy/Input/configs.js
+++ b/packages/sage-react/lib/themes/legacy/Input/configs.js
@@ -1,0 +1,13 @@
+export const INPUT_MODE = {
+  DEFAULT: null,
+  NUMBERIC: 'numeric',
+  TEXT: 'text',
+};
+
+export const INPUT_TYPE = {
+  DEFAULT: null,
+  EMAIL: 'email',
+  NUMBER: 'number',
+  PASSWORD: 'password',
+  TEXT: 'text',
+};

--- a/packages/sage-react/lib/themes/next/Input/Input.jsx
+++ b/packages/sage-react/lib/themes/next/Input/Input.jsx
@@ -3,20 +3,39 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Icon } from '../Icon';
 import { SageTokens } from '../configs';
+import {
+  INPUT_MODE,
+  INPUT_TYPE
+} from './configs';
 
 export const Input = ({
+  autocomplete,
   className,
+  disabled,
   hasError,
+  hasPlaceholder,
   hideLabel,
   icon,
   id,
+  inputMode,
   label,
+  max,
+  maxLength,
   message,
+  min,
+  minLength,
+  name,
   onChange,
+  pattern,
+  placeholder,
   popover,
   prefix,
+  readonly,
+  required,
   standalone,
+  step,
   suffix,
+  type,
   value,
   ...rest
 }) => {
@@ -125,34 +144,66 @@ export const Input = ({
     </div>
   );
 };
+Input.Mode = INPUT_MODE;
+Input.Type = INPUT_TYPE;
 
 Input.defaultProps = {
+  autocomplete: null,
   className: null,
+  disabled: false,
   hasError: false,
+  hasPlaceholder: false,
   hideLabel: false,
   icon: null,
+  inputMode: null,
   label: null,
+  max: null,
+  maxLength: null,
   message: null,
+  min: null,
+  minLength: null,
+  name: null,
   onChange: null,
+  pattern: null,
+  placeholder: null,
   popover: null,
   prefix: null,
+  readonly: false,
+  required: false,
   standalone: false,
+  step: null,
   suffix: null,
+  type: null,
   value: '',
 };
 
 Input.propTypes = {
+  autocomplete: PropTypes.string,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   id: PropTypes.string.isRequired,
   hasError: PropTypes.bool,
+  hasPlaceholder: PropTypes.bool,
   hideLabel: PropTypes.bool,
+  inputMode: PropTypes.oneOf(Object.values(Input.Mode)),
   label: PropTypes.string,
+  max: PropTypes.string,
+  maxLength: PropTypes.string,
+  min: PropTypes.string,
+  minLength: PropTypes.string,
   message: PropTypes.string,
+  name: PropTypes.string,
   onChange: PropTypes.func,
+  pattern: PropTypes.string,
+  placeholder: PropTypes.string,
   popover: PropTypes.node,
   prefix: PropTypes.string,
+  readonly: PropTypes.bool,
+  required: PropTypes.bool,
   standalone: PropTypes.bool,
+  step: PropTypes.string,
   suffix: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(Input.Type)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/sage-react/lib/themes/next/Input/Input.jsx
+++ b/packages/sage-react/lib/themes/next/Input/Input.jsx
@@ -18,6 +18,7 @@ export const Input = ({
   icon,
   id,
   inputMode,
+  inputType,
   label,
   max,
   maxLength,
@@ -35,7 +36,6 @@ export const Input = ({
   standalone,
   step,
   suffix,
-  type,
   value,
   ...rest
 }) => {
@@ -113,6 +113,7 @@ export const Input = ({
         disabled={disabled}
         id={id}
         inputMode={inputMode}
+        inputType={inputType}
         max={max}
         maxLength={maxLength}
         min={min}
@@ -125,7 +126,6 @@ export const Input = ({
         required={required}
         step={step}
         style={inputStyles}
-        type={type}
         value={fieldValue || value}
         {...rest}
       />
@@ -176,6 +176,7 @@ Input.defaultProps = {
   hideLabel: false,
   icon: null,
   inputMode: null,
+  inputType: null,
   label: null,
   max: null,
   maxLength: null,
@@ -193,7 +194,6 @@ Input.defaultProps = {
   standalone: false,
   step: null,
   suffix: null,
-  type: null,
   value: '',
 };
 
@@ -207,6 +207,7 @@ Input.propTypes = {
   hasPlaceholder: PropTypes.bool,
   hideLabel: PropTypes.bool,
   inputMode: PropTypes.oneOf(Object.values(Input.Mode)),
+  inputType: PropTypes.oneOf(Object.values(Input.Type)),
   label: PropTypes.string,
   max: PropTypes.string,
   maxLength: PropTypes.string,
@@ -224,6 +225,5 @@ Input.propTypes = {
   standalone: PropTypes.bool,
   step: PropTypes.string,
   suffix: PropTypes.string,
-  type: PropTypes.oneOf(Object.values(Input.Type)),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/sage-react/lib/themes/next/Input/Input.jsx
+++ b/packages/sage-react/lib/themes/next/Input/Input.jsx
@@ -74,6 +74,13 @@ export const Input = ({
       'visually-hidden': hideLabel,
     });
 
+  const setPlaceholder = () => {
+    if (placeholder) {
+      return placeholder;
+    }
+    return label;
+  };
+
   useEffect(() => {
     const newInputStyles = {
       ...inputStyles,
@@ -101,11 +108,24 @@ export const Input = ({
   return (
     <div className={classNames}>
       <input
+        autoComplete={autocomplete}
         className="sage-form-field sage-input__field"
+        disabled={disabled}
         id={id}
+        inputMode={inputMode}
+        max={max}
+        maxLength={maxLength}
+        min={min}
+        minLength={minLength}
+        name={name}
         onChange={handleChange}
-        placeholder={label}
+        pattern={pattern}
+        placeholder={setPlaceholder()}
+        readOnly={readonly}
+        required={required}
+        step={step}
         style={inputStyles}
+        type={type}
         value={fieldValue || value}
         {...rest}
       />

--- a/packages/sage-react/lib/themes/next/Input/Input.story.jsx
+++ b/packages/sage-react/lib/themes/next/Input/Input.story.jsx
@@ -10,6 +10,8 @@ export default {
   argTypes: {
     ...selectArgs({
       icon: SageTokens.ICONS,
+      inputMode: Input.Mode,
+      inputType: Input.Type
     }),
   },
   args: {
@@ -62,7 +64,7 @@ InputReadonly.args = {
 
 export const InputEmail = Template.bind({});
 InputEmail.args = {
-  type: Input.Type.EMAIL,
+  inputType: Input.Type.EMAIL,
   label: 'Email address'
 };
 

--- a/packages/sage-react/lib/themes/next/Input/Input.story.jsx
+++ b/packages/sage-react/lib/themes/next/Input/Input.story.jsx
@@ -43,6 +43,29 @@ export const Default = (args) => {
   );
 };
 
+const Template = (args) => <Input {...args} />;
+export const InputWithError = Template.bind({});
+InputWithError.args = {
+  hasError: true
+};
+
+export const InputDisabled = Template.bind({});
+InputDisabled.args = {
+  disabled: true
+};
+
+export const InputReadonly = Template.bind({});
+InputReadonly.args = {
+  readonly: true,
+  value: 'You cannot change me'
+};
+
+export const InputEmail = Template.bind({});
+InputEmail.args = {
+  type: Input.Type.EMAIL,
+  label: 'Email address'
+};
+
 export const InputWithStaticIcon = (args) => {
   const [value, updateValue] = useState('Test');
   const onChange = (e) => {

--- a/packages/sage-react/lib/themes/next/Input/configs.js
+++ b/packages/sage-react/lib/themes/next/Input/configs.js
@@ -1,0 +1,13 @@
+export const INPUT_MODE = {
+  DEFAULT: null,
+  NUMBERIC: 'numeric',
+  TEXT: 'text',
+};
+
+export const INPUT_TYPE = {
+  DEFAULT: null,
+  EMAIL: 'email',
+  NUMBER: 'number',
+  PASSWORD: 'password',
+  TEXT: 'text',
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add all props to the react version that exists in the rails version

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="930" alt="Screen_Shot_2022-05-12_at_11_10_18_AM" src="https://user-images.githubusercontent.com/1241836/168120655-f483a3d6-a098-465c-b865-6bfc9e60159e.png">|<img width="1088" alt="Screen_Shot_2022-05-12_at_11_01_03_AM" src="https://user-images.githubusercontent.com/1241836/168120678-5fae645d-fb9a-4d77-97a4-83d2d8cb17ff.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the React Input page and verify that the properties are now aligned:
- [React](http://localhost:4110/?path=/story/sage-input--input-with-popover)
- [Rails](http://localhost:4000/pages/component/form_input?tab=preview)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adding new props to `<Input>` react component. Does not affect existing usage in the app.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-303](https://kajabi.atlassian.net/browse/SAGE-303)