### PR TITLE
Hero: Make CTA attributes optionally generate interactive button

### DIFF
--- a/docs/app/views/examples/components/themes/legacy/hero/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/hero/_preview.html.erb
@@ -1,60 +1,68 @@
+
 <h2 class="t-sage-heading-6">Small</h2>
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageHero, {
-    alt_text: "Well done alt text",
-    cta_attributes: {
-      "data-js-modaltrigger": "cool-modal",
-      href: "#",
-    },
-    description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-    image: "card-placeholder-sm.png",
-    size: "small",
-    title: "Be the first to try what Kajabi is building 1",
-  } %>
-<% end %>
+<%= sage_component SageHero, {
+  alt_text: "Well done alt text",
+  cta_attributes: {
+    "data-js-modaltrigger": "cool-modal",
+    href: "#",
+  },
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-sm.png",
+  size: "small",
+  title: "Be the first to try what Kajabi is building 1",
+} %>
+
+<h2 class="t-sage-heading-6">Small with no CTA</h2>
+<%= sage_component SageHero, {
+  alt_text: "Well done alt text",
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-sm.png",
+  size: "small",
+  title: "Be the first to try what Kajabi is building 1",
+} %>
 
 <h2 class="t-sage-heading-6">Large - with dismiss button</h2>
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageHero, {
-    alt_text: "",
-    cta_attributes: {
-      "data-js-modaltrigger": "cool-modal",
-      href: "#",
+<%= sage_component SageHero, {
+  alt_text: "",
+  cta_attributes: {
+    "data-js-modaltrigger": "cool-modal",
+    href: "#",
+  },
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-sm.png",
+  title: "Be the first to try what Kajabi is building 2",
+  title_tag: "h3",
+  button: sage_component(SageButton, {
+    subtle: true,
+    style: "secondary",
+    value: "Dismiss",
+    icon: {
+      name: "remove",
+      style: "left"
     },
-    description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-    image: "card-placeholder-sm.png",
-    title: "Be the first to try what Kajabi is building 2",
-    title_tag: "h3",
-    button: sage_component(SageButton, {
-      subtle: true,
-      style: "secondary",
-      value: "Dismiss",
-      icon: {
-        name: "remove",
-        style: "left"
-      },
-      attributes: {
-        "data-js-hero--dismiss": ""
-      }
-    })
-  } %>
-  <%= sage_component SageModal, { id: "cool-modal" } do %>
-    <header class="sage-modal__header">
-      <h1 class="t-sage-heading-4">Example Sage Modal</h1>
-      <aside class="sage-modal__header-aside">
-        <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
-          <span class="visually-hidden">Menu</span>
-        </button>
-      </aside>
-    </header>
-    <div class="sage-modal__content">
-      <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    </div>
-    <footer class="sage-modal__footer">
-      <aside class="sage-modal__footer-aside">
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
-      </aside>
-      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
-    </footer>
-  <% end %>
+    attributes: {
+      "data-js-hero--dismiss": ""
+    }
+  })
+} %>
+
+<%# Video player modal %>
+<%= sage_component SageModal, { id: "cool-modal" } do %>
+  <header class="sage-modal__header">
+    <h1 class="t-sage-heading-4">Example Sage Modal</h1>
+    <aside class="sage-modal__header-aside">
+      <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
+        <span class="visually-hidden">Menu</span>
+      </button>
+    </aside>
+  </header>
+  <div class="sage-modal__content">
+    <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+  </div>
+  <footer class="sage-modal__footer">
+    <aside class="sage-modal__footer-aside">
+      <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
+    </aside>
+    <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
+  </footer>
 <% end %>

--- a/docs/app/views/examples/components/themes/legacy/hero/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/hero/_props.html.erb
@@ -12,8 +12,8 @@
 </tr>
 <tr>
   <td><%= md('`cta_attributes`') %></td>
-  <td><%= md('Allows for adding attributes to the Hero CTA artwork') %></td>
-  <td><%= md('Array') %></td>
+  <td><%= md('Include this property in order to activate a "play button" action on the image. This property allows for adding attributes to the Hero CTA artwork.') %></td>
+  <td><%= md('Hash') %></td>
   <td><%= md('') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/components/themes/next/hero/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/hero/_preview.html.erb
@@ -1,77 +1,82 @@
 <h2 class="t-sage-heading-6">Small</h2>
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageHero, {
-    alt_text: "Well done alt text",
-    cta_attributes: {
-      "data-js-modaltrigger": "cool-modal",
-      href: "#",
-    },
-    description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-    image: "card-placeholder-hero.jpeg",
-    size: "small",
-    title: "Be the first to try what Kajabi is building 1",
-  } %>
-<% end %>
+<%= sage_component SageHero, {
+  alt_text: "Well done alt text",
+  cta_attributes: {
+    "data-js-modaltrigger": "cool-modal",
+    href: "#",
+  },
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-hero.jpeg",
+  size: "small",
+  title: "Be the first to try what Kajabi is building 1",
+} %>
+
+<h2 class="t-sage-heading-6">Small with no CTA</h2>
+<%= sage_component SageHero, {
+  alt_text: "Well done alt text",
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-hero.jpeg",
+  size: "small",
+  title: "Be the first to try what Kajabi is building 1",
+} %>
 
 <h2 class="t-sage-heading-6">Small - Borderless with Custom Background</h2>
-<%= sage_component SageCardBlock, {} do %>
-	<%= sage_component SageHero, {
-		alt_text: "Well done alt text",
-    borderless: true,
-		cta_attributes: {
-			"data-js-modaltrigger": "cool-modal",
-			href: "#",
-		},
-    custom_background_color: "#E6F4FE",
-		description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-		image: "card-placeholder-hero.jpeg",
-		size: "small",
-		title: "Be the first to try what Kajabi is building 1",
-	} %>
-<% end %>
+<%= sage_component SageHero, {
+  alt_text: "Well done alt text",
+  borderless: true,
+  cta_attributes: {
+    "data-js-modaltrigger": "cool-modal",
+    href: "#",
+  },
+  custom_background_color: "#E6F4FE",
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-hero.jpeg",
+  size: "small",
+  title: "Be the first to try what Kajabi is building 1",
+} %>
 
 <h2 class="t-sage-heading-6">Large - with dismiss button</h2>
-<%= sage_component SageCardBlock, {} do %>
-  <%= sage_component SageHero, {
-    alt_text: "",
-    cta_attributes: {
-      "data-js-modaltrigger": "cool-modal",
-      href: "#",
+<%= sage_component SageHero, {
+  alt_text: "",
+  cta_attributes: {
+    "data-js-modaltrigger": "cool-modal",
+    href: "#",
+  },
+  description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
+  image: "card-placeholder-hero.jpeg",
+  title: "Be the first to try what Kajabi is building 2",
+  title_tag: "h3",
+  button: sage_component(SageButton, {
+    subtle: true,
+    style: "secondary",
+    value: "Dismiss",
+    icon: {
+      name: "remove",
+      style: "left"
     },
-    description: "Get early access to new unreleased features and work along side our team by beta testing features before they go live.",
-    image: "card-placeholder-hero.jpeg",
-    title: "Be the first to try what Kajabi is building 2",
-    title_tag: "h3",
-    button: sage_component(SageButton, {
-      subtle: true,
-      style: "secondary",
-      value: "Dismiss",
-      icon: {
-        name: "remove",
-        style: "left"
-      },
-      attributes: {
-        "data-js-hero--dismiss": ""
-      }
-    })
-  } %>
-  <%= sage_component SageModal, { id: "cool-modal" } do %>
-    <header class="sage-modal__header">
-      <h1 class="t-sage-heading-4">Example Sage Modal</h1>
-      <aside class="sage-modal__header-aside">
-        <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
-          <span class="visually-hidden">Menu</span>
-        </button>
-      </aside>
-    </header>
-    <div class="sage-modal__content">
-      <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    </div>
-    <footer class="sage-modal__footer">
-      <aside class="sage-modal__footer-aside">
-        <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
-      </aside>
-      <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
-    </footer>
-  <% end %>
+    attributes: {
+      "data-js-hero--dismiss": ""
+    }
+  })
+} %>
+
+<%# Video player modal %>
+<%= sage_component SageModal, { id: "cool-modal" } do %>
+  <header class="sage-modal__header">
+    <h1 class="t-sage-heading-4">Example Sage Modal</h1>
+    <aside class="sage-modal__header-aside">
+      <button class="sage-btn sage-btn--secondary sage-btn--subtle sage-btn--icon-only-dot-menu-horizontal">
+        <span class="visually-hidden">Menu</span>
+      </button>
+    </aside>
+  </header>
+  <div class="sage-modal__content">
+    <p class="t-sage-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+  </div>
+  <footer class="sage-modal__footer">
+    <aside class="sage-modal__footer-aside">
+      <button class="sage-btn sage-btn--subtle sage-btn--secondary" data-js-modal-close>Close Modal</button>
+    </aside>
+    <button class="sage-btn sage-btn--primary sage-btn--icon-left-check">Take An Action</button>
+  </footer>
 <% end %>

--- a/docs/app/views/examples/components/themes/next/hero/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/hero/_props.html.erb
@@ -12,8 +12,8 @@
 </tr>
 <tr>
   <td><%= md('`cta_attributes`') %></td>
-  <td><%= md('Allows for adding attributes to the Hero CTA artwork') %></td>
-  <td><%= md('Array') %></td>
+  <td><%= md('Include this property in order to activate a "play button" action on the image. This property allows for adding attributes to the Hero CTA artwork.') %></td>
+  <td><%= md('Hash') %></td>
   <td><%= md('') %></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_hero.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_hero.html.erb
@@ -1,6 +1,17 @@
 <%
   html_tag = component.title_tag ? component.title_tag : "h2"
   size = component.size || "large"
+
+  image_options = {
+    alt: component.alt_text,
+    class: "sage-hero__artwork-image"
+  }.merge((component.alt_text.blank? ? { "aria-hidden": true } : {}))
+
+  artwork = %(
+    <span class="sage-hero__artwork-image-container">
+      #{image_tag(component.image, image_options)}
+    </span>
+  ).html_safe
 %>
 
 <article class="sage-hero sage-hero--<%= size %> <%= component.generated_css_classes %>" data-js-hero <%= component.generated_html_attributes.html_safe %>>
@@ -14,18 +25,18 @@
       <%= component.button.html_safe %>
     <% end %>
   </div>
-  <a
-    <% component.cta_attributes.each do |key, value| %>
-      <%= "#{key}='#{value}'".html_safe %>
-    <% end if component.cta_attributes&.is_a?(Hash) %>
-    class="sage-hero__artwork"
-  >
-    <span class="sage-hero__artwork-image-container">
-      <% image_options = {
-        alt: component.alt_text,
-        class: "sage-hero__artwork-image"
-      }.merge((component.alt_text.blank? ? { "aria-hidden": true } : {})) %>
-      <%= image_tag component.image, image_options %>
-    </span>
-  </a>
+  <% if component.cta_attributes.present? %>
+    <a
+      <% component.cta_attributes.each do |key, value| %>
+        <%= "#{key}='#{value}'".html_safe %>
+      <% end if component.cta_attributes&.is_a?(Hash) %>
+      class="sage-hero__artwork sage-hero__artwork--cta"
+    >
+      <%= artwork %>
+    </a>
+  <% else %>
+    <div class="sage-hero__artwork">
+      <%= artwork %>
+    </div>
+  <% end %>
 </article>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_hero.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_hero.html.erb
@@ -1,6 +1,17 @@
 <%
   html_tag = component.title_tag ? component.title_tag : "h2"
   size = component.size || "large"
+
+  image_options = {
+    alt: component.alt_text,
+    class: "sage-hero__artwork-image"
+  }.merge((component.alt_text.blank? ? { "aria-hidden": true } : {}))
+
+  artwork = %(
+    <span class="sage-hero__artwork-image-container">
+      #{image_tag(component.image, image_options)}
+    </span>
+  ).html_safe
 %>
 
 <article
@@ -27,18 +38,18 @@
       <%= component.button.html_safe %>
     <% end %>
   </div>
-  <a
-    <% component.cta_attributes.each do |key, value| %>
-      <%= "#{key}='#{value}'".html_safe %>
-    <% end if component.cta_attributes&.is_a?(Hash) %>
-    class="sage-hero__artwork"
-  >
-    <span class="sage-hero__artwork-image-container">
-      <% image_options = {
-        alt: component.alt_text,
-        class: "sage-hero__artwork-image"
-      }.merge((component.alt_text.blank? ? { "aria-hidden": true } : {})) %>
-      <%= image_tag component.image, image_options %>
-    </span>
-  </a>
+  <% if component.cta_attributes.present? %>
+    <a
+      <% component.cta_attributes.each do |key, value| %>
+        <%= "#{key}='#{value}'".html_safe %>
+      <% end if component.cta_attributes&.is_a?(Hash) %>
+      class="sage-hero__artwork sage-hero__artwork--cta"
+    >
+      <%= artwork %>
+    </a>
+  <% else %>
+    <div class="sage-hero__artwork">
+      <%= artwork %>
+    </div>
+  <% end %>
 </article>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_hero.scss
@@ -98,11 +98,9 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
     height: 0;
     padding-top: $-hero-mobile-aspect-ratio;
   }
+}
 
