### PR TITLE
Progressbar: add custom background and update Next React to match Rails

### DIFF
--- a/docs/app/views/examples/components/themes/legacy/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/progress_bar/_preview.html.erb
@@ -4,9 +4,10 @@
   label: "Cloning product"
 } %>
 
-<h2 class="t-sage-heading-6">Custom color</h2>
+<h2 class="t-sage-heading-6">Custom colors</h2>
 <%= sage_component SageProgressBar, {
   color: SageTokens::COLOR_PALETTE[:ORANGE_300],
-  percent: 100,
+  background_color: SageTokens::COLOR_PALETTE[:ORANGE_100],
+  percent: 80,
   label: "Reached limit"
 } %>

--- a/docs/app/views/examples/components/themes/next/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/progress_bar/_preview.html.erb
@@ -31,6 +31,7 @@
 
 <h2 class="t-sage-heading-6">Custom color</h2>
 <%= sage_component SageProgressBar, {
+  background_color: SageTokens::COLOR_PALETTE[:PRIMARY_100],
   color: "#4edbe6",
   percent: 86,
   label: "Reached limit"

--- a/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_progress_bar.rb
@@ -1,5 +1,6 @@
 class SageProgressBar < SageComponent
   set_attribute_schema({
+    background_color: [:optional, String],
     color: [:optional, String],
     disable_tooltip: [:optional, TrueClass],
     display_percent: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_progress_bar.html.erb
@@ -7,6 +7,7 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_300]
 <div
   class="sage-progress-bar <%= component.generated_css_classes %>"
   data-js-tooltip="<%= content %>"
+  style="<%= "--sage-progress-bar-background-color: #{component.background_color}" if component.background_color %>"
   <%= component.generated_html_attributes.html_safe %>
 >
   <progress

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_progress_bar.html.erb
@@ -15,7 +15,10 @@ color = component.color || SageTokens::COLOR_PALETTE[:SAGE_300]
   <% end %>
   <%= component.generated_html_attributes.html_safe %>
 >
-	<div class="sage-progress-bar__background">
+	<div
+    class="sage-progress-bar__background"
+    style="<%= "--sage-progress-bar-background-color: #{component.background_color}" if component.background_color %>"
+  >
     <progress
       class="sage-progress-bar__element"
       aria-valuemax="100"

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_progress_bar.scss
@@ -14,11 +14,10 @@
   }
 }
 
