### PR TITLE
[SAGE-681] - Sass: Limit Badge and Label status keys to avoid color combo errors

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_label.scss
@@ -10,6 +10,14 @@ $-label-interactive-icon-size-decor: rem(28px);
 $-label-padding: 0 sage-spacing(xs);
 $-label-border-radius: sage-border(radius-x-large);
 $-label-inset-border: 0 0 0 1px inset;
+$-label-statuses: (
+  danger,
+  draft,
+  info,
+  locked,
+  published,
+  warning,
+);
 
 
 .sage-label {
@@ -59,7 +67,7 @@ $-label-inset-border: 0 0 0 1px inset;
   pointer-events: none;
 }
 
-@each $-color-name, $-color-settings in $sage-color-combos {
+@each $-color-name in $-label-statuses {
   $-color-modifier: ".sage-label--#{$-color-name}";
 
   #{$-color-modifier} .sage-label__value {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_badge.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_badge.scss
@@ -11,7 +11,14 @@ $-badge-interactive-icon-size-decor: rem(28px);
 $-badge-padding: 0 rem(10px) 0 sage-spacing(xs);
 $-badge-border-radius: sage-border(radius-x-large);
 $-badge-inset-border: 0 0 0 1px inset;
-
+$-badge-statuses: (
+  danger,
+  draft,
+  info,
+  locked,
+  published,
+  warning,
+);
 
 .sage-badge {
   display: inline-flex;
@@ -67,7 +74,7 @@ $-badge-inset-border: 0 0 0 1px inset;
   pointer-events: none;
 }
 
-@each $-color-name, $-color-settings in $sage-color-combos {
+@each $-color-name in $-badge-statuses {
   $-color-modifier: ".sage-badge--#{$-color-name}";
 
   #{$-color-modifier} {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_label.scss
@@ -10,6 +10,14 @@ $-label-interactive-icon-size-decor: rem(28px);
 $-label-padding: 0 sage-spacing(xs);
 $-label-border-radius: sage-border(radius-x-large);
 $-label-inset-border: 0 0 0 1px inset;
+$-label-statuses: (
+  danger,
+  draft,
+  info,
+  locked,
+  published,
+  warning,
+);
 
 
 .sage-label {
@@ -59,7 +67,7 @@ $-label-inset-border: 0 0 0 1px inset;
   pointer-events: none;
 }
 
-@each $-color-name, $-color-settings in $sage-color-combos {
+@each $-color-name in $-label-statuses {
   $-color-modifier: ".sage-label--#{$-color-name}";
 
   #{$-color-modifier} .sage-label__value {


### PR DESCRIPTION
## Description

The `Label` and `Badge` components rely on the color combinations tokens to generate colors for the status variations. Yet, this color combinations set also includes items that are not needed for these components but for others. The existing loop generating color styles is therefore looping through more than necessary, and looking for some subkeys that are not present. The result is errors such as these in the console:

```
WARNING: Could not retrieve color combo: primary default background-accent. Got `` from `sd-sage-color-combos()`. Default color grey 500 (`#b5bac0`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 77 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_badge.scss
         from line 8 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_index.scss
         from line 19 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/_scoped.scss
         from line 3 of stdin

WARNING: Could not retrieve color combo: primary default icon-background-accent. Got `` from `sd-sage-color-combos()`. Default color grey 500 (`#b5bac0`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 82 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_badge.scss
         from line 8 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_index.scss
         from line 19 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/_scoped.scss
         from line 3 of stdin

WARNING: Could not retrieve color combo: primary default background-accent. Got `` from `sd-sage-color-combos()`. Default color grey 500 (`#b5bac0`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 87 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_badge.scss
         from line 8 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_index.scss
         from line 19 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/_scoped.scss
         from line 3 of stdin

WARNING: Could not retrieve color combo: primary default background-accent. Got `` from `sd-sage-color-combos()`. Default color charcoal 400 (`#263240`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 104 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/components/_label.scss
         from line 36 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/components/_index.scss
         from line 16 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/_scoped.scss
         from line 3 of stdin

WARNING: Could not retrieve color combo: primary default background-accent. Got `` from `sd-sage-color-combos()`. Default color charcoal 400 (`#263240`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 113 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/components/_label.scss
         from line 36 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/components/_index.scss
         from line 16 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/legacy/_scoped.scss
         from line 3 of stdin

WARNING: Could not retrieve color combo: primary default background-accent. Got `` from `sd-sage-color-combos()`. Default color grey 500 (`#b5bac0`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 104 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_label.scss
         from line 37 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_index.scss
         from line 19 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/_scoped.scss
         from line 3 of stdin

WARNING: Could not retrieve color combo: primary default background-accent. Got `` from `sd-sage-color-combos()`. Default color grey 500 (`#b5bac0`) returned instead.
         on line 29 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/tokens/_color_combos.scss, in function `sage-color-combo`
         from line 113 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_label.scss
         from line 37 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/components/_index.scss
         from line 19 of node_modules/@kajabi/sage-assets/lib/stylesheets/themes/next/_scoped.scss
         from line 3 of stdin
```

This PR adds local lists of statuses to these components to ensure that only those expected by the component's schema are looped through and thus avoids those that generate the errors above.

## Testing in `sage-lib`

See same label and badges are still displaying as expected by design specs:

- http://localhost:4000/pages/component/badge?sage_theme=sage_theme_next&tab=preview
- http://localhost:4000/pages/component/label?sage_theme=sage_theme_next&tab=preview
- http://localhost:4000/pages/component/label?sage_theme=sage_theme_legacy&tab=preview

## Testing in `kajabi-products`

1. (**LOW**) Update to internal style logic in Label (Legacy and Next) and Badge (Next only)


## Related

[SAGE-681](https://kajabi.atlassian.net/browse/SAGE-681)
