### PR TITLE
fix: change get started button back to accent in next

### DIFF
--- a/docs/app/views/application/_home_hero.html.erb
+++ b/docs/app/views/application/_home_hero.html.erb
@@ -15,7 +15,7 @@
               href: pages_component_path(sorted_sage_components.first[:title]),
               title: "Get Started"
             },
-            style: "primary",
+            style: SageRails.next_theme? ? "accent" : "primary",
           } %>
           <%= sage_component SageButton, {
             value: "View GitHub Repo",


### PR DESCRIPTION
## Description
Add logic to set `Get Started` button on Docs index page to display as `accent` in `Next` and `primary` in `Legacy`. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
| |  Before  |  After  |
 |--|--------|--------|
Legacy (no change)|<img width="378" alt="Screen Shot 2022-06-23 at 11 43 00 AM" src="https://user-images.githubusercontent.com/791670/175339870-c1e55375-e1b6-4bbd-a99c-0ca24eb9866c.png">|<img width="372" alt="Screen Shot 2022-06-23 at 11 42 20 AM" src="https://user-images.githubusercontent.com/791670/175340037-ab1db670-e4d3-4e1a-8617-f999aadb3a8c.png">
Next|<img width="339" alt="Screen Shot 2022-06-23 at 11 42 48 AM" src="https://user-images.githubusercontent.com/791670/175340029-f79a66b7-b4f9-4d3d-bfb6-edc402b99984.png">|<img width="361" alt="Screen Shot 2022-06-23 at 11 42 33 AM" src="https://user-images.githubusercontent.com/791670/175339920-fd45779c-9f37-4059-a902-b978944e8fc9.png">

## Testing in `sage-lib`
Check the Get Started CTA on Legacy and Next index pages. Legacy should have no change while Next should revert back to blue.
http://localhost:4000/pages/index


## Testing in `kajabi-products`
(LOW) Adjusts homepage hero CTA/button color for Next only. Docs only update and does not effect KP.

## Related
[SAGE-690: Docs Site - Hero CTA doesn't pass color contrast (Next)](https://kajabi.atlassian.net/browse/SAGE-690)