### PR TITLE
[SAGE-712] Progress Bar within Fullscreen modal

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_progress_bar.scss
@@ -17,6 +17,12 @@ $-progress-bar-height: sage-spacing(xs);
 
 .sage-progress-bar {
   height: $-progress-bar-height;
+
+  .sage-modal__header & {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
 }
 
 .sage-progress-bar--has-percentage {
@@ -29,6 +35,10 @@ $-progress-bar-height: sage-spacing(xs);
   width: 100%;
   border-radius: sage-border(radius-small);
   background-color: var(--sage-progress-bar-background-color, sage-color(grey, 300));
+
+  .sage-modal__header & {
+    border-radius: 0;
+  }
 }
 
 .sage-progress-bar__value {

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_progress_bar.scss
@@ -47,6 +47,10 @@ $-progress-bar-height: sage-spacing(xs);
   background-color: var(--progress-bar-value-color, sage-color(sage, 300));
   border-radius: sage-border(radius-small);
   animation: 3s sage-progress-bar--slide ease;
+
+  .sage-modal__header & {
+    border-radius: 0;
+  }
 }
 
 .sage-progress-bar__element {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update sage next version of the progress within a fullscreen modal

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-07-05 at 12 00 01 PM](https://user-images.githubusercontent.com/1241836/177381527-fc3007db-9d41-4e73-b271-f9102247f575.png)|![Screen Shot 2022-07-05 at 12 11 11 PM](https://user-images.githubusercontent.com/1241836/177381546-516ba462-7ad0-4d75-a947-e55688e499da.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the modal views and verify that the progress bar is aligned properly
- [Rails](http://localhost:4000/pages/component/modal?tab=preview): modal -> Fullscreen Modal with Header Actions
- [React](http://localhost:4110/?path=/story/sage-modal--fullscreen)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update progress bar styles for fullscreen modals.
   - [ ] Creation Wizard


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-712](https://kajabi.atlassian.net/browse/SAGE-712)
