### PR TITLE
[SAGE-335] Select - remove inverted icon functionality

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_form_select.html.erb
@@ -18,5 +18,6 @@
     <% end %>
   </select>
   <label class="sage-select__label" for="<%= selectID %>"><%= component.name %></label>
+  <i class="sage-select__arrow" aria-hidden="true"></i>
   <div class="sage-select__message"><%= component.message %></div>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_form_select.html.erb
@@ -23,6 +23,7 @@
     <% end %>
   </select>
   <label class="sage-select__label" for="<%= select_name %>"><%= label %></label>
+  <i class="sage-select__arrow" aria-hidden="true"></i>
   <% if component.message.present? %>
     <div class="sage-select__message"><%= component.message %></div>
   <% end %>

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
@@ -82,8 +82,6 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
   }
 
   .sage-select--value-selected &:not(:disabled) + .sage-select__arrow::before {
-    @include sage-icon-base(up-small);
-
     height: $-select-height;
   }
 

--- a/packages/sage-system/lib/select.js
+++ b/packages/sage-system/lib/select.js
@@ -4,8 +4,7 @@ Sage.select = (function() {
   // Variables
   // ==================================================
   var elSelectClass = '.sage-select',
-      classActive = 'sage-select--value-selected',
-      htmlArrow = '<i class="sage-select__arrow" aria-hidden="true"></i>';
+      classActive = 'sage-select--value-selected';
 
   // ==================================================
   // Functions
@@ -38,7 +37,6 @@ Sage.select = (function() {
   function init(el) {
     var elSelect = el.querySelector('select');
 
-    el.insertAdjacentHTML('beforeEnd', htmlArrow);
     disableSelectPromptOptions(elSelect);
     updateValueSelectedState(elSelect.value, el);
     bindEvents(elSelect, el);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove inverted icon functionality
Currently we invert the icon when the select is open, but that is not consistent with expected `<select>` functionality
## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![selectInteractionBefore](https://user-images.githubusercontent.com/1241836/171441535-39d0be50-58d8-4d95-b842-c7026eb3dc11.gif)|![selectInteractionAfter](https://user-images.githubusercontent.com/1241836/171441567-9cc4708a-bf18-42c6-b842-24ae469c0871.gif)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the form select views and verify that the icon doesn't invert when a value is present:
- [Rails](http://localhost:4000/pages/component/form_select?tab=preview)
- [React](http://localhost:4110/?path=/docs/sage-select--search-with-state)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Subtle visual change involving the select icon no longer inverting when a value is present.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-335](https://kajabi.atlassian.net/browse/SAGE-335)