### PR TITLE
Tidy up Frame setup and enhance with wrap, min-width, and max-width

### DIFF
--- a/docs/lib/sage_rails/app/sage_layouts/sage_layout.rb
+++ b/docs/lib/sage_rails/app/sage_layouts/sage_layout.rb
@@ -11,6 +11,7 @@ class SageLayout
     spacer: [:optional, SageSchemas::SPACER],
     css_classes: [:optional, NilClass, String],
     content: [:optional, String],
+    styles: [:optional, Hash],
   }
 
   def generated_css_classes
@@ -19,6 +20,10 @@ class SageLayout
 
   def generated_html_attributes
     @generated_html_attributes ||= ""
+  end
+
+  def generated_styles
+    @generated_styles ||= ""
   end
 
   def css_classes
@@ -67,6 +72,17 @@ class SageLayout
     @html_attributes = html_attributes_hash
     html_attributes_hash.each do |key, value|
       generated_html_attributes << " #{key}=\"#{value.to_s}\""
+    end
+  end
+
+  def styles
+    @styles ||= {}
+  end
+
+  def styles=(styles_hash)
+    @styles = styles_hash
+    styles_hash.each do |key, value|
+      generated_styles << " #{key}: #{value.to_s}; "
     end
   end
 

--- a/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
@@ -125,6 +125,7 @@ module SageSchemas
     min_width: [:optional, NilClass, String, Set.new(SageTokens::FRAME_WIDTHS)],
     width: [:optional, NilClass, String, Set.new(SageTokens::FRAME_WIDTHS)],
     width_ratio: [:optional, NilClass, String],
+    wrap: [:optional, NilClass, Set.new(SageTokens::FRAME_WRAPS)]
   }
 
   LIST_ITEM = {

--- a/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
@@ -121,6 +121,8 @@ module SageSchemas
     gap: [:optional, NilClass, Set.new(SageTokens::FRAME_SPACINGS)],
     padding: [:optional, NilClass, Set.new(SageTokens::FRAME_SPACINGS)],
     tag: [:optional, NilClass, String],
+    max_width: [:optional, NilClass, String, Set.new(SageTokens::FRAME_WIDTHS)],
+    min_width: [:optional, NilClass, String, Set.new(SageTokens::FRAME_WIDTHS)],
     width: [:optional, NilClass, String, Set.new(SageTokens::FRAME_WIDTHS)],
     width_ratio: [:optional, NilClass, String],
   }

--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -402,11 +402,18 @@ module SageTokens
     "none"
   ])
 
+  # Keep in sync with `packages/sage-assets/lib/stylesheets/components/_frame.scss`
   FRAME_WIDTHS = [
     "hug",
     "fill",
     "flex",
     "initial",
+  ]
+
+  # Keep in sync with `packages/sage-assets/lib/stylesheets/components/_frame.scss`
+  FRAME_WRAPS = [
+    "none",
+    "wrap",
   ]
 
 end

--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -406,6 +406,7 @@ module SageTokens
     "hug",
     "fill",
     "flex",
+    "initial",
   ]
 
 end

--- a/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
@@ -13,7 +13,7 @@ tag = component.tag.present? ? component.tag : "div"
 # Set up additional style configs
 #
 
-has_custom_styles = false
+has_custom_styles = component.styles.present? ? true : false
 
 is_custom_width = false
 if (width && !SageTokens::FRAME_WIDTHS.include?(width))
@@ -71,6 +71,7 @@ end
       <%= "--sage-frame-min-width: #{component.min_width}; " if is_custom_min_width %>
       <%= "--sage-frame-background: #{component.background}; " if is_custom_background %>
       <%= "flex: #{component.width_ratio}; " if component.width_ratio %>
+      <%= component.generated_styles.html_safe %>
     "
   <% end %>
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
@@ -1,48 +1,55 @@
 <%
-# Set up defaults
-# due to cascading values set on custom props,
-# we need to ensure defaults are provided for all values
+#
+# Set up defaults for options that allow open-ended values
+#
 
-align = component.align.present? ? component.align : "top-left"
-background = component.background.present? ? component.background : "transparent"
-border = component.border.present? ? component.border : "none"
-border_radius = component.border_radius.present? ? component.border_radius : "none"
-direction = component.direction.present? ? component.direction : "vertical"
-gap = component.gap.present? ? component.gap : "md"
-padding = component.padding.present? ? component.padding : "none"
-width = component.width.present? ? component.width : "flex"
+background = component.background.present? ? component.background : nil
+width = component.width.present? ? component.width : nil
 tag = component.tag.present? ? component.tag : "div"
 
-# Set up additional width configs
+#
+# Set up additional style configs
+#
+
+has_custom_styles = false
+
 is_custom_width = false
 if (width && !SageTokens::FRAME_WIDTHS.include?(width))
   is_custom_width = true
+  has_custom_styles = true
+  width = "custom"
 end
 
 # Set up additional background configs
 is_custom_background = false
 if (background && !SageTokens::COLOR_SLIDERS.include?(background))
   is_custom_background = true
+  has_custom_styles = true
+  background = "custom"
+end
+
+if (component.width_ratio.present?)
+  has_custom_styles = true
 end
 
 %>
 <<%= tag %>
   class="
     sage-frame
