### PR TITLE
PageHeading: Implement gap to separate items in toolbar and actions

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_button.scss
@@ -273,18 +273,6 @@ $-btn-loading-min-height: rem(36px);
     margin-top: sage-spacing(md);
   }
 
-  .sage-page-heading__actions & {
-    &:not(:last-child) {
-      margin-right: sage-spacing();
-    }
-  }
-
-  .sage-page-heading__toolbar & {
-    &:not(:last-child) {
-      margin-right: sage-spacing();
-    }
-  }
-
   .sage-sortable__item-actions & {
     &:not(:last-child) {
       margin-right: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_page_heading.scss
@@ -112,6 +112,7 @@ $-page-heading-image-height-mobile: rem(120px);
   display: flex;
   grid-area: toolbar;
   flex-wrap: wrap;
+  gap: sage-spacing();
   margin-top: sage-spacing(sm);
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`
@@ -124,6 +125,7 @@ $-page-heading-image-height-mobile: rem(120px);
 .sage-page-heading__actions-inner {
   display: flex;
   align-items: center;
+  gap: sage-spacing();
 
   @media (max-width: sage-breakpoint(sm-max)) {
     flex-wrap: wrap;

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -282,18 +282,6 @@ $-btn-loading-min-height: rem(36px);
     margin-top: sage-spacing(md);
   }
 
-  .sage-page-heading__actions & {
-    &:not(:last-child) {
-      margin-right: sage-spacing();
-    }
-  }
-
-  .sage-page-heading__toolbar & {
-    &:not(:last-child) {
-      margin-right: sage-spacing();
-    }
-  }
-
   .sage-sortable__item-actions & {
     &:not(:last-child) {
       margin-right: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_page_heading.scss
@@ -112,6 +112,7 @@ $-page-heading-image-height-mobile: rem(120px);
   display: flex;
   grid-area: toolbar;
   flex-wrap: wrap;
+  gap: sage-spacing();
   margin-top: sage-spacing();
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`
@@ -124,6 +125,7 @@ $-page-heading-image-height-mobile: rem(120px);
 .sage-page-heading__actions-inner {
   display: flex;
   align-items: center;
+  gap: sage-spacing();
 
   @media (max-width: sage-breakpoint(sm-max)) {
     flex-wrap: wrap;

--- a/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/themes/legacy/PageHeading/PageHeading.jsx
@@ -59,7 +59,9 @@ export const PageHeading = ({
     )}
     {actionItems && (
       <div className="sage-page-heading__actions">
-        {actionItems.map((action) => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
+        <div className="sage-page-heading__actions-inner">
+          {actionItems.map((action) => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
+        </div>
       </div>
     )}
     {secondaryText && (

--- a/packages/sage-react/lib/themes/next/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/themes/next/PageHeading/PageHeading.jsx
@@ -59,7 +59,9 @@ export const PageHeading = ({
     )}
     {actionItems && (
       <div className="sage-page-heading__actions">
-        {actionItems.map((action) => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
+        <div className="sage-page-heading__actions-inner">
+          {actionItems.map((action) => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
+        </div>
       </div>
     )}
     {secondaryText && (


### PR DESCRIPTION
## Description

This PR switches out margin set on buttons within actions and toolbar of PageHeading for `gap`. 

## Testing in `sage-lib`

See http://localhost:4000/pages/component/page_heading

## Testing in `kajabi-products`

1. (**LOW**) Adjust how spacing is set up for actions and toolbar within PageHeading. Kajabi/sage-lib/pull/1458 includes a non-breaking patch


## Related

[SAGE-658](https://kajabi.atlassian.net/browse/SAGE-658)