-  &:hover::after {
-    background-color: $-hero-play-icon-background-color-hover;
-  }
-
+.sage-hero__artwork--cta {
   &:focus {
     border: 3px solid sage-color(primary);
   }
@@ -125,29 +123,35 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   width: 100%;
   height: 100%;
 
-  &::before {
-    @include sage-icon-base(play);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: sage-z-index(default, 1);
-    align-items: center;
-    width: $-hero-icon-size;
-    font-size: $-hero-icon-size;
-    color: sage-color(primary, 300);
-  }
+  .sage-hero__artwork--cta & {
+    &::before {
+      @include sage-icon-base(play);
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      z-index: sage-z-index(default, 1);
+      align-items: center;
+      width: $-hero-icon-size;
+      font-size: $-hero-icon-size;
+      color: sage-color(primary, 300);
+    }
 
-  &::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: $-hero-artwork-size;
-    height: $-hero-artwork-size;
-    border-radius: 50%;
-    background-color: $-hero-play-icon-background-color;
-    transition: background-color 0.2s ease;
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: $-hero-artwork-size;
+      height: $-hero-artwork-size;
+      border-radius: 50%;
+      background-color: $-hero-play-icon-background-color;
+      transition: background-color 0.2s ease;
+    }
+
+    &:hover::after {
+      background-color: $-hero-play-icon-background-color-hover;
+    }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_hero.scss
@@ -19,7 +19,6 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   display: grid;
   grid-column-gap: sage-spacing(md);
   grid-row-gap: sage-spacing(sm);
-  overflow: hidden;
   min-height: $-hero-min-height;
   background-color: sage-color(white);
   border: sage-border();
@@ -91,16 +90,8 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   position: relative;
   overflow: hidden;
   outline: none;
-
-  &:focus {
-    border: rem(4px) solid sage-color(primary, 200);
-    border-top-right-radius: sage-spacing(sm);
-    border-bottom-right-radius: sage-spacing(sm);
-  }
-
-  &:hover::after {
-    background-color: $-hero-play-icon-background-color-hover;
-  }
+  border-top-right-radius: sage-spacing(sm);
+  border-bottom-right-radius: sage-spacing(sm);
 
   @media (min-width: sage-breakpoint(lg-max)) {
     .sage-hero--small & {
@@ -117,12 +108,16 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   @media (max-width: sage-breakpoint(sm-max)) {
     height: 0;
     padding-top: $-hero-mobile-aspect-ratio;
+    border-top-left-radius: sage-spacing(sm);
+    border-bottom-right-radius: 0;
+  }
+}
 
-    &:focus {
-      border-top-right-radius: sage-spacing(sm);
-      border-top-left-radius: sage-spacing(sm);
-      border-bottom-right-radius: 0;
-    }
+.sage-hero__artwork--cta {
+  @include sage-focus-ring;
+
+  &:focus {
+    @include sage-focus-outline--update-color(sage-color(primary, 200));
   }
 }
 
@@ -143,29 +138,35 @@ $-hero-play-icon-background-color-hover: rgba(sage-color(white, 100), 1);
   width: 100%;
   height: 100%;
 
-  &::before {
-    @include sage-icon-base(play);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: sage-z-index(default, 1);
-    align-items: center;
-    width: $-hero-icon-size;
-    font-size: $-hero-icon-size;
-    color: sage-color(primary, 200);
-  }
+  .sage-hero__artwork--cta & {
+    &::before {
+      @include sage-icon-base(play);
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      z-index: sage-z-index(default, 1);
+      align-items: center;
+      width: $-hero-icon-size;
+      font-size: $-hero-icon-size;
+      color: sage-color(primary, 200);
+    }
 
-  &::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: $-hero-artwork-size;
-    height: $-hero-artwork-size;
-    border-radius: 50%;
-    background-color: $-hero-play-icon-background-color;
-    transition: background-color 0.2s ease;
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: $-hero-artwork-size;
+      height: $-hero-artwork-size;
+      border-radius: 50%;
+      background-color: $-hero-play-icon-background-color;
+      transition: background-color 0.2s ease;
+    }
+
+    &:hover::after {
+      background-color: $-hero-play-icon-background-color-hover;
+    }
   }
 }