-    <%= "sage-frame--align-#{align}" %>
-    <%= "sage-frame--background-#{background}" if !is_custom_background && background %>
-    <%= "sage-frame--border-#{border}" %>
-    <%= "sage-frame--border-radius-#{border_radius}" %>
-    <%= "sage-frame--direction-#{direction}" %>
-    <%= "sage-frame--gap-#{gap}" %>
-    <%= "sage-frame--padding-#{padding}" %>
-    <%= "sage-frame--width-#{width}" if !is_custom_width && width %>
+    <%= "sage-frame--align-#{component.align}" if component.align.present? %>
+    <%= "sage-frame--background-#{background}" if background %>
+    <%= "sage-frame--border-#{component.border}" if component.border.present? %>
+    <%= "sage-frame--border-radius-#{component.border_radius}" if component.border_radius.present? %>
+    <%= "sage-frame--direction-#{component.direction}" if component.direction.present? %>
+    <%= "sage-frame--gap-#{component.gap}" if component.gap.present? %>
+    <%= "sage-frame--padding-#{component.padding}" if component.padding.present?%>
+    <%= "sage-frame--width-#{width}" if width %>
     <%= component.generated_css_classes %>
   "
-  <% if is_custom_width || is_custom_background %>
+  <% if has_custom_styles %>
     style="
-      <%= "--sage-frame-width: #{width}; " if is_custom_width %>
-      <%= "--sage-frame-background: #{background}; " if is_custom_background %>
+      <%= "--sage-frame-width: #{component.width}; " if is_custom_width %>
+      <%= "--sage-frame-background: #{component.background}; " if is_custom_background %>
       <%= "flex: #{component.width_ratio}; " if component.width_ratio %>
     "
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
@@ -62,6 +62,7 @@ end
     <%= "sage-frame--width-#{width}" if width %>
     <%= "sage-frame--max-width-#{max_width}" if !is_custom_max_width && max_width %>
     <%= "sage-frame--min-width-#{min_width}" if !is_custom_min_width && min_width %>
+    <%= "sage-frame--wrap-#{component.wrap}" if component.wrap.present?%>
     <%= component.generated_css_classes %>
   "
   <% if has_custom_styles %>

--- a/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_layouts/_sage_frame.html.erb
@@ -5,6 +5,8 @@
 
 background = component.background.present? ? component.background : nil
 width = component.width.present? ? component.width : nil
+max_width = component.max_width.present? ? component.max_width : nil
+min_width = component.min_width.present? ? component.min_width : nil
 tag = component.tag.present? ? component.tag : "div"
 
 #
@@ -18,6 +20,20 @@ if (width && !SageTokens::FRAME_WIDTHS.include?(width))
   is_custom_width = true
   has_custom_styles = true
   width = "custom"
+end
+
+is_custom_max_width = false
+if (max_width && !SageTokens::FRAME_WIDTHS.include?(max_width))
+  is_custom_max_width = true
+  has_custom_styles = true
+  max_width = "custom"
+end
+
+is_custom_min_width = false
+if (min_width && !SageTokens::FRAME_WIDTHS.include?(min_width))
+  is_custom_min_width = true
+  has_custom_styles = true
+  min_width = "custom"
 end
 
 # Set up additional background configs
@@ -44,11 +60,15 @@ end
     <%= "sage-frame--gap-#{component.gap}" if component.gap.present? %>
     <%= "sage-frame--padding-#{component.padding}" if component.padding.present?%>
     <%= "sage-frame--width-#{width}" if width %>
+    <%= "sage-frame--max-width-#{max_width}" if !is_custom_max_width && max_width %>
+    <%= "sage-frame--min-width-#{min_width}" if !is_custom_min_width && min_width %>
     <%= component.generated_css_classes %>
   "
   <% if has_custom_styles %>
     style="
       <%= "--sage-frame-width: #{component.width}; " if is_custom_width %>
+      <%= "--sage-frame-max-width: #{component.max_width}; " if is_custom_max_width %>
+      <%= "--sage-frame-min-width: #{component.min_width}; " if is_custom_min_width %>
       <%= "--sage-frame-background: #{component.background}; " if is_custom_background %>
       <%= "flex: #{component.width_ratio}; " if component.width_ratio %>
     "

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_frame.scss
@@ -133,6 +133,13 @@ $-sage-frame-widths: (
   initial: initial,
 );
 
+// Width presets to map to `width` (custom settings are also allowed)
+// named to resemble the auto layout settings in Figma
+$-sage-frame-wraps: (
+  wrap: wrap,
+  none: nowrap,
+);
+
 
 //
 // 2. Variables for default settings
@@ -147,6 +154,7 @@ $-sage-frame-padding: none;
 $-sage-frame-width: fill;
 $-sage-frame-min-width: initial;
 $-sage-frame-max-width: initial;
+$-sage-frame-wrap: none;
 
 
 //
