### PR TITLE
MOCKS: All payouts and payout details

### DIFF
--- a/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
+++ b/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
@@ -89,6 +89,15 @@ module Mocks::KpOnboardingPayoutsHelper
     end
   end
 
+  def payouts_table_get_amount_ui_style(type)
+    case type
+    when "refund"
+      "#{SageClassnames::TYPE_COLORS::GREY_500}"
+    else
+      ""
+    end
+  end
+
   def payouts_balance_settings_options
     [
       { 
@@ -159,5 +168,38 @@ module Mocks::KpOnboardingPayoutsHelper
         },
       ]
     }
+  end
+
+  def payout_detail_line_items
+    [
+      {
+        date: "Jan 20, 2022 07:52",
+        type: "charge",
+        amount: "$127.50",
+        fee: "-$6.68",
+        net: "$120.82",
+      },
+      {
+        date: "Jan 21, 2022 09:14",
+        type: "subscription",
+        amount: "$127.50",
+        fee: "-$7.02",
+        net: "$120.48",
+      },
+      {
+        date: "Jan 22, 2022 13:05",
+        type: "refund",
+        amount: "$127.50",
+        fee: "-$6.68",
+        net: "-$120.82",
+      },
+      {
+        date: "Jan 23, 2022 12:36",
+        type: "charge",
+        amount: "$127.50",
+        fee: "-$6.68",
+        net: "$120.48",
+      },
+    ]
   end
 end

--- a/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
+++ b/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
@@ -124,4 +124,40 @@ module Mocks::KpOnboardingPayoutsHelper
       { text: value.to_s, value: value.to_s }
     end
   end
+
+  def payout_detail_summary
+    {
+      date: "Jan 19, 2022",
+      amount: "$2,888.71",
+      currency: "USD",
+      status: "transferring",
+      account: {
+        ending_digits: "37",
+        currency: "USD",
+      },
+      data: [
+        {
+          label: "Sales",
+          quantity: "273",
+          gross: "$3,390.68",
+          fees: "-$139.51",
+          total: "$3.251.17",
+        },
+        {
+          label: "Refunds",
+          quantity: "3",
+          gross: "-$362.46",
+          fees: "N/A",
+          total: "-$362.46",
+        },
+        {
+          label: "Adjustments",
+          quantity: "0",
+          gross: "$0.00",
+          fees: "$0.00",
+          total: "$0.00",
+        },
+      ]
+    }
+  end
 end

--- a/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
+++ b/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
@@ -77,6 +77,11 @@ module Mocks::KpOnboardingPayoutsHelper
         value: "Transferring",
         color: "draft"
       }
+    when "topup"
+      {
+        value: "Top-up",
+        color: "draft"
+      }
     end
   end
 
@@ -89,12 +94,23 @@ module Mocks::KpOnboardingPayoutsHelper
     end
   end
 
-  def payouts_table_get_amount_ui_style(type)
+  def payout_details_table_get_amount_ui_style(type)
     case type
     when "refund"
       "#{SageClassnames::TYPE_COLORS::GREY_500}"
     else
       ""
+    end
+  end
+
+  def payouts_table_get_amount_ui_style(type)
+    case type
+    when "topup"
+      "#{SageClassnames::TYPE_COLORS::CHARCOAL_100}"
+    when "withdraw"
+      "#{SageClassnames::TYPE_COLORS::CHARCOAL_100}"
+    else
+      "#{SageClassnames::TYPE::BODY_MED}"
     end
   end
 
@@ -200,6 +216,46 @@ module Mocks::KpOnboardingPayoutsHelper
         fee: "-$6.68",
         net: "$120.48",
       },
+    ]
+  end
+
+  def payouts_sample_bank_acct
+    {
+      ending_digits: "••••2324",
+      name: "Wells Fargo Bank, N.A.",
+    }
+  end
+
+  def payouts_all_data
+    [
+      {
+        amount: "$2,888.71",
+        currency: "USD",
+        status: "transferring",
+        date: "Yesterday at 3:30 pm",
+        account: payouts_sample_bank_acct,
+      },
+      {
+        amount: "$654.82",
+        currency: "USD",
+        status: "paid",
+        date: "Jan 18 at 2:29 pm",
+        account: payouts_sample_bank_acct,
+      },
+      {
+        amount: "($130.37)",
+        currency: "USD",
+        status: "withdraw",
+        date: "Jan 17 at 3:29 pm",
+        account: payouts_sample_bank_acct,
+      },
+      {
+        amount: "+$200.00",
+        currency: "USD",
+        status: "topup",
+        date: "Jan 14 at 2:29 pm",
+        account: payouts_sample_bank_acct,
+      }
     ]
   end
 end

