### PR TITLE
[SAGE-709] Gap - use .sage-grid-gap instead on component level gap classes

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_button_group.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_button_group.html.erb
@@ -3,7 +3,7 @@
     <%= "sage-btn-group--align-#{component.align}" if component.align.present? %>
     <%= "sage-btn-group--border-top" if component.borderTop %>
     <%= "sage-btn-group--wrap" if component.wrap %>
-    <%= "sage-btn-group--gap-#{component.gap}" if component.gap.present? %>
+    <%= "sage-grid-gap-#{component.gap}" if component.gap.present? %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_card_list_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_card_list_item.html.erb
@@ -2,7 +2,7 @@
   class="
     sage-card__list-item
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
-    <%= "sage-card__list-item--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-gap-#{component.gap}" if component.gap %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_card_row.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_card_row.html.erb
@@ -1,7 +1,7 @@
 <div
   class="sage-card__row
     <%= "sage-card__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
-    <%= "sage-card__row--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-gap-#{component.gap}" if component.gap %>
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_label_group.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_label_group.html.erb
@@ -1,7 +1,7 @@
 <div class="
   sage-label-group
   <%= "sage-label-group--align-#{component.align}" if component.align.present? %>
-  <%= "sage-label-group--gap-#{component.gap}" if component.gap.present? %>
+  <%= "sage-grid-gap-#{component.gap}" if component.gap.present? %>
   <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_panel_list_item.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_panel_list_item.html.erb
@@ -1,7 +1,7 @@
 <li
   class="sage-panel__list-item
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
-    <%= "sage-panel__list-item--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-gap-#{component.gap}" if component.gap %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_panel_row.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_panel_row.html.erb
@@ -1,7 +1,7 @@
 <div
   class="sage-panel__row
     <%= "sage-panel__row--vertical-align-#{component.vertical_align}" if component.vertical_align %>
-    <%= "sage-panel__row--gap-#{component.gap}" if component.gap %>
+    <%= "sage-grid-gap-#{component.gap}" if component.gap %>
     <%= "sage-grid-template-#{component.grid_template}" if component.grid_template %>
     <%= component.generated_css_classes %>
   "

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -771,12 +771,6 @@ $-alert-colors: (
   }
 }
 
-@each $-key, $-value in $sage-spacings {
-  .sage-btn-group--gap-#{$-key} {
-    gap: sage-spacing($-key);
-  }
-}
-
 .sage-btn-group--wrap {
   @media screen and (min-width: sage-breakpoint(sm-min)) {
     flex-wrap: wrap;

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_card.scss
@@ -172,13 +172,6 @@
   }
 }
 
-@each $-key, $-value in $sage-spacings {
-  .sage-card__row--gap-#{$-key},
-  .sage-card__list-item--gap-#{$-key} {
-    gap: sage-spacing($-key);
-  }
-}
-
 .sage-card__row--vertical-align-start {
   align-items: start;
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_label.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_label.scss
@@ -166,12 +166,6 @@ $-label-statuses: (
   gap: sage-spacing(xs);
 }
 
-@each $-key, $-value in $sage-spacings {
-  .sage-label-group--gap-#{$-key} {
-    gap: sage-spacing($-key);
-  }
-}
-
 .sage-label-group--align-center {
   justify-content: center;
 }

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_panel.scss
@@ -151,13 +151,6 @@
   @include sage-grid-panel-row();
 }
 
-@each $-key, $-value in $sage-spacings {
-  .sage-panel__row--gap-#{$-key},
-  .sage-panel__list-item--gap-#{$-key} {
-    gap: sage-spacing($-key);
-  }
-}
-
 .sage-panel__row--media {
   grid-template-columns: 160px 1fr;
 }

--- a/packages/sage-react/lib/themes/next/Button/ButtonGroup.jsx
+++ b/packages/sage-react/lib/themes/next/Button/ButtonGroup.jsx
@@ -20,7 +20,7 @@ export const ButtonGroup = ({
       'sage-btn-group--align-end': alignEnd,
       [`sage-btn-group--align-${align}`]: align,
       'sage-btn-group--border-top': borderTop,
-      [`sage-btn-group--gap-${gap}`]: gap,
+      [`sage-grid-gap-${gap}`]: gap,
       'sage-btn-group--wrap': wrap,
     }
   );

--- a/packages/sage-react/lib/themes/next/Card/CardListItem.jsx
+++ b/packages/sage-react/lib/themes/next/Card/CardListItem.jsx
@@ -16,7 +16,7 @@ export const CardListItem = ({
     className,
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
-      [`sage-card__list-item--gap-${gap}`]: gap
+      [`sage-grid-gap-${gap}`]: gap
     }
   );
 

--- a/packages/sage-react/lib/themes/next/Card/CardRow.jsx
+++ b/packages/sage-react/lib/themes/next/Card/CardRow.jsx
@@ -18,7 +18,7 @@ export const CardRow = ({
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
       [`sage-card__row--vertical-align-${verticalAlign}`]: verticalAlign,
-      [`sage-card__row--gap-${gap}`]: gap,
+      [`sage-grid-gap-${gap}`]: gap,
     }
   );
 

--- a/packages/sage-react/lib/themes/next/Label/LabelGroup.jsx
+++ b/packages/sage-react/lib/themes/next/Label/LabelGroup.jsx
@@ -15,7 +15,7 @@ export const LabelGroup = ({
     className,
     {
       [`sage-label-group--align-${align}`]: align,
-      [`sage-label-group--gap-${gap}`]: gap
+      [`sage-grid-gap-${gap}`]: gap
     }
   );
 

--- a/packages/sage-react/lib/themes/next/Panel/PanelListItem.jsx
+++ b/packages/sage-react/lib/themes/next/Panel/PanelListItem.jsx
@@ -16,7 +16,7 @@ export const PanelListItem = ({
     className,
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
-      [`sage-panel__list-item--gap-${gap}`]: gap
+      [`sage-grid-gap-${gap}`]: gap
     }
   );
 

--- a/packages/sage-react/lib/themes/next/Panel/PanelRow.jsx
+++ b/packages/sage-react/lib/themes/next/Panel/PanelRow.jsx
@@ -18,7 +18,7 @@ export const PanelRow = ({
     {
       [`${SageClassnames.lookupGridTemplate(gridTemplate)}`]: gridTemplate,
       [`sage-panel__row--vertical-align-${verticalAlign}`]: verticalAlign,
-      [`sage-panel__row--gap-${gap}`]: gap,
+      [`sage-grid-gap-${gap}`]: gap,
     }
   );
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- update all component level `gap` refs to use `.sage-grid-gap-` prefix
- remove all component level CSS gap declarations


## Screenshots
**There is no visual change**

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Click through the app and verify that items with the `gap` function properly. There should be no visual changes:
- ButtonGroup
- CardList
- CardRow
- LabelGroup
- PanelList
- PanelRow

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Updates gap property classname reference within the components. Required QE


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-709](https://kajabi.atlassian.net/browse/SAGE-709)