### PR TITLE
[Sage-400] Table - Verify Text Color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_table.scss
@@ -22,7 +22,7 @@ $-table-cell-font-color-strong: sage-color(charcoal, 400);
 $-table-cell-type-spec: "%t-sage-body-small-med";
 $-table-cell-type-spec-strong: "%t-sage-body-small-semi";
 $-table-heading-font-color: sage-color(charcoal, 500);
-$-table-heading-type-spec: "%t-sage-body-small-med";
+$-table-heading-type-spec: "%t-sage-body-small-semi";
 
 // Overflow gradient
 $-table-overflow-indicator-width: sage-spacing(sm);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Verifies text colors match Figma files. Updates table header to match Figma.

Note: `medium` font in Figma is `semibold` in code due to the way Circular handles font weight names.

[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage-components?node-id=2738%3A23243)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1205" alt="Screen Shot 2022-06-27 at 4 31 47 PM" src="https://user-images.githubusercontent.com/14791307/176039552-1032c669-da08-42c1-a651-aa50426d78d2.png">|<img width="1271" alt="Screen Shot 2022-06-27 at 4 33 27 PM" src="https://user-images.githubusercontent.com/14791307/176039561-c8b3dc26-92d2-42a0-b25f-1b4242684077.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Table](http://localhost:4000/pages/component/table?tab=preview)
- Check that font colors and weights for table text matches Figma

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Verifies text colors match Figma files. Updates table header to match Figma.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-400](https://kajabi.atlassian.net/browse/SAGE-400)