### PR TITLE
[SAGE-529] Update select state color

### DIFF
--- a/docs/app/views/examples/components/themes/next/choice/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/choice/_preview.html.erb
@@ -1,7 +1,7 @@
 <%
 long_description = "Description with longer text to cause wrapping and make the top alignment appear more necessary."
 %>
-<h3 class="t-sage-heading-6">Single Line (radio type)</h3>
+<h3 class="t-sage-heading-6">Single Line with Active State (radio type)</h3>
 
 <%= sage_component SageChoice, {
     target: "example",

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
@@ -68,16 +68,12 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     outline: none;
   }
 
-  &:active,
   &.sage-choice--active {
     color: $-choice-color-active;
 
     &::after {
-      border-color: sage-color(primary, 300);
-    }
-
-    &:hover::after {
-      border-color: sage-color(primary, 400);
+      border-color: sage-color(charcoal, 400);
+      border-width: rem(4px);
     }
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] Update `selected` state color to `sage-color(charcoal, 400)`
  - After full audit, `Choice` was the only remaining component

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2022-05-20_at_2_46_18_PM](https://user-images.githubusercontent.com/1241836/169601116-ec9ab3f1-fa67-4efd-9dce-2f59eaf0b9eb.png)|![Screen_Shot_2022-05-20_at_2_48_57_PM](https://user-images.githubusercontent.com/1241836/169601135-eb4a01a5-5231-4bc6-b09f-230f78eb2826.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify that the selected state border color is `charcoal 400`: 
- [Rails](http://localhost:4000/pages/component/choice?tab=preview)
- [React](http://localhost:4110/?path=/story/sage-choice--wired-icon) -> Click on any of the `Choice` component to see the desired affect

Note: In React you may see the focus ring on click. That behavior is expected as the active border should appear on load with no interaction

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update the selected border color for the `Choice` component.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-529](https://kajabi.atlassian.net/browse/SAGE-529)