### PR TITLE
[Sage-531] Form Elements - Color Update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_checkbox.scss
@@ -8,10 +8,12 @@
 // Colors
 //
 $-checkbox-color-default: sage-color(grey, 500);
-$-checkbox-color-checked: sage-color(primary, 300);
-$-checkbox-color-checked-hover: sage-color(primary, 400);
-$-checkbox-color-disabled: sage-color(grey, 300);
-$-checkbox-color-disabled-checked: sage-color(primary, 100);
+$-checkbox-color-default-border: sage-color(grey, 400);
+$-checkbox-color-checked: sage-color(charcoal, 400);
+$-checkbox-color-checked-hover: sage-color(charcoal, 500);
+$-checkbox-color-disabled: sage-color(grey, 200);
+$-checkbox-color-disabled-border: sage-color(grey, 300);
+$-checkbox-color-disabled-checked: sage-color(charcoal, 100);
 $-checkbox-color-error: sage-color(red, 300);
 
 $-checkbox-size: rem(20px);
@@ -133,7 +135,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
   width: $-checkbox-size;
   margin: 0;
   color: $-checkbox-color-default;
-  border: rem(1px) solid $-checkbox-color-default;
+  border: rem(1px) solid $-checkbox-color-default-border;
   border-radius: $-checkbox-border-radius-inner;
   outline: none;
   transition: $-checkbox-transition;
@@ -172,6 +174,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
     $-checkbox-scale: 14 / 16;
     transform: translate3d(-50%, -50%, 0) scale3d(#{$-checkbox-scale}, #{$-checkbox-scale}, #{$-checkbox-scale});
     color: sage-color(white);
+    font-weight: sage-font-weight(bold);
     opacity: 0;
   }
 
@@ -204,8 +207,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
   }
 
   &:hover:not(:checked):not(:disabled) {
-    border-color: sage-color(charcoal, 100);
-    box-shadow: sage-shadow(sm);
+    border-color: $-checkbox-color-default;
   }
 
   &:focus:not(:disabled),
