### PR TITLE
Classnames helper

### DIFF
--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -55,6 +55,11 @@
       items: [
         { link: pages_helpers_path(:spacing), text: "HELPERS", items: [
           {
+            text: "Classnames",
+            link: pages_helpers_path(:classnames),
+            active: current_page?(pages_helpers_path(:classnames)),
+          },
+          {
             text: "Spacing",
             link: pages_helpers_path(:spacing),
             active: current_page?(pages_helpers_path(:spacing)),

--- a/docs/app/views/examples/helpers/classnames/_on_property.html.erb
+++ b/docs/app/views/examples/helpers/classnames/_on_property.html.erb
@@ -1,0 +1,9 @@
+<%= sage_layout SageFrame, {
+  border: "default",
+  border_radius: "md",
+  css_classes: sage_classnames({ text_align: "CENTER" }),
+  padding: "md",
+} do %>
+  <h4>Lorem ipsum</h4>
+  <p>Lorem ipsum color sit</p>
+<% end %>

--- a/docs/app/views/examples/helpers/classnames/_on_tag.html.erb
+++ b/docs/app/views/examples/helpers/classnames/_on_tag.html.erb
@@ -1,0 +1,3 @@
+<p class="<%= sage_classnames({ type: "BODY_SMALL", color: "CHARCOAL_100" }) %>">
+  Lorem ipsum color sit
+</p>

--- a/docs/app/views/examples/shared/_code_renderer.html.erb
+++ b/docs/app/views/examples/shared/_code_renderer.html.erb
@@ -1,0 +1,7 @@
+<div
+  class="sage-code-snippet <%= defined?(nowrap) && nowrap ? "sage-code-snippet--no-wrap" : "gooobers" %>"
+  <%= "id='example-rails-code-#{id}'" if defined?(id) %>
+  tabindex="-1"
+>
+  <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/#{partial}.html.erb")) %></code></pre>
+</div>

--- a/docs/app/views/examples/shared/_example_rendered.html.erb
+++ b/docs/app/views/examples/shared/_example_rendered.html.erb
@@ -4,8 +4,9 @@
 <% if partial.present? %>
   <%= render "examples/#{folder_root}/examples/#{partial}" %>
   <%= sage_component SageCard, { spacer: { bottom: :md } } do %>
-    <div id="example-rails-code-<%= partial %>" class="sage-code-snippet" tabindex="-1">
-      <pre class="prettyprint"><code><%= File.read(File.join(Rails.root, "app/views/examples/#{folder_root}/examples/_#{partial}.html.erb")) %></code></pre>
-    </div>
+    <%= render "examples/shared/code_renderer",
+      partial: "examples/#{folder_root}/examples/_#{partial}",
+      id: partial
+    %>
   <% end %>
 <% end %>

--- a/docs/app/views/pages/classnames.html.erb
+++ b/docs/app/views/pages/classnames.html.erb
@@ -1,0 +1,86 @@
+<%
+classnames_collection = []
+sage_classnames_map.keys.map do | key |
+  item = sage_classnames_map[key]
+  classnames_collection.push({
+    category: key,
+    value: item,
+    description: case key
+      when :color
+        md("Colors from the [Sage color palette](#{pages_foundation_path(:color)}) that apply to text of an element")
+      when :grid
+        md("Enables the standard grid settings for Panel or Card contexts.")
+      when :gap
+        md("Applies a [Sage spacer value](#{pages_helpers_path(:spacing)}) to an element's CSS `gap` (`grid-gap`) property. Note that either `flex` or CSS Grid must also be employed in order for this to be observable.")
+      when :grid_template
+        md("Enables a [grid template](#{pages_patterns_path(:grid_templates)}) on an element")
+      when :reveal
+        md("Classes used with the [Reveal utility](#{pages_helpers_path(:reveal)})")
+      when :spacers
+        md("Adds a [Sage spacer value](#{pages_helpers_path(:spacing)}) as margin on the element depending on the settings used. Set several as desired by passing an array to this option.")
+      when :strikethrough
+        md("Adds a strike through text within the element.")
+      when :text_align
+        md("Sets the alignment for text within an element.")
+      when :truncate
+        md("Sets an element to truncate overflowing text within the element. See [Truncation](#{pages_helpers_path(:truncation)}) for more details.")
+      when :type_block
+        md("Make a container enforce Sage type specs within it based on default mapping to plain HTML tags.")
+      when :type
+        md("Apply a [Sage type spec](#{pages_foundation_path(:typography)}) to an element.")
+      else
+        "TBD"
+    end
+  })
+end
+%>
+<%= content_for :heading do %>
+<%= md(%(
+# Classnames
+
+<p class="docs-heading__lead">
+  Tools for accessing and applying Sage HTML classnames
+</p>
+)) %>
+<% end %>
+<%= sage_layout SageFrame, { gap: "lg", width: "fill" } do %>
+  <%= md("
+### Classnames Helper
+
+We expose a helper `sage_classnames` that accepts a hash of classname categories and values (see below)
+and outputs a single string with the corresponding classnames.
+
+- This can be used inside any HTML element's `class` attribute and on a Sage component's `css_classes` property.
+- If multiple values are useful (such as with `spacer`), pass an array with the desired options.
+", use_sage_type: true) %>
+  <%= render "examples/shared/code_renderer",
+    nowrap: true,
+    partial: "examples/helpers/classnames/_on_tag",
+    id: "classnames-helper"
+  %>
+  <%= render "examples/shared/code_renderer",
+    nowrap: true,
+    partial: "examples/helpers/classnames/_on_property",
+    id: "classnames-helper"
+  %>
+  <%= md("
+#### Configuration options
+
+The follow values can be used as options within the `sage_classnames()` helper:
+", use_sage_type: true) %>
+  <%= sage_table_for classnames_collection, responsive: true do | t | %>
+    <% t.column :key do | c | %>
+      <%= md("`#{c[:category]}`") %>
+    <% end %>
+    <% t.column :description do | c | %>
+      <%= c[:description] %>
+    <% end %>
+    <% t.column :options do | c | %>
+      <% if c[:value].is_a?(String) %>
+        <%= md('`true` to enable.') %>
+      <% else %>
+        <%= md("`#{c[:value].keys.join("`, `")}`") %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/docs/lib/sage-frontend/stylesheets/docs/themes/legacy/_snippet.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/themes/legacy/_snippet.scss
@@ -6,8 +6,9 @@
 
 .sage-code-snippet {
   position: relative;
+  width: 100%;
 
-  &::after {
+  &:not(.sage-code-snippet--no-wrap)::after {
     content: "";
     display: block;
     position: absolute;

--- a/docs/lib/sage-frontend/stylesheets/docs/themes/next/_snippet.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/themes/next/_snippet.scss
@@ -6,8 +6,9 @@
 
 .sage-code-snippet {
   position: relative;
+  width: 100%;
 
-  &::after {
+  &:not(.sage-code-snippet--no-wrap)::after {
     content: "";
     display: block;
     position: absolute;

--- a/docs/lib/sage_rails/app/helpers/sage_classnames_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_classnames_helper.rb
@@ -1,0 +1,110 @@
+module SageClassnamesHelper
+  #
+  # The set of classnames we expose through this helper
+  # pulled from the SageClassnames module
+  #
+  # This leaves `SageClassnames` intact for current uses,
+  # but future deprecate that token and then consolidate definitions
+  # in this file alone.
+  #
+  def sage_classnames_map
+    {
+      # Text color
+      color: module_consts_to_hash(SageClassnames::TYPE_COLORS),
+
+      # Internal grid configurations
+      grid: {
+        CARD: SageClassnames::GRID_CARD,
+        PANEL: SageClassnames::GRID_PANEL,
+      },
+
+      # Internal gap (grid-gap) settings
+      gap: module_consts_to_hash(SageClassnames::GRID_GAP_OPTIONS),
+
+      # Grid templates
+      grid_template: module_consts_to_hash(SageClassnames::GRID_TEMPLATES),
+
+      # Reveal utility classnames
+      reveal: {
+        CONTAINER: SageClassnames::REVEAL_CONTAINER,
+        ON_HOVER: SageClassnames::REVEAL_ON_HOVER,
+        ON_CONTAINER_HOVER: SageClassnames::REVEAL_ON_CONTAINER_HOVER,
+      },
+
+      # Spacers (margin)
+      spacer: module_consts_to_hash(SageClassnames::SPACERS),
+
+      # Strikethrough style for text
+      strikethrough: SageClassnames::TYPE_STRIKETHROUGH,
+
+      # Text alignment
+      text_align: {
+        CENTER: SageClassnames::TYPE_ALIGN_CENTER,
+        RIGHT: SageClassnames::TYPE_ALIGN_RIGHT,
+      },
+      # Truncate inner contents with ellipses
+      truncate: SageClassnames::TRUNCATE_TEXT,
+
+      # Container to auto-space and format inner HTML contents to Sage type spec
+      type_block: SageClassnames::TYPE_BLOCK,
+
+      # Type specs
+      type: module_consts_to_hash(SageClassnames::TYPE),
+    }
+  end
+  
+  #
+  # Given a hash of classname keys, retrieve classnames from main map
+  # and combine them into a single string of classnames
+  # that can be rendered within an HTML `class` attribute.
+  # 
+  # NOTE: Inspect `sage_classnames_hash` for possible options and keys
+  #
+  def sage_classnames(opts)
+    # Main list of available classnames
+    classnames = sage_classnames_map
+
+    # array of classnames requested
+    classes = []
+
+    # Check each provided option
+    opts.keys.each do | key |
+      # The associated value for this key
+      value = opts[key]
+    
+      # Ensure provided key exists in classnames list
+      if classnames.keys.include? key
+        classnames_child = classnames[key]
+
+        # Return the only value available if this classname is just a string
+        # and the provided option is truthy
+        if classnames_child.is_a?(String) && value
+          classes.push(classnames_child)
+        else
+          # Output the specified classname value
+          if value.is_a?(Array)
+            # Add all items specified in an array of values
+            value.each do | sub_value |
+              if classnames_child.keys.include? sub_value.to_sym
+                classes.push(classnames_child[sub_value.to_sym])
+              else
+                classes.push("sage-nil--#{key}-#{sub_value}")
+              end
+            end
+          elsif classnames_child.keys.include? value.to_sym
+            classes.push(classnames_child[value.to_sym])
+          else
+            # Output a nil class with the key and value as a modifier
+            classes.push("sage-nil--#{key}-#{value}")
+          end
+        end
+      else
+        # Output a nil class with the key as a modifier
+        classes.push("sage-nil--#{key}")
+      end
+    end
+
+    # Join all resulting classnames and return a signle string
+    classes.join(" ")
+  end
+end

--- a/docs/lib/sage_rails/app/helpers/sage_misc_helpers.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_misc_helpers.rb
@@ -1,0 +1,18 @@
+module SageMiscHelpers
+  #
+  # Converts the constants within a module into a has
+  #
+  def module_consts_to_hash(mod)
+    # Declare an initial hash
+    hash = {}
+
+    # Loop through constants in this module
+    mod.constants.each do | const |
+      # Add this constant and its value to the main hash
+      hash[const] = mod.const_get(const)
+    end
+
+    # Return resulting hash
+    hash
+  end
+end


### PR DESCRIPTION
## Description

This PR adds a new helper for working with classname tokens within the system.

Currently we have to do things like this:

```erb
<p class="<%= "#{SageClassnames::TYPE::BODY_SMALL} #{SageClassnames::TYPE_COLOR::CHARCOAL_100}" %>">
  My cool content
</p>
```

But this will allow a little trimming like this:

```erb
<p class="<%= sage_classnames({ type: "BODY_SMALL", color: "CHARCOAL_100" }) %>">
  My cool content
</p>
```

- [x] Adds Rails helper
- [ ] Adds React helper
- [ ] Documents helpers for both platforms

A follow-up will handle populating this helper throughout the docs site and mocks.

## Screenshots

![Screen Shot 2022-05-19 at 10 57 48 AM](https://user-images.githubusercontent.com/17955295/169327346-a24115f6-ce6f-4db5-9d93-48eca4c8cd21.png)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