--- a/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
+++ b/docs/app/helpers/mocks/kp_onboarding_payouts_helper.rb
@@ -258,4 +258,38 @@ module Mocks::KpOnboardingPayoutsHelper
       }
     ]
   end
+
+  def payouts_filter_status_options
+    # TODO: Dev to wire selected state to true status
+    [
+      {
+        selected: false,
+        name: "paid",
+      },
+      {
+        selected: false,
+        name: "scheduled",
+      },
+      {
+        selected: false,
+        name: "canceled",
+      },
+      {
+        selected: false,
+        name: "transferring",
+      },
+      {
+        selected: false,
+        name: "failed",
+      },
+      {
+        selected: false,
+        name: "withdraw",
+      },
+      {
+        selected: false,
+        name: "top-up",
+      }
+    ]
+  end
 end

--- a/docs/app/views/mocks/kp_onboarding_payouts/_main.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/_main.html.erb
@@ -3,6 +3,7 @@
     id: "example-tabs1",
     items: [
       {
+        active: true,
         target: "feature-1",
         text: "KP Onboarding",
       },
@@ -19,7 +20,6 @@
         text: "Payouts: Index",
       },
       {
-        active: true,
         target: "feature-5",
         text: "Payouts: Payout Details",
       },

--- a/docs/app/views/mocks/kp_onboarding_payouts/_main.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/_main.html.erb
@@ -4,34 +4,40 @@
     items: [
       {
         target: "feature-1",
-        text: "Payouts: Empty State",
-      },
-      {
-        target: "feature-2",
-        text: "Payouts: Index",
-      },
-      {
-        target: "feature-3",
         text: "KP Onboarding",
       },
       {
-        active: true,
-        target: "feature-4",
+        target: "feature-2",
         text: "KP Settings",
+      },
+      {
+        target: "feature-3",
+        text: "Payouts: Empty State",
+      },
+      {
+        target: "feature-4",
+        text: "Payouts: Index",
+      },
+      {
+        active: true,
+        target: "feature-5",
+        text: "Payouts: Payout Details",
       },
     ]
   } %>
   <%= sage_component SageTabsPane, { id: "feature-1" } do %>
-    <%= render "mocks/kp_onboarding_payouts/payouts/empty_state" %>
-  <% end %>
-  <%= sage_component SageTabsPane, { id: "feature-2" } do %>
-    <%= render "mocks/kp_onboarding_payouts/payouts/index" %>
-  <% end %>
-  <%= sage_component SageTabsPane, { id: "feature-3" } do %>
     <%= render "mocks/kp_onboarding_payouts/onboarding/index" %>
   <% end %>
-  <%= sage_component SageTabsPane, { id: "feature-4" } do %>
+  <%= sage_component SageTabsPane, { id: "feature-2" } do %>
     <%= render "mocks/kp_onboarding_payouts/settings/index" %>
   <% end %>
+  <%= sage_component SageTabsPane, { id: "feature-3" } do %>
+    <%= render "mocks/kp_onboarding_payouts/payouts/empty_state" %>
+  <% end %>
+  <%= sage_component SageTabsPane, { id: "feature-4" } do %>
+    <%= render "mocks/kp_onboarding_payouts/payouts/index" %>
+  <% end %>
+  <%= sage_component SageTabsPane, { id: "feature-5" } do %>
+    <%= render "mocks/kp_onboarding_payouts/payouts/details" %>
+  <% end %>
 </div>
- 

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details.html.erb
@@ -1,0 +1,11 @@
+<%= sage_layout SageFrame, { gap: "lg", width: "fill", align: "start-spread" } do %>
+  <%= sage_component SageButton, {
+    attributes: { href: "#TODO-dev-back-to-index-url" },
+    icon: { name: "arrow-left", style: "left" },
+    style: "secondary",
+    subtle: true,
+    value: "Back",
+  } %>
+  <%= render "mocks/kp_onboarding_payouts/payouts/details_summary", payout: payout_detail_summary %>
+  <%= render "mocks/kp_onboarding_payouts/payouts/details_table" %>
+<% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details.html.erb
@@ -7,5 +7,5 @@
     value: "Back",
   } %>
   <%= render "mocks/kp_onboarding_payouts/payouts/details_summary", payout: payout_detail_summary %>
-  <%= render "mocks/kp_onboarding_payouts/payouts/details_table" %>
+  <%= render "mocks/kp_onboarding_payouts/payouts/details_table", payout_data: payout_detail_line_items %>
 <% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_summary.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_summary.html.erb