--- a/packages/sage-react/lib/themes/legacy/Hero/Hero.jsx
+++ b/packages/sage-react/lib/themes/legacy/Hero/Hero.jsx
@@ -25,6 +25,12 @@ export const Hero = ({
 
   const TitleTag = titleTag || 'h2';
 
+  const renderArtwork = (
+    <span className="sage-hero__artwork-image-container">
+      <img className="sage-hero__artwork-image" src={image.src} alt={image.alt || ''} />
+    </span>
+  );
+
   return (
     <article
       className={className}
@@ -58,12 +64,15 @@ export const Hero = ({
           )}
         </div>
       </div>
-      {/* TODO - hook up ctaAttributes */}
-      <a href="https://example.com" className="sage-hero__artwork">
-        <span className="sage-hero__artwork-image-container">
-          <img className="sage-hero__artwork-image" src={image.src} alt={image.alt || ''} />
-        </span>
-      </a>
+      {ctaAttributes ? (
+        <a className="sage-hero__artwork sage-hero__artwork--cta" {...ctaAttributes}>
+          {renderArtwork}
+        </a>
+      ) : (
+        <div className="sage-hero__artwork">
+          {renderArtwork}
+        </div>
+      )}
       {children}
     </article>
   );

--- a/packages/sage-react/lib/themes/next/Hero/Hero.jsx
+++ b/packages/sage-react/lib/themes/next/Hero/Hero.jsx
@@ -25,6 +25,12 @@ export const Hero = ({
 
   const TitleTag = titleTag || 'h2';
 
+  const renderArtwork = (
+    <span className="sage-hero__artwork-image-container">
+      <img className="sage-hero__artwork-image" src={image.src} alt={image.alt || ''} />
+    </span>
+  );
+
   return (
     <article
       className={className}
@@ -58,12 +64,15 @@ export const Hero = ({
           )}
         </div>
       </div>
-      {/* TODO - hook up ctaAttributes */}
-      <a href="https://example.com" className="sage-hero__artwork">
-        <span className="sage-hero__artwork-image-container">
-          <img className="sage-hero__artwork-image" src={image.src} alt={image.alt || ''} />
-        </span>
-      </a>
+      {ctaAttributes ? (
+        <a className="sage-hero__artwork sage-hero__artwork--cta" {...ctaAttributes}>
+          {renderArtwork}
+        </a>
+      ) : (
+        <div className="sage-hero__artwork">
+          {renderArtwork}
+        </div>
+      )}
       {children}
     </article>
   );


### PR DESCRIPTION
## Description

Aligning with latest spec, this PR adjusts Hero to allow both an interactive video CTA button on the artwork as well as just plain artwork based on the `cta_attributes` property.

Similar feature is added in React as well.

## Screenshots

![Screen Shot 2022-06-06 at 4 19 22 PM](https://user-images.githubusercontent.com/17955295/172264941-39702ce1-6487-46fb-943d-5f3a24c49645.png)

## Testing in `sage-lib`

See http://localhost:4000/pages/component/hero

## Testing in `kajabi-products`

1. (**LOW/MEDIUM/HIGH/BREAKING**) Make plain artwork possible within Hero (omit play button effect and CTA)

## Related

[SAGE-630](https://kajabi.atlassian.net/browse/SAGE-630)
