### PR TITLE
[SAGE-729] Description - remove icononly variation and update docs

### DIFF
--- a/docs/app/views/examples/components/themes/next/description/_preview.html.erb
+++ b/docs/app/views/examples/components/themes/next/description/_preview.html.erb
@@ -112,16 +112,9 @@
     },
     {
       title: "Default action",
-      data: "Default actions show just an arrow icon.",
+      data: md("Default actions show an arrow icon next to the `value` text."),
       action: {
-        attributes: { href: "#" }
-      }
-    },
-    {
-      title: "Default action showing label",
-      data: md("Set `icon_only: false` to show the default label."),
-      action: {
-        icon_only: false,
+        value: "View more",
         attributes: { href: "#" }
       }
     },
@@ -130,15 +123,6 @@
       data: "Actions can be set to use a label. In such cases an custom action width may also be needed.",
       action: {
         value: "Details",
-        attributes: { href: "#" }
-      }
-    },
-    {
-      title: "Custom labeled action visually hidden",
-      data: md("Custom labels can also be made visually hidden with `value` set but `icon_only: true`"),
-      action: {
-        value: "Details",
-        icon_only: true,
         attributes: { href: "#" }
       }
     },

--- a/docs/lib/sage_rails/app/sage_components/sage_description.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_description.rb
@@ -5,7 +5,6 @@ class SageDescription < SageComponent
     items: [:optional, [[NilClass, {
       action: [:optional, NilClass, {
         attributes: [:optional, NilClass, Hash],
-        icon_only: [:optional, NilClass, TrueClass],
         test_id: [:optional, NilClass, String],
         value: [:optional, NilClass, String],
       }],

--- a/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_description.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/themes/next/_sage_description.html.erb
@@ -26,17 +26,6 @@ end
     if !item
       next
     end
-
-    icon_only = true
-    if item[:action].present?
-      if item[:action][:value].present?
-        icon_only = false
-      end
-
-      if item[:action][:icon_only] != nil
-        icon_only = item[:action][:icon_only]
-      end
-    end
     %>
     <div
       class="
@@ -54,19 +43,19 @@ end
           <%= item[:data] %>
 
           <% if item[:action] %>
-            <dd class="sage-description__action">
+            <span class="sage-description__action">
               <%= sage_component SageButton, {
                 value: item[:action][:value] || "View more",
                 style: "primary",
                 subtle: true,
                 icon: {
                   name: "caret-right",
-                  style: icon_only ? "only" : "right",
+                  style: "right",
                 },
                 test_id: item[:action][:test_id],
                 attributes: item[:action][:attributes],
               } %>
-            </dd>
+            </span>
           <% end %>
         </dd>
       <% end %>

--- a/packages/sage-react/lib/themes/next/Description/Description.jsx
+++ b/packages/sage-react/lib/themes/next/Description/Description.jsx
@@ -48,7 +48,7 @@ export const Description = ({
             {data}
 
             {action && (
-              <dd className="sage-description__action">
+              <span className="sage-description__action">
                 <Button
                   color={Button.COLORS.PRIMARY}
                   subtle={true}
@@ -59,7 +59,7 @@ export const Description = ({
                 >
                   {action.value || 'View more'}
                 </Button>
-              </dd>
+              </span>
             )}
           </dd>
         )}
@@ -119,14 +119,14 @@ export const Description = ({
   };
 
   return (
-    <div
+    <dl
       className={classNames}
       style={getCustomProps()}
       {...rest}
     >
       {renderItems()}
       {children}
-    </div>
+    </dl>
   );
 };
 
@@ -149,7 +149,6 @@ Description.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({
     action: PropTypes.shape({
       attributes: PropTypes.objectOf(PropTypes.object),
-      iconOnly: PropTypes.bool,
       value: PropTypes.string,
     }),
     data: PropTypes.node,

--- a/packages/sage-react/lib/themes/next/Description/Description.story.jsx
+++ b/packages/sage-react/lib/themes/next/Description/Description.story.jsx
@@ -75,14 +75,7 @@ MultipleItemsWithActionButton.args = {
       title: 'Default action',
       data: 'Default actions show just an arrow icon.',
       action: {
-        attributes: { href: '#' }
-      }
-    },
-    {
-      title: 'Default action showing label',
-      data: 'Set `icon_only: false` to show the default label.',
-      action: {
-        iconOnly: false,
+        value: 'View more',
         attributes: { href: '#' }
       }
     },
@@ -91,15 +84,6 @@ MultipleItemsWithActionButton.args = {
       data: 'Actions can be set to use a label. In such cases an custom action width may also be needed.',
       action: {
         value: 'Details',
-        attributes: { href: '#' }
-      }
-    },
-    {
-      title: 'Custom labeled action visually hidden',
-      data: 'Custom labels can also be made visually hidden with `value` set but `icon_only: true`',
-      action: {
-        value: 'Details',
-        iconOnly: true,
         attributes: { href: '#' }
       }
     },


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove iconOnly props
- [x] updated docs to remove any examples with icon only actions
- [x] resolve a11y issues: update to `dl` wrapper and update button wrapper to `span`
- [x] ~update `kp` refs~ - [SAGE-715](https://github.com/Kajabi/kajabi-products/pull/24218)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-07-12 at 9 27 27 AM](https://user-images.githubusercontent.com/1241836/178514180-fdf958d0-cb1e-46fb-9ba2-aa98089cc883.png)|![Screen Shot 2022-07-12 at 9 26 33 AM](https://user-images.githubusercontent.com/1241836/178514200-e42d88a0-169b-4099-90b2-0cf5f4df8223.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Description views and verify that icon only variations are correct: 
- [Rails](http://localhost:4000/pages/component/description?tab=preview)
- [React](http://localhost:4110/?path=/story/sage-description--multiple-items-with-action-button)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Removes `icon_only` property from the Description component.
   - [ ] People Page contact drawer


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-729](https://kajabi.atlassian.net/browse/SAGE-729)