### PR TITLE
[SAGE-707] Borders align interactive borders to spec

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_checkbox.scss
@@ -189,7 +189,6 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
     color: $-checkbox-color-checked;
     background: $-checkbox-color-checked;
     border-color: $-checkbox-color-checked;
-    box-shadow: sage-shadow(sm);
 
     &::after {
       opacity: 1;
@@ -208,6 +207,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
   &:hover:not(:checked):not(:disabled) {
     border-color: $-checkbox-color-default;
+    background-color: sage-color(grey, 100);
   }
 
   &:focus:not(:disabled),

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_choice.scss
@@ -157,13 +157,13 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   }
 
   &:hover::#{$-choice-el-radio} {
-    box-shadow: sage-shadow(sm);
+    border-color: sage-color(grey, 500);
+    background-color: sage-color(grey, 100);
   }
 
   &:active,
   &.sage-choice--active {
     &::#{$-choice-el-radio} {
-      box-shadow: sage-shadow(sm);
       border-width: 5px;
       border-color: $-choice-radio-color-checked;
     }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_radio.scss
@@ -132,7 +132,6 @@ $-radio-focus-outline-color: currentColor;
     color: $-radio-color-checked;
     background: $-radio-color-checked;
     border-color: transparent;
-    box-shadow: sage-shadow(sm);
 
     &::after {
       transform: translate3d(-50%, -50%, 0) scale(1);
@@ -173,8 +172,8 @@ $-radio-focus-outline-color: currentColor;
       box-shadow: none;
     }
 
-    &:checked::after {
-      background-color: $-radio-color-hover;
+    &:checked::before {
+      background-color: $-radio-color-text-disabled;
     }
 
     + .sage-radio__label,

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_switch.scss
@@ -194,10 +194,6 @@ $-switch-toggle-size: rem(16px);
       background: $-switch-color-disabled-checked;
     }
 
-    &:checked::after {
-      background-color: $-switch-color-default-hover;
-    }
-
     &:checked ~ .sage-switch__label,
     &:checked ~ .sage-switch__message {
       color: $-switch-color-disabled-checked-text;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Go through the interactive elements and align borders to the spec

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->

#### Checkbox
 - remove checkbox `box-shadow`
 - update default hover `background-color`
 
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-30 at 9 30 25 AM](https://user-images.githubusercontent.com/1241836/176703707-8b4a6c21-1d6e-470a-b049-682f23da2956.png)|![Screen Shot 2022-06-30 at 9 30 16 AM](https://user-images.githubusercontent.com/1241836/176703725-4ce4c115-db80-4b6d-b6c1-c419f1c9ea5d.png)|

#### Choice
- remove `box-shadow` to radio
- update default hover `background-color` to radio

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-30 at 9 29 59 AM](https://user-images.githubusercontent.com/1241836/176703833-3c2402eb-a16f-4189-9b39-3882784ad523.png)|![Screen Shot 2022-06-30 at 9 29 43 AM](https://user-images.githubusercontent.com/1241836/176703858-9f089c6d-a24d-44d9-809c-befee07dc7cc.png)|

#### Radio
- remove `box-shadow`
- updated colors for the `disabled`, `checked` state

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-30 at 9 28 40 AM](https://user-images.githubusercontent.com/1241836/176703943-367d36e1-952e-4c9e-8320-2b27e5081cec.png)|![Screen Shot 2022-06-30 at 9 28 25 AM](https://user-images.githubusercontent.com/1241836/176703971-8925621d-d4a9-463a-8537-e26837e91c9a.png)|

#### Switch
- updated colors for the `disabled`, `checked` state

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-30 at 9 27 34 AM](https://user-images.githubusercontent.com/1241836/176704071-10d7e60c-1c68-4e62-958a-dd9b98958d03.png)|![Screen Shot 2022-06-30 at 9 27 46 AM](https://user-images.githubusercontent.com/1241836/176704048-fa51fa38-2435-490b-88ce-6b4894b452f4.png)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the following views and verify borders / shadows align to the spec:
- Checkbox
  - [Rails](http://localhost:4000/pages/component/checkbox?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-checkbox--default)
- Choice
  - [Rails](http://localhost:4000/pages/component/choice?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-choice--default)
- Radio
  - [Rails](http://localhost:4000/pages/component/radio?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-radio--default)
- Switch
  - [Rails](http://localhost:4000/pages/component/switch?tab=preview)
  - [React](http://localhost:4110/?path=/docs/sage-switch--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Updates borders for most interactive elements. Required full QE.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-707](https://kajabi.atlassian.net/browse/SAGE-707)