### PR TITLE
[SAGE-663] List borders styling followup - (hide_first_border)

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
@@ -36,7 +36,8 @@ $-catalogue-item-image-height-mobile: rem(120px);
     border-bottom: 0;
   }
 
-  .sage-card__list--hide-first-border & {
+  .sage-card__list--hide-first-border &,
+  .sage-panel__list--hide-first-border & {
     &:first-child {
       border-top: 0;
     }


### PR DESCRIPTION
## Description
Missed a style property when recently adding the `hide_first_border` prop while working on SAGE-649.

This adds the styling needed for catalog lists within a panel for the next theme.

## Screenshots
No visual changes.


## Testing in `sage-lib`

- Navigate to catalog item preview file `app/views/examples/components/themes/NEXT OR LEGACY/catalog_item/_preview.html.erb`
- Add `hide_first_border: true` to SagePanelList 
- Verify border no longer displays in preview.


## Testing in `kajabi-products`
1. (**LOW**) Adds missing styling related to Catalog item in PanelList when hide_first_border: true. No impact on KP.


## Related
https://kajabi.atlassian.net/browse/SAGE-663
