### PR TITLE
[QINBOX-403] Empty State - page variation button alignment

### DIFF
--- a/docs/app/views/examples/components/themes/next/empty_state/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/empty_state/_preview.html.erb
@@ -41,17 +41,19 @@
     </p>
   <% end %>
   <% content_for :sage_empty_state_actions do %>
-    <%= sage_component SageButton, {
-      attributes: { href: "#" },
-      style: "primary",
-      value: "Create Email Campaigns",
-    } %>
-    <%= sage_component SageButton, {
-      attributes: { href: "#" },
-      style: "secondary",
-      subtle: true,
-      value: "Learn More",
-    } %>
+    <%= sage_component SageButtonGroup, { gap: :sm } do %>
+      <%= sage_component SageButton, {
+        attributes: { href: "#" },
+        style: "primary",
+        value: "Create Email Campaigns",
+      } %>
+      <%= sage_component SageButton, {
+        attributes: { href: "#" },
+        style: "secondary",
+        subtle: true,
+        value: "Learn More",
+      } %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_empty_state.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_empty_state.html.erb
@@ -35,7 +35,7 @@ end
         <%= component.title %>
       </<%= title_tag %>>
     <% end %>
-    
+
     <% if component.text.present? %>
       <p class="sage-empty-state__text">
         <%= component.text %>
@@ -50,9 +50,7 @@ end
 
     <% if content_for? :sage_empty_state_actions %>
       <div class="sage-empty-state__actions">
-        <%= sage_component SageButtonGroup, { gap: :sm } do %>
-          <%= content_for :sage_empty_state_actions %>
-        <% end %>
+        <%= content_for :sage_empty_state_actions %>
       </div>
     <% end %>
 

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
@@ -698,6 +698,12 @@ $-alert-colors: (
   @media screen and (min-width: sage-breakpoint(sm-min)) {
     flex-wrap: nowrap;
   }
+
+  .sage-empty-state & {
+    @media screen and (max-width: sage-breakpoint(lg-max)) {
+      justify-content: center;
+    }
+  }
 }
 
 .sage-btn-group--wrap {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -775,6 +775,12 @@ $-alert-colors: (
   @media screen and (min-width: sage-breakpoint(sm-min)) {
     flex-wrap: nowrap;
   }
+
+  .sage-empty-state--page & {
+    @media screen and (max-width: sage-breakpoint(lg-max)) {
+      justify-content: center;
+    }
+  }
 }
 
 @each $-key, $-value in $sage-spacings {

--- a/packages/sage-react/lib/themes/legacy/EmptyState/EmptyState.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/EmptyState/EmptyState.story.jsx
@@ -14,10 +14,10 @@ export default {
     })
   },
   args: {
-    children: (
-      <>
-        <Button>Lorem ipsum</Button>
-      </>
+    actions: (
+      <Button.Group gap={Button.Group.GAP_OPTIONS.SM}>
+        <Button>Add Email Campaign</Button>
+      </Button.Group>
     ),
     compact: false,
     icon: SageTokens.ICONS.GEAR,
@@ -45,7 +45,4 @@ PageScope.args = {
   title: 'Create your first Email Campaign',
   titleTag: 'h1',
   children: null,
-  actions: (
-    <Button>Add Email Campaign</Button>
-  )
 };

--- a/packages/sage-react/lib/themes/next/EmptyState/EmptyState.story.jsx
+++ b/packages/sage-react/lib/themes/next/EmptyState/EmptyState.story.jsx
@@ -14,11 +14,6 @@ export default {
     })
   },
   args: {
-    children: (
-      <>
-        <Button>Lorem ipsum</Button>
-      </>
-    ),
     actions: (
       <>
         <Button.Group gap={Button.Group.GAP_OPTIONS.SM}>

--- a/packages/sage-react/lib/themes/next/EmptyState/EmptyState.story.jsx
+++ b/packages/sage-react/lib/themes/next/EmptyState/EmptyState.story.jsx
@@ -19,6 +19,13 @@ export default {
         <Button>Lorem ipsum</Button>
       </>
     ),
+    actions: (
+      <>
+        <Button.Group gap={Button.Group.GAP_OPTIONS.SM}>
+          <Button>Lorem ipsum</Button>
+        </Button.Group>
+      </>
+    ),
     compact: false,
     icon: SageTokens.ICONS.GEAR,
     text: 'Text Here',


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] be sure that the page variation button alignment is centered on mobile displays and not left aligned

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![nextemptystatebefore](https://user-images.githubusercontent.com/1241836/172185805-1dea9041-39a8-4e2f-824b-e51c53e68b47.gif)|![nextemptystateafter](https://user-images.githubusercontent.com/1241836/172185828-8ef3549e-4c2a-4ad3-8731-d1120a51fe24.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Empty State views and verify that the actions for the page variation are center aligned on mobile:
- [Rails](http://localhost:4000/pages/component/empty_state)
- [React](http://localhost:4100/?path=/docs/sage-emptystate--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Updates the button alignment in the EmptyState actions slot.
   - [ ] Products -> Product -> Offers
   - [ ] Podcast -> Episode -> Offers


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Relates to [QINBOX-403](https://kajabi.atlassian.net/browse/QEINBOX-403)