### PR TITLE
[Sage-704] Button - Icon Button Height

### DIFF
--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -138,7 +138,7 @@ $-btn-subtle-styles: (
 $-btn-interactive-badge-icon-size: rem(24px);
 $-btn-loading-min-height: rem(36px);
 
-
+// stylelint-disable max-nesting-depth
 .sage-btn {
   @extend %t-sage-body-semi;
   @include sage-button-style-reset();

--- a/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/components/_button.scss
@@ -139,15 +139,6 @@ $-btn-interactive-badge-icon-size: rem(24px);
 $-btn-loading-min-height: rem(36px);
 
 
-// stylelint-disable max-nesting-depth
-:root {
-  --icon-block-padding: #{rem(6px)};
-
-  @media screen and (min-width: sage-breakpoint(lg-min)) {
-    --icon-block-padding: #{rem(4px)};
-  }
-}
-
 .sage-btn {
   @extend %t-sage-body-semi;
   @include sage-button-style-reset();

--- a/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/themes/next/core/mixins/_sage.scss
@@ -83,7 +83,6 @@
 
         align-self: center;
         margin-left: sage-spacing(xs);
-        padding: var(--icon-block-padding) 0;
       }
     }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Removes padding from icons to correct Button height. Buttons should now properly be 40px in height.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="222" alt="Screen Shot 2022-07-07 at 2 51 32 PM" src="https://user-images.githubusercontent.com/14791307/177860698-30969a1d-506a-4292-888a-741acd1d96da.png">|<img width="216" alt="Screen Shot 2022-07-07 at 2 28 20 PM" src="https://user-images.githubusercontent.com/14791307/177860711-46a30369-4726-4f09-bf0d-c8ec7c786ada.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Button](http://localhost:4000/pages/component/button?tab=preview)
- Check that Buttons with icons are now 40px tall.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Removes padding from icons to correct Button height.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-704](https://kajabi.atlassian.net/browse/SAGE-704)