### PR TITLE
SAGE-682: [Sage Next] - Focus ring has shifted due to padding

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -152,7 +152,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 .sage-dropdown__item-control {
   @include sage-button-style-reset();
-  @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
+  @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: -2px);
   @include sage-focus-outline--update-color(sage-color(primary, 200));
 
   @extend %t-sage-body-med;
@@ -183,7 +183,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   }
 
   &:focus-within {
-    @include sage-focus-outline($outline-offset-inline: -2px, $outline-offset-block: -2px);
+    @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: -2px);
     @include sage-focus-outline--update-color(sage-color(primary, 200));
 
     &::after {


### PR DESCRIPTION
## Description
Update mixin values to align focus rings with hover state background

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="242" alt="Screen Shot 2022-07-18 at 2 53 12 PM" src="https://user-images.githubusercontent.com/791670/179582328-3e2df908-29bd-47fd-bc11-a10d39b0c05c.png">|<img width="242" alt="Screen Shot 2022-07-18 at 2 52 53 PM" src="https://user-images.githubusercontent.com/791670/179582346-f6c110ea-b8d4-42ce-aadc-d789d7f18772.png">

## Testing in `sage-lib`
1. Navigate to Dropdown Multiselect component
2. Validate focus state aligns hover background

http://localhost:4100/?path=/story/sage-dropdown--multiselect

## Testing in `kajabi-products`
1. (**LOW**) Updates values passed to mixin to make dropdown focus ring a bit wider

## Related
[SAGE-682: [Sage Next] - Focus ring has shifted due to padding](https://kajabi.atlassian.net/browse/SAGE-682)
