### PR TITLE
Remove Inter var font from stack on Next theme

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -661,10 +661,6 @@
 ///
 @mixin sage-font-family() {
   font-family: $-body-font-stack;
-
-  @supports (font-variation-settings: normal) {
-    font-family: "Inter var", $-body-font-stack;
-  }
 }
 
 ///


### PR DESCRIPTION
## Description

We found in testing that we still accidentally had `Inter Var` set up as a font in the font stack on the Next theme. This PR removes it.


## Testing in `kajabi-products`
1. (**LOW**) Removes Inter Var font from font stack in Next Theme.

