### PR TITLE
Fix boolean for hasCustomWidth in Frame

### DIFF
--- a/packages/sage-react/lib/themes/legacy/Frame/Frame.jsx
+++ b/packages/sage-react/lib/themes/legacy/Frame/Frame.jsx
@@ -34,7 +34,7 @@ export const Frame = ({
   const hasCustomBackground = background
     && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
   const hasCustomWidth = width
-    && !Object.values(FRAME_WIDTHS).includes(background);
+    && !Object.values(FRAME_WIDTHS).includes(width);
   const hasCustomMaxWidth = maxWidth
     && !Object.values(FRAME_WIDTHS).includes(maxWidth);
   const hasCustomMinWidth = minWidth

--- a/packages/sage-react/lib/themes/next/Frame/Frame.jsx
+++ b/packages/sage-react/lib/themes/next/Frame/Frame.jsx
@@ -34,7 +34,7 @@ export const Frame = ({
   const hasCustomBackground = background
     && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
   const hasCustomWidth = width
-    && !Object.values(FRAME_WIDTHS).includes(background);
+    && !Object.values(FRAME_WIDTHS).includes(width);
   const hasCustomMaxWidth = maxWidth
     && !Object.values(FRAME_WIDTHS).includes(maxWidth);
   const hasCustomMinWidth = minWidth


### PR DESCRIPTION
## Description
I was trying to use the `width` prop on frame with the value of "fill", but I noticed that it still kept adding the class name of `sage-frame--width-custom`, then I noticed that the conditional was using the wrong prop


## Testing in `kajabi-products`
1. (**LOW**) Fixes the `width` prop on Frame to add the correct class
   - [ ] Add `width` prop with a value of "fill" to a frame component and make sure now that the class matches (`sage-frame--width-fill` and not ``sage-frame--width-custom`)
