### PR TITLE
[SAGE-647] Side nav updates

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_nav.scss
@@ -15,29 +15,17 @@ $-nav-subitem-border-width: rem(2px);
 .sage-nav__icon {
   display: inline-flex;
   margin-right: $-nav-icon-spacing;
-  color: sage-color(charcoal, 500);
-
-  .sage-nav__link--active & {
-    color: sage-color(charcoal, 500);
-  }
 }
 
 .sage-nav__label {
-  @extend %t-sage-heading-6;
-
-  color: sage-color(charcoal, 500);
-
-  .sage-nav__link--sub & {
-    font-size: sage-font-size(body-sm);
-  }
-
-  .sage-nav__link--active & {
-    color: sage-color(charcoal, 500);
-  }
-
+  .sage-nav__link--active &,
   .sage-nav__link--sub.sage-nav__link--active & {
-    color: sage-color(charcoal, 500);
+    color: $-nav-color-text;
   }
+}
+
+.sage-nav__link {
+  @extend %t-sage-heading-6;
 }
 
 .sage-nav__link,
@@ -71,6 +59,8 @@ $-nav-subitem-border-width: rem(2px);
 }
 
 .sage-nav__link--sub {
+  @extend %t-sage-body-small-semi;
+
   &.sage-nav__link--active {
     @include sage-focus-outline--update-color(sage-color(primary, 200));
 
@@ -98,21 +88,17 @@ $-nav-subitem-border-width: rem(2px);
   &:not(.sage-nav__list--sub) {
     .sage-nav__link--active {
       @include sage-focus-outline--update-color(sage-color(primary, 200));
+    }
 
-      /* stylelint-disable max-nesting-depth */
-      &::after {
-        opacity: 0;
-      }
-      /* stylelint-enable max-nesting-depth */
+    .sage-nav__link--active::after {
+      opacity: 0;
     }
   }
 }
 
 .sage-nav__link--with-icon {
-  &.sage-nav__link {
-    &::after {
-      opacity: 0;
-    }
+  &.sage-nav__link::after {
+    opacity: 0;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_nav.scss
@@ -23,7 +23,7 @@ $-nav-subitem-border-width: rem(2px);
 }
 
 .sage-nav__label {
-  @extend %t-sage-body-semi;
+  @extend %t-sage-heading-6;
 
   color: sage-color(charcoal, 500);
 


### PR DESCRIPTION
## Description
Aligns sidenav style to match Figma. Applied styles were more strict than implementation in KP currently allows.

- Primary nav links updated to `h6` font styles 
- Subnav links inherit body/sm medium (14px) from parent link rather than child `span`
- Minor refactor/cleanup to flatten structure

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  |Before  |  After  |
|----|----|--------|
|Nav links (no visual change)|<img width="360" alt="nav-before" src="https://user-images.githubusercontent.com/816579/171272226-35514e6a-5acb-43ff-bec8-ce53442dc965.png">|<img width="360" alt="nav-after" src="https://user-images.githubusercontent.com/816579/171272256-45072385-ac6c-42b2-b3f6-57cabbaf5eee.png">|
|KP sidenav |![sidebar-before](https://user-images.githubusercontent.com/816579/171288236-45428437-692b-45c7-8bd4-cafcfefa1aba.png)|![sidebar-after](https://user-images.githubusercontent.com/816579/171272325-84e98447-fead-4b32-a39a-9678da704484.png)|



## Testing in `sage-lib`
1. Navigate to the [Nav link example page](http://localhost:4000/pages/component/nav_link?tab=preview)
2. Inspect any `.sage-nav__link` and verify that the `h6` font styles are applied
3. Inspect any `.sage-nav__link--sub` sublink, and confirm that `body-sm` styles are applied


## Testing in `kajabi-products`
1. (**MEDIUM**) Applies to sidebar navigation links only with `sage_next` feature flag enabled. 


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
