### PR TITLE
[QINBOX-375] Fix width for panel control toolbar actions

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_panel_controls.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_panel_controls.scss
@@ -65,10 +65,6 @@
   .sage-panel-controls--show-pagination .sage-panel-controls__toolbar &:last-child {
     flex: 0 1;
   }
-
-  .sage-search {
-    width: auto;
-  }
 }
 
 .sage-panel-controls__pagination {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] Resolve issue in which the panel control toolbar actions are not spanning full width

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen_Shot_2022-05-23_at_9_49_44_AM](https://user-images.githubusercontent.com/1241836/169846642-aa46fbfe-ed5b-4749-a83b-a23b9157c494.png)|![Screen_Shot_2022-05-23_at_9_49_37_AM](https://user-images.githubusercontent.com/1241836/169846661-440cfddb-0e07-43f2-a4a1-7edc55dd075d.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the panel controls views and verify that the toolbar content has `width: 100%`:
- [Rails](http://localhost:4000/pages/component/panel_controls?tab=preview)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Resolve issue with the width of the search subcomponent within Panel Controls.
   - [ ] Website Pages


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Related to [QINBOX-375](https://kajabi.atlassian.net/browse/QEINBOX-375)