### PR TITLE
[SAGE-685] Foundations: add tokens and vars for additional border states

### DIFF
--- a/docs/lib/sage-frontend/stylesheets/docs/themes/next/_token.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/themes/next/_token.scss
@@ -32,6 +32,14 @@
       content: "#{$token}";
     }
   }
+  &-border-interactive::after {
+    content: "#{sage-border-interactive()}";
+  }
+  @each $name, $token in $sage-borders-interactive {
+    &-border-interactive-#{$name}::after {
+      content: "#{$token}";
+    }
+  }
   &-breakpoint::after {
     content: "#{sage-breakpoint()}";
   }

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
@@ -37,9 +37,10 @@ $sage-border-styles: (
   default: 0 0 0 1px sage-color(grey, 400),
   hover: 0 0 0 1px sage-color(grey, 500),
   focus: 0 0 0 4px sage-color(primary, 200),
-  active-hover: 0 0 0 4px sage-color(charcoal, 400),
-  error: 0 0 0 1px sage-color(red, 400),
+  selected: 0 0 0 4px sage-color(charcoal, 400),
+  error: 0 0 0 1px sage-color(red, 300),
   error-focus: 0 0 0 4px sage-color(red, 300),
+  disabled: 0 0 0 1px sage-color(grey, 300),
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
@@ -31,19 +31,6 @@ $sage-banner-heights: (
 );
 
 ///
-/// Sage border styles as box-shadows
-///
-$sage-border-styles: (
-  default: 0 0 0 1px sage-color(grey, 400),
-  hover: 0 0 0 1px sage-color(grey, 500),
-  focus: 0 0 0 4px sage-color(primary, 200),
-  selected: 0 0 0 4px sage-color(charcoal, 400),
-  error: 0 0 0 1px sage-color(red, 300),
-  error-focus: 0 0 0 4px sage-color(red, 300),
-  disabled: 0 0 0 1px sage-color(grey, 300),
-);
-
-///
 /// Field configurations
 ///
 $sage-field-configs: (

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/_variables.scss
@@ -31,6 +31,18 @@ $sage-banner-heights: (
 );
 
 ///
+/// Sage border styles as box-shadows
+///
+$sage-border-styles: (
+  default: 0 0 0 1px sage-color(grey, 400),
+  hover: 0 0 0 1px sage-color(grey, 500),
+  focus: 0 0 0 4px sage-color(primary, 200),
+  active-hover: 0 0 0 4px sage-color(charcoal, 400),
+  error: 0 0 0 1px sage-color(red, 400),
+  error-focus: 0 0 0 4px sage-color(red, 300),
+);
+
+///
 /// Field configurations
 ///
 $sage-field-configs: (

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -375,7 +375,7 @@
   padding: sage-spacing(sm);
   color: sage-color(charcoal, 200);
   appearance: none;
-  border: rem(1px) solid sage-color(grey, 500);
+  border: sage-border(interactive);
   border-radius: sage-border(radius-medium);
   background: transparent;
   transition: map-get($sage-transitions, input);
@@ -387,16 +387,16 @@
 
   &:hover:not(:disabled) {
     color: sage-color(charcoal, 400);
-    border-color: sage-color(charcoal, 100);
+    border: sage-border(interactive-hover);
 
     .sage-form-field--error & {
-      border-color: sage-color(red, 300);
+      border: sage-border(error);
     }
   }
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    border-color: sage-color(primary, 200);
+    border-color: transparent; /* further discovery */
 
     @include placeholder {
       opacity: 0;
@@ -442,7 +442,7 @@
   .sage-form-field--error &:required:not(:placeholder-shown):not(:valid) {
     @include sage-focus-ring(sage-color(red, 200));
 
-    border-color: sage-color(red, 300);
+    border: sage-border(error);
 
     ~ label {
       color: sage-color(charcoal, 400);
@@ -453,6 +453,10 @@
     &,
     ~ label {
       transition: none !important; /* stylelint-disable-line declaration-no-important */
+    }
+
+    &:focus {
+      border-color: transparent;
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -375,7 +375,8 @@
   padding: sage-spacing(sm);
   color: sage-color(charcoal, 200);
   appearance: none;
-  border: sage-border(interactive);
+  box-shadow: map-get($sage-border-styles, default);
+  border: 0;
   border-radius: sage-border(radius-medium);
   background: transparent;
   transition: map-get($sage-transitions, input);
@@ -387,17 +388,15 @@
 
   &:hover:not(:disabled) {
     color: sage-color(charcoal, 400);
-    border: sage-border(interactive-hover);
+    box-shadow: map-get($sage-border-styles, hover);
 
     .sage-form-field--error & {
-      border: sage-border(error);
+      box-shadow: map-get($sage-border-styles, error);
     }
   }
 
   &:focus:not(:disabled),
   &:active:not(:disabled) {
-    border-color: transparent; /* further discovery */
-
     @include placeholder {
       opacity: 0;
     }
@@ -414,6 +413,7 @@
   &:disabled {
     color: sage-color(grey, 500);
     background-color: sage-color(grey, 100);
+    box-shadow: map-get($sage-border-styles, disabled);
     cursor: not-allowed;
     resize: none;
 
@@ -442,10 +442,14 @@
   .sage-form-field--error &:required:not(:placeholder-shown):not(:valid) {
     @include sage-focus-ring(sage-color(red, 200));
 
-    border: sage-border(error);
+    box-shadow: map-get($sage-border-styles, error);
 
     ~ label {
       color: sage-color(charcoal, 400);
+    }
+
+    &:hover:not(:disabled) {
+      box-shadow: map-get($sage-border-styles, error);
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -375,7 +375,7 @@
   padding: sage-spacing(sm);
   color: sage-color(charcoal, 200);
   appearance: none;
-  box-shadow: map-get($sage-border-styles, default);
+  box-shadow: sage-border-interactive(default);
   border: 0;
   border-radius: sage-border(radius-medium);
   background: transparent;
@@ -388,10 +388,10 @@
 
   &:hover:not(:disabled) {
     color: sage-color(charcoal, 400);
-    box-shadow: map-get($sage-border-styles, hover);
+    box-shadow: sage-border-interactive(hover);
 
     .sage-form-field--error & {
-      box-shadow: map-get($sage-border-styles, error);
+      box-shadow: sage-border-interactive(error);
     }
   }
 
@@ -413,7 +413,7 @@
   &:disabled {
     color: sage-color(grey, 500);
     background-color: sage-color(grey, 100);
-    box-shadow: map-get($sage-border-styles, disabled);
+    box-shadow: sage-border-interactive(disabled);
     cursor: not-allowed;
     resize: none;
 
@@ -442,14 +442,14 @@
   .sage-form-field--error &:required:not(:placeholder-shown):not(:valid) {
     @include sage-focus-ring(sage-color(red, 200));
 
-    box-shadow: map-get($sage-border-styles, error);
+    box-shadow: sage-border-interactive(error);
 
     ~ label {
       color: sage-color(charcoal, 400);
     }
 
     &:hover:not(:disabled) {
-      box-shadow: map-get($sage-border-styles, error);
+      box-shadow: sage-border-interactive(error);
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_border.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_border.scss
@@ -9,8 +9,10 @@
 /// Sage borders token
 ///
 $sage-borders: (
-  light: rem(1px) solid sage-color(grey, 300), /* TODO UXD - quinton remove in followup  */
   default: rem(1px) solid sage-color(grey, 300),
+  error: rem(1px) solid sage-color(red, 300),
+  interactive: rem(1px) solid sage-color(grey, 400),
+  interactive-hover: rem(1px) solid sage-color(grey, 500),
   radius-small: rem(4px),
   radius: rem(8px),
   radius-medium: rem(10px),

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_border_interactive.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_border_interactive.scss
@@ -1,0 +1,29 @@
+////
+/// Sage border interactive tokens
+///
+/// @group sage
+////
+
+
+///
+/// Sage borders interactive token
+///
+$sage-borders-interactive: (
+  default: 0 0 0 1px sage-color(grey, 400),
+  hover: 0 0 0 1px sage-color(grey, 500),
+  focus: 0 0 0 4px sage-color(primary, 200),
+  selected: 0 0 0 4px sage-color(charcoal, 400),
+  error: 0 0 0 1px sage-color(red, 300),
+  error-focus: 0 0 0 4px sage-color(red, 300),
+  disabled: 0 0 0 1px sage-color(grey, 300),
+);
+
+///
+/// Sage border interactive token utility
+///
+/// @param {string} $key [default] The token to retrieve
+///
+@function sage-border-interactive($key: default) {
+  $value: map-get($sage-borders-interactive, $key);
+  @return $value;
+}

--- a/packages/sage-assets/lib/stylesheets/themes/next/tokens/_index.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/tokens/_index.scss
@@ -3,6 +3,7 @@
 @import "color_palette";
 @import "color_combos";
 @import "border";
+@import "border_interactive";
 @import "breakpoints";
 @import "container";
 @import "font_size";


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add tokens and vars for additional border states
- [x] update `sage-form-field()` mixin border state values
- [x] ~add docs around use of borders and box-shadows~ [UXD-Handbook#71](https://github.com/Kajabi/UXD-Handbook/pull/71)

**Things to look for while testing:**
- In the form elements, all visual borders should now be `box-shadow`s
- The focus ring **DOES NOT** appear when the form field is hovered

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-17 at 8 07 31 AM](https://user-images.githubusercontent.com/1241836/174304324-1381f457-b94a-463d-bfce-b1601097aa63.png)|![Screen Shot 2022-06-17 at 8 05 17 AM](https://user-images.githubusercontent.com/1241836/174304053-d913c85b-c4de-49e8-ad5b-823609a5658f.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify the `default`, `:hover`, `:focus`, and `:disabled` states match the spec in the following views:
- Form Input
  - [Rails](http://localhost:4000/pages/component/form_input?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-input--default)
- Form Textarea
  - [Rails](http://localhost:4000/pages/component/form_textarea?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-textarea--default)
- Form Select
  - [Rails](http://localhost:4000/pages/component/form_select?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-select--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Affects high usage form elements. Requires full QE.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-685](https://kajabi.atlassian.net/browse/SAGE-685)