### PR TITLE
[SAGE-671] Proof of Concept - :has integration 

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_catalog_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_catalog_item.html.erb
@@ -2,6 +2,7 @@
 <% link_tag = is_loading ? "div" : "a" %>
 <li class="
   sage-catalog-item
+  <%# UXD TODO - remove .sage-catalog-item--loading, .sage-catalog-item--img, .sage-catalog-item--icon when we move forward with :has integration %>
   <%= "sage-catalog-item--loading" if is_loading %>
   <%= "sage-catalog-item--img" if component.image.present? %>
   <%= "sage-catalog-item--icon" if component.icon.present? %>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/core/mixins/_utilities.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/core/mixins/_utilities.scss
@@ -43,7 +43,7 @@
 
 ///
 /// Generates cross-browser icon rotations
-/// 
+///
 /// @param {number} $degrees Degrees value
 /// @param {number} $rotation Rotation value
 ///
@@ -54,7 +54,7 @@
 
 ///
 /// Generates cross-browser icon flip in either axis
-/// 
+///
 /// @param {number} $horiz Whether or not to flip on the horizontal axis
 /// @param {number} $vert Whether or not to flip on the vertical axis
 /// @param {number} $rotation Rotation value

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
@@ -67,18 +67,18 @@ $-catalogue-item-image-height-mobile: rem(120px);
     }
   }
 
-  // @supports not (-webkit-appearance:none) {
-    &.sage-catalog-item--icon {
+  @include supports-has() {
+    &:has(.sage-catalog-item__icon) {
       grid-template-columns: min-content 1fr min-content;
       grid-template-rows: auto auto auto;
       grid-template-areas:
         "icon title aside"
         "icon content aside";
     }
-  // }
+  }
 
-  @supports (-webkit-appearance:none) {
-    &:has(.sage-catalog-item__icon) {
+  @include supports-has($value: false) {
+    &.sage-catalog-item--icon {
       grid-template-columns: min-content 1fr min-content;
       grid-template-rows: auto auto auto;
       grid-template-areas:

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
@@ -67,12 +67,24 @@ $-catalogue-item-image-height-mobile: rem(120px);
     }
   }
 
-  &.sage-catalog-item--icon {
-    grid-template-columns: min-content 1fr min-content;
-    grid-template-rows: auto auto auto;
-    grid-template-areas:
-      "icon title aside"
-      "icon content aside";
+  @supports not (-webkit-appearance:none) {
+    &.sage-catalog-item--icon {
+      grid-template-columns: min-content 1fr min-content;
+      grid-template-rows: auto auto auto;
+      grid-template-areas:
+        "icon title aside"
+        "icon content aside";
+    }
+  }
+
+  @supports (-webkit-appearance:none) {
+    &:has(.sage-catalog-item__icon) {
+      grid-template-columns: min-content 1fr min-content;
+      grid-template-rows: auto auto auto;
+      grid-template-areas:
+        "icon title aside"
+        "icon content aside";
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_catalog_item.scss
@@ -67,7 +67,7 @@ $-catalogue-item-image-height-mobile: rem(120px);
     }
   }
 
-  @supports not (-webkit-appearance:none) {
+  // @supports not (-webkit-appearance:none) {
     &.sage-catalog-item--icon {
       grid-template-columns: min-content 1fr min-content;
       grid-template-rows: auto auto auto;
@@ -75,7 +75,7 @@ $-catalogue-item-image-height-mobile: rem(120px);
         "icon title aside"
         "icon content aside";
     }
-  }
+  // }
 
   @supports (-webkit-appearance:none) {
     &:has(.sage-catalog-item__icon) {

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_utilities.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_utilities.scss
@@ -191,7 +191,7 @@
 
 @mixin supports-has($value: true) {
   @if $value {
-    /* tests for browsers that support the :has pseudo selector */
+    /* tests for browsers that support the :has pseudo selector. */
     @supports selector(a) {
       @content;
     }

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_utilities.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_utilities.scss
@@ -43,7 +43,7 @@
 
 ///
 /// Generates cross-browser icon rotations
-/// 
+///
 /// @param {number} $degrees Degrees value
 /// @param {number} $rotation Rotation value
 ///
@@ -54,7 +54,7 @@
 
 ///
 /// Generates cross-browser icon flip in either axis
-/// 
+///
 /// @param {number} $horiz Whether or not to flip on the horizontal axis
 /// @param {number} $vert Whether or not to flip on the vertical axis
 /// @param {number} $rotation Rotation value
@@ -184,6 +184,22 @@
 @mixin target-safari-13-and-below {
   @supports (-webkit-marquee-repetition:infinite) and (object-fit:fill) {
     @supports (-webkit-appearance:none) {
+      @content;
+    }
+  }
+}
+
+@mixin supports-has($value: true) {
+  @if $value {
+    /* tests for browsers that support the :has pseudo selector */
+    @supports selector(a) {
+      @content;
+    }
+  }
+
+  @else {
+    // tests for browsers that do not support the :has pseudo selector
+    @supports (contain: paint) {
       @content;
     }
   }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [ ] implement `:has` pseudo selector into the code base
- [ ] set patterns for how we will plan future removal of unnecessary props

## Screenshots
#### Safari
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Safari  |  Chrome  |
|--------|--------|
|![Screen_Shot_2022-06-14_at_4_23_12_PM](https://user-images.githubusercontent.com/1241836/173691806-f5c9d146-e0c5-42e7-b41b-921273a89522.png)|![Screen_Shot_2022-06-14_at_4_13_39_PM](https://user-images.githubusercontent.com/1241836/173691821-7444ecfe-7169-476a-bf97-aec55ec8a878.png)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
 There should be no visual change. The goal is to future proof further implementation while progressively enhancing unsupported browsers

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Adds `:has` integrated to all components. Requires Full Audit as there should be no visual change

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Related to [SAGE-671](https://kajabi.atlassian.net/browse/SAGE-671)