### PR TITLE
Tabs: Add gap and justify options to tabs

### DIFF
--- a/docs/app/views/examples/components/themes/legacy/tabs/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/tabs/_props.html.erb
@@ -5,6 +5,12 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between tabs.') %></td>
+  <td><%= md('[`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('Unique identifier for this tab set.') %></td>
   <td><%= md('String') %></td>
@@ -35,6 +41,12 @@ Array<{
 ') %>
   </td>
   <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`justify`') %></td>
+  <td><%= md('Sets the CSS `flex` justification for the tabs.') %></td>
+  <td><%= md('`"center"` | '`"end"` | '`"space-between"`') %></td>
+  <td><%= md('`nil` (start)') %></td>
 </tr>
 <tr>
   <td><%= md('`navigational`') %></td>

--- a/docs/app/views/examples/components/themes/next/tabs/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/tabs/_props.html.erb
@@ -5,6 +5,12 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`gap`') %></td>
+  <td><%= md('Adjusts the size of the gap between tabs.') %></td>
+  <td><%= md('[`:xs` | `:sm` | `:md` | `:lg`]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`id`') %></td>
   <td><%= md('Unique identifier for this tab set.') %></td>
   <td><%= md('String') %></td>
@@ -35,6 +41,12 @@ Array<{
 ') %>
   </td>
   <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`justify`') %></td>
+  <td><%= md('Sets the CSS `flex` justification for the tabs.') %></td>
+  <td><%= md('`"center"` | '`"end"` | '`"space-between"`') %></td>
+  <td><%= md('`nil` (start)') %></td>
 </tr>
 <tr>
   <td><%= md('`navigational`') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -1,8 +1,10 @@
 class SageTabs < SageComponent
   set_attribute_schema({
     align_items_center: [:optional, TrueClass],
+    gap: [:optional, NilClass, SageSchemas::GRID_GAP_OPTION],
     id: [:optional, String],
     items: [:optional, [[SageSchemas::CHOICE]], [[SageSchemas::TAB]]],
+    justify: [:optional, NilClass, Set.new(["center", "end", "space-between"])],
     navigational: [:optional, TrueClass],
     permalink: [:optional, TrueClass], # For Docs site use only.
     progressbar: [:optional, TrueClass],

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_tabs.html.erb
@@ -1,3 +1,6 @@
+<%
+gap = component.gap.present? ? component.gap : "sm"
+%>
 <nav
   <%= "data-js-tabs=#{component.id}" if !component.navigational && component.id.present? %>
   <%= "data-js-tabs-permalink=#{component.permalink}" if component.permalink.present? -%>
@@ -7,6 +10,8 @@
     <%= "sage-tabs--progressbar" if component.progressbar.present? && component.progressbar == true %>
     <%= "sage-tabs--align-items-center" if component.align_items_center.present? && component.align_items_center == true %>
     <%= "sage-tabs--choice" if component.style.present? && component.style === "choice" %>
+    <%= "sage-tabs--justify-#{component.justify}" if component.justify.present? %>
+    <%= "sage-grid-gap-#{component.gap}" if gap %>
     <%= component.generated_css_classes %>
   "
   role="tablist"

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_tabs.html.erb
@@ -1,3 +1,6 @@
+<%
+gap = component.gap.present? ? component.gap : "sm"
+%>
 <nav
   <%= "data-js-tabs=#{component.id}" if !component.navigational && component.id.present? %>
   <%= "data-js-tabs-permalink=#{component.permalink}" if component.permalink.present? -%>
@@ -7,6 +10,8 @@
     <%= "sage-tabs--progressbar" if component.progressbar.present? && component.progressbar == true %>
     <%= "sage-tabs--align-items-center" if component.align_items_center.present? && component.align_items_center == true %>
     <%= "sage-tabs--choice" if component.style.present? && component.style === "choice" %>
+    <%= "sage-tabs--justify-#{component.justify}" if component.justify.present? %>
+    <%= "sage-grid-gap-#{component.gap}" if gap %>
     <%= component.generated_css_classes %>
   "
   role="tablist"

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_choice.scss
@@ -101,10 +101,6 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     @media (max-width: sage-breakpoint(sm-max)) {
       margin-bottom: sage-spacing(sm);
     }
-
-    @media (min-width: sage-breakpoint(md-min)) {
-      margin-right: sage-spacing(sm);
-    }
   }
 
   .sage-tabs--align-items-center & {

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_tab.scss
@@ -72,16 +72,10 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
     }
   }
 
-  .sage-tabs &:not(:last-child) {
-    margin-right: sage-spacing(sm);
-  }
-
   .sage-tabs--progressbar & {
     overflow: visible;
 
     &:not(:last-child) {
-      margin-right: rem(40px);
-
       &::before {
         position: absolute;
         z-index: 2;

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_tabs.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_tabs.scss
@@ -26,6 +26,18 @@
   }
 }
 
+.sage-tabs--justify-center {
+  justify-content: center;
+}
+
+.sage-tabs--justify-end {
+  justify-content: flex-end;
+}
+
+.sage-tabs--justify-space-between {
+  justify-content: space-between;
+}
+
 .sage-tabs--with-background {
   padding-top: sage-spacing(sm);
   padding-left: sage-spacing(xs);
@@ -71,7 +83,6 @@
 
 .sage-tabs__list-item {
   position: relative;
-  margin-right: sage-spacing(sm);
 
   .sage-tab--active {
     background-color: sage-color(white);

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
@@ -96,10 +96,6 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     @media (max-width: sage-breakpoint(sm-max)) {
       margin-bottom: sage-spacing(sm);
     }
-
-    @media (min-width: sage-breakpoint(md-min)) {
-      margin-right: sage-spacing(sm);
-    }
   }
 
   .sage-tabs--align-items-center & {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_tab.scss
@@ -86,16 +86,10 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
     }
   }
 
-  .sage-tabs &:not(:last-child) {
-    margin-right: sage-spacing(md);
-  }
-
   .sage-tabs--progressbar & {
     overflow: visible;
 
     &:not(:last-child) {
-      margin-right: rem(40px);
-
       &::before {
         position: absolute;
         z-index: 2;

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_tabs.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_tabs.scss
@@ -22,6 +22,18 @@
   }
 }
 
+.sage-tabs--justify-center {
+  justify-content: center;
+}
+
+.sage-tabs--justify-end {
+  justify-content: flex-end;
+}
+
+.sage-tabs--justify-space-between {
+  justify-content: space-between;
+}
+
 .sage-tabs--with-background {
   padding-top: sage-spacing(sm);
   padding-left: sage-spacing(xs);
@@ -67,7 +79,6 @@
 
 .sage-tabs__list-item {
   position: relative;
-  margin-right: sage-spacing(sm);
 
   .sage-tab--active {
     background-color: sage-color(white);

--- a/packages/sage-react/lib/themes/legacy/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/themes/legacy/Tabs/Tabs.jsx
@@ -1,14 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { SageTokens } from '../configs';
 import { TabsItem } from './TabsItem';
 import { TabsPane } from './TabsPane';
-import { TAB_STYLES, TAB_LAYOUTS, tabsItemsPropTypes } from './configs';
+import {
+  TAB_STYLES,
+  TAB_LAYOUTS,
+  TAB_JUSTIFY_OPTIONS,
+  tabsItemsPropTypes,
+} from './configs';
 
 export const Tabs = ({
   alignItemsCenter,
   className,
+  gap,
   initialActiveId,
+  justify,
   onClickTab,
   onChangeTabsHook,
   panesClassName,
@@ -29,7 +37,9 @@ export const Tabs = ({
       'sage-tabs--align-items-center': tabStyle === TAB_STYLES.CHOICE && alignItemsCenter,
       'sage-tabs--choice': tabStyle === TAB_STYLES.CHOICE,
       [`sage-tabs--layout-${tabLayout}`]: tabLayout,
+      [`sage-tabs--justify-${justify}`]: justify,
       'sage-tabs--with-background': withBackground,
+      [`sage-grid-gap-${gap}`]: gap,
     },
   );
 
@@ -104,12 +114,15 @@ export const Tabs = ({
 Tabs.Item = TabsItem;
 Tabs.Pane = TabsPane;
 Tabs.itemsPropTypes = tabsItemsPropTypes;
+Tabs.JUSTIFY_OPTIONS = TAB_JUSTIFY_OPTIONS;
 Tabs.LAYOUTS = TAB_LAYOUTS;
 Tabs.STYLES = TAB_STYLES;
 
 Tabs.defaultProps = {
   alignItemsCenter: false,
   className: '',
+  gap: SageTokens.GRID_GAP_OPTIONS.SM,
+  justify: Tabs.JUSTIFY_OPTIONS.DEFAULT,
   initialActiveId: null,
   onChangeTabsHook: null,
   onClickTab: null,
@@ -124,7 +137,9 @@ Tabs.defaultProps = {
 Tabs.propTypes = {
   alignItemsCenter: PropTypes.bool,
   className: PropTypes.string,
+  gap: PropTypes.oneOf(Object.values(SageTokens.GRID_GAP_OPTIONS.SM)),
   initialActiveId: PropTypes.string,
+  justify: PropTypes.oneOf(Object.values(Tabs.JUSTIFY_OPTIONS)),
   onChangeTabsHook: PropTypes.func,
   onClickTab: PropTypes.func,
   panesClassName: PropTypes.string,

--- a/packages/sage-react/lib/themes/legacy/Tabs/configs.js
+++ b/packages/sage-react/lib/themes/legacy/Tabs/configs.js
@@ -13,6 +13,13 @@ export const CHOICE_ICON_ALIGNMENTS = {
   START: 'start',
 };
 
+export const TAB_JUSTIFY_OPTIONS = {
+  DEFAULT: null,
+  CENTER: 'center',
+  END: 'end',
+  SPACE_BETWEEN: 'space-between',
+};
+
 export const TAB_LAYOUTS = {
   DEFAULT: 'default',
   STACKED: 'stacked',

--- a/packages/sage-react/lib/themes/next/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/themes/next/Tabs/Tabs.jsx
@@ -1,14 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { SageTokens } from '../configs';
 import { TabsItem } from './TabsItem';
 import { TabsPane } from './TabsPane';
-import { TAB_STYLES, TAB_LAYOUTS, tabsItemsPropTypes } from './configs';
+import {
+  TAB_STYLES,
+  TAB_LAYOUTS,
+  TAB_JUSTIFY_OPTIONS,
+  tabsItemsPropTypes,
+} from './configs';
 
 export const Tabs = ({
   alignItemsCenter,
   className,
+  gap,
   initialActiveId,
+  justify,
   onClickTab,
   onChangeTabsHook,
   panesClassName,
@@ -29,7 +37,9 @@ export const Tabs = ({
       'sage-tabs--align-items-center': tabStyle === TAB_STYLES.CHOICE && alignItemsCenter,
       'sage-tabs--choice': tabStyle === TAB_STYLES.CHOICE,
       [`sage-tabs--layout-${tabLayout}`]: tabLayout,
+      [`sage-tabs--justify-${justify}`]: justify,
       'sage-tabs--with-background': withBackground,
+      [`sage-grid-gap-${gap}`]: gap,
     },
   );
 
@@ -104,13 +114,16 @@ export const Tabs = ({
 Tabs.Item = TabsItem;
 Tabs.Pane = TabsPane;
 Tabs.itemsPropTypes = tabsItemsPropTypes;
+Tabs.JUSTIFY_OPTIONS = TAB_JUSTIFY_OPTIONS;
 Tabs.LAYOUTS = TAB_LAYOUTS;
 Tabs.STYLES = TAB_STYLES;
 
 Tabs.defaultProps = {
   alignItemsCenter: false,
   className: '',
+  gap: SageTokens.GRID_GAP_OPTIONS.SM,
   initialActiveId: null,
+  justify: Tabs.JUSTIFY_OPTIONS.DEFAULT,
   onChangeTabsHook: null,
   onClickTab: null,
   panesClassName: null,
@@ -124,7 +137,9 @@ Tabs.defaultProps = {
 Tabs.propTypes = {
   alignItemsCenter: PropTypes.bool,
   className: PropTypes.string,
+  gap: PropTypes.oneOf(Object.values(SageTokens.GRID_GAP_OPTIONS.SM)),
   initialActiveId: PropTypes.string,
+  justify: PropTypes.oneOf(Object.values(Tabs.JUSTIFY_OPTIONS)),
   onChangeTabsHook: PropTypes.func,
   onClickTab: PropTypes.func,
   panesClassName: PropTypes.string,

--- a/packages/sage-react/lib/themes/next/Tabs/configs.js
+++ b/packages/sage-react/lib/themes/next/Tabs/configs.js
@@ -13,6 +13,13 @@ export const CHOICE_ICON_ALIGNMENTS = {
   START: 'start',
 };
 
+export const TAB_JUSTIFY_OPTIONS = {
+  DEFAULT: null,
+  CENTER: 'center',
+  END: 'end',
+  SPACE_BETWEEN: 'space-between',
+};
+
 export const TAB_LAYOUTS = {
   DEFAULT: 'default',
   STACKED: 'stacked',


### PR DESCRIPTION
## Description

This PR adds gap customization to Tabs and a justify configuration option.

## Testing in `sage-lib`

See http://localhost:4000/pages/component/tabs

## Testing in `kajabi-products`

1. (**LOW**) Adjust SageTabs to include customizable `gap` and justification settings.


## Related

[SAGE-628](https://kajabi.atlassian.net/browse/SAGE-628)
