### PR TITLE
[SAGE-668] Docs Site Bug - Hero Heading Color (Next)

### DIFF
--- a/docs/lib/sage-frontend/stylesheets/docs/themes/next/_home.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/themes/next/_home.scss
@@ -37,6 +37,7 @@
   margin-top: sage-spacing();
   font-size: 4rem;
   line-height: 4rem;
+  color: sage-color(white);
 }
 
 .docs-hero__img {


### PR DESCRIPTION
## Description
The hero heading on the docs site is the wrong color for next theme.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-17 at 10 12 42 AM](https://user-images.githubusercontent.com/1175111/174348655-a7f1b8e8-5d70-4e69-92d4-6196dfca63ed.png)|![Screen Shot 2022-06-17 at 10 13 18 AM](https://user-images.githubusercontent.com/1175111/174348681-9a59e114-2df9-4bbe-8681-d0e49f12b5e5.png)|


## Testing in `sage-lib`

- Navigate to the docs site.
- Make sure next toggle is enabled.
- Navigate to home page
- Verify hero heading is correct color.


## Testing in `kajabi-products`

1. (**LOW**) Updates docs site heading color. Does not affect KP.


## Related
https://kajabi.atlassian.net/browse/SAGE-688
