### PR TITLE
[SAGE-337] Update form select error classes

### DIFF
--- a/docs/app/views/examples/components/themes/legacy/dynamic_select/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/dynamic_select/_props.html.erb
@@ -24,7 +24,7 @@
 </tr>
 <tr>
   <td><%= md('`has_error`') %></td>
-  <td><%= md('Enabling this property adds the `.sage-select--error` class to the component.') %></td>
+  <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/themes/next/dynamic_select/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/dynamic_select/_props.html.erb
@@ -24,7 +24,7 @@
 </tr>
 <tr>
   <td><%= md('`has_error`') %></td>
-  <td><%= md('Enabling this property adds the `.sage-select--error` class to the component.') %></td>
+  <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_dynamic_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_dynamic_select.html.erb
@@ -1,7 +1,7 @@
 
 <div class="
   sage-dynamic-select
-  <%= "sage-select--error" if component.has_error %>
+  <%= "sage-form-field--error" if component.has_error %>
   <%= component.generated_css_classes %>">
   <% unless component.theme.present? && component.theme != 'sage' %>
     <label class="sage-select__label" for="<%= component.id %>"><%= component.label || component.id %></label>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_dynamic_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_dynamic_select.html.erb
@@ -1,7 +1,7 @@
 
 <div class="
   sage-dynamic-select
-  <%= "sage-select--error" if component.has_error %>
+  <%= "sage-form-field--error" if component.has_error %>
   <%= component.generated_css_classes %>">
   <% unless component.theme.present? && component.theme != 'sage' %>
     <label class="sage-select__label" for="<%= component.id %>"><%= component.label || component.id %></label>

--- a/packages/sage-assets/lib/stylesheets/themes/legacy/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/legacy/components/_form_select.scss
@@ -96,7 +96,7 @@ $-select-arrow-icon-width: map-get($sage-icon-sizes, md);
     }
   }
 
-  .sage-select--error & {
+  .sage-form-field--error & {
     border-color: $-select-color-error;
     box-shadow: $-select-border-box-shadow-size $-select-color-error;
   }
@@ -104,7 +104,7 @@ $-select-arrow-icon-width: map-get($sage-icon-sizes, md);
   &:hover:not(:disabled) {
     border-color: $-select-color-border-selected;
 
-    .sage-select--error & {
+    .sage-form-field--error & {
       border-color: $-select-color-error;
     }
   }
@@ -114,7 +114,7 @@ $-select-arrow-icon-width: map-get($sage-icon-sizes, md);
     border-color: $-select-color-success;
     box-shadow: $-select-border-box-shadow-size $-select-color-success;
 
-    .sage-select--error & {
+    .sage-form-field--error & {
       border-color: $-select-color-error;
       box-shadow: $-select-border-box-shadow-size $-select-color-error;
     }
@@ -123,7 +123,7 @@ $-select-arrow-icon-width: map-get($sage-icon-sizes, md);
   &:hover:not(:disabled) {
     border-color: $-select-color-default;
 
-    .sage-select--error {
+    .sage-form-field--error {
       border-color: currentColor;
     }
   }

--- a/packages/sage-react/lib/themes/legacy/Select/Select.jsx
+++ b/packages/sage-react/lib/themes/legacy/Select/Select.jsx
@@ -21,7 +21,6 @@ export const Select = ({
     className,
     {
       'sage-form-field--error': hasError,
-      'sage-select--error': hasError,
       'sage-select--value-selected': value,
     }
   );

--- a/packages/sage-react/lib/themes/next/Select/Select.jsx
+++ b/packages/sage-react/lib/themes/next/Select/Select.jsx
@@ -21,7 +21,6 @@ export const Select = ({
     className,
     {
       'sage-form-field--error': hasError,
-      'sage-select--error': hasError,
       'sage-select--value-selected': value,
     }
   );


### PR DESCRIPTION
## Description
Updates Form Select and Dynamic Select, replacing `sage-select--error` with `sage-form-field--error.`

Corresponding change for https://github.com/Kajabi/kajabi-products/pull/23937 

## Screenshots
No visual changes expected


## Testing in `sage-lib`
1. Navigate to Form Select in Next or Legacy
2. Verify that error states appear as expected


## Testing in `kajabi-products`
1. (**MED**) Updates Form Select and Dynamic Select error state classes


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