@@ -221,6 +229,12 @@ $-sage-frame-max-width: initial;
 @each $-key, $-val in $-sage-frame-directions {
   .sage-frame--direction-#{$-key} {
     flex-direction: #{$-val};
+  }
+}
+
+@each $-key, $-val in $-sage-frame-wraps {
+  .sage-frame--wrap-#{$-key} {
+    flex-wrap: #{$-val};
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_frame.scss
@@ -123,10 +123,11 @@ $-sage-frame-spacings: map-merge($sage-spacings, (
 ));
 
 // Width presets to map to `width` (custom settings are also allowed)
-// named to resemble the auto layout settings in Figma
+// named to resemble the auto layout settings in Figma.
+// Used for width, min-width, and max-width settings.
 $-sage-frame-widths: (
   fill: 100%,
-  flex: auto,
+  flex: auto, // will also add `flex: 1` when applied
   hug: max-content,
   custom: auto,
 );
@@ -146,146 +147,123 @@ $-sage-frame-width: fill;
 
 
 //
-// 3. Mixins for easy use
-//
-
-///
-/// Setup an element with the sage frame configuration variables
-///
-@mixin sage-frame(
-  $align: $-sage-frame-alignment,
-  $background: $-sage-frame-background,
-  $border: $-sage-frame-border,
-  $border-radius: $-sage-frame-border-radius,
-  $direction: $-sage-frame-direction,
-  $gap: $-sage-frame-gap,
-  $padding: $-sage-frame-padding,
-  $width: $-sage-frame-width,
-) {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: var(--sage-frame-align-vertical, #{map-get(map-get($-sage-frame-alignments, $align), v)});
-  justify-content: var(--sage-frame-align-horizontal, #{map-get(map-get($-sage-frame-alignments, $align), h)});
-  flex-direction: var(--sage-frame-direction, #{map-get($-sage-frame-directions, $direction)});
-  gap: var(--sage-frame-gap, #{map-get($-sage-frame-spacings, $gap)});
-  width: var(--sage-frame-width, #{map-get($-sage-frame-widths, $width)});
-  padding: var(--sage-frame-padding, #{map-get($-sage-frame-spacings, $padding)});
-  border: var(--sage-frame-border, #{map-get($-sage-frame-borders, $border)});
-  border-radius: var(--sage-frame-border-radius, #{map-get($-sage-frame-border-radii, $border-radius)});
-  background: var(--sage-frame-background, #{$background});
-}
-
-///
-/// Configure a setup for a particular frame. Must also have implemented `sage-frame()` for initial setup.
-///
-@mixin sage-frame-config(
-  $align: $-sage-frame-alignment,
-  $background: $-sage-frame-background,
-  $border: $-sage-frame-border,
-  $border-radius: $-sage-frame-border-radius,
-  $direction: $-sage-frame-direction,
-  $gap: $-sage-frame-gap,
-  $padding: $-sage-frame-padding,
-  $width: $-sage-frame-width,
-) {
-  @if ($direction == vertical) {
-    --sage-frame-align-horizontal: #{map-get(map-get($-sage-frame-alignments, $align), v)};
-    --sage-frame-align-vertical: #{map-get(map-get($-sage-frame-alignments, $align), h)};
-  }
-  @else {
-    --sage-frame-align-horizontal: #{map-get(map-get($-sage-frame-alignments, $align), h)};
-    --sage-frame-align-vertical: #{map-get(map-get($-sage-frame-alignments, $align), v)};
-  }
-  --sage-frame-background: #{$background};
-  --sage-frame-border: #{map-get($-sage-frame-borders, $border)};
-  --sage-frame-border-radius: #{map-get($-sage-frame-border-radii, $border-radius)};
-  --sage-frame-direction: #{map-get($-sage-frame-directions, $direction)};
-  --sage-frame-gap: #{map-get($-sage-frame-spacings, $gap)};
-  --sage-frame-padding: #{map-get($-sage-frame-spacings, $padding)};
-  --sage-frame-width: #{map-get($-sage-frame-widths, $width)};
-}
-
-//
-// 4. Set up element and data attributes for implementing Frame
+// 3. Set up element and data attributes for implementing Frame
 //
 
 // Root element
-.sage-frame,
-[data-sage-frame] {
-  @include sage-frame();
+.sage-frame {
+  display: flex;
+
+  // Add default settings
+  &:not([class*="sage-frame--align-"]) {
+    align-items: map-get(map-get($-sage-frame-alignments, $-sage-frame-alignment), v);
+    justify-content: map-get(map-get($-sage-frame-alignments, $-sage-frame-alignment), h);
+  }
+
+  &:not([class*="sage-frame--direction-"]) {
+    flex-direction: map-get($-sage-frame-directions, $-sage-frame-direction);
+  }
+
+  &:not([class*="sage-frame--gap-"]) {
+    gap: map-get($-sage-frame-spacings, $-sage-frame-gap);
+  }
+
+  &:not([class*="sage-frame--width-"]) {
+    width: map-get($-sage-frame-widths, $-sage-frame-width);
+  }
 }
 
 //
-// 5. A la carte configurations
+// 4. A la carte configurations
 //
 
 @each $-key, $-val in $-sage-frame-alignments {
-  .sage-frame--align-#{$-key},
-  [data-sage-frame-align="#{$-key}"] {
+  .sage-frame--align-#{$-key} {
     // NOTE: The mappings are inverted by default because "vertical" orientation is default
     // and this makes for "top/bottom" apply to the horizontal axis and vice versa for "left/right"
-    --sage-frame-align-horizontal: #{map-get($-val, v)};
-    --sage-frame-align-vertical: #{map-get($-val, h)};
+    justify-content: #{map-get($-val, v)};
+    align-items: #{map-get($-val, h)};
 
-    &.sage-frame--direction-horizontal,
-    &[data-sage-frame-direction="horizontal"] {
-      --sage-frame-align-horizontal: #{map-get($-val, h)};
-      --sage-frame-align-vertical: #{map-get($-val, v)};
+    &.sage-frame--direction-horizontal {
+      justify-content: #{map-get($-val, h)};
+      align-items: #{map-get($-val, v)};
     }
   }
 }
 
+.sage-frame--background-custom {
+  background: var(--sage-frame-background, transparent);
+}
+
 @each $-color, $-sliders in $sage-colors {
   @each $-number, $-configs in $-sliders {
-    .sage-frame--background-#{"" + $-color}-#{$-number},
-    [data-sage-frame-background="#{'' + $-color}-#{$-number}"] {
-      --sage-frame-background: #{sage-color($-color, $-number)};
+    .sage-frame--background-#{"" + $-color}-#{$-number} {
+      background: #{sage-color($-color, $-number)};
     }
   }
 }
 
 @each $-key, $-val in $-sage-frame-borders {
-  .sage-frame--border-#{$-key},
-  [data-sage-frame-border="#{$-key}"] {
-    --sage-frame-border: #{$-val};
+  .sage-frame--border-#{$-key} {
+    border: #{$-val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-border-radii {
-  .sage-frame--border-radius-#{$-key},
-  [data-sage-frame-border-radius="#{$-key}"] {
-    --sage-frame-border-radius: #{$-val};
+  .sage-frame--border-radius-#{$-key} {
+    border-radius: #{$-val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-directions {
-  .sage-frame--direction-#{$-key},
-  [data-sage-frame-direction="#{$-key}"] {
-    --sage-frame-direction: #{$-val};
+  .sage-frame--direction-#{$-key} {
+    flex-direction: #{$-val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-spacings {
-  .sage-frame--gap-#{$-key},
-  [data-sage-frame-gap="#{$-key}"] {
-    --sage-frame-gap: #{$-val};
+  .sage-frame--gap-#{$-key} {
+    gap: #{$-val};
   }
   
-  .sage-frame--padding-#{$-key},
-  [data-sage-frame-padding="#{$-key}"] {
-    --sage-frame-padding: #{$_val};
+  .sage-frame--padding-#{$-key} {
+    padding: #{$_val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-widths {
-  @if ($-key != "custom") {
-    .sage-frame--width-#{$-key},
-    [data-sage-frame-width="#{$-key}"] {
-      --sage-frame-width: #{$-val};
-
+  .sage-frame--width-#{$-key} {
+    @if ($-key == "custom") {
+      width: var(--sage-frame-width, auto);
+    }
+    @else {
       @if ($-key == "flex") {
         flex: 1;
       }
+
+      width: #{$-val};
+    }
+  }
+}
+
+@each $-key, $-val in $-sage-frame-widths {
+  .sage-frame--max-width-#{$-key} {
+    @if ($-key != "custom") {
+      max-width: #{$-val};
+    }
+    @else {
+      max-width: var(--sage-frame-max-width, auto);
+    }
+  }
+}
+
+@each $-key, $-val in $-sage-frame-widths {
+  .sage-frame--min-width-#{$-key} {
+    @if ($-key != "custom") {
+      min-width: #{$-val};
+    }
+    @else {
+      min-width: var(--sage-frame-min-width, auto);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/layout/_frame.scss
@@ -130,6 +130,7 @@ $-sage-frame-widths: (
   flex: auto, // will also add `flex: 1` when applied
   hug: max-content,
   custom: auto,
+  initial: initial,
 );
 
 
@@ -144,6 +145,8 @@ $-sage-frame-direction: vertical;
 $-sage-frame-gap: md;
 $-sage-frame-padding: none;
 $-sage-frame-width: fill;
+$-sage-frame-min-width: initial;
+$-sage-frame-max-width: initial;
 
 
 //

--- a/packages/sage-assets/lib/stylesheets/themes/next/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/layout/_frame.scss
@@ -123,12 +123,21 @@ $-sage-frame-spacings: map-merge($sage-spacings, (
 ));
 
 // Width presets to map to `width` (custom settings are also allowed)
-// named to resemble the auto layout settings in Figma
+// named to resemble the auto layout settings in Figma.
+// Used for width, min-width, and max-width settings.
 $-sage-frame-widths: (
   fill: 100%,
-  flex: auto,
+  flex: auto, // will also add `flex: 1` when applied
   hug: max-content,
   custom: auto,
+  initial: initial,
+);
+
+// Width presets to map to `width` (custom settings are also allowed)
+// named to resemble the auto layout settings in Figma
+$-sage-frame-wraps: (
+  wrap: wrap,
+  none: nowrap,
 );
 
 
@@ -143,149 +152,135 @@ $-sage-frame-direction: vertical;
 $-sage-frame-gap: md;
 $-sage-frame-padding: none;
 $-sage-frame-width: fill;
+$-sage-frame-min-width: initial;
+$-sage-frame-max-width: initial;
+$-sage-frame-wrap: none;
 
 
 //
-// 3. Mixins for easy use
-//
-
-///
-/// Setup an element with the sage frame configuration variables
-///
-@mixin sage-frame(
-  $align: $-sage-frame-alignment,
-  $background: $-sage-frame-background,
-  $border: $-sage-frame-border,
-  $border-radius: $-sage-frame-border-radius,
-  $direction: $-sage-frame-direction,
-  $gap: $-sage-frame-gap,
-  $padding: $-sage-frame-padding,
-  $width: $-sage-frame-width,
-) {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: var(--sage-frame-align-vertical, #{map-get(map-get($-sage-frame-alignments, $align), v)});
-  justify-content: var(--sage-frame-align-horizontal, #{map-get(map-get($-sage-frame-alignments, $align), h)});
-  flex-direction: var(--sage-frame-direction, #{map-get($-sage-frame-directions, $direction)});
-  gap: var(--sage-frame-gap, #{map-get($-sage-frame-spacings, $gap)});
-  width: var(--sage-frame-width, #{map-get($-sage-frame-widths, $width)});
-  padding: var(--sage-frame-padding, #{map-get($-sage-frame-spacings, $padding)});
-  border: var(--sage-frame-border, #{map-get($-sage-frame-borders, $border)});
-  border-radius: var(--sage-frame-border-radius, #{map-get($-sage-frame-border-radii, $border-radius)});
-  background: var(--sage-frame-background, #{$background});
-}
-
-///
-/// Configure a setup for a particular frame. Must also have implemented `sage-frame()` for initial setup.
-///
-@mixin sage-frame-config(
-  $align: $-sage-frame-alignment,
-  $background: $-sage-frame-background,
-  $border: $-sage-frame-border,
-  $border-radius: $-sage-frame-border-radius,
-  $direction: $-sage-frame-direction,
-  $gap: $-sage-frame-gap,
-  $padding: $-sage-frame-padding,
-  $width: $-sage-frame-width,
-) {
-  @if ($direction == vertical) {
-    --sage-frame-align-horizontal: #{map-get(map-get($-sage-frame-alignments, $align), v)};
-    --sage-frame-align-vertical: #{map-get(map-get($-sage-frame-alignments, $align), h)};
-  }
-  @else {
-    --sage-frame-align-horizontal: #{map-get(map-get($-sage-frame-alignments, $align), h)};
-    --sage-frame-align-vertical: #{map-get(map-get($-sage-frame-alignments, $align), v)};
-  }
-  --sage-frame-background: #{$background};
-  --sage-frame-border: #{map-get($-sage-frame-borders, $border)};
-  --sage-frame-border-radius: #{map-get($-sage-frame-border-radii, $border-radius)};
-  --sage-frame-direction: #{map-get($-sage-frame-directions, $direction)};
-  --sage-frame-gap: #{map-get($-sage-frame-spacings, $gap)};
-  --sage-frame-padding: #{map-get($-sage-frame-spacings, $padding)};
-  --sage-frame-width: #{map-get($-sage-frame-widths, $width)};
-}
-
-//
-// 4. Set up element and data attributes for implementing Frame
+// 3. Set up element and data attributes for implementing Frame
 //
 
 // Root element
-.sage-frame,
-[data-sage-frame] {
-  @include sage-frame();
+.sage-frame {
+  display: flex;
+
+  // Add default settings
+  &:not([class*="sage-frame--align-"]) {
+    align-items: map-get(map-get($-sage-frame-alignments, $-sage-frame-alignment), v);
+    justify-content: map-get(map-get($-sage-frame-alignments, $-sage-frame-alignment), h);
+  }
+
+  &:not([class*="sage-frame--direction-"]) {
+    flex-direction: map-get($-sage-frame-directions, $-sage-frame-direction);
+  }
+
+  &:not([class*="sage-frame--gap-"]) {
+    gap: map-get($-sage-frame-spacings, $-sage-frame-gap);
+  }
+
+  &:not([class*="sage-frame--width-"]) {
+    width: map-get($-sage-frame-widths, $-sage-frame-width);
+  }
 }
 
 //
-// 5. A la carte configurations
+// 4. A la carte configurations
 //
 
 @each $-key, $-val in $-sage-frame-alignments {
-  .sage-frame--align-#{$-key},
-  [data-sage-frame-align="#{$-key}"] {
+  .sage-frame--align-#{$-key} {
     // NOTE: The mappings are inverted by default because "vertical" orientation is default
     // and this makes for "top/bottom" apply to the horizontal axis and vice versa for "left/right"
-    --sage-frame-align-horizontal: #{map-get($-val, v)};
-    --sage-frame-align-vertical: #{map-get($-val, h)};
+    justify-content: #{map-get($-val, v)};
+    align-items: #{map-get($-val, h)};
 
-    &.sage-frame--direction-horizontal,
-    &[data-sage-frame-direction="horizontal"] {
-      --sage-frame-align-horizontal: #{map-get($-val, h)};
-      --sage-frame-align-vertical: #{map-get($-val, v)};
+    &.sage-frame--direction-horizontal {
+      justify-content: #{map-get($-val, h)};
+      align-items: #{map-get($-val, v)};
     }
   }
 }
 
+.sage-frame--background-custom {
+  background: var(--sage-frame-background, transparent);
+}
+
 @each $-color, $-sliders in $sage-colors {
   @each $-number, $-configs in $-sliders {
-    .sage-frame--background-#{"" + $-color}-#{$-number},
-    [data-sage-frame-background="#{'' + $-color}-#{$-number}"] {
-      --sage-frame-background: #{sage-color($-color, $-number)};
+    .sage-frame--background-#{"" + $-color}-#{$-number} {
+      background: #{sage-color($-color, $-number)};
     }
   }
 }
 
 @each $-key, $-val in $-sage-frame-borders {
-  .sage-frame--border-#{$-key},
-  [data-sage-frame-border="#{$-key}"] {
-    --sage-frame-border: #{$-val};
+  .sage-frame--border-#{$-key} {
+    border: #{$-val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-border-radii {
-  .sage-frame--border-radius-#{$-key},
-  [data-sage-frame-border-radius="#{$-key}"] {
-    --sage-frame-border-radius: #{$-val};
+  .sage-frame--border-radius-#{$-key} {
+    border-radius: #{$-val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-directions {
-  .sage-frame--direction-#{$-key},
-  [data-sage-frame-direction="#{$-key}"] {
-    --sage-frame-direction: #{$-val};
+  .sage-frame--direction-#{$-key} {
+    flex-direction: #{$-val};
+  }
+}
+
+@each $-key, $-val in $-sage-frame-wraps {
+  .sage-frame--wrap-#{$-key} {
+    flex-wrap: #{$-val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-spacings {
-  .sage-frame--gap-#{$-key},
-  [data-sage-frame-gap="#{$-key}"] {
-    --sage-frame-gap: #{$-val};
+  .sage-frame--gap-#{$-key} {
+    gap: #{$-val};
   }
   
-  .sage-frame--padding-#{$-key},
-  [data-sage-frame-padding="#{$-key}"] {
-    --sage-frame-padding: #{$_val};
+  .sage-frame--padding-#{$-key} {
+    padding: #{$_val};
   }
 }
 
 @each $-key, $-val in $-sage-frame-widths {
-  @if ($-key != "custom") {
-    .sage-frame--width-#{$-key},
-    [data-sage-frame-width="#{$-key}"] {
-      --sage-frame-width: #{$-val};
-
+  .sage-frame--width-#{$-key} {
+    @if ($-key == "custom") {
+      width: var(--sage-frame-width, auto);
+    }
+    @else {
       @if ($-key == "flex") {
         flex: 1;
       }
+
+      width: #{$-val};
+    }
+  }
+}
+
+@each $-key, $-val in $-sage-frame-widths {
+  .sage-frame--max-width-#{$-key} {
+    @if ($-key != "custom") {
+      max-width: #{$-val};
+    }
+    @else {
+      max-width: var(--sage-frame-max-width, auto);
+    }
+  }
+}
+
+@each $-key, $-val in $-sage-frame-widths {
+  .sage-frame--min-width-#{$-key} {
+    @if ($-key != "custom") {
+      min-width: #{$-val};
+    }
+    @else {
+      min-width: var(--sage-frame-min-width, auto);
     }
   }
 }

--- a/packages/sage-react/lib/themes/legacy/Frame/Frame.jsx
+++ b/packages/sage-react/lib/themes/legacy/Frame/Frame.jsx
@@ -106,17 +106,17 @@ Frame.WIDTHS = FRAME_WIDTHS;
 Frame.WRAPS = FRAME_WRAPS;
 
 Frame.defaultProps = {
-  align: FRAME_ALIGNMENTS.TOP_LEFT,
-  background: 'transparent',
-  border: FRAME_BORDERS.NONE,
-  borderRadius: FRAME_BORDER_RADII.NONE,
+  align: null,
+  background: null,
+  border: null,
+  borderRadius: null,
   children: null,
   className: '',
   direction: FRAME_DIRECTIONS.VERTICAL,
   gap: FRAME_SPACINGS.MD,
   maxWidth: null,
   minWidth: null,
-  padding: FRAME_SPACINGS.NONE,
+  padding: null,
   tag: 'div',
   width: null,
   widthRatio: null,

--- a/packages/sage-react/lib/themes/legacy/Frame/Frame.jsx
+++ b/packages/sage-react/lib/themes/legacy/Frame/Frame.jsx
@@ -9,6 +9,7 @@ import {
   FRAME_DIRECTIONS,
   FRAME_SPACINGS,
   FRAME_WIDTHS,
+  FRAME_WRAPS,
 } from './configs';
 
 export const Frame = ({
@@ -20,36 +21,63 @@ export const Frame = ({
   borderRadius,
   direction,
   gap,
+  maxWidth,
+  minWidth,
   padding,
   tag,
   width,
   widthRatio,
+  wrap,
   ...rest
 }) => {
+  const Tag = tag;
+  const hasCustomBackground = background
+    && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
+  const hasCustomWidth = width
+    && !Object.values(FRAME_WIDTHS).includes(background);
+  const hasCustomMaxWidth = maxWidth
+    && !Object.values(FRAME_WIDTHS).includes(maxWidth);
+  const hasCustomMinWidth = minWidth
+    && !Object.values(FRAME_WIDTHS).includes(minWidth);
+
   const classNames = classnames(
     'sage-frame',
     className,
     {
       [`sage-frame--align-${align}`]: align,
-      [`sage-frame--background-${background}`]: background,
+      'sage-frame--background-custom': hasCustomBackground,
+      [`sage-frame--background-${background}`]: background && !hasCustomBackground,
       [`sage-frame--border-${border}`]: border,
       [`sage-frame--border-radius-${borderRadius}`]: borderRadius,
       [`sage-frame--direction-${direction}`]: direction,
       [`sage-frame--gap-${gap}`]: gap,
       [`sage-frame--padding-${padding}`]: padding,
-      [`sage-frame--width-${width}`]: width,
+      'sage-frame--width-custom': hasCustomWidth,
+      [`sage-frame--width-${width}`]: width && !hasCustomWidth,
+      'sage-frame--max-width-custom': hasCustomMaxWidth,
+      [`sage-frame--max-width-${maxWidth}`]: maxWidth && !hasCustomMaxWidth,
+      'sage-frame--min-width-custom': hasCustomMinWidth,
+      [`sage-frame--min-width-${minWidth}`]: minWidth && !hasCustomMinWidth,
+      [`sage-frame--wrap-${wrap}`]: wrap,
     }
   );
 
-  const Tag = tag;
+  const { style } = rest;
+  const styles = style || {};
 
-  const styles = {};
-
-  if (!Object.values(FRAME_WIDTHS).includes(width)) {
+  if (width && !Object.values(FRAME_WIDTHS).includes(width)) {
     styles['--sage-frame-width'] = width;
   }
 
-  if (!Object.values(SageTokens.COLOR_SLIDERS).includes(background)) {
+  if (hasCustomMaxWidth) {
+    styles['--sage-frame-max-width'] = maxWidth;
+  }
+
+  if (hasCustomMinWidth) {
+    styles['--sage-frame-min-width'] = minWidth;
+  }
+
+  if (hasCustomBackground) {
     styles['--sage-frame-background'] = background;
   }
 
@@ -60,8 +88,8 @@ export const Frame = ({
   return (
     <Tag
       className={classNames}
-      style={styles}
       {...rest}
+      style={styles}
     >
       {children}
     </Tag>
@@ -75,6 +103,7 @@ Frame.DIRECTIONS = FRAME_DIRECTIONS;
 Frame.GAPS = FRAME_SPACINGS;
 Frame.PADDINGS = FRAME_SPACINGS;
 Frame.WIDTHS = FRAME_WIDTHS;
+Frame.WRAPS = FRAME_WRAPS;
 
 Frame.defaultProps = {
   align: FRAME_ALIGNMENTS.TOP_LEFT,
@@ -85,10 +114,13 @@ Frame.defaultProps = {
   className: '',
   direction: FRAME_DIRECTIONS.VERTICAL,
   gap: FRAME_SPACINGS.MD,
+  maxWidth: null,
+  minWidth: null,
   padding: FRAME_SPACINGS.NONE,
   tag: 'div',
-  width: FRAME_WIDTHS.FLEX,
+  width: null,
   widthRatio: null,
+  wrap: null,
 };
 
 Frame.propTypes = {
@@ -103,6 +135,14 @@ Frame.propTypes = {
   borderRadius: PropTypes.oneOf(Object.values(Frame.BORDER_RADII)),
   direction: PropTypes.oneOf(Object.values(Frame.DIRECTIONS)),
   gap: PropTypes.oneOf(Object.values(Frame.GAPS)),
+  maxWidth: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(Object.values(Frame.WIDTHS)),
+  ]),
+  minWidth: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(Object.values(Frame.WIDTHS)),
+  ]),
   padding: PropTypes.oneOf(Object.values(Frame.PADDINGS)),
   tag: PropTypes.oneOfType([
     PropTypes.string,
@@ -113,4 +153,5 @@ Frame.propTypes = {
     PropTypes.oneOf(Object.values(Frame.WIDTHS)),
   ]),
   widthRatio: PropTypes.string,
+  wrap: PropTypes.oneOf(Object.values(Frame.WRAPS)),
 };

--- a/packages/sage-react/lib/themes/legacy/Frame/configs.js
+++ b/packages/sage-react/lib/themes/legacy/Frame/configs.js
@@ -54,4 +54,11 @@ export const FRAME_WIDTHS = {
   HUG: 'hug',
   FILL: 'fill',
   FLEX: 'flex',
+  INITIAL: 'initial',
+};
+
+// Keep in sync with `packages/sage-assets/lib/stylesheets/components/_frame.scss`
+export const FRAME_WRAPS = {
+  NONE: 'nowrap',
+  WRAP: 'wrap',
 };

--- a/packages/sage-react/lib/themes/next/Frame/Frame.jsx
+++ b/packages/sage-react/lib/themes/next/Frame/Frame.jsx
@@ -106,17 +106,17 @@ Frame.WIDTHS = FRAME_WIDTHS;
 Frame.WRAPS = FRAME_WRAPS;
 
 Frame.defaultProps = {
-  align: FRAME_ALIGNMENTS.TOP_LEFT,
-  background: 'transparent',
-  border: FRAME_BORDERS.NONE,
-  borderRadius: FRAME_BORDER_RADII.NONE,
+  align: null,
+  background: null,
+  border: null,
+  borderRadius: null,
   children: null,
   className: '',
   direction: FRAME_DIRECTIONS.VERTICAL,
   gap: FRAME_SPACINGS.MD,
   maxWidth: null,
   minWidth: null,
-  padding: FRAME_SPACINGS.NONE,
+  padding: null,
   tag: 'div',
   width: null,
   widthRatio: null,

--- a/packages/sage-react/lib/themes/next/Frame/Frame.jsx
+++ b/packages/sage-react/lib/themes/next/Frame/Frame.jsx
@@ -9,6 +9,7 @@ import {
   FRAME_DIRECTIONS,
   FRAME_SPACINGS,
   FRAME_WIDTHS,
+  FRAME_WRAPS,
 } from './configs';
 
 export const Frame = ({
@@ -20,36 +21,63 @@ export const Frame = ({
   borderRadius,
   direction,
   gap,
+  maxWidth,
+  minWidth,
   padding,
   tag,
   width,
   widthRatio,
+  wrap,
   ...rest
 }) => {
+  const Tag = tag;
+  const hasCustomBackground = background
+    && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
+  const hasCustomWidth = width
+    && !Object.values(FRAME_WIDTHS).includes(background);
+  const hasCustomMaxWidth = maxWidth
+    && !Object.values(FRAME_WIDTHS).includes(maxWidth);
+  const hasCustomMinWidth = minWidth
+    && !Object.values(FRAME_WIDTHS).includes(minWidth);
+
   const classNames = classnames(
     'sage-frame',
     className,
     {
       [`sage-frame--align-${align}`]: align,
-      [`sage-frame--background-${background}`]: background,
+      'sage-frame--background-custom': hasCustomBackground,
+      [`sage-frame--background-${background}`]: background && !hasCustomBackground,
       [`sage-frame--border-${border}`]: border,
       [`sage-frame--border-radius-${borderRadius}`]: borderRadius,
       [`sage-frame--direction-${direction}`]: direction,
       [`sage-frame--gap-${gap}`]: gap,
       [`sage-frame--padding-${padding}`]: padding,
-      [`sage-frame--width-${width}`]: width,
+      'sage-frame--width-custom': hasCustomWidth,
+      [`sage-frame--width-${width}`]: width && !hasCustomWidth,
+      'sage-frame--max-width-custom': hasCustomMaxWidth,
+      [`sage-frame--max-width-${maxWidth}`]: maxWidth && !hasCustomMaxWidth,
+      'sage-frame--min-width-custom': hasCustomMinWidth,
+      [`sage-frame--min-width-${minWidth}`]: minWidth && !hasCustomMinWidth,
+      [`sage-frame--wrap-${wrap}`]: wrap,
     }
   );
 
-  const Tag = tag;
+  const { style } = rest;
+  const styles = style || {};
 
-  const styles = {};
-
-  if (!Object.values(FRAME_WIDTHS).includes(width)) {
+  if (width && !Object.values(FRAME_WIDTHS).includes(width)) {
     styles['--sage-frame-width'] = width;
   }
 
-  if (!Object.values(SageTokens.COLOR_SLIDERS).includes(background)) {
+  if (hasCustomMaxWidth) {
+    styles['--sage-frame-max-width'] = maxWidth;
+  }
+
+  if (hasCustomMinWidth) {
+    styles['--sage-frame-min-width'] = minWidth;
+  }
+
+  if (hasCustomBackground) {
     styles['--sage-frame-background'] = background;
   }
 
@@ -60,8 +88,8 @@ export const Frame = ({
   return (
     <Tag
       className={classNames}
-      style={styles}
       {...rest}
+      style={styles}
     >
       {children}
     </Tag>
@@ -75,6 +103,7 @@ Frame.DIRECTIONS = FRAME_DIRECTIONS;
 Frame.GAPS = FRAME_SPACINGS;
 Frame.PADDINGS = FRAME_SPACINGS;
 Frame.WIDTHS = FRAME_WIDTHS;
+Frame.WRAPS = FRAME_WRAPS;
 
 Frame.defaultProps = {
   align: FRAME_ALIGNMENTS.TOP_LEFT,
@@ -85,10 +114,13 @@ Frame.defaultProps = {
   className: '',
   direction: FRAME_DIRECTIONS.VERTICAL,
   gap: FRAME_SPACINGS.MD,
+  maxWidth: null,
+  minWidth: null,
   padding: FRAME_SPACINGS.NONE,
   tag: 'div',
-  width: FRAME_WIDTHS.FLEX,
+  width: null,
   widthRatio: null,
+  wrap: null,
 };
 
 Frame.propTypes = {
@@ -103,6 +135,14 @@ Frame.propTypes = {
   borderRadius: PropTypes.oneOf(Object.values(Frame.BORDER_RADII)),
   direction: PropTypes.oneOf(Object.values(Frame.DIRECTIONS)),
   gap: PropTypes.oneOf(Object.values(Frame.GAPS)),
+  maxWidth: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(Object.values(Frame.WIDTHS)),
+  ]),
+  minWidth: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(Object.values(Frame.WIDTHS)),
+  ]),
   padding: PropTypes.oneOf(Object.values(Frame.PADDINGS)),
   tag: PropTypes.oneOfType([
     PropTypes.string,
@@ -113,4 +153,5 @@ Frame.propTypes = {
     PropTypes.oneOf(Object.values(Frame.WIDTHS)),
   ]),
   widthRatio: PropTypes.string,
+  wrap: PropTypes.oneOf(Object.values(Frame.WRAPS)),
 };

--- a/packages/sage-react/lib/themes/next/Frame/configs.js
+++ b/packages/sage-react/lib/themes/next/Frame/configs.js
@@ -54,4 +54,11 @@ export const FRAME_WIDTHS = {
   HUG: 'hug',
   FILL: 'fill',
   FLEX: 'flex',
+  INITIAL: 'initial',
+};
+
+// Keep in sync with `packages/sage-assets/lib/stylesheets/components/_frame.scss`
+export const FRAME_WRAPS = {
+  NONE: 'nowrap',
+  WRAP: 'wrap',
 };


### PR DESCRIPTION
## Description

This PR completes some tidying and enhancements to Frame:

- Reduce use of CSS custom props due to how these can bleed inwards and need many values overridden for every use
- Remove `[data-]` attributes due to little need for the use case
- Reduce amount of default configuration and remove mixin
- Add min-width, max-width, and wrap configuration options
- Add wrap options
- Add ability to provide additional local inline styles alongside built-in ones

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|


## Testing in `sage-lib`

- See http://localhost:4000/pages/layout/frame
- See http://localhost:4100/?path=/story/sage-frame--default
- See http://localhost:4110/?path=/story/sage-frame--default

## Testing in `kajabi-products`

1. (**LOW**) Improvements to Frame component.


## Related

[SAGE-580](https://kajabi.atlassian.net/browse/SAGE-580)
