### PR TITLE
Select: Ensure arrow does not overlap text

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_form_select.scss
@@ -19,6 +19,7 @@ $-select-filled-top-padding: rem(4.4px);
 $-select-height: rem(40px);
 $-select-padding-x: sage-spacing(sm);
 $-select-padding-label: sage-spacing(2xs);
+$-select-arrow-icon-width: map-get($sage-icon-sizes, md);
 
 
 .sage-select {
@@ -69,7 +70,7 @@ $-select-padding-label: sage-spacing(2xs);
 
   position: relative;
   height: $-select-height;
-  padding: 0 $-select-padding-x 0;
+  padding: 0 ($-select-padding-x + $-select-arrow-icon-width + rem(4px)) 0 $-select-padding-x;
   color: transparent;
   outline: none;
   transition: border map-get($sage-transitions, default);

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_form_select.scss
@@ -18,6 +18,7 @@ $-select-height: rem(40px);
 $-select-padding-x: sage-spacing(sm);
 $-select-margin-label: rem(6px);
 $-select-arrow-font-size: rem(16px);
+$-select-arrow-icon-width: map-get($sage-icon-sizes, md);
 $-select-arrow-position: calc(100% - #{$-select-height});
 $-select-arrow-position-inverse: calc(100% - #{$-select-arrow-font-size + $-select-margin-label});
 $-select-arrow-position-with-message: calc(100% - #{$-select-height + $-select-arrow-font-size});
@@ -66,7 +67,7 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
   grid-area: field;
   position: relative;
   height: $-select-height;
-  padding: 0 $-select-padding-x 0;
+  padding: 0 ($-select-padding-x + $-select-arrow-icon-width + rem(4px)) 0 $-select-padding-x;
   outline: none;
   transition: border map-get($sage-transitions, default);
   cursor: pointer;


### PR DESCRIPTION
## Description

This PR adjusts Select so that longer selected values are not covered by the arrow icon.


## Screenshots

|  Before  |  After  |
|--------|--------|
| ![Screen Shot 2022-06-07 at 10 45 02 AM](https://user-images.githubusercontent.com/17955295/172448605-e6149811-ae95-47af-bb6e-79383113da96.png) | ![Screen Shot 2022-06-07 at 10 46 54 AM](https://user-images.githubusercontent.com/17955295/172448701-4fd681e2-4e4d-42da-b1f3-b8ddf21083c6.png) |



## Testing in `sage-lib`

See http://localhost:4000/pages/component/form_select?sage_theme=sage_theme_next

## Testing in `kajabi-products`

1. (**LOW/MEDIUM/HIGH/BREAKING**) Fix how Select arrow icon overlaps with long selected values.


## Related

[SAGE-543](https://kajabi.atlassian.net/browse/SAGE-543)
