### PR TITLE
Next Modal size

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_modal.scss
@@ -5,12 +5,13 @@
 ////
 
 
-$-modal-padding-x: rem(36px);
-$-modal-padding-y: rem(36px);
+$-modal-padding-x: sage-spacer(md);
+$-modal-padding-y: sage-spacer(md);
 $-modal-margin-lg: 6vh;
 $-modal-margin-xl: 8vh;
 $-modal-header-image-size: rem(28px);
 $-modal-fullscreen-top-spacing: rem(104px);
+$-modal-inner-size: sage-container(md);
 
 
 .sage-modal {
@@ -69,7 +70,7 @@ $-modal-fullscreen-top-spacing: rem(104px);
   visibility: hidden;
   z-index: sage-z-index(modal);
   width: calc(100vw - #{sage-spacing(md)});
-  max-width: sage-container(md);
+  max-width: $-modal-inner-size + (2 * $-modal-padding-x);
   margin: 0;
   border-radius: sage-border(radius-large);
   background-color: sage-color(white);

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_modal.scss
@@ -5,8 +5,8 @@
 ////
 
 
-$-modal-padding-x: sage-spacer(md);
-$-modal-padding-y: sage-spacer(md);
+$-modal-padding-x: sage-spacing(md);
+$-modal-padding-y: sage-spacing(md);
 $-modal-margin-lg: 6vh;
 $-modal-margin-xl: 8vh;
 $-modal-header-image-size: rem(28px);


### PR DESCRIPTION
## Description

Per design request (official branch pending) this size adjustment helps to make modals closer to the legacy modal size so that `kp` uses don't appear a little squished. Here we shifted so that the container `md` of `520px` is applied as the inner width (with spacing on outside that) rather than the outer width being this and then constricted by padding. This also updates to latest spec for Modal with smaller padding of `24px`.

## Screenshots

| Before | After |
|---|---|
| ![Screen Shot 2022-05-31 at 3 54 11 PM](https://user-images.githubusercontent.com/17955295/171273983-16c7e2a0-ab6b-48a0-92f1-2aebe1ee93a9.png) | ![Screen Shot 2022-05-31 at 3 53 32 PM](https://user-images.githubusercontent.com/17955295/171274000-333763fc-2073-4d50-b9c1-c20adbe3de72.png) |


## Testing in `sage-lib`

See http://localhost:4000/pages/component/modal?sage_theme=sage_theme_next

## Testing in `kajabi-products`

1. (**LOW**) Modal size in Next is increased to `520px` from `448px`


## Related

[SAGE 560](https://kajabi.atlassian.net/browse/SAGE-560)
