### PR TITLE
[ SAGE-666] 👿 Sage search reset button misaligned in Toolbar

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_search.scss
@@ -214,4 +214,12 @@ $-search-icon: "::before";
   .sage-search--has-text & {
     visibility: visible;
   }
+
+  .sage-search & {
+    .sage-toolbar__group & {
+      &:last-child {
+        align-self: center;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
When text has been entered in a Sage Search field nested within a Sage Toolbar, the “reset” button does not appear centered within the input.

These updates correct the alignment.


## Screenshots
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-06-30 at 12 46 10 PM](https://user-images.githubusercontent.com/1175111/176764483-ab4ecd7a-0b0c-40ac-a891-eadfa3f0acfb.png)|![Screen Shot 2022-06-30 at 12 47 13 PM](https://user-images.githubusercontent.com/1175111/176764539-188860ac-7aaf-4ea3-9016-5e0030d30697.png)|


## Testing in `sage-lib`

- Enable `sage_next` toggle
- Navigate to [Toolbar](http://localhost:4000/pages/component/toolbar?tab=preview)
- Enter text within the search input within a `SageToolbarGroup`
- Verify clear button aligns as expected.


## Testing in `kajabi-products`

1. (**LOW**) Adjust the alignment of the clear search button within a `SageToolbarGroup`. No effect on KP as the `SageToolbarGroup` component isn't yet used in KP.

## Related
https://kajabi.atlassian.net/browse/SAGE-666