-
 .sage-progress-bar {
   height: rem(6px);
   border-radius: sage-border(radius-large);
-  background-color: sage-color(grey, 300);
+  background-color: var(--sage-progress-bar-background-color, sage-color(grey, 300));
 
   .sage-modal--fullscreen & {
     position: absolute;

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_progress_bar.scss
@@ -28,7 +28,7 @@ $-progress-bar-height: sage-spacing(xs);
   height: $-progress-bar-height;
   width: 100%;
   border-radius: sage-border(radius-small);
-  background-color: sage-color(grey, 300);
+  background-color: var(--sage-progress-bar-background-color, sage-color(grey, 300));
 }
 
 .sage-progress-bar__value {

--- a/packages/sage-react/lib/themes/legacy/ProgressBar/ProgressBar.jsx
+++ b/packages/sage-react/lib/themes/legacy/ProgressBar/ProgressBar.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { SageTokens } from '../configs';
 
 export const ProgressBar = ({
+  backgroundColor,
   className,
   color,
   label,
@@ -15,10 +16,19 @@ export const ProgressBar = ({
     className,
   );
 
+  let styles = {};
+  if (backgroundColor) {
+    styles['--sage-progress-bar-background-color'] = backgroundColor;
+  }
+
+  if (rest.style) {
+    styles = Object.assign(styles, rest.stlye);
+  }
+
   const displayText = label ? `${label}: ${percent}% progress` : '';
 
   return (
-    <div className={classNames} {...rest}>
+    <div className={classNames} style={styles} {...rest}>
       <progress
         className="sage-progress-bar__element"
         aria-valuemax="100"
@@ -38,6 +48,7 @@ export const ProgressBar = ({
 ProgressBar.COLORS = SageTokens.COLOR_PALETTE;
 
 ProgressBar.defaultProps = {
+  backgroundColor: null,
   className: null,
   color: ProgressBar.COLORS.PRIMARY_300,
   label: null,
@@ -45,6 +56,7 @@ ProgressBar.defaultProps = {
 };
 
 ProgressBar.propTypes = {
+  backgroundColor: PropTypes.string,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(ProgressBar.COLORS)),
   label: PropTypes.string,

--- a/packages/sage-react/lib/themes/legacy/ProgressBar/ProgressBar.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/ProgressBar/ProgressBar.story.jsx
@@ -19,3 +19,10 @@ export default {
 
 const Template = (args) => <ProgressBar {...args} />;
 export const Default = Template.bind({});
+export const CustomColor = Template.bind({});
+CustomColor.args = {
+  color: ProgressBar.COLORS.ORANGE_300,
+  backgroundColor: ProgressBar.COLORS.ORANGE_100,
+  label: 'Cloning product',
+  percent: '44',
+};

--- a/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.jsx
+++ b/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.jsx
@@ -95,5 +95,5 @@ ProgressBar.propTypes = {
   displayPercent: PropTypes.bool,
   label: PropTypes.string,
   percent: PropTypes.string,
-  tooltipPosition: PropTypes.oneOf(Object.values()),
+  tooltipPosition: PropTypes.oneOf(Object.values(ProgressBar.TOOLTIP_POSITIONS)),
 };

--- a/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.jsx
+++ b/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.jsx
@@ -1,52 +1,99 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Tooltip } from '../Tooltip';
 import { SageTokens } from '../configs';
+import { PROGRESSBAR_TOOLTIP_POSITIONS } from './configs';
 
 export const ProgressBar = ({
+  backgroundColor,
   className,
   color,
+  disableTooltip,
+  displayPercent,
   label,
   percent,
+  tooltipPosition,
   ...rest
 }) => {
   const classNames = classnames(
     'sage-progress-bar',
     className,
+    {
+      'sage-progress-bar--has-percentage': displayPercent,
+    }
   );
-
   const displayText = label ? `${label}: ${percent}% progress` : '';
+
+  const renderBar = () => {
+    const bgStyles = {};
+    if (backgroundColor) {
+      bgStyles['--sage-progress-bar-background-color'] = backgroundColor;
+    }
+
+    return (
+      <div className="sage-progress-bar__background" style={bgStyles}>
+        <progress
+          className="sage-progress-bar__element"
+          aria-valuemax="100"
+          max="100"
+          aria-valuemin="0"
+          value={String(percent)}
+          aria-valuenow={percent}
+          aria-valuetext={displayText}
+        >
+          {displayText}
+        </progress>
+        <div
+          className="sage-progress-bar__value"
+          style={{
+            width: `${percent}%`,
+            '--progress-bar-value-color': color,
+          }}
+        />
+      </div>
+    );
+  };
 
   return (
     <div className={classNames} {...rest}>
-      <progress
-        className="sage-progress-bar__element"
-        aria-valuemax="100"
-        max="100"
-        aria-valuemin="0"
-        value={String(percent)}
-        aria-valuenow={percent}
-        aria-valuetext={displayText}
-      >
-        {displayText}
-      </progress>
-      <div className="sage-progress-bar__value" style={{ width: `${percent}%`, '--progress-bar-value-color': color }} />
+      {disableTooltip
+        ? renderBar()
+        : (
+          <Tooltip content={displayText}>
+            {renderBar()}
+          </Tooltip>
+        )}
+      {displayPercent && (
+        <span className="sage-progress-bar__percent">
+          {percent}%
+        </span>
+      )}
     </div>
   );
 };
 
 ProgressBar.COLORS = SageTokens.COLOR_PALETTE;
+ProgressBar.TOOLTIP_POSITIONS = PROGRESSBAR_TOOLTIP_POSITIONS;
 
 ProgressBar.defaultProps = {
+  backgroundColor: null,
   className: null,
-  color: ProgressBar.COLORS.PRIMARY_200,
+  color: ProgressBar.COLORS.PRIMARY_300,
+  disableTooltip: false,
+  displayPercent: false,
   label: null,
   percent: null,
+  tooltipPosition: null,
 };
 
 ProgressBar.propTypes = {
+  backgroundColor: PropTypes.string,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(ProgressBar.COLORS)),
+  disableTooltip: PropTypes.bool,
+  displayPercent: PropTypes.bool,
   label: PropTypes.string,
   percent: PropTypes.string,
+  tooltipPosition: PropTypes.oneOf(Object.values()),
 };

--- a/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.story.jsx
+++ b/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.story.jsx
@@ -6,7 +6,7 @@ export default {
   title: 'Sage/ProgressBar',
   component: ProgressBar,
   args: {
-    color: ProgressBar.COLORS.PRIMARY_200,
+    color: ProgressBar.COLORS.PRIMARY_300,
     label: 'Cloning product',
     percent: '44',
   },
@@ -19,3 +19,10 @@ export default {
 
 const Template = (args) => <ProgressBar {...args} />;
 export const Default = Template.bind({});
+export const CustomColor = Template.bind({});
+CustomColor.args = {
+  color: ProgressBar.COLORS.ORANGE_300,
+  backgroundColor: ProgressBar.COLORS.ORANGE_100,
+  label: 'Cloning product',
+  percent: '44',
+};

--- a/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.story.jsx
+++ b/packages/sage-react/lib/themes/next/ProgressBar/ProgressBar.story.jsx
@@ -12,7 +12,8 @@ export default {
   },
   argTypes: {
     ...selectArgs({
-      color: ProgressBar.COLORS
+      color: ProgressBar.COLORS,
+      tooltipPosition: ProgressBar.TOOLTIP_POSITIONS,
     })
   }
 };

--- a/packages/sage-react/lib/themes/next/ProgressBar/configs.js
+++ b/packages/sage-react/lib/themes/next/ProgressBar/configs.js
@@ -1,0 +1,4 @@
+export const PROGRESSBAR_TOOLTIP_POSITIONS = {
+  TOP: 'top',
+  BOTTOM: 'bottom',
+};


### PR DESCRIPTION
## Description

This PR updates Next React version of Progressbar to match the new structure in Next Rails. Then a new background color customization affordance is added.

## Screenshots
![Screen Shot 2022-05-16 at 8 59 40 PM](https://user-images.githubusercontent.com/17955295/168706470-4d69fe99-9010-42ce-b25e-52455b7a7e2f.png)
![Screen Shot 2022-05-16 at 8 59 47 PM](https://user-images.githubusercontent.com/17955295/168706472-87f55e86-8c1c-4ffd-87df-2c662efa16d6.png)



## Testing in `sage-lib`

See http://localhost:4000/pages/component/progress_bar?sage_theme=sage_theme_next&tab=preview
See http://localhost:4100/?path=/story/sage-progressbar--custom-color and http://localhost:4110/?path=/story/sage-progressbar--custom-color

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) New custom background color option provided for Progressbar.
2. (**LOW**) React Progressbar is updated to match Rails in Next theme (new markup and props)


## Related

https://kajabi.atlassian.net/browse/SAGE-573