### PR TITLE
[SAGE-563] Button - Within grid button full-width by default

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
@@ -128,6 +128,7 @@ $-btn-loading-min-height: rem(36px);
   display: inline-flex;
   align-self: inherit;
   align-items: center;
+  justify-self: flex-start;
   padding: $-padding-block sage-spacing(sm);
   text-align: left; // Prevents text alignment issue when inner text is truncated
   border: 0;
@@ -670,6 +671,7 @@ $-alert-colors: (
 .sage-btn--full-width {
   align-self: stretch;
   justify-content: center;
+  justify-self: stretch;
   width: 100%;
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -159,6 +159,7 @@ $-btn-loading-min-height: rem(36px);
   position: relative;
   align-self: inherit;
   align-items: center;
+  justify-self: flex-start;
   padding: $-padding-block sage-spacing(sm);
   text-align: left; // Prevents text alignment issue when inner text is truncated
   border: 0;
@@ -747,6 +748,7 @@ $-alert-colors: (
 .sage-btn--full-width {
   align-self: stretch;
   justify-content: center;
+  justify-self: stretch;
   width: 100%;
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] resolve issue in which buttons as grid items were stretching by default

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-05-26 at 8 20 23 AM](https://user-images.githubusercontent.com/1241836/170495881-fe52f1f2-3e80-43fa-92d7-39fc0fc065fa.png)|![Screen Shot 2022-05-25 at 4 15 58 PM](https://user-images.githubusercontent.com/1241836/170495661-2e37616d-8e05-4221-9c81-a1f2eecccd6b.png)|

## Testing in `sage-lib`

Insert the following into the `sandbox.html.erb` file to view this work:
```
<%= sage_component SagePanel, {} do %>
  <%= sage_component SagePanelList, {} do %>
    <%= sage_component SagePanelListItem, { grid_template: "et" } do %>
      <%= sage_component SageButton, {
        value: "Sage button",
        style: "primary",
      } %>
      <%= sage_component SageButton, {
        value: "Full width button",
        style: "primary",
        full_width: true
      } %>
    <% end %>
    <%= sage_component SagePanelListItem, { grid_template: "et" } do %>
      <%= sage_component SageButton, {
        value: "Sage button",
        style: "primary",
      } %>
      <%= sage_component SageButton, {
        value: "Sage button",
        style: "primary",
      } %>
    <% end %>
  <% end %>
<% end %>
```

Visit the sandbox page to verify changes: 
- [Rails](http://localhost:4000/pages/sandbox)
- React - css only change mirrors on the react side but no sandbox 
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Visual update to button alignment. High usage component so requires QA, specifically buttons in Card and Panel lists.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-563](https://kajabi.atlassian.net/browse/SAGE-563)