### PR TITLE
[SAGE-644] Link - update font-weight to semibold

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_link.scss
@@ -58,7 +58,7 @@ $-link-base-styles: (
 );
 
 .sage-link {
-  @extend %t-sage-body-med;
+  @extend %t-sage-body-semi;
 
   display: inline-flex;
   position: relative;
@@ -74,7 +74,7 @@ $-link-base-styles: (
 
   &:focus {
     color: sage-color(primary, 300);
-    
+
     @include sage-focus-outline--update-color(sage-color(primary, 200));
   }
 }
@@ -160,7 +160,7 @@ $-link-base-styles: (
 }
 
 .sage-link--small {
-  @extend %t-sage-body-small-med;
+  @extend %t-sage-body-small-semi;
 }
 
 .sage-link--subtext {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update the `font-weight` from `500` to `600` for the `Link` component, will ripple to other components that consume this

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-05-31 at 2 31 40 PM](https://user-images.githubusercontent.com/1241836/171270963-29b2121b-b8d4-4d06-976f-cb1b4ceddb41.png)|![Screen Shot 2022-05-31 at 2 31 15 PM](https://user-images.githubusercontent.com/1241836/171270986-1dc88d69-0da6-40a3-afaf-0f6504ac1b55.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Link view and verify 

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Subtle change to the `font-weight` of the `Link` component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-644](https://kajabi.atlassian.net/browse/SAGE-644)