### PR TITLE
[Sage-738] Toast - Danger Button Color

### DIFF
--- a/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
@@ -33,11 +33,6 @@
   }
 }
 
-.sage-btn--subtle.sage-btn--secondary,
-.sage-btn--subtle.sage-btn--secondary::before {
-  color: inherit;
-}
-
 // build individual color blocks
 @each $name, $color in $sage-colors {
   @each $value, $map in $color {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -613,6 +613,8 @@ $-alert-colors: (
       }
 
       &.sage-toast__button {
+        color: sage-color(white);
+
         &:focus,
         &:active {
           &::after {

--- a/packages/sage-assets/lib/stylesheets/components/_toast.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_toast.scss
@@ -133,7 +133,7 @@ $-toast-bottom-spacing: sage-spacing(xs);
   margin-right: auto;
   color: sage-color(white);
 
-  @extend %t-sage-body-semi;
+  @extend %t-sage-body-small-semi;
 }
 
 .sage-toast__button {
@@ -144,7 +144,7 @@ $-toast-bottom-spacing: sage-spacing(xs);
   align-items: center;
   margin-left: sage-spacing(sm);
   white-space: nowrap;
-  color: sage-color(grey, 200);
+  color: sage-color(white);
   border-radius: sage-border(radius-large);
 
   &:hover,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes danger Toast button color. Also changes font size for value text to `body small` to match Figma specs.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="393" alt="Screen Shot 2022-07-18 at 11 52 55 AM" src="https://user-images.githubusercontent.com/14791307/179562970-0b230eb7-7182-48fb-9402-e4811175fe34.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Toast](http://localhost:4000/pages/component/toast?tab=preview)
- Check that close button is white and there are no color overrides in dev tools

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Fixes danger Toast button color. Also changes font size for value text to `body small` to match Figma specs.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-738](https://kajabi.atlassian.net/browse/SAGE-738)