### PR TITLE
Alert dismiss callback

### DIFF
--- a/docs/app/views/examples/components/themes/legacy/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/alert/_preview.html.erb
@@ -204,3 +204,18 @@
   icon_name: "sage-icon-danger",
   small: true,
 } %>
+
+<%= md("
+### Events
+
+Alerts emits a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
+You can listen for this event as it bubbles and respond as you see fit.
+", use_sage_type: true) %>
+
+<script>
+(function() {
+  window.addEventListener("sage.alert.dismiss", function (evt) {
+    console.log("local dismiss click", evt);
+  });
+})();
+</script>

--- a/docs/app/views/examples/components/themes/legacy/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/alert/_preview.html.erb
@@ -208,7 +208,7 @@
 <%= md("
 ### Events
 
-Alerts emits a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
+Alerts emit a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
 You can listen for this event as it bubbles and respond as you see fit.
 ", use_sage_type: true) %>
 

--- a/docs/app/views/examples/components/themes/legacy/alert/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/alert/_props.html.erb
@@ -80,3 +80,17 @@ Array<{
   <td><%= md('This area holds additional action links for the component. This should be used only if more than a primary and secondary button is needed. See properties `primary_action` and `secondary_action`.') %></td>
   <td colspan="2"><%= md('`link_to`(s)') %></td>
 </tr>
+<tr>
+  <td colspan="4">
+    <strong>Events</strong>
+  </td>
+</tr>
+<tr>
+  <td colspan="4">
+    <em>Global/window events</em>
+  </td>
+</tr>
+<tr>
+  <td><%= md('`sage.alert.dismiss`') %></td>
+  <td colspan="3"><%= md("Fires when an alert's dismiss button is clicked.") %></td>
+</tr>

--- a/docs/app/views/examples/components/themes/next/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/alert/_preview.html.erb
@@ -279,7 +279,7 @@
 <%= md("
 ### Events
 
-Alerts emits a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
+Alerts emit a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
 You can listen for this event as it bubbles and respond as you see fit.
 ", use_sage_type: true) %>
 

--- a/docs/app/views/examples/components/themes/next/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/alert/_preview.html.erb
@@ -275,3 +275,18 @@
   icon_name: "sage-icon-danger-filled",
   small: true,
 } %>
+
+<%= md("
+### Events
+
+Alerts emits a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
+You can listen for this event as it bubbles and respond as you see fit.
+", use_sage_type: true) %>
+
+<script>
+(function() {
+  window.addEventListener("sage.alert.dismiss", function (evt) {
+    console.log("local dismiss click", evt);
+  });
+})();
+</script>

--- a/docs/app/views/examples/components/themes/next/alert/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/alert/_props.html.erb
@@ -79,3 +79,17 @@ Array<{
   <td><%= md('This area holds additional action links for the component. This should be used only if more than a primary and secondary button is needed. See properties `primary_action` and `secondary_action`.') %></td>
   <td colspan="2"><%= md('`link_to`(s)') %></td>
 </tr>
+<tr>
+  <td colspan="4">
+    <strong>Events</strong>
+  </td>
+</tr>
+<tr>
+  <td colspan="4">
+    <em>Global/window events</em>
+  </td>
+</tr>
+<tr>
+  <td><%= md('`sage.alert.dismiss`') %></td>
+  <td colspan="3"><%= md("Fires when an alert's dismiss button is clicked.") %></td>
+</tr>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_alert.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_alert.html.erb
@@ -6,6 +6,7 @@
     <%= "sage-alert--small-dismissable" if component.small && component.dismissable %>
     <%= component.generated_css_classes %>
   "
+  data-js-alert="true"
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.icon_name %>
@@ -25,34 +26,34 @@
     <% end %>
   </div>
   <% if component.primary_action or component.secondary_actions or content_for? :sage_alert_actions %>
-      <div class="sage-alert__actions">
-        <% if component.primary_action %>
+    <div class="sage-alert__actions">
+      <% if component.primary_action %>
+        <%= sage_component SageButton, {
+          value: component.primary_action[:value],
+          test_id: component.primary_action[:test_id],
+          style: "secondary",
+          raised: false,
+          css_classes: "sage-alert__primary-action",
+          attributes: component.primary_action[:attributes]
+        } %>
+      <% end %>
+      <% if component.secondary_actions %>
+        <% component.secondary_actions.each do | secondary_action | %>
           <%= sage_component SageButton, {
-            value: component.primary_action[:value],
-            test_id: component.primary_action[:test_id],
+            value: secondary_action[:value],
+            test_id: secondary_action[:test_id],
             style: "secondary",
-            raised: false,
-            css_classes: "sage-alert__primary-action",
-            attributes: component.primary_action[:attributes]
+            subtle: true,
+            css_classes: "sage-alert__secondary-action",
+            attributes: secondary_action[:attributes]
           } %>
         <% end %>
-        <% if component.secondary_actions %>
-          <% component.secondary_actions.each do | secondary_action | %>
-            <%= sage_component SageButton, {
-              value: secondary_action[:value],
-              test_id: secondary_action[:test_id],
-              style: "secondary",
-              subtle: true,
-              css_classes: "sage-alert__secondary-action",
-              attributes: secondary_action[:attributes]
-            } %>
-          <% end %>
-        <% end %>
-        <% if content_for? :sage_alert_actions %>
-          <%= content_for :sage_alert_actions %>
-        <% end %>
-      </div>
-    <% end %>
+      <% end %>
+      <% if content_for? :sage_alert_actions %>
+        <%= content_for :sage_alert_actions %>
+      <% end %>
+    </div>
+  <% end %>
   <% if component.dismissable %>
     <div class="sage-alert__close">
       <%= sage_component SageButton, {

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_alert.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_alert.html.erb
@@ -6,6 +6,7 @@
     <%= "sage-alert--small-dismissable" if component.small && component.dismissable %>
     <%= component.generated_css_classes %>
   "
+  data-js-alert="true"
   <%= component.generated_html_attributes.html_safe %>
 >
   <% if component.icon_name %>
@@ -25,31 +26,31 @@
     <% end %>
   </div>
   <% if component.primary_action or component.secondary_actions or content_for? :sage_alert_actions %>
-      <div class="sage-alert__actions">
-        <% if component.primary_action %>
-          <%= sage_component SageButton, {
-            value: component.primary_action[:value],
-            test_id: component.primary_action[:test_id],
-            style: "primary",
-            css_classes: "sage-alert__primary-action sage-alert__primary-action--#{component.color}",
-            attributes: component.primary_action[:attributes]
+    <div class="sage-alert__actions">
+      <% if component.primary_action %>
+        <%= sage_component SageButton, {
+          value: component.primary_action[:value],
+          test_id: component.primary_action[:test_id],
+          style: "primary",
+          css_classes: "sage-alert__primary-action sage-alert__primary-action--#{component.color}",
+          attributes: component.primary_action[:attributes]
+        } %>
+      <% end %>
+      <% if component.secondary_actions %>
+        <% component.secondary_actions.each do | secondary_action | %>
+          <%= sage_component SageLink, {
+            label: secondary_action[:value],
+            show_label: true,
+            style: "secondary",
+            url: secondary_action[:url]
           } %>
         <% end %>
-        <% if component.secondary_actions %>
-          <% component.secondary_actions.each do | secondary_action | %>
-            <%= sage_component SageLink, {
-              label: secondary_action[:value],
-              show_label: true,
-              style: "secondary",
-              url: secondary_action[:url]
-            } %>
-          <% end %>
-        <% end %>
-        <% if content_for? :sage_alert_actions %>
-          <%= content_for :sage_alert_actions %>
-        <% end %>
-      </div>
-    <% end %>
+      <% end %>
+      <% if content_for? :sage_alert_actions %>
+        <%= content_for :sage_alert_actions %>
+      <% end %>
+    </div>
+  <% end %>
   <% if component.dismissable %>
     <div class="sage-alert__close">
       <%= sage_component SageButton, {

--- a/packages/sage-react/lib/themes/legacy/Alert/Alert.jsx
+++ b/packages/sage-react/lib/themes/legacy/Alert/Alert.jsx
@@ -13,7 +13,7 @@ export const Alert = ({
   description,
   dismissable,
   icon,
-  onClickDismiss,
+  onDismiss,
   small,
   title,
   titleAddon,
@@ -30,9 +30,9 @@ export const Alert = ({
     }
   );
 
-  const handleClickDismiss = () => {
+  const handleDismiss = () => {
     setSelfDismissed(true);
-    if (onClickDismiss) onClickDismiss();
+    if (onDismiss) onDismiss();
   };
 
   const renderIcon = () => {
@@ -97,7 +97,7 @@ export const Alert = ({
             small={true}
             subtle={true}
             value="Close"
-            onClick={handleClickDismiss}
+            onClick={handleDismiss}
             aria-label="Close Alert"
           />
         </div>
@@ -114,7 +114,7 @@ Alert.defaultProps = {
   description: null,
   dismissable: false,
   icon: null,
-  onClickDismiss: null,
+  onDismiss: null,
   small: false,
   title: null,
   titleAddon: null,
@@ -127,7 +127,7 @@ Alert.propTypes = {
   description: PropTypes.string,
   dismissable: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
-  onClickDismiss: PropTypes.func,
+  onDismiss: PropTypes.func,
   small: PropTypes.bool,
   title: PropTypes.string,
   titleAddon: PropTypes.string,

--- a/packages/sage-react/lib/themes/legacy/Alert/Alert.jsx
+++ b/packages/sage-react/lib/themes/legacy/Alert/Alert.jsx
@@ -13,9 +13,10 @@ export const Alert = ({
   description,
   dismissable,
   icon,
+  onClickDismiss,
+  small,
   title,
   titleAddon,
-  small,
   ...rest
 }) => {
   const [selfDismissed, setSelfDismissed] = useState(false);
@@ -29,8 +30,9 @@ export const Alert = ({
     }
   );
 
-  const onClickDismiss = () => {
+  const handleClickDismiss = () => {
     setSelfDismissed(true);
+    if (onClickDismiss) onClickDismiss();
   };
 
   const renderIcon = () => {
@@ -95,7 +97,7 @@ export const Alert = ({
             small={true}
             subtle={true}
             value="Close"
-            onClick={onClickDismiss}
+            onClick={handleClickDismiss}
             aria-label="Close Alert"
           />
         </div>
@@ -112,9 +114,10 @@ Alert.defaultProps = {
   description: null,
   dismissable: false,
   icon: null,
+  onClickDismiss: null,
+  small: false,
   title: null,
   titleAddon: null,
-  small: false,
 };
 
 Alert.propTypes = {
@@ -124,7 +127,8 @@ Alert.propTypes = {
   description: PropTypes.string,
   dismissable: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
+  onClickDismiss: PropTypes.func,
+  small: PropTypes.bool,
   title: PropTypes.string,
   titleAddon: PropTypes.string,
-  small: PropTypes.bool,
 };

--- a/packages/sage-react/lib/themes/legacy/Alert/Alert.spec.jsx
+++ b/packages/sage-react/lib/themes/legacy/Alert/Alert.spec.jsx
@@ -56,7 +56,7 @@ describe('Sage Alert', () => {
     expect(screen.getByRole('button'));
   });
 
-  it('renders icon a custom icon when provided', () => {
+  it('renders a custom icon when provided', () => {
     const defaultProps = {
       color: Alert.COLORS.DEFAULT,
       icon: 'pen',
@@ -79,7 +79,7 @@ describe('Sage Alert', () => {
     expect(actions).toHaveTextContent('Testing actions');
   });
 
-  it('dismisses the alert when closed', async () => {
+  it('dismisses the alert when dismissed', async () => {
     const props = {
       color: Alert.COLORS.DANGER,
       dismissable: true,
@@ -93,7 +93,7 @@ describe('Sage Alert', () => {
     expect(screen.queryByRole('button')).toBeFalsy();
   });
 
-  it('allows for a callback the alert when closed', async () => {
+  it('allows for a callback when the alert is dismissed', async () => {
     let callbackClicked = false;
     const props = {
       color: Alert.COLORS.DANGER,

--- a/packages/sage-react/lib/themes/legacy/Alert/Alert.spec.jsx
+++ b/packages/sage-react/lib/themes/legacy/Alert/Alert.spec.jsx
@@ -56,7 +56,30 @@ describe('Sage Alert', () => {
     expect(screen.getByRole('button'));
   });
 
-  it('dismisses the modal when closed', async () => {
+  it('renders icon a custom icon when provided', () => {
+    const defaultProps = {
+      color: Alert.COLORS.DEFAULT,
+      icon: 'pen',
+    };
+    setup(defaultProps);
+
+    const icon = document.querySelector('.sage-alert__icon');
+    expect(icon).toHaveClass('sage-icon-pen');
+  });
+
+  it('renders actions when provided', () => {
+    const defaultProps = {
+      color: Alert.COLORS.DEFAULT,
+      actions: (<p>Testing actions</p>),
+    };
+    setup(defaultProps);
+
+    const actions = document.querySelector('.sage-alert__actions');
+    expect(actions).toBeTruthy();
+    expect(actions).toHaveTextContent('Testing actions');
+  });
+
+  it('dismisses the alert when closed', async () => {
     const props = {
       color: Alert.COLORS.DANGER,
       dismissable: true,
@@ -68,5 +91,23 @@ describe('Sage Alert', () => {
     await user.click(screen.getByRole('button', { value: 'Close' }));
 
     expect(screen.queryByRole('button')).toBeFalsy();
+  });
+
+  it('allows for a callback the alert when closed', async () => {
+    let callbackClicked = false;
+    const props = {
+      color: Alert.COLORS.DANGER,
+      dismissable: true,
+      onDismiss: () => {
+        callbackClicked = true;
+      },
+    };
+
+    const user = userEvent.setup();
+    render(<Alert {...props} />);
+
+    await user.click(screen.getByRole('button', { value: 'Close' }));
+
+    expect(callbackClicked).toBeTruthy();
   });
 });

--- a/packages/sage-react/lib/themes/legacy/Alert/Alert.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Alert/Alert.story.jsx
@@ -15,6 +15,7 @@ export default {
     }),
   },
   args: {
+    color: Alert.COLORS.DEFAULT,
     title: "You've used 80% of available pages",
     titleAddon: '(# of # pages)',
   },
@@ -28,6 +29,7 @@ DismissableAlert.args = {
   description: 'Body duis rhoncus neque, sed nulla sed quis fames. Eu eu ut at odio ultrices orci varius habitant. Tempor vulputate in nisl massa eget id.',
   color: Alert.COLORS.DEFAULT,
   dismissable: true,
+  onClickDismiss: () => console.log('clicked to dismiss'), // eslint-disable-line
   actions: (
     <>
       <Button
@@ -91,4 +93,4 @@ SmallAlert.args = {
   small: true,
 };
 
-export const Accessible = () => <Alert>Accessible button</Alert>;
+export const Accessible = () => <Alert color={Alert.COLORS.DEFAULT}>Accessible button</Alert>;

--- a/packages/sage-react/lib/themes/next/Alert/Alert.jsx
+++ b/packages/sage-react/lib/themes/next/Alert/Alert.jsx
@@ -13,7 +13,7 @@ export const Alert = ({
   description,
   dismissable,
   icon,
-  onClickDismiss,
+  onDismiss,
   small,
   title,
   titleAddon,
@@ -30,9 +30,9 @@ export const Alert = ({
     }
   );
 
-  const handleClickDismiss = () => {
+  const handleDismiss = () => {
     setSelfDismissed(true);
-    if (onClickDismiss) onClickDismiss();
+    if (onDismiss) onDismiss();
   };
 
   const renderIcon = () => {
@@ -97,7 +97,7 @@ export const Alert = ({
             small={true}
             subtle={true}
             value="Close"
-            onClick={handleClickDismiss}
+            onClick={handleDismiss}
             aria-label="Close Alert"
           />
         </div>
@@ -114,7 +114,7 @@ Alert.defaultProps = {
   description: null,
   dismissable: false,
   icon: null,
-  onClickDismiss: null,
+  onDismiss: null,
   small: false,
   title: null,
   titleAddon: null,
@@ -127,7 +127,7 @@ Alert.propTypes = {
   description: PropTypes.string,
   dismissable: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
-  onClickDismiss: PropTypes.func,
+  onDismiss: PropTypes.func,
   small: PropTypes.bool,
   title: PropTypes.string,
   titleAddon: PropTypes.string,

--- a/packages/sage-react/lib/themes/next/Alert/Alert.jsx
+++ b/packages/sage-react/lib/themes/next/Alert/Alert.jsx
@@ -13,9 +13,10 @@ export const Alert = ({
   description,
   dismissable,
   icon,
+  onClickDismiss,
+  small,
   title,
   titleAddon,
-  small,
   ...rest
 }) => {
   const [selfDismissed, setSelfDismissed] = useState(false);
@@ -29,8 +30,9 @@ export const Alert = ({
     }
   );
 
-  const onClickDismiss = () => {
+  const handleClickDismiss = () => {
     setSelfDismissed(true);
+    if (onClickDismiss) onClickDismiss();
   };
 
   const renderIcon = () => {
@@ -95,7 +97,7 @@ export const Alert = ({
             small={true}
             subtle={true}
             value="Close"
-            onClick={onClickDismiss}
+            onClick={handleClickDismiss}
             aria-label="Close Alert"
           />
         </div>
@@ -112,9 +114,10 @@ Alert.defaultProps = {
   description: null,
   dismissable: false,
   icon: null,
+  onClickDismiss: null,
+  small: false,
   title: null,
   titleAddon: null,
-  small: false,
 };
 
 Alert.propTypes = {
@@ -124,7 +127,8 @@ Alert.propTypes = {
   description: PropTypes.string,
   dismissable: PropTypes.bool,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
+  onClickDismiss: PropTypes.func,
+  small: PropTypes.bool,
   title: PropTypes.string,
   titleAddon: PropTypes.string,
-  small: PropTypes.bool,
 };

--- a/packages/sage-react/lib/themes/next/Alert/Alert.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Alert/Alert.spec.jsx
@@ -57,6 +57,29 @@ describe('Sage Alert', () => {
     expect(screen.getByRole('button'));
   });
 
+  it('renders icon a custom icon when provided', () => {
+    const defaultProps = {
+      color: Alert.COLORS.DEFAULT,
+      icon: 'pen',
+    };
+    setup(defaultProps);
+
+    const icon = document.querySelector('.sage-alert__icon');
+    expect(icon).toHaveClass('sage-icon-pen');
+  });
+
+  it('renders actions when provided', () => {
+    const defaultProps = {
+      color: Alert.COLORS.DEFAULT,
+      actions: (<p>Testing actions</p>),
+    };
+    setup(defaultProps);
+
+    const actions = document.querySelector('.sage-alert__actions');
+    expect(actions).toBeTruthy();
+    expect(actions).toHaveTextContent('Testing actions');
+  });
+
   it('dismisses the modal when closed', async () => {
     const props = {
       color: Alert.COLORS.DANGER,
@@ -69,5 +92,23 @@ describe('Sage Alert', () => {
     await user.click(screen.getByRole('button', { value: 'Close' }));
 
     expect(screen.queryByRole('button')).toBeFalsy();
+  });
+
+  it('allows for a callback the alert when closed', async () => {
+    let callbackClicked = false;
+    const props = {
+      color: Alert.COLORS.DANGER,
+      dismissable: true,
+      onDismiss: () => {
+        callbackClicked = true;
+      },
+    };
+
+    const user = userEvent.setup();
+    render(<Alert {...props} />);
+
+    await user.click(screen.getByRole('button', { value: 'Close' }));
+
+    expect(callbackClicked).toBeTruthy();
   });
 });

--- a/packages/sage-react/lib/themes/next/Alert/Alert.spec.jsx
+++ b/packages/sage-react/lib/themes/next/Alert/Alert.spec.jsx
@@ -57,7 +57,7 @@ describe('Sage Alert', () => {
     expect(screen.getByRole('button'));
   });
 
-  it('renders icon a custom icon when provided', () => {
+  it('renders a custom icon when provided', () => {
     const defaultProps = {
       color: Alert.COLORS.DEFAULT,
       icon: 'pen',
@@ -80,7 +80,7 @@ describe('Sage Alert', () => {
     expect(actions).toHaveTextContent('Testing actions');
   });
 
-  it('dismisses the modal when closed', async () => {
+  it('dismisses the modal when dismissed', async () => {
     const props = {
       color: Alert.COLORS.DANGER,
       dismissable: true,
@@ -94,7 +94,7 @@ describe('Sage Alert', () => {
     expect(screen.queryByRole('button')).toBeFalsy();
   });
 
-  it('allows for a callback the alert when closed', async () => {
+  it('allows for a callback when the alert is dismissed', async () => {
     let callbackClicked = false;
     const props = {
       color: Alert.COLORS.DANGER,

--- a/packages/sage-react/lib/themes/next/Alert/Alert.story.jsx
+++ b/packages/sage-react/lib/themes/next/Alert/Alert.story.jsx
@@ -15,6 +15,7 @@ export default {
     }),
   },
   args: {
+    color: Alert.COLORS.DEFAULT,
     title: "You've used 80% of available pages",
     titleAddon: '(# of # pages)',
   },
@@ -27,6 +28,7 @@ DismissableAlert.args = {
   description: 'Body duis rhoncus neque, sed nulla sed quis fames. Eu eu ut at odio ultrices orci varius habitant. Tempor vulputate in nisl massa eget id.',
   color: Alert.COLORS.DEFAULT,
   dismissable: true,
+  onClickDismiss: () => console.log('clicked to dismiss'), // eslint-disable-line
   actions: (
     <>
       <Button
@@ -90,4 +92,4 @@ SmallAlert.args = {
   small: true,
 };
 
-export const Accessible = () => <Alert>Accessible button</Alert>;
+export const Accessible = () => <Alert color={Alert.COLORS.DEFAULT}>Accessible button</Alert>;

--- a/packages/sage-system/lib/alert.js
+++ b/packages/sage-system/lib/alert.js
@@ -1,34 +1,38 @@
-Sage.alert = (function () {
+Sage.alert = (() => {
   // ==================================================
   // Variables
   // ==================================================
 
-  const SELECTOR_ALERT = ".sage-alert";
-  const SELECTOR_ALERT_CLOSE = ".sage-alert__close";
-
-  var alertCloseBtns = document.querySelectorAll(SELECTOR_ALERT_CLOSE);
+  const CLASSNAME_ALERT = "sage-alert";
+  const CLASSNAME_ALERT_CLOSE = "sage-alert__close";
+  const EVENT_DISMISS_CLICK = "sage.alert.dismiss";
 
   // ==================================================
   // Functions
   // ==================================================
 
-  alertCloseBtns.forEach(function (btn) {
-    addCloseHandler(btn);
-  });
+  const init = (el) => {
+    if (!el) return;
 
-  function init(el) {
-    if (el) addCloseHandler(el);
-  }
+    el.addEventListener("click", handleClicks);
+  };
 
-  function addCloseHandler(el) {
-    var alert = el.closest(SELECTOR_ALERT);
-    var closeBtn = alert.querySelector(SELECTOR_ALERT_CLOSE);
-    closeBtn.addEventListener("click", function () {
+  const unbind = (el) => {
+    el.removeEventListener("click", handleClicks);
+  };
+
+  const handleClicks = (event) => {
+    const { target } = event;
+    
+    if (target.closest(`.${CLASSNAME_ALERT_CLOSE}`)) {
+      const alert = target.closest(`.${CLASSNAME_ALERT}`);
       alert.style.display = "none";
-    });
-  }
+      alert.dispatchEvent(new CustomEvent(EVENT_DISMISS_CLICK, { bubbles: true, detail: { alert, event }}));
+    }
+  };
 
   return {
-    init: init,
+    init,
+    unbind,
   };
 })();

--- a/packages/sage-system/lib/init.js
+++ b/packages/sage-system/lib/init.js
@@ -52,7 +52,7 @@ Sage.init = function(elementNamesToInitLegacy) {
   initDocumentPresenceListener('[data-js-banner], [data-js-toggle-banner]',      Sage.banner.init,        Sage.banner.unbind);
   initDocumentPresenceListener('[data-js-input-suffix], [data-js-input-prefix]', Sage.inputaffixes.init,  Sage.inputaffixes.unbind);
   initDocumentPresenceListener('[data-js-carousel]',                             Sage.carousel.init,      false);
-  initDocumentPresenceListener('[data-js-alert]', Sage.alert.init, false);
+  initDocumentPresenceListener('[data-js-alert]', Sage.alert.init, Sage.alert.unbind);
   initDocumentPresenceListener('[data-js-list-sortable]', Sage.sortableList.init, Sage.sortableList.unbind);
   initDocumentPresenceListener('[data-js-drawer-expand]', Sage.drawerExpandCollapse.initExpand, Sage.drawerExpandCollapse.unbindExpand);
   initDocumentPresenceListener('[data-js-drawer-collapse]', Sage.drawerExpandCollapse.initCollapse, Sage.drawerExpandCollapse.unbindCollapse);


### PR DESCRIPTION
## Description

This PR adds ability to respond externally when the dismiss button within Sage Alert is clicked.

- Rails version now issues  a custom event `sage.alert.dismiss`
- React allows a callback function to provided through `onClickDismiss`


## Testing in `sage-lib`

See http://localhost:4000/pages/component/alert
See http://localhost:4100/?path=/docs/sage-alert--dismissable-alert
See http://localhost:4110/?path=/docs/sage-alert--dismissable-alert

## Testing in `kajabi-products`

1. (**LOW**) Sage Alert now allows for responding to clicks on dismiss button.


## Related

[SAGE-655](https://kajabi.atlassian.net/browse/SAGE-655)
