### PR TITLE
[SAGE-641] Headings - update color value

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_typography.scss
@@ -90,15 +90,6 @@ body:not(.sage-excluded),
   text-size-adjust: 100%;
   color: map-get($sage-text-colors, body);
   font-size: sage-font-size();
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    color: sage-color(charcoal, 500);
-  }
 }
 
 // Automate setting up classes that extend the specs

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_typography.scss
@@ -90,6 +90,15 @@ body:not(.sage-excluded),
   text-size-adjust: 100%;
   color: map-get($sage-text-colors, body);
   font-size: sage-font-size();
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: sage-color(charcoal, 500);
+  }
 }
 
 // Automate setting up classes that extend the specs

--- a/packages/sage-assets/lib/stylesheets/themes/next/global/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/global/_reboot.scss
@@ -60,6 +60,7 @@ h5,
 h6 {
   margin-top: 0;
   margin-bottom: 0;
+  color: sage-color(charcoal, 500);
 }
 
 p {

--- a/packages/sage-assets/lib/stylesheets/themes/next/global/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/global/_reboot.scss
@@ -60,7 +60,6 @@ h5,
 h6 {
   margin-top: 0;
   margin-bottom: 0;
-  color: sage-color(charcoal, 500);
 }
 
 p {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update the color of all heading elements (`h1` - `h6`) to `#040506`
  - currently uses `#202327` inherited from the `body` element

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-05-31 at 2 13 20 PM](https://user-images.githubusercontent.com/1241836/171267722-32fa2fd8-d338-4053-9836-6a775838bef9.png)|![Screen Shot 2022-05-31 at 2 13 11 PM](https://user-images.githubusercontent.com/1241836/171267731-f8681bb6-ae3b-4c5d-b3f9-b9ee51a41ad3.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Page Heading element or an element that has a `title` attribute and verify that the color is `#040506`:
- [Page Heading](http://localhost:4000/pages/component/page_heading?tab=preview)
- [Card](http://localhost:4000/pages/component/card?tab=preview)
- [Panel -> Panel Heading](http://localhost:4000/pages/component/panel?tab=preview)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Subtle color update but affects ALL headings, (`h1` - `h6`) so required QE.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-641](https://kajabi.atlassian.net/browse/SAGE-641)