### PR TITLE
[SAGE-624] Select - resolve label overlapping issue

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
@@ -35,7 +35,7 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
 }
 
 .sage-select__label {
-  @extend %t-sage-body-semi;
+  @include sage-form-field-label;
 
   grid-area: label;
   margin-bottom: $-select-margin-label;
@@ -141,17 +141,9 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
 // Shim for handling Select Labels within Simpleform markup
 .sage-select {
   .form-group ~ .sage-select__label {
-    @extend %t-sage-body;
+    @extend %t-sage-body-semi;
 
     opacity: 1;
-  }
-
-  &.sage-select--value-selected .form-group ~ .sage-select__label {
-    @extend %t-sage-body-xsmall-semi;
-
-    transform: translateY(calc(#{-$-select-height} + 50%));
-    background-color: $-select-color-label-background;
-    transition: transform 0.15s ease-in-out, color 0.15s ease-out;
   }
 
   &.sage-select--value-selected .form-group:focus-within:not(:disabled) ~ .sage-select__label {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] make label visible with or without a value Rails
- [x] make label visible with or without a value React

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-05-18 at 9 50 01 AM](https://user-images.githubusercontent.com/1241836/169086982-03d4ae7f-447a-4bba-9f0a-f2fd704a834f.png)|<img width="594" alt="Screen Shot 2022-05-18 at 10 39 17 AM" src="https://user-images.githubusercontent.com/1241836/169087004-1fee325b-498f-4558-93be-f257334e6e9f.png">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Select views and verify that the labels are visible and properly aligned with and without values selected:
- [Rails](http://localhost:4000/pages/component/form_select?tab=preview)
- [React](http://localhost:4100/?path=/story/sage-select--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Updates label alignment for `FormSelect` when a value is selected across the app.
   - [ ] Offer Page -> Post purchase select


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-624](https://kajabi.atlassian.net/browse/SAGE-624 )