@@ -36,7 +36,9 @@
         <%= c[:gross] %>
       <% end %>
       <% t.column :fee, align: "right" do | c | %>
-        <%= c[:fees] %>
+        <span data-js-tooltip="Standard fee: (2.9% + $0.30); Subscription fee: (0.5%)">
+          <%= c[:fees] %>
+        </span>
       <% end %>
       <% t.column :total, align: "right" do | c | %>
         <%= c[:total] %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_summary.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_summary.html.erb
@@ -1,0 +1,59 @@
+<%= sage_component SageFrame, {
+  border: "default",
+  border_radius: "md",
+  padding: "md",
+  direction: "horizontal",
+  background: SageTokens::COLOR_PALETTE[:WHITE],
+  width: "fill",
+} do %>
+  <%= sage_layout SageFrame, { gap: "sm", width: "33%" } do %>
+    <h2 class="<%= "#{SageClassnames::TYPE::HEADING_4} #{SageClassnames::TYPE_COLORS::CHARCOAL_500}" %>">
+      <%= payout[:date] %>
+    </h2>
+    <%= sage_layout SageFrame, { tag: "p", direction: "horizontal", gap: "xs", align: "center-left" } do %>
+      <span class="<%= "#{SageClassnames::TYPE::HEADING_4} #{SageClassnames::TYPE_COLORS::CHARCOAL_500}" %>">
+        <%= payout[:amount] %>
+      </span>
+      <span class="<%= "#{SageClassnames::TYPE::BODY} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
+        <%= payout[:currency] %>
+      </span>
+      <%= sage_component SageLabel, payouts_get_activity_status_ui_configs(payout[:status]) %>
+    <% end %>
+    <%= sage_component SageProperty, {
+      value: "••••• #{payout[:account][:ending_digits]} (#{payout[:account][:currency]})",
+      icon: "ban", # TODO: Need `temple` icon here https://kajabi.atlassian.net/browse/SAGE-544
+    } %>
+  <% end %>
+  <%= sage_layout SageFrame, { width: "flex", align: "start-spread", gap: "sm" } do %>
+    <%= sage_table_for payout[:data], responsive: true do | t | %>
+      <% t.column :label, label: "" do | c | %>
+        <%= c[:label] %>
+      <% end %>
+      <% t.column :quantity, align: "right" do | c | %>
+        <%= c[:quantity] %>
+      <% end %>
+      <% t.column :gross, align: "right" do | c | %>
+        <%= c[:gross] %>
+      <% end %>
+      <% t.column :fee, align: "right" do | c | %>
+        <%= c[:fees] %>
+      <% end %>
+      <% t.column :total, align: "right" do | c | %>
+        <%= c[:total] %>
+      <% end %>
+    <% end %>
+    <%= sage_layout SageFrame, {
+      direction: "horizontal",
+      align: "center-spread",
+      tag: "p",
+      width: "fill",
+    } do %>
+      <strong class="<%= SageClassnames::SPACERS::MD_LEFT %>">
+        Payout
+      </strong>
+      <strong class="<%= SageClassnames::SPACERS::MD_RIGHT %>">
+        <%= payout[:amount] %>
+      </strong>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
@@ -6,6 +6,22 @@
   padding: "md",
   width: "fill",
 } do %>
+  <%= sage_layout SageFrame, {
+    direction: "horizontal",
+    align: "center-spread"
+  } do %>
+    <h4 class="<%= SageClassnames::TYPE::HEADING_5 %>">
+      Details
+    </h4>
+    <%= sage_component SageButton, {
+      value: "Export",
+      style: "secondary",
+      raised: false,
+      attributes: {
+        "data-js-modaltrigger": "modal-export-payout-records",
+      }
+    } %>
+  <% end %>
   <%= sage_table_for payout_data, responsive: true do |t| %>
     <% t.column :date do |c| %>
       <%= c[:date] %>
@@ -48,3 +64,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= render "mocks/kp_onboarding_payouts/payouts/modal_export_payout_records" %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
@@ -38,7 +38,7 @@
       </span>
     <% end %>
     <% t.column :net, align: "right" do |c| %>
-      <span class="<%= payouts_table_get_amount_ui_style(c[:type]) %>">
+      <span class="<%= payout_details_table_get_amount_ui_style(c[:type]) %>">
         <%= c[:net] %>
       </span>
     <% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
@@ -17,7 +17,9 @@
       <%= c[:amount] %>
     <% end %>
     <% t.column :fee, align: "right" do |c| %>
