### PR TITLE
[SAGE-528] Color - update charcoal 500 value

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/dictionary/_tokens.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/dictionary/_tokens.scss
@@ -432,7 +432,7 @@ $sd-sage-color-base-charcoal-400-classname: "t-sage--color-charcoal-400";
 ///
 /// color color-base-charcoal-500-hex
 ///
-$sd-sage-color-base-charcoal-500-hex: #181b20;
+$sd-sage-color-base-charcoal-500-hex: #040506;
 ///
 /// color color-base-charcoal-500-code
 ///


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update `charcoal 500` from `#181b20` -> `#040506`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2022-05-20_at_3_46_15_PM](https://user-images.githubusercontent.com/1241836/169609952-f09b8e3d-9554-49cc-b97b-ea48e69b40de.png)|![Screen_Shot_2022-05-20_at_3_47_05_PM](https://user-images.githubusercontent.com/1241836/169609980-632ca3ac-54cc-4e33-9336-3aa6f77455de.png)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
There are several instances of elements that consumed this change, one is the `Title` in the `EmptyState` component:
- [Rails](http://localhost:4000/pages/component/empty_state?tab=preview)
- [React](http://localhost:4110/?path=/story/sage-emptystate--page-scope)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Subtle but widespread charcoal 500 color change.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-528](https://kajabi.atlassian.net/browse/SAGE-528)