### PR TITLE
Adds fallback graphic to replace removed initials in Avatar (Next)

### DIFF
--- a/packages/sage-react/lib/themes/next/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/themes/next/Avatar/Avatar.jsx
@@ -10,6 +10,7 @@ export const Avatar = ({
   centered,
   color,
   image,
+  useFallbackGraphic,
   size,
   ...rest
 }) => {
@@ -62,11 +63,11 @@ export const Avatar = ({
           />
         </div>
       )}
-      {(!image.src) && (
-        <svg className="sage-avatar__graphic" viewBox="0 0 28 28"><path fillRule="evenodd" clipRule="evenodd" d="M19.038 14.594a8.167 8.167 0 1 0-10.077 0C3.767 16.236 0 21.094 0 26.834a1.167 1.167 0 1 0 2.333 0c0-5.8 4.701-10.5 10.5-10.5h2.334c5.799 0 10.5 4.7 10.5 10.5a1.167 1.167 0 1 0 2.333 0c0-5.74-3.766-10.598-8.962-12.24ZM8.167 8.167a5.833 5.833 0 1 1 11.666 0 5.833 5.833 0 0 1-11.666 0Z" fill="#054FB8" /></svg>
-      )}
       {image.src && (
         <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
+      )}
+      {(!image.src || useFallbackGraphic) && (
+        <svg className="sage-avatar__graphic" viewBox="0 0 28 28"><path fillRule="evenodd" clipRule="evenodd" d="M19.038 14.594a8.167 8.167 0 1 0-10.077 0C3.767 16.236 0 21.094 0 26.834a1.167 1.167 0 1 0 2.333 0c0-5.8 4.701-10.5 10.5-10.5h2.334c5.799 0 10.5 4.7 10.5 10.5a1.167 1.167 0 1 0 2.333 0c0-5.74-3.766-10.598-8.962-12.24ZM8.167 8.167a5.833 5.833 0 1 1 11.666 0 5.833 5.833 0 0 1-11.666 0Z" fill="#054FB8" /></svg>
       )}
     </div>
   );
@@ -81,6 +82,7 @@ Avatar.defaultProps = {
   color: AVATAR_COLORS.DEFAULT,
   image: {},
   size: null,
+  useFallbackGraphic: true,
 };
 
 Avatar.propTypes = {
@@ -94,4 +96,5 @@ Avatar.propTypes = {
     id: PropTypes.string
   }),
   size: PropTypes.string,
+  useFallbackGraphic: PropTypes.bool,
 };


### PR DESCRIPTION
## Description
React avatar is not loading the default icon when an image is not present.
These updates bring back the check and display the avatar if there is no image.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![3c3ce3fb-12d8-4642-967e-6e778f79fcbc](https://user-images.githubusercontent.com/1175111/172498082-b16759af-6e59-4a64-9b9e-e9382e87f5dd.png)|![Screen Shot 2022-06-07 at 4 04 53 PM](https://user-images.githubusercontent.com/1175111/172498140-2ad0c342-4778-4c4a-98d3-3c42c77cdba2.png)|

## Testing in `sage-lib`
Navigate to http://localhost:4110/?path=/story/sage-avatar--default
Verify default icon displays.

## Testing in `kajabi-products`
1. (**LOW**) Brings default avatar icon to sage_next avatar when no image present.
   - [ ] People page.

## Related
https://kajabi.atlassian.net/browse/QEINBOX-403