### PR TITLE
[SAGE-532] Upload Card - remove drop area style

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
@@ -11,11 +11,7 @@ $-upload-card-selected-width: rem(200px);
 $-upload-card-preview-width: rem(32px);
 $-upload-card-preview-max-width: rem(190px);
 $-upload-card-preview-max-width-mobile: rem(304px);
-$-upload-card-border-color-default: sage-color(grey, 400);
-$-upload-card-border-color-error: sage-color(red, 300);
-$-upload-card-border-color-error-hover: sage-color(red, 300);
 $-upload-card-background: sage-color(white);
-$-upload-card-background-hover: sage-color(grey, 200);
 
 .sage-upload-card {
   &:focus {
@@ -52,7 +48,7 @@ $-upload-card-background-hover: sage-color(grey, 200);
   padding: sage-spacing(md);
   background-color: $-upload-card-background;
   border-radius: $-upload-card-border-radius;
-  border: 1px solid $-upload-card-border-color-default;
+  border: sage-border(default);
 
   .sage-upload-card:not(.sage-upload-card--selected) & {
     flex-flow: column;
@@ -64,14 +60,14 @@ $-upload-card-background-hover: sage-color(grey, 200);
   }
 
   .sage-upload-card.sage-upload-card--error & {
-    border-color: $-upload-card-border-color-error;
+    border: sage-border(error);
   }
 
   .sage-upload-card.sage-upload-card--error:not(.sage-upload-card--selected) & {
     &:hover,
     &:focus,
     &:focus-within {
-      border-color: $-upload-card-border-color-error;
+      border: sage-border(error);
     }
   }
 }
@@ -82,7 +78,7 @@ $-upload-card-background-hover: sage-color(grey, 200);
   > p {
     @extend %t-sage-body-med;
 
-    color: $-upload-card-border-color-error;
+    color: sage-color(red, 300);
 
     &:not(:last-child) {
       margin-bottom: sage-spacing(2xs);
@@ -95,7 +91,7 @@ $-upload-card-background-hover: sage-color(grey, 200);
 
     &:focus,
     &:hover {
-      color: $-upload-card-border-color-error-hover;
+      color: sage-color(red, 300);
       text-decoration: underline;
       outline: 0;
     }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
@@ -12,12 +12,8 @@ $-upload-card-preview-width: rem(32px);
 $-upload-card-preview-max-width: rem(190px);
 $-upload-card-preview-max-width-mobile: rem(304px);
 $-upload-card-border-color-default: sage-color(grey, 400);
-$-upload-card-border-color-hover: sage-color(primary, 300);
 $-upload-card-border-color-error: sage-color(red, 300);
 $-upload-card-border-color-error-hover: sage-color(red, 300);
-$-upload-card-border-color-focus: sage-color(primary, 300);
-$-upload-card-border-color-focus-ring: 0 0 0 4px sage-color(primary, 200);
-$-upload-card-border-color-error-focus-ring: 0 0 0 4px sage-color(red, 200);
 $-upload-card-background: sage-color(white);
 $-upload-card-background-hover: sage-color(grey, 200);
 
@@ -75,7 +71,7 @@ $-upload-card-background-hover: sage-color(grey, 200);
     &:hover,
     &:focus,
     &:focus-within {
-      border-color: $-upload-card-border-color-error-hover;
+      border-color: $-upload-card-border-color-error;
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
@@ -60,14 +60,14 @@ $-upload-card-background: sage-color(white);
   }
 
   .sage-upload-card.sage-upload-card--error & {
-    border: sage-border(error);
+    border-color: sage-color(red, 300);
   }
 
   .sage-upload-card.sage-upload-card--error:not(.sage-upload-card--selected) & {
     &:hover,
     &:focus,
     &:focus-within {
-      border: sage-border(error);
+      border-color: sage-color(red, 300);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_upload_card.scss
@@ -56,62 +56,26 @@ $-upload-card-background-hover: sage-color(grey, 200);
   padding: sage-spacing(md);
   background-color: $-upload-card-background;
   border-radius: $-upload-card-border-radius;
+  border: 1px solid $-upload-card-border-color-default;
 
   .sage-upload-card:not(.sage-upload-card--selected) & {
     flex-flow: column;
-
-    @include sage-dashed-border(
-      $color: $-upload-card-border-color-default,
-      $border-radius: $-upload-card-border-radius,
-    );
-
-    &:hover {
-      @include sage-dashed-border(
-        $color: $-upload-card-border-color-hover,
-        $border-radius: $-upload-card-border-radius,
-      );
-    }
-
-    &:focus,
-    &:focus-within {
-      box-shadow: $-upload-card-border-color-focus-ring;
-
-      @include sage-dashed-border(
-        $color: $-upload-card-border-color-focus,
-        $border-radius: $-upload-card-border-radius,
-      );
-    }
   }
 
   .sage-upload-card--selected & {
     flex-flow: row wrap;
     gap: sage-spacing();
-    border: 1px solid $-upload-card-border-color-default;
   }
 
   .sage-upload-card.sage-upload-card--error & {
-    @include sage-dashed-border(
-      $color: $-upload-card-border-color-error,
-      $border-radius: $-upload-card-border-radius,
-    );
+    border-color: $-upload-card-border-color-error;
   }
 
   .sage-upload-card.sage-upload-card--error:not(.sage-upload-card--selected) & {
-    &:hover {
-      @include sage-dashed-border(
-        $color: $-upload-card-border-color-error-hover,
-        $border-radius: $-upload-card-border-radius,
-      );
-    }
-
+    &:hover,
     &:focus,
     &:focus-within {
-      box-shadow: $-upload-card-border-color-error-focus-ring;
-
-      @include sage-dashed-border(
-        $color: $-upload-card-border-color-error-hover,
-        $border-radius: $-upload-card-border-radius,
-      );
+      border-color: $-upload-card-border-color-error-hover;
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove drop area and border styles

Since the intended use is to click the button, we're removing styles from the border

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-05-18 at 2 42 49 PM](https://user-images.githubusercontent.com/1241836/169143059-c1d2c8cc-ddb8-4c1e-acde-05bb0e9d3aa1.png)|![Screen Shot 2022-05-18 at 2 33 21 PM](https://user-images.githubusercontent.com/1241836/169143078-d5a1434d-38c7-4aa8-87cc-1fbc3644afff.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Upload card views and verify that the drop area styles are removed:
- [Rails](http://localhost:4000/pages/component/upload_card?tab=preview)
- [React](http://localhost:4110/?path=/docs/sage-uploadcard--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Removed drop area styles on the UploadCard component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-532](https://kajabi.atlassian.net/browse/SAGE-532)