-      <%= c[:fee] %>
+      <span data-js-tooltip="Standard fee: (2.9% + $0.30)">
+        <%= c[:fee] %>
+      </span>
     <% end %>
     <% t.column :net, align: "right" do |c| %>
       <span class="<%= payouts_table_get_amount_ui_style(c[:type]) %>">

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
@@ -1,0 +1,8 @@
+<%= sage_component SageFrame, {
+  border: "default",
+  border_radius: "md",
+  padding: "md",
+  background: SageTokens::COLOR_PALETTE[:WHITE],
+} do %>
+<p>Testing</p>
+<% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_details_table.html.erb
@@ -1,8 +1,48 @@
 <%= sage_component SageFrame, {
+  align: "start-spread", 
+  background: SageTokens::COLOR_PALETTE[:WHITE],
   border: "default",
   border_radius: "md",
   padding: "md",
-  background: SageTokens::COLOR_PALETTE[:WHITE],
+  width: "fill",
 } do %>
-<p>Testing</p>
+  <%= sage_table_for payout_data, responsive: true do |t| %>
+    <% t.column :date do |c| %>
+      <%= c[:date] %>
+    <% end %>
+    <% t.column :type do |c| %>
+      <%= c[:type].capitalize %>
+    <% end %>
+    <% t.column :amount, align: "right" do |c| %>
+      <%= c[:amount] %>
+    <% end %>
+    <% t.column :fee, align: "right" do |c| %>
+      <%= c[:fee] %>
+    <% end %>
+    <% t.column :net, align: "right" do |c| %>
+      <span class="<%= payouts_table_get_amount_ui_style(c[:type]) %>">
+        <%= c[:net] %>
+      </span>
+    <% end %>
+    <% t.column :options, align: "right", label: "" do |c| %>
+      <%= sage_component SageDropdown, {
+        align: "right",
+        items: [
+          {
+            value: "View details",
+            attributes: { href: "#TODO-dev-action-url" },
+          }
+        ],
+      } do %>
+        <% content_for :sage_dropdown_trigger, flush: true do %>
+          <%= sage_component SageButton, {
+            value: "Options",
+            style: "secondary",
+            subtle: true,
+            icon: { name: "dot-menu-horizontal", style: "only" },
+          } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_empty_state_video.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_empty_state_video.html.erb
@@ -20,13 +20,13 @@
     [video thumbnail]
   <% end %>
   <%= sage_layout SageFrame, { gap: "none" } do %>
-    <p class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+    <p class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
       SHOW ME HOW
     </p>
     <p class="<%= "#{SageClassnames::TYPE::HEADING_5}" %>">
       All about payments
     </p>
-    <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+    <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
       1:30
     </p>
   <% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_future_payouts.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_future_payouts.html.erb
@@ -26,7 +26,7 @@
       <h4 class="<%= "#{SageClassnames::TYPE::HEADING_6}" %>">
         Not seeing any estimated payouts?
       </h4>
-      <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+      <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
         Your estimated payouts will appear here after a few cycles (needs copy pass).
       </p>
     -->
@@ -39,14 +39,14 @@
       gap: "xs",
       width: "fill"
     } do %>
-      <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+      <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
         Est. for <%= next_payout[:estimated_date] %>
       </p>
       <p>
         <span class="<%= "#{SageClassnames::TYPE::HEADING_6} #{SageClassnames::TYPE_COLORS::CHARCOAL_400}" %>">
           <%= next_payout[:amount] %>
         </span>
-        <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+        <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
           <%= next_payout[:currency] %>*
         </span>
       </p>
@@ -60,14 +60,14 @@
       gap: "xs",
       width: "fill",
     } do %>
-      <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+      <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
         Lifetime payouts
       </p>
       <p>
         <span class="<%= "#{SageClassnames::TYPE::HEADING_6} #{SageClassnames::TYPE_COLORS::CHARCOAL_400}" %>">
           <%= lifetime_payouts[:amount] %>
         </span>
-        <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+        <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
           <%= lifetime_payouts[:currency] %>
         </span>
       </p>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index.html.erb
