### PR TITLE
[SAGE-572] Border update across foundations

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_checkbox.scss
@@ -189,7 +189,6 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
     color: $-checkbox-color-checked;
     background: $-checkbox-color-checked;
     border-color: $-checkbox-color-checked;
-    box-shadow: sage-shadow(sm);
 
     &::after {
       opacity: 1;
@@ -216,7 +215,6 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
     border-color: $-checkbox-focus-outline-color;
 
     &::before {
-      transform: translate3d(-50%, -50%, 0) scale(1);
       opacity: 1;
     }
   }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
@@ -41,40 +41,33 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   padding: sage-spacing();
   text-decoration: none;
   color: $-choice-color-default;
-  border: sage-border();
+  // border: sage-border(interactive);
+  box-shadow: map-get($sage-border-styles, default);
   border-radius: sage-border(radius-large);
   transition: map-get($sage-transitions, default);
   transition-property: color, background-color, border-color, box-shadow;
 
   @extend %t-sage-body-med;
 
-  &::after {
-    content: "";
-    position: absolute;
-    border: 1px solid transparent;
-    border-radius: sage-border(radius-large);
-
-    @include position(-1px, -1px, -1px, -1px);
-  }
-
   &:hover {
-    @include sage-focus-outline--update-color(sage-color(grey, 500));
-
     color: $-choice-color-active;
+    // border: sage-border(interactive-hover);
+    box-shadow: map-get($sage-border-styles, hover);
   }
 
   &:focus {
-    border-color: sage-color(primary, 200);
+    // border-color: sage-color(primary, 200);
     outline: none;
   }
 
   &.sage-choice--active {
     color: $-choice-color-active;
+    box-shadow: map-get($sage-border-styles, selected);
 
-    &::after {
-      border-color: sage-color(charcoal, 400);
-      border-width: rem(4px);
-    }
+    // &::after {
+    //   border-color: sage-color(charcoal, 400);
+    // border-width: rem(4px);
+    // }
   }
 
   &[aria-disabled="true"],
@@ -151,13 +144,13 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     margin: 0 sage-spacing(xs) 0 0;
     background-color: $-choice-radio-color-checked-inner;
     border-radius: sage-border(radius-round);
-    border: sage-border();
+    border: sage-border(interactive);
     transition: map-get($sage-transitions, default);
     transition-property: border, box-shadow;
   }
 
   &:hover::#{$-choice-el-radio} {
-    box-shadow: sage-shadow(sm);
+    border: sage-border(interactive-hover);
   }
 
   &:active,

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
@@ -40,6 +40,7 @@ $sage-border-styles: (
   active-hover: 0 0 0 4px sage-color(charcoal, 400),
   error: 0 0 0 1px sage-color(red, 400),
   error-focus: 0 0 0 4px sage-color(red, 300),
+  selected: 0 0 0 4px sage-color(charcoal, 400),
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
@@ -31,6 +31,18 @@ $sage-banner-heights: (
 );
 
 ///
+/// Sage border styles
+///
+$sage-border-styles: (
+  default: 0 0 0 1px sage-color(grey, 400),
+  hover: 0 0 0 1px sage-color(grey, 500),
+  focus: 0 0 0 4px sage-color(primary, 200),
+  active-hover: 0 0 0 4px sage-color(charcoal, 400),
+  error: 0 0 0 1px sage-color(red, 400),
+  error-focus: 0 0 0 4px sage-color(red, 300),
+);
+
+///
 /// Field configurations
 ///
 $sage-field-configs: (

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -375,7 +375,7 @@
   padding: sage-spacing(sm);
   color: sage-color(charcoal, 200);
   appearance: none;
-  border: rem(1px) solid sage-color(grey, 500);
+  border: sage-border(interactive);
   border-radius: sage-border(radius-medium);
   background: transparent;
   transition: map-get($sage-transitions, input);
@@ -387,16 +387,16 @@
 
   &:hover:not(:disabled) {
     color: sage-color(charcoal, 400);
-    border-color: sage-color(charcoal, 100);
+    border: sage-border(interactive-hover);
 
     .sage-form-field--error & {
-      border-color: sage-color(red, 300);
+      border: sage-border(error);
     }
   }
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    border-color: sage-color(primary, 200);
+    border-color: transparent;
 
     @include placeholder {
       opacity: 0;
@@ -442,10 +442,14 @@
   .sage-form-field--error &:required:not(:placeholder-shown):not(:valid) {
     @include sage-focus-ring(sage-color(red, 200));
 
-    border-color: sage-color(red, 300);
+    border: sage-border(error);
 
     ~ label {
       color: sage-color(charcoal, 400);
+    }
+
+    &:focus {
+      border-color: transparent;
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_border.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_border.scss
@@ -9,8 +9,10 @@
 /// Sage borders token
 ///
 $sage-borders: (
-  light: rem(1px) solid sage-color(grey, 300),
-  default: rem(1px) solid sage-color(grey, 400),
+  default: rem(1px) solid sage-color(grey, 300),
+  error: rem(1px) solid sage-color(red, 300),
+  interactive: rem(1px) solid sage-color(grey, 400),
+  interactive-hover: rem(1px) solid sage-color(grey, 500),
   radius-small: rem(4px),
   radius: rem(8px),
   radius-medium: rem(10px),


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update border values
  - [ ] Default border from Grey/400 to Grey/300
  - [x] Removed subtle border styles
    - [x] Deprecation task assigned for `kp`- [SAGE-626](https://kajabi.atlassian.net/browse/SAGE-626) cc @Kajabi/sage-implementation 
- [ ] update interactive border states to align with new spec values
  - [ ] Interactive border from Grey/500 to Grey/400
  - [ ] Interactive border hover from Grey/600 to Grey/500

The interactive update will also involve an audit of all existing component with interactive elements to update `border` vs `box-shadow` use


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Updates to the border tokens and values. Affects most elements in the app and requires QA


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-572](https://kajabi.atlassian.net/browse/SAGE-572)
