### PR TITLE
[SAGE-710] Update Form Select option attributes

### DIFF
--- a/docs/app/views/examples/components/themes/legacy/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/form_select/_preview.html.erb
@@ -29,7 +29,6 @@
     {
       text: "Toad",
       value: "toad",
-      disabled: true
     },
   ],
   message: "This is a message"

--- a/docs/app/views/examples/components/themes/legacy/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/form_select/_preview.html.erb
@@ -29,6 +29,7 @@
     {
       text: "Toad",
       value: "toad",
+      disabled: true
     },
   ],
   message: "This is a message"
@@ -45,6 +46,7 @@
     {
       text: "(None Specified)",
       value: "",
+      selected: true
     },
     {
       text: "Dog",
@@ -65,6 +67,7 @@
     {
       text: "Spider",
       value: "spider",
+      disabled: true
     },
     {
       text: "Goldfish",

--- a/docs/app/views/examples/components/themes/legacy/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/form_select/_preview.html.erb
@@ -1,6 +1,7 @@
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Default</h3>
 <%= sage_component SageFormSelect, {
   name: "Characters",
-  has_error: false,
+  id: "characters",
   select_options: [
     {
       text: "-- Please Select a Character --",
@@ -34,6 +35,7 @@
   message: "This is a message"
 } %>
 
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Error state with message and disabled option</h3>
 <%= sage_component SageFormSelect, {
   name: "Pets",
   has_error: true,
@@ -76,6 +78,7 @@
   message: "This is a message"
 } %>
 
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Disabled (with pre-selected option)</h3>
 <%= sage_component SageFormSelect, {
   name: "Sports",
   disabled: true,
@@ -94,7 +97,8 @@
     },
     {
       text: "Baseball",
-      value: "baseball"
+      value: "baseball",
+      selected: true
     },
     {
       text: "Blitzball",

--- a/docs/app/views/examples/components/themes/legacy/form_select/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/form_select/_props.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= md('`has_error`') %></td>
   <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
-  <td><%= md('String') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -19,6 +19,13 @@
 <tr>
   <td><%= md('`select_options`') %></td>
   <td><%= md('An array of items that will serve as the `<select>`\'s `<option>`s') %></td>
-  <td><%= md('Array') %></td>
+  <td><%= md('```
+Array<{
+  text: String,
+  value: String (optional),
+  disabled: Boolean (false),
+  selected: Boolean (false)
+}>
+  ```') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/app/views/examples/components/themes/legacy/form_select/_props.html.erb
+++ b/docs/app/views/examples/components/themes/legacy/form_select/_props.html.erb
@@ -1,4 +1,10 @@
 <tr>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Enabling this property adds the `disabled` attribute to the component. <br>⚠️ `disabled` inputs are not submitted in forms.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`has_error`') %></td>
   <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/components/themes/next/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/form_select/_preview.html.erb
@@ -1,7 +1,7 @@
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Default</h3>
 <%= sage_component SageFormSelect, {
   name: "Characters",
   id: "characters",
-  has_error: false,
   select_options: [
     {
       text: "-- Please Select a Character --",
@@ -35,6 +35,7 @@
   message: "This is a message"
 } %>
 
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Error state with message and disabled option</h3>
 <%= sage_component SageFormSelect, {
   name: "Pets",
   has_error: true,
@@ -77,6 +78,7 @@
   message: "This is a message"
 } %>
 
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Disabled (with pre-selected option)</h3>
 <%= sage_component SageFormSelect, {
   name: "Sports",
   disabled: true,
@@ -95,7 +97,8 @@
     },
     {
       text: "Baseball",
-      value: "baseball"
+      value: "baseball",
+      selected: true
     },
     {
       text: "Blitzball",

--- a/docs/app/views/examples/components/themes/next/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/form_select/_preview.html.erb
@@ -46,6 +46,7 @@
     {
       text: "(None Specified)",
       value: "",
+      selected: true
     },
     {
       text: "Dog",
@@ -66,6 +67,7 @@
     {
       text: "Spider",
       value: "spider",
+      disabled: true
     },
     {
       text: "Goldfish",

--- a/docs/app/views/examples/components/themes/next/form_select/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/form_select/_props.html.erb
@@ -1,4 +1,10 @@
 <tr>
+  <td><%= md('`disabled`') %></td>
+  <td><%= md('Enabling this property adds the `disabled` attribute to the component. <br>⚠️ `disabled` inputs are not submitted in forms.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`has_error`') %></td>
   <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/app/views/examples/components/themes/next/form_select/_props.html.erb
+++ b/docs/app/views/examples/components/themes/next/form_select/_props.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td><%= md('`has_error`') %></td>
   <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
-  <td><%= md('String') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`message`') %></td>
@@ -19,6 +19,13 @@
 <tr>
   <td><%= md('`select_options`') %></td>
   <td><%= md('An array of items that will serve as the `<select>`\'s `<option>`s') %></td>
-  <td><%= md('Array') %></td>
+  <td><%= md('```
+Array<{
+  text: String,
+  value: String (optional),
+  disabled: Boolean (false),
+  selected: Boolean (false)
+}>
+  ```') %></td>
   <td><%= md('`nil`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_form_select.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_form_select.rb
@@ -10,6 +10,8 @@ class SageFormSelect < SageComponent
     select_options: [:optional, [[{
       text: String,
       value: [:optional, NilClass, String],
+      disabled: [:optional, TrueClass],
+      selected: [:optional, TrueClass],
     }]]],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_form_select.html.erb
@@ -25,5 +25,7 @@
   </select>
   <label class="sage-select__label" for="<%= selectID %>"><%= component.name %></label>
   <i class="sage-select__arrow" aria-hidden="true"></i>
-  <div class="sage-select__message"><%= component.message %></div>
+  <% if component.message.present? %>
+    <div class="sage-select__message"><%= component.message %></div>
+  <% end %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/legacy/_sage_form_select.html.erb
@@ -14,7 +14,13 @@
     <%= "disabled" if component.disabled %>
   >
     <% component.select_options.each do |option| %>
-      <option value="<%= option[:value] %>"><%= option[:text] %></option>
+      <option
+        value="<%= option[:value] %>"
+        <%= option[:selected] && !option[:disabled] ? " selected=true" : nil -%>
+        <%= option[:disabled] ? " disabled" : nil -%>
+      >
+        <%= option[:text] %>
+      </option>
     <% end %>
   </select>
   <label class="sage-select__label" for="<%= selectID %>"><%= component.name %></label>

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_form_select.html.erb
@@ -19,7 +19,13 @@
     <%= "disabled" if component.disabled %>
   >
     <% component.select_options.each do |option| %>
-      <option value="<%= option[:value] %>"><%= option[:text] %></option>
+      <option
+        value="<%= option[:value] %>"
+        <%= option[:selected] && !option[:disabled] ? " selected=true" : nil -%>
+        <%= option[:disabled] ? " disabled" : nil -%>
+      >
+        <%= option[:text] %>
+      </option>
     <% end %>
   </select>
   <label class="sage-select__label" for="<%= select_name %>"><%= label %></label>

--- a/packages/sage-react/lib/themes/legacy/Select/Select.jsx
+++ b/packages/sage-react/lib/themes/legacy/Select/Select.jsx
@@ -8,8 +8,8 @@ export const Select = ({
   disabled,
   hasError,
   id,
-  label,
   includeLabelInOptions,
+  label,
   message,
   onChange,
   options,
@@ -40,6 +40,7 @@ export const Select = ({
 
         {options.map((option, i) => {
           let optionLabel,
+            optionDisabled,
             optionValue;
           if (typeof option === 'string') {
             optionLabel = option;
@@ -47,10 +48,17 @@ export const Select = ({
           } else {
             optionLabel = option.label;
             optionValue = option.value;
+            optionDisabled = option.disabled;
           }
 
           return (
-            <option key={i.toString()} value={optionValue}>{optionLabel}</option>
+            <option
+              key={i.toString()}
+              value={optionValue}
+              disabled={optionDisabled}
+            >
+              {optionLabel}
+            </option>
           );
         })}
       </select>
@@ -77,14 +85,14 @@ Select.defaultProps = {
   message: null,
   onChange: (evt) => evt,
   options: [],
-  value: null,
+  value: '',
 };
 
 Select.propTypes = {
   className: PropTypes.string,
-  id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   hasError: PropTypes.bool,
+  id: PropTypes.string.isRequired,
   includeLabelInOptions: PropTypes.bool,
   label: PropTypes.string,
   message: PropTypes.string,

--- a/packages/sage-react/lib/themes/legacy/Select/Select.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Select/Select.story.jsx
@@ -7,6 +7,7 @@ export default {
   decorators: [(Story) => <div style={{ width: 300, marginLeft: 'auto', marginRight: 'auto' }}><Story /></div>],
   args: {
     label: 'Select',
+    id: 'field-1',
     includeLabelInOptions: false,
     options: [
       'Option 1',
@@ -21,7 +22,7 @@ const Template = (args) => <Select {...args} />;
 
 export const Default = Template.bind({});
 
-export const SearchWithState = (args) => {
+export const SelectWithState = (args) => {
   const [value, updateValue] = useState('');
   return (
     <Select
@@ -31,7 +32,7 @@ export const SearchWithState = (args) => {
     />
   );
 };
-SearchWithState.args = {
+SelectWithState.args = {
   id: 'field-2',
   label: 'Cool stuff',
   options: [
@@ -43,7 +44,26 @@ SearchWithState.args = {
   placeholder: 'Choose...'
 };
 
-export const SearchDisabled = (args) => {
+export const DisabledSelectFieldWithOptionPreselected = (args) => {
+  return (
+    <Select {...args} />
+  );
+};
+DisabledSelectFieldWithOptionPreselected.args = {
+  id: 'field-3',
+  label: 'Choose wisely…',
+  options: [
+    'Option 1',
+    'Option 2',
+    'Option 3',
+    'Option 4',
+  ],
+  disabled: true,
+  value: 'Option 3',
+  placeholder: 'Choose wisely…'
+};
+
+export const SelectWithOptionDisabled = (args) => {
   const [value, updateValue] = useState('');
   return (
     <Select
@@ -53,14 +73,19 @@ export const SearchDisabled = (args) => {
     />
   );
 };
-SearchDisabled.args = {
-  id: 'field-3',
-  label: 'Choose...',
+SelectWithOptionDisabled.args = {
+  id: 'field-4',
+  label: 'Select from the following:',
   options: [
-    'Option 1',
-    'Option 2',
-    'Option 3',
-    'Option 4',
+    'First option',
+    {
+      label: 'Second option',
+      value: 'second-option',
+      disabled: true,
+    },
+    'Third option',
+    'Fourth option',
+    'Fifth option',
   ],
-  disabled: true
+  placeholder: 'Select from the following:'
 };

--- a/packages/sage-react/lib/themes/legacy/Select/Select.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Select/Select.story.jsx
@@ -44,9 +44,8 @@ SelectWithState.args = {
   placeholder: 'Choose...'
 };
 
-export const DisabledSelectFieldWithOptionPreselected = (args) => {
-  return <Select {...args} />;
-};
+export const DisabledSelectFieldWithOptionPreselected = (args) => <Select {...args} />;
+
 DisabledSelectFieldWithOptionPreselected.args = {
   id: 'field-3',
   label: 'Choose wisely…',

--- a/packages/sage-react/lib/themes/legacy/Select/Select.story.jsx
+++ b/packages/sage-react/lib/themes/legacy/Select/Select.story.jsx
@@ -45,9 +45,7 @@ SelectWithState.args = {
 };
 
 export const DisabledSelectFieldWithOptionPreselected = (args) => {
-  return (
-    <Select {...args} />
-  );
+  return <Select {...args} />;
 };
 DisabledSelectFieldWithOptionPreselected.args = {
   id: 'field-3',

--- a/packages/sage-react/lib/themes/next/Select/Select.jsx
+++ b/packages/sage-react/lib/themes/next/Select/Select.jsx
@@ -8,8 +8,8 @@ export const Select = ({
   disabled,
   hasError,
   id,
-  label,
   includeLabelInOptions,
+  label,
   message,
   onChange,
   options,
@@ -40,6 +40,7 @@ export const Select = ({
 
         {options.map((option, i) => {
           let optionLabel,
+            optionDisabled,
             optionValue;
           if (typeof option === 'string') {
             optionLabel = option;
@@ -47,10 +48,17 @@ export const Select = ({
           } else {
             optionLabel = option.label;
             optionValue = option.value;
+            optionDisabled = option.disabled;
           }
 
           return (
-            <option key={i.toString()} value={optionValue}>{optionLabel}</option>
+            <option
+              key={i.toString()}
+              value={optionValue}
+              disabled={optionDisabled}
+            >
+              {optionLabel}
+            </option>
           );
         })}
       </select>
@@ -79,14 +87,14 @@ Select.defaultProps = {
   message: null,
   onChange: (evt) => evt,
   options: [],
-  value: null,
+  value: '',
 };
 
 Select.propTypes = {
   className: PropTypes.string,
-  id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   hasError: PropTypes.bool,
+  id: PropTypes.string.isRequired,
   includeLabelInOptions: PropTypes.bool,
   label: PropTypes.string,
   message: PropTypes.string,

--- a/packages/sage-react/lib/themes/next/Select/Select.story.jsx
+++ b/packages/sage-react/lib/themes/next/Select/Select.story.jsx
@@ -7,6 +7,7 @@ export default {
   decorators: [(Story) => <div style={{ width: 300, marginLeft: 'auto', marginRight: 'auto' }}><Story /></div>],
   args: {
     label: 'Select',
+    id: 'field-1',
     includeLabelInOptions: false,
     options: [
       'Option 1',
@@ -21,7 +22,7 @@ const Template = (args) => <Select {...args} />;
 
 export const Default = Template.bind({});
 
-export const SearchWithState = (args) => {
+export const SelectWithState = (args) => {
   const [value, updateValue] = useState('');
   return (
     <Select
@@ -31,7 +32,7 @@ export const SearchWithState = (args) => {
     />
   );
 };
-SearchWithState.args = {
+SelectWithState.args = {
   id: 'field-2',
   label: 'Cool stuff',
   options: [
@@ -43,7 +44,26 @@ SearchWithState.args = {
   placeholder: 'Choose...'
 };
 
-export const SearchDisabled = (args) => {
+export const DisabledSelectFieldWithOptionPreselected = (args) => {
+  return (
+    <Select {...args} />
+  );
+};
+DisabledSelectFieldWithOptionPreselected.args = {
+  id: 'field-3',
+  label: 'Choose wisely…',
+  options: [
+    'Option 1',
+    'Option 2',
+    'Option 3',
+    'Option 4',
+  ],
+  disabled: true,
+  value: 'Option 3',
+  placeholder: 'Choose wisely…'
+};
+
+export const SelectWithOptionDisabled = (args) => {
   const [value, updateValue] = useState('');
   return (
     <Select
@@ -53,14 +73,19 @@ export const SearchDisabled = (args) => {
     />
   );
 };
-SearchDisabled.args = {
-  id: 'field-3',
-  label: 'Choose...',
+SelectWithOptionDisabled.args = {
+  id: 'field-4',
+  label: 'Select from the following:',
   options: [
-    'Option 1',
-    'Option 2',
-    'Option 3',
-    'Option 4',
+    'First option',
+    {
+      label: 'Second option',
+      value: 'second-option',
+      disabled: true,
+    },
+    'Third option',
+    'Fourth option',
+    'Fifth option',
   ],
-  disabled: true
+  placeholder: 'Select from the following:'
 };

--- a/packages/sage-react/lib/themes/next/Select/Select.story.jsx
+++ b/packages/sage-react/lib/themes/next/Select/Select.story.jsx
@@ -44,9 +44,8 @@ SelectWithState.args = {
   placeholder: 'Choose...'
 };
 
-export const DisabledSelectFieldWithOptionPreselected = (args) => {
-  return <Select {...args} />;
-};
+export const DisabledSelectFieldWithOptionPreselected = (args) => <Select {...args} />;
+
 DisabledSelectFieldWithOptionPreselected.args = {
   id: 'field-3',
   label: 'Choose wisely…',

--- a/packages/sage-react/lib/themes/next/Select/Select.story.jsx
+++ b/packages/sage-react/lib/themes/next/Select/Select.story.jsx
@@ -45,9 +45,7 @@ SelectWithState.args = {
 };
 
 export const DisabledSelectFieldWithOptionPreselected = (args) => {
-  return (
-    <Select {...args} />
-  );
+  return <Select {...args} />;
 };
 DisabledSelectFieldWithOptionPreselected.args = {
   id: 'field-3',

--- a/packages/sage-react/lib/themes/next/Select/configs.js
+++ b/packages/sage-react/lib/themes/next/Select/configs.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 export const selectStructuredItemPropTypes = PropTypes.shape({
   label: PropTypes.string,
   value: PropTypes.string,
+  disabled: PropTypes.bool,
 });
 
 export const selectItemPropTypes = PropTypes.oneOfType([


### PR DESCRIPTION
## Description
Updates `SageFormSelect` to permit passing `selected` and `disabled` attributes to individual options.

The `selected` change affects Rails only. This is not applicable to the React component, since `value` can already be used to pre-select an item.

- Also corrects several errors in Storybook caused by missing and invalid props
- Documentation updated in Rails and React


## Screenshots
No visual changes


## Testing in `sage-lib`

### Rails
1. Navigate to the [Form Select](http://localhost:4000/pages/component/form_select) documentation page in Next or Legacy
2. Locate that the second example, "Pets"
3. Confirm that (None Specified) `option` is selected on page load
4. Confirm that the "Spider" `option` is disabled and cannot be selected 

### React
1. Navigate to [Select in Storybook](http://localhost:4110/?path=/docs/sage-select--default)
2. Verify that the "Disabled Select Field" example has "Option 3" selected on page load
3. Confirm that the "Second Option" in the "Select With Option Disabled" is disabled and cannot be selected

## Testing in `kajabi-products`

1. (**HIGH**) New attributes for `SageFormSelect` are optional. No expected impact on current use. 


## Related
[SAGE-710](https://kajabi.atlassian.net/browse/SAGE-710)
[SAGE-600](https://kajabi.atlassian.net/browse/SAGE-600)
[SAGE-633](https://github.com/Kajabi/sage-lib/pull/1503)