@@ -4,11 +4,11 @@
       id: "payouts-index-tabs",
       items: [
         {
+          active: true,
           target: "payouts-tabs-overview",
           text: "Overview",
         },
         {
-          active: true,
           target: "payouts-tabs-all-payouts",
           text: "All payouts",
         },

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index.html.erb
@@ -1,29 +1,98 @@
-<%= sage_component SageGridRow, {} do %>
-  <%= sage_component SageGridCol, { medium: "8" } do %>
-    <%= render "mocks/kp_onboarding_payouts/payouts/recent_activity",
-      activity_data: payouts_recent_activity,
-      overall_status: "These are funds that are currently on their way to your bank or have been paid."
-      # overall_status: "Your payouts will appear here once you schedule payouts to your external account."
-    %>
-  <% end %>
-  <%= sage_component SageGridCol, { medium: "4", css_classes: SageClassnames::GRID_PANEL } do %>
-    <div class="<%= SageClassnames::GRID_PANEL %>">
-      <%= render "mocks/kp_onboarding_payouts/payouts/balance",
-        amount: "$352.14",
-        currency: "USD",
-        expected_date: "Apr 11"
-      %>
-      <%= render "mocks/kp_onboarding_payouts/payouts/future_payouts",
-        next_payout: {
-          amount: "$830.50",
-          currency: "USD",
-          estimated_date: "Jan 16 – Jan 22",
+<%= sage_component SagePageHeading, { title: "Payouts", spacer: { bottom: :lg } } do %>
+  <% content_for :sage_page_heading_toolbar do %>
+    <%= sage_component SageTabs, {
+      id: "payouts-index-tabs",
+      items: [
+        {
+          target: "payouts-tabs-overview",
+          text: "Overview",
         },
-        lifetime_payouts: {
-          amount: "$3,263,830.94",
-          currency: "USD",
-        }
+        {
+          active: true,
+          target: "payouts-tabs-all-payouts",
+          text: "All payouts",
+        },
+      ]
+    } %>
+  <% end %>
+<% end %>
+
+<%= sage_component SageTabsPane, { id: "payouts-tabs-overview" } do %>
+  <%= sage_component SageGridRow, {} do %>
+    <%= sage_component SageGridCol, { medium: "8" } do %>
+      <%= render "mocks/kp_onboarding_payouts/payouts/recent_activity",
+        activity_data: payouts_recent_activity,
+        overall_status: "These are funds that are currently on their way to your bank or have been paid."
+        # overall_status: "Your payouts will appear here once you schedule payouts to your external account."
       %>
-    </div>
+    <% end %>
+    <%= sage_component SageGridCol, { medium: "4", css_classes: SageClassnames::GRID_PANEL } do %>
+      <div class="<%= SageClassnames::GRID_PANEL %>">
+        <%= render "mocks/kp_onboarding_payouts/payouts/balance",
+          amount: "$352.14",
+          currency: "USD",
+          expected_date: "Apr 11"
+        %>
+        <%= render "mocks/kp_onboarding_payouts/payouts/future_payouts",
+          next_payout: {
+            amount: "$830.50",
+            currency: "USD",
+            estimated_date: "Jan 16 – Jan 22",
+          },
+          lifetime_payouts: {
+            amount: "$3,263,830.94",
+            currency: "USD",
+          }
+        %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= sage_component SageTabsPane, { id: "payouts-tabs-all-payouts" } do %>
+  <%= sage_layout SageFrame, {
+    border: "default",
+    border_radius: "md",
+    padding: "md",
+    align: "start-spread",
+    background: SageTokens::COLOR_PALETTE[:WHITE],
+  } do %>
+
+    <%= sage_component SagePagination, {
+      items: Kaminari.paginate_array(Array.new(50, 1)).page(1).per(10), # TODO: Dev to replace this with table collection
+      collection_name: "Payout",
+      window: 2,
+      page_count_prefix: "Displaying",
+      # hide_counter: true,
+      hide_pages: true,
+    } %>
+    <%= sage_table_for payouts_all_data, responsive: true do |t| %>
+      <% t.column :amount do |c| %>
+        <p class="<%= SageClassnames::TYPE_ALIGN_RIGHT %>">
+          <span class="<%= payouts_table_get_amount_ui_style(c[:status]) %>">
+            <%= c[:amount] %>
+          </span>
+          <span class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+            <%= c[:currency] %>
+          </span>
+        </p>
+      <% end %>
+      <% t.column :status, label: "" do |c| %>
+        <%= sage_component SageLabel, payouts_get_activity_status_ui_configs(c[:status]) %>
+      <% end %>
+      <% t.column :bank do |c| %>
+        <%= c[:account][:name] %>
+        <%= c[:account][:ending_digits] %>
+      <% end %>
+      <% t.column :date, align: "right" do |c| %>
+        <%= c[:date] %>
+      <% end %>
+    <% end %>
+    <%= sage_component SagePagination, {
+      items: Kaminari.paginate_array(Array.new(50, 1)).page(1).per(10), # TODO: Dev to replace this with table collection
+      collection_name: "Payout",
+      window: 2,
+      page_count_prefix: "Displaying",
+    } %>
   <% end %>
 <% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index.html.erb
@@ -18,81 +18,9 @@
 <% end %>
 
 <%= sage_component SageTabsPane, { id: "payouts-tabs-overview" } do %>
-  <%= sage_component SageGridRow, {} do %>
-    <%= sage_component SageGridCol, { medium: "8" } do %>
-      <%= render "mocks/kp_onboarding_payouts/payouts/recent_activity",
-        activity_data: payouts_recent_activity,
-        overall_status: "These are funds that are currently on their way to your bank or have been paid."
-        # overall_status: "Your payouts will appear here once you schedule payouts to your external account."
-      %>
-    <% end %>
-    <%= sage_component SageGridCol, { medium: "4", css_classes: SageClassnames::GRID_PANEL } do %>
-      <div class="<%= SageClassnames::GRID_PANEL %>">
-        <%= render "mocks/kp_onboarding_payouts/payouts/balance",
-          amount: "$352.14",
-          currency: "USD",
-          expected_date: "Apr 11"
-        %>
-        <%= render "mocks/kp_onboarding_payouts/payouts/future_payouts",
-          next_payout: {
-            amount: "$830.50",
-            currency: "USD",
-            estimated_date: "Jan 16 – Jan 22",
-          },
-          lifetime_payouts: {
-            amount: "$3,263,830.94",
-            currency: "USD",
-          }
-        %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render "mocks/kp_onboarding_payouts/payouts/index_overview" %>
 <% end %>
 
 <%= sage_component SageTabsPane, { id: "payouts-tabs-all-payouts" } do %>
-  <%= sage_layout SageFrame, {
-    border: "default",
-    border_radius: "md",
-    padding: "md",
-    align: "start-spread",
-    background: SageTokens::COLOR_PALETTE[:WHITE],
-  } do %>
-
-    <%= sage_component SagePagination, {
-      items: Kaminari.paginate_array(Array.new(50, 1)).page(1).per(10), # TODO: Dev to replace this with table collection
-      collection_name: "Payout",
-      window: 2,
-      page_count_prefix: "Displaying",
-      # hide_counter: true,
-      hide_pages: true,
-    } %>
-    <%= sage_table_for payouts_all_data, responsive: true do |t| %>
-      <% t.column :amount do |c| %>
-        <p class="<%= SageClassnames::TYPE_ALIGN_RIGHT %>">
-          <span class="<%= payouts_table_get_amount_ui_style(c[:status]) %>">
-            <%= c[:amount] %>
-          </span>
-          <span class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
-            <%= c[:currency] %>
-          </span>
-        </p>
-      <% end %>
-      <% t.column :status, label: "" do |c| %>
-        <%= sage_component SageLabel, payouts_get_activity_status_ui_configs(c[:status]) %>
-      <% end %>
-      <% t.column :bank do |c| %>
-        <%= c[:account][:name] %>
-        <%= c[:account][:ending_digits] %>
-      <% end %>
-      <% t.column :date, align: "right" do |c| %>
-        <%= c[:date] %>
-      <% end %>
-    <% end %>
-    <%= sage_component SagePagination, {
-      items: Kaminari.paginate_array(Array.new(50, 1)).page(1).per(10), # TODO: Dev to replace this with table collection
-      collection_name: "Payout",
-      window: 2,
-      page_count_prefix: "Displaying",
-    } %>
-  <% end %>
+  <%= render "mocks/kp_onboarding_payouts/payouts/index_all_payouts" %>
 <% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_all_payouts.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_all_payouts.html.erb
@@ -46,7 +46,7 @@
             align: "center-spread",
             padding: "sm",
           } do %>
-            <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+            <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
               STATUS
             </p>
             <%= sage_layout SageFrame, { gap: "none" } do %>
@@ -61,7 +61,7 @@
               <% end %>
             <% end %>
 
-            <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+            <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
               IN THE LAST
             </p>
             <%= sage_component SageFormSelect, {
@@ -121,7 +121,7 @@
         <span class="<%= payouts_table_get_amount_ui_style(c[:status]) %>">
           <%= c[:amount] %>
         </span>
-        <span class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+        <span class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
           <%= c[:currency] %>
         </span>
       </p>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_all_payouts.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_all_payouts.html.erb
@@ -45,6 +45,7 @@
           <%= sage_layout SageFrame, {
             align: "center-spread",
             padding: "sm",
+            gap: "sm",
           } do %>
             <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
               STATUS

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_all_payouts.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_all_payouts.html.erb
@@ -1,0 +1,149 @@
+<%= sage_layout SageFrame, {
+  border: "default",
+  border_radius: "md",
+  padding: "md",
+  align: "start-spread",
+  background: SageTokens::COLOR_PALETTE[:WHITE],
+} do %>
+  <%= sage_layout SageFrame, {
+    direction: "horizontal",
+  } do %>
+    <%= sage_layout SageFrame, {
+      direction: "horizontal",
+      tag: "p",
+      css_classes: SageClassnames::TYPE::BODY_SMALL,
+      width: "flex",
+      gap: "2xs",
+    } do %>
+      <%# TODO: Dev to wire live data in here %>
+      Display 1–25 of 502 payouts
+      <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL_SEMI}" %>">
+        all-time
+      </span>
+    <% end %>
+    <%= sage_component SageButton, {
+      attributes: {
+        "data-js-modaltrigger": "modal-export-payout-records",
+      },
+      icon: { name: "download", style: "only" },
+      raised: false,
+      style: "secondary",
+      value: "Export",
+    } %>
+    <%# TODO: Dev to use desired form setup here %>
+    <form action="#TODO-form-action-url" method="get">
+      <%= sage_component SageDropdown, { align: "right", wrap_footer: true } do %>
+        <% content_for :sage_dropdown_trigger, flush: true do %>
+          <%= sage_component SageButton, {
+            icon: { name: "caret-down", style: "right" },
+            raised: false,
+            style: "secondary",
+            value: "Filter",
+          } %>
+        <% end %>
+        <% content_for :sage_dropdown_custom_panel_content do %>
+          <%= sage_layout SageFrame, {
+            align: "center-spread",
+            padding: "sm",
+          } do %>
+            <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+              STATUS
+            </p>
+            <%= sage_layout SageFrame, { gap: "none" } do %>
+              <% payouts_filter_status_options.each do | status | %>
+                <%= sage_component SageCheckbox, {
+                  id: "all-payouts-filter-status-#{status[:name]}",
+                  name: "all-payouts-filter-status",
+                  value: status[:name],
+                  label_text: status[:name].capitalize,
+                  checked: status[:selected],
+                } %>
+              <% end %>
+            <% end %>
+
+            <p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+              IN THE LAST
+            </p>
+            <%= sage_component SageFormSelect, {
+              id: "all-payouts-filter-timeframe",
+              name: "",
+              standalone: true,
+              select_options: [
+                {
+                  text: "All-time",
+                  value: "all",
+                },
+                # TODO: Dev to add other desired options here
+              ],
+            } %>
+          <% end %>
+          <%= sage_component SagePanelDivider, {} %>
+          <%= sage_layout SageFrame, {
+            align: "center-right",
+            direction: "horizontal",
+            padding: "sm",
+          } do %>
+            <%= sage_component SageButton, {
+              value: "Apply",
+              style: "primary",
+              attributes: { type: "submit" },
+            } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </form>
+    <%= sage_component SageDropdown, {
+      align: "right",
+      items: [
+        {
+          value: "Date",
+          attributes: { href: "#TODO-dev-payouts-sortby-date-url" },
+        },
+        {
+          value: "Amount",
+          attributes: { href: "#TODO-dev-payouts-sortby-amount-url" },
+        },
+      ],
+    } do %>
+      <% content_for :sage_dropdown_trigger, flush: true do %>
+        <%= sage_component SageButton, {
+          icon: { name: "caret-down", style: "right" },
+          raised: false,
+          style: "secondary",
+          value: "Sort by",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= sage_table_for payouts_all_data, responsive: true do |t| %>
+    <% t.column :amount do |c| %>
+      <p class="<%= SageClassnames::TYPE_ALIGN_RIGHT %>">
+        <span class="<%= payouts_table_get_amount_ui_style(c[:status]) %>">
+          <%= c[:amount] %>
+        </span>
+        <span class="<%= "#{SageClassnames::TYPE::BODY_XSMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+          <%= c[:currency] %>
+        </span>
+      </p>
+    <% end %>
+    <% t.column :status, label: "" do |c| %>
+      <%= sage_component SageLabel, payouts_get_activity_status_ui_configs(c[:status]) %>
+    <% end %>
+    <% t.column :bank do |c| %>
+      <%= c[:account][:name] %>
+      <%= c[:account][:ending_digits] %>
+    <% end %>
+    <% t.column :date, align: "right" do |c| %>
+      <%= c[:date] %>
+    <% end %>
+  <% end %>
+  <%= sage_component SagePagination, {
+    # TODO: Dev to replace this with table collection for accurate pagination
+    items: Kaminari.paginate_array(Array.new(50, 1)).page(1).per(10),
+    collection_name: "Payout",
+    window: 2,
+    page_count_prefix: "Displaying",
+  } %>
+<% end %>
+
+<%= render "mocks/kp_onboarding_payouts/payouts/modal_export_payout_records" %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_overview.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_index_overview.html.erb
@@ -1,0 +1,29 @@
+<%= sage_component SageGridRow, {} do %>
+  <%= sage_component SageGridCol, { medium: "8" } do %>
+    <%= render "mocks/kp_onboarding_payouts/payouts/recent_activity",
+      activity_data: payouts_recent_activity,
+      overall_status: "These are funds that are currently on their way to your bank or have been paid."
+      # overall_status: "Your payouts will appear here once you schedule payouts to your external account."
+    %>
+  <% end %>
+  <%= sage_component SageGridCol, { medium: "4", css_classes: SageClassnames::GRID_PANEL } do %>
+    <div class="<%= SageClassnames::GRID_PANEL %>">
+      <%= render "mocks/kp_onboarding_payouts/payouts/balance",
+        amount: "$352.14",
+        currency: "USD",
+        expected_date: "Apr 11"
+      %>
+      <%= render "mocks/kp_onboarding_payouts/payouts/future_payouts",
+        next_payout: {
+          amount: "$830.50",
+          currency: "USD",
+          estimated_date: "Jan 16 – Jan 22",
+        },
+        lifetime_payouts: {
+          amount: "$3,263,830.94",
+          currency: "USD",
+        }
+      %>
+    </div>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_modal_export_payout_records.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_modal_export_payout_records.html.erb
@@ -1,0 +1,52 @@
+<%= sage_component SageModal, { id: "modal-export-payout-records" } do %>
+  <%= sage_component SageModalContent, {
+    spacing: "card",
+    title: "Export payout records",
+    subtitle: "", 
+  } do %>
+    <% content_for :sage_header_aside do %>
+      <%= sage_component SageButton, {
+        attributes: {
+          "data-js-modal": true,
+        },
+        icon: { name: "remove", style: "only" },
+        style: "secondary",
+        subtle: true,
+        value: "Close",
+      } %>
+    <% end %>
+
+    <p class="<%= "#{SageClassnames::TYPE::BODY} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
+      <%# TODO: Dev to update copy here %>
+      Text to explain exporting payout information.
+    </p>
+
+    <%= sage_component SageFormSelect, {
+      id: "payout-schedule-auto-time-base",
+      name: "",
+      standalone: true,
+      select_options: [
+        {
+          text: "Last 30 days",
+          value: "days-last-30",
+        },
+        # TODO: Dev to add other options here...
+      ],
+    } %>
+
+    <% content_for :sage_footer do %>
+      <%= sage_component SageButton, {
+        attributes: { "data-js-modal": true },
+        style: "secondary",
+        raised: false,
+        value: "Cancel",
+      } %>
+      <%= sage_component SageButton, {
+        # TODO: Dev need to map to desired action
+        attributes: { "data-js-modal": true },
+        style: "primary",
+        value: "Export",
+      } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/app/views/mocks/kp_onboarding_payouts/payouts/_payout_activity_item.html.erb
+++ b/docs/app/views/mocks/kp_onboarding_payouts/payouts/_payout_activity_item.html.erb
@@ -22,7 +22,7 @@
       <span class="<%= payouts_get_amount_ui_style(data[:type]) %>">
         <%= data[:amount] %>
       </span>
-      <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_100}" %>">
+      <span class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLORS::CHARCOAL_200}" %>">
         <%= data[:currency] %>
       </span>
     </p>


### PR DESCRIPTION
## Description

This PR adds the All payouts and Payout Details views for the KP Onboarding and Payouts project.

## Screenshots

![Screen Shot 2022-05-16 at 11 22 36 AM](https://user-images.githubusercontent.com/17955295/168628322-9e489f7c-a177-4b49-95a4-2f2631e3eec4.png)

---

![Screen Shot 2022-05-16 at 11 22 44 AM](https://user-images.githubusercontent.com/17955295/168628334-210d92bb-d6ed-4c9b-835a-26f3d8c8246c.png)


## Testing in `sage-lib`

See http://localhost:4000/pages/mock/kp_onboarding_payouts

## Testing in `kajabi-products`

N/A New Mocks 


## Related

[SAGE-546](https://kajabi.atlassian.net/browse/SAGE-546)