@@ -221,6 +223,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
   &:disabled {
     background: $-checkbox-color-disabled;
+    border-color: $-checkbox-color-disabled-border;
     cursor: not-allowed;
     opacity: 0.5;
 
@@ -230,10 +233,14 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
     // disabled & checked
     &:checked {
-      background: $-checkbox-color-disabled-checked;
-      border-color: $-checkbox-color-disabled-checked;
+      background: $-checkbox-color-disabled-border;
+      border-color: $-checkbox-color-disabled-border;
       box-shadow: none;
       opacity: 1;
+    }
+
+    &:checked::after {
+      color: $-checkbox-color-disabled-checked;
     }
 
     &:checked::before {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_radio.scss
@@ -143,7 +143,7 @@ $-radio-focus-outline-color: currentColor;
   &:hover {
     &:not(:checked):not(:disabled) {
       border-color: $-radio-color-hover;
-      box-shadow: sage-shadow(sm);
+      background-color: sage-color(grey, 100);
     }
   }
 
@@ -164,12 +164,17 @@ $-radio-focus-outline-color: currentColor;
 
   &:disabled {
     background: $-radio-color-disabled;
+    border-color: $-radio-color-checked-disabled;
     cursor: not-allowed;
 
     // disabled & checked
     &:checked {
       background: $-radio-color-checked-disabled;
       box-shadow: none;
+    }
+
+    &:checked::after {
+      background-color: $-radio-color-hover;
     }
 
     + .sage-radio__label,

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_switch.scss
@@ -7,13 +7,16 @@
 
 // Colors
 $-switch-color-default: sage-color(grey, 400);
+$-switch-color-default-hover: sage-color(grey, 500);
 $-switch-color-default-text: sage-color(charcoal, 300);
-$-switch-color-checked: sage-color(primary, 300);
-$-switch-color-checked-hover: sage-color(primary, 400);
+$-switch-color-checked: sage-color(charcoal, 400);
+$-switch-color-checked-hover: sage-color(charcoal, 500);
 $-switch-color-disabled: sage-color(grey, 300);
 $-switch-color-disabled-text: sage-color(charcoal, 300);
-$-switch-color-disabled-checked: sage-color(primary, 100);
+$-switch-color-disabled-checked: sage-color(grey, 300);
 $-switch-color-disabled-checked-text: sage-color(charcoal, 100);
+$-switch-color-error: sage-color(red, 300);
+$-switch-focus-outline-error-color: sage-color(red, 200);
 
 // Switch
 $-switch-label-left-spacing: sage-spacing(xs);
@@ -23,8 +26,6 @@ $-switch-width: rem(36px);
 
 // Toggle
 $-switch-toggle-size: rem(16px);
-
-$-switch-focus-outline-error-color: sage-color(red, 200);
 
 
 .sage-switch {
@@ -115,6 +116,10 @@ $-switch-focus-outline-error-color: sage-color(red, 200);
     }
   }
 
+  &:hover:not(:checked):not(:disabled) {
+    background-color: $-switch-color-default-hover;
+  }
+
   &::after {
     content: "";
     display: block;
@@ -135,18 +140,21 @@ $-switch-focus-outline-error-color: sage-color(red, 200);
 
   .sage-switch--error &,
   &:invalid {
-    @include sage-focus-ring(sage-color(red, 200));
+    @include sage-focus-ring($-switch-focus-outline-error-color);
 
-    background-color: sage-color(red, 300);
+    background-color: $-switch-color-error;
     ~ .sage-switch__label,
     ~ .sage-switch__message {
-      color: sage-color(red, 300);
+      color: $-switch-color-error;
+    }
+    &:hover:not(:checked):not(:disabled) {
+      background-color: $-switch-color-error;
     }
     &:checked {
-      background-color: sage-color(red, 300);
+      background-color: $-switch-color-error;
     }
     &:checked:hover {
-      background-color: sage-color(red, 300);
+      background-color: $-switch-color-error;
     }
   }
 
@@ -177,13 +185,17 @@ $-switch-focus-outline-error-color: sage-color(red, 200);
 
     ~ .sage-switch__label,
     ~ .sage-switch__message {
-      color: $-switch-color-disabled-text;
+      color: $-switch-color-disabled-checked-text;
       cursor: inherit;
     }
 
     // disabled & checked
     &:checked {
       background: $-switch-color-disabled-checked;
+    }
+
+    &:checked::after {
+      background-color: $-switch-color-default-hover;
     }
 
     &:checked ~ .sage-switch__label,

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
@@ -65,14 +65,14 @@ $sage-field-colors: (
 /// Radio button colors
 ///
 $sage-radio-colors: (
-  checked: sage-color(primary, 300),
-  checked-disabled: sage-color(primary, 100),
-  checked-hover: sage-color(primary, 400),
+  checked: sage-color(charcoal, 400),
+  checked-disabled: sage-color(grey, 300),
+  checked-hover: sage-color(charcoal, 500),
   checked-inner: sage-color(white),
-  default: sage-color(grey, 500),
-  disabled: sage-color(grey, 100),
+  default: sage-color(grey, 400),
+  disabled: sage-color(grey, 200),
   error: sage-color(red, 300),
-  hover: sage-color(charcoal, 100),
+  hover: sage-color(grey, 500),
 );
 
 ///


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates color for the following components to match new Figma specs: Checkbox, Switch, Radio.

[Checkbox - Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=557%3A23176)
[Switch - Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=736%3A21748)
[Radio - Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage?node-id=557%3A27894)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="487" alt="Screen Shot 2022-05-19 at 3 16 30 PM" src="https://user-images.githubusercontent.com/14791307/169397190-5f135234-e890-442f-aa4f-3c4b88b4940e.png">|<img width="484" alt="Screen Shot 2022-05-19 at 3 13 29 PM" src="https://user-images.githubusercontent.com/14791307/169397205-66bfc8f3-1dd2-4cf4-9397-367ba41620a7.png">
<img width="540" alt="Screen Shot 2022-05-19 at 3 16 04 PM" src="https://user-images.githubusercontent.com/14791307/169397222-46d2c5be-d832-447d-b215-667c044baffa.png">|<img width="577" alt="Screen Shot 2022-05-19 at 3 13 53 PM" src="https://user-images.githubusercontent.com/14791307/169397233-50a1a975-c15e-4c2f-a92c-864e4a597a6c.png">
<img width="1414" alt="Screen Shot 2022-05-19 at 3 16 56 PM" src="https://user-images.githubusercontent.com/14791307/169397552-29ec2a37-1d8f-4b40-b6e6-f9a536194172.png">|<img width="1409" alt="Screen Shot 2022-05-19 at 3 18 27 PM" src="https://user-images.githubusercontent.com/14791307/169397562-33f50b07-ee46-4821-9240-81c6daac1094.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Checkbox](http://localhost:4000/pages/component/checkbox?tab=preview), [Radio](http://localhost:4000/pages/component/radio?tab=preview), [Switch](http://localhost:4000/pages/component/switch?tab=preview)
- Check that colors align with new Figma specs.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(MEDIUM) Updates color for the following components to match new Figma specs: Checkbox, Switch, Radio.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-531](https://kajabi.atlassian.net/browse/SAGE-531)