### PR TITLE
Tabs: Fix console error for spacing settings

### DIFF
--- a/packages/sage-react/lib/themes/legacy/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/themes/legacy/Tabs/Tabs.jsx
@@ -60,6 +60,8 @@ export const Tabs = ({
           tabChoiceIconAlignment,
           tabChoiceType,
           subtext,
+          panelSpacing,
+          cardSpacing,
           ...rest
         }) => (
           <TabsItem

--- a/packages/sage-react/lib/themes/next/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/themes/next/Tabs/Tabs.jsx
@@ -60,6 +60,8 @@ export const Tabs = ({
           tabChoiceIconAlignment,
           tabChoiceType,
           subtext,
+          panelSpacing,
+          cardSpacing,
           ...rest
         }) => (
           <TabsItem


### PR DESCRIPTION
## Description

This PR cleans up the TabsItem map within React Tabs to ensure that `panelSpacing` and `cardSpacing` are not inadvertently passed down.

## Screenshots

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2022-06-06 at 4 45 24 PM](https://user-images.githubusercontent.com/17955295/172267116-b93c03c8-bfa1-4a0c-ada2-1e7ccc725b23.png) | No error |



## Testing in `sage-lib`

See http://localhost:4110/?path=/story/sage-tabs--default
See http://localhost:4100/?path=/story/sage-tabs--default


## Testing in `kajabi-products`

1. (**LOW**) Fixes a console error appearing on React Tabs when passing down `panelSpacing` or `cardSpacing` to TabsItems.


## Related

[SAGE-422](https://kajabi.atlassian.net/browse/SAGE-422)
