### PR TITLE
[SAGE-460] BUG: Non-focusable form labels

### DIFF
--- a/docs/app/views/examples/components/themes/next/form_input/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/form_input/_preview.html.erb
@@ -29,7 +29,7 @@
 
   <h3 class="t-sage-heading-6">Text (prefilled)</h3>
   <%= sage_component SageFormInput, {
-    id: "form__country",
+    id: "form__country1",
     input_type: "text",
     label_text: "Country",
     placeholder: "Country",
@@ -42,7 +42,7 @@
 
   <h3 class="t-sage-heading-6">Text (prefilled) with hidden label</h3>
   <%= sage_component SageFormInput, {
-    id: "form__country",
+    id: "form__country2",
     input_type: "text",
     label_text: "Country",
     placeholder: "Country",
@@ -111,7 +111,7 @@
 
   <h3 class="t-sage-heading-6">Numbers</h3>
   <%= sage_component SageFormInput, {
-    id: "form__num",
+    id: "form__num1",
     input_type: "number",
     label_text: "Enter quantity (max 48)",
     placeholder: "Enter quantity (max 48)",
@@ -127,7 +127,7 @@
 
   <h3 class="t-sage-heading-6">Numbers (incremented)</h3>
   <%= sage_component SageFormInput, {
-    id: "form__num",
+    id: "form__num2",
     input_type: "number",
     label_text: "Enter percentage (max 5%)",
     placeholder: "Enter percentage (max 5%)",
@@ -189,7 +189,7 @@
   <h3 class="t-sage-heading-6">With Static Icon</h3>
   <%= sage_component SageFormInput, {
     icon: "info-circle",
-    id: "form__fname1",
+    id: "form__fname3",
     input_type: "text",
     label_text: "First name",
     placeholder: "First name",
@@ -203,7 +203,7 @@
   <h3 class="t-sage-heading-6">With Static Icon with Error</h3>
   <%= sage_component SageFormInput, {
     icon: "info-circle",
-    id: "form__fname1",
+    id: "form__fname4",
     input_type: "text",
     label_text: "First name",
     placeholder: "First name",
@@ -217,7 +217,7 @@
 
   <h3 class="t-sage-heading-6">With Popover</h3>
   <%= sage_component SageFormInput, {
-    id: "form__fname1",
+    id: "form__fname5",
     input_type: "text",
     label_text: "First name",
     placeholder: "First name",

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -432,7 +432,6 @@
     color: inherit;
     white-space: nowrap;
     background-color: sage-color(white);
-    pointer-events: none;
   }
 
   // TODO: add support for Simpleform classes
@@ -487,7 +486,6 @@
   @extend %t-sage-body-semi;
 
   white-space: nowrap;
-  pointer-events: none;
 }
 
 ///

--- a/packages/sage-react/lib/themes/next/Input/Input.story.jsx
+++ b/packages/sage-react/lib/themes/next/Input/Input.story.jsx
@@ -48,24 +48,28 @@ export const Default = (args) => {
 const Template = (args) => <Input {...args} />;
 export const InputWithError = Template.bind({});
 InputWithError.args = {
-  hasError: true
+  hasError: true,
+  id: 'field-3'
 };
 
 export const InputDisabled = Template.bind({});
 InputDisabled.args = {
-  disabled: true
+  disabled: true,
+  id: 'field-4'
 };
 
 export const InputReadonly = Template.bind({});
 InputReadonly.args = {
   readonly: true,
-  value: 'You cannot change me'
+  value: 'You cannot change me',
+  id: 'field-5'
 };
 
 export const InputEmail = Template.bind({});
 InputEmail.args = {
   inputType: Input.Type.EMAIL,
-  label: 'Email address'
+  label: 'Email address',
+  id: 'field-6'
 };
 
 export const InputWithStaticIcon = (args) => {
@@ -129,7 +133,7 @@ InputWithStaticIcon.args = {
 };
 
 InputWithPopover.args = {
-  id: 'field-1',
+  id: 'field-7',
   message: 'this is a test message',
   popover: (
     <Popover


### PR DESCRIPTION
## Description
When clicking on a Form Input or Textarea’s label, the focus is not moved to the associated form field as expected.

These updates adjust the label styling to allow pointer events by removing `pointer-events: none` on the labels. This seems to be a carry-over from the floating labels.

In addition, some inputs on the docs preview page had duplicate IDs. Cleaned these up as well.

## Screenshots:
No visual changes are expected.


## Testing in `sage-lib`

- Navigate to [Form Inputs](http://localhost:4000/pages/component/form_input?tab=preview) and/or [Form Textarea](http://localhost:4000/pages/component/form_textarea?tab=preview)
- Verify clicking on a label applies focus to correct input.


## Testing in `kajabi-products`
1. (**LOW**) Adjusts label styling to allow pointer-events on input/textarea labels.


## Related
https://kajabi.atlassian.net/browse/SAGE-460