### PR TITLE
MOCK: Add Transactions page mocks

### DIFF
--- a/packages/sage-react/lib/mocks/payment-transactions/Main.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/Main.jsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Frame,
+  Grid,
+  OptionsDropdown,
+  PageHeading,
+  Pagination,
+  SageClassnames,
+  SageTokens,
+  Search,
+  Table,
+} from '../..';
+import { ModalCustomizeColumns, ModalFilters } from './components';
+import { PriceField } from './components/PriceField';
+import {
+  transactionItemOptions,
+  transactionPageOptions,
+  transactionsTableData,
+  transactionsTableSchema,
+} from './data-helper';
+
+export const Main = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize] = useState(25); // TODO: Dev: Wire to page size selection/default
+  const [searchValue, setSearchValue] = useState('');
+  const [showCustomizeColumnsModal, setShowCustomizeColumnsModal] = useState(false);
+  const [showFiltersModal, setShowFiltersModal] = useState(false);
+  const [timeframe] = useState('30 days'); // TODO: Dev: Wire to timeframe selection
+  const [totalItems] = useState(112); // TODO: Dev: Wire to accurate total item count
+
+  // TODO: Dev: wire page change to service to load new page
+  const onClickPage = (newPage) => setCurrentPage(newPage);
+
+  return (
+    <Grid container={Grid.CONTAINER_SIZES.FULL}>
+      <PageHeading
+        actionItems={[
+          <OptionsDropdown
+            options={transactionPageOptions({ transactionPageOptions })}
+            triggerButtonSubtle={false}
+          />,
+          /*
+            TODO: DSS: Search border radius is not as shown in design
+            TODO: DSS: Search value change is behaving odd...
+              confirm unique to Storybook and not a bigger issue
+          */
+          <Search
+            hideLabel={true}
+            id="search_default"
+            label="Find"
+            onChange={({ target: { value } }) => setSearchValue(value)}
+            placeholder="Search transactions..."
+            style={{ width: '340px' }}
+            value={searchValue}
+          />
+        ]}
+        className={SageClassnames.SPACERS.LG_BOTTOM}
+      >
+        Transactions
+      </PageHeading>
+      <Frame
+        direction={Frame.DIRECTIONS.HORIZONTAL}
+        align={Frame.ALIGNMENTS.CENTER_SPREAD}
+        className={SageClassnames.SPACERS.MD_BOTTOM}
+      >
+        <p className={[SageClassnames.TYPE.BODY, SageClassnames.TYPE_COLORS.CHARCOAL_400].join(' ')}>
+          Displaying{' '}
+          <b>{currentPage * pageSize} &ndash; {((currentPage + 1) * pageSize) - 1}</b>{' '}
+          of{' '}
+          <b>{totalItems}</b>{' '}
+          transactions in the last{' '}
+          <b>{timeframe}</b>
+        </p>
+        {/*
+          TODO: DSS: Look more at the number badge shown in the mock above this button
+            https://www.figma.com/file/8wkkXKHaOigsAl5Ye9vaKh/Transactions-page?node-id=1268%3A1704
+        */}
+        <Button
+          icon={SageTokens.ICONS.FILTER}
+          color={Button.COLORS.SECONDARY}
+          onClick={() => setShowFiltersModal(true)}
+        >
+          Filters
+        </Button>
+      </Frame>
+      {/*
+        TODO: DSS: Are table styles all up to date with what design requests?
+        TODO: DSS: Need to ensure table sorting hooks are set up.
+        TODO: DSS: Need responsive pattern enacted.
+        TODO: DSS: Need to make options cell only visible on hover.
+      */}
+      <Table
+        isResponsive={false}
+        schema={transactionsTableSchema}
+        selectable={false}
+        rows={transactionsTableData.map(({
+          id,
+          price,
+          type,
+          name,
+          email,
+          offerName,
+          date,
+        }) => ({
+          price: <PriceField {...price} />,
+          type,
+          name,
+          email,
+          offerName,
+          date,
+          options: (
+            <OptionsDropdown
+              align={OptionsDropdown.POSITIONS.RIGHT}
+              isPinned={false}
+              options={transactionItemOptions({ id })}
+            />
+          ),
+        }))}
+      />
+      <Pagination
+        currentPage={currentPage}
+        hideCounter={true}
+        itemsTotalCount={totalItems}
+        onClickPage={onClickPage}
+        pageSize={pageSize}
+        /*
+          TODO: DSS: Adjust how pagination is calculated here;
+            odd to have to set pageSize to null...
+        */
+        pageCount={null}
+      />
+      <ModalCustomizeColumns
+        active={showCustomizeColumnsModal}
+        onExit={() => setShowCustomizeColumnsModal(false)}
+      />
+      <ModalFilters
+        active={showFiltersModal}
+        onExit={() => setShowFiltersModal(false)}
+      />
+    </Grid>
+  );
+};

--- a/packages/sage-react/lib/mocks/payment-transactions/Main.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/Main.jsx
@@ -35,24 +35,13 @@ export const Main = () => {
   return (
     <Grid container={Grid.CONTAINER_SIZES.FULL}>
       <PageHeading
+        // TODO: DSS: `actionItems` should not be an array but just nodes as children.
+        //   https://kajabi.atlassian.net/browse/SAGE-752
         actionItems={[
           <OptionsDropdown
-            options={transactionPageOptions({ transactionPageOptions })}
+            options={transactionPageOptions({ setShowCustomizeColumnsModal })}
             triggerButtonSubtle={false}
-          />,
-          /*
-            TODO: DSS: Search border radius is not as shown in design
-            TODO: DSS: Search value change is behaving odd...
-              confirm unique to Storybook and not a bigger issue
-          */
-          <Search
-            hideLabel={true}
-            id="search_default"
-            label="Find"
-            onChange={({ target: { value } }) => setSearchValue(value)}
-            placeholder="Search transactions..."
-            style={{ width: '340px' }}
-            value={searchValue}
+            align={OptionsDropdown.POSITIONS.RIGHT}
           />
         ]}
         className={SageClassnames.SPACERS.LG_BOTTOM}
@@ -66,31 +55,55 @@ export const Main = () => {
       >
         <p className={[SageClassnames.TYPE.BODY, SageClassnames.TYPE_COLORS.CHARCOAL_400].join(' ')}>
           Displaying{' '}
-          <b>{currentPage * pageSize} &ndash; {((currentPage + 1) * pageSize) - 1}</b>{' '}
+          <b>{(currentPage - 1) * pageSize + 1} &ndash; {currentPage * pageSize}</b>{' '}
           of{' '}
           <b>{totalItems}</b>{' '}
           transactions in the last{' '}
           <b>{timeframe}</b>
         </p>
-        {/*
-          TODO: DSS: Look more at the number badge shown in the mock above this button
-            https://www.figma.com/file/8wkkXKHaOigsAl5Ye9vaKh/Transactions-page?node-id=1268%3A1704
-        */}
-        <Button
-          icon={SageTokens.ICONS.FILTER}
-          color={Button.COLORS.SECONDARY}
-          onClick={() => setShowFiltersModal(true)}
+
+        <Frame
+          direction={Frame.DIRECTIONS.HORIZONTAL}
+          align={Frame.ALIGNMENTS.CENTER_SPREAD}
+          width={Frame.WIDTHS.HUG}
         >
-          Filters
-        </Button>
+          <Search
+            contained={true}
+            hideLabel={true}
+            id="transaction-search"
+            label="Find"
+            onChange={(event) => setSearchValue(event.target.value)}
+            placeholder="Search transactions..."
+            style={{ width: '340px' }}
+            value={searchValue}
+          />
+          {/*
+            TODO: DSS: Need design specs to add the "number" badge as shown here
+              https://www.figma.com/file/8wkkXKHaOigsAl5Ye9vaKh/Transactions-page?node-id=1268%3A1704
+              https://kajabi.atlassian.net/browse/SAGE-755
+              DESIGN spec needed
+          */}
+          <Button
+            icon={SageTokens.ICONS.FILTER}
+            color={Button.COLORS.SECONDARY}
+            onClick={() => setShowFiltersModal(true)}
+          >
+            Filters
+          </Button>
+        </Frame>
       </Frame>
       {/*
-        TODO: DSS: Are table styles all up to date with what design requests?
+        TODO: DSS: Sync to latest table styles
+          https://kajabi.atlassian.net/browse/SAGE-756
+          DESIGN specs needed
+        TODO: DSS: Need responsive pattern enacted
+          https://kajabi.atlassian.net/browse/SAGE-757
+          DESIGN specs needed
         TODO: DSS: Need to ensure table sorting hooks are set up.
-        TODO: DSS: Need responsive pattern enacted.
-        TODO: DSS: Need to make options cell only visible on hover.
+          https://kajabi.atlassian.net/browse/SAGE-758
       */}
       <Table
+        className={SageClassnames.SPACERS.MD_BOTTOM}
         isResponsive={false}
         schema={transactionsTableSchema}
         selectable={false}
@@ -127,6 +140,7 @@ export const Main = () => {
         /*
           TODO: DSS: Adjust how pagination is calculated here;
             odd to have to set pageSize to null...
+            https://kajabi.atlassian.net/browse/SAGE-751
         */
         pageCount={null}
       />

--- a/packages/sage-react/lib/mocks/payment-transactions/PaymentTransactions.story.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/PaymentTransactions.story.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Main } from './Main';
+
+export default {
+  title: 'Mocks/Payments: Transactions',
+  argTypes: {},
+  args: {}
+};
+const Template = () => <Main />;
+
+export const Index = Template.bind({});

--- a/packages/sage-react/lib/mocks/payment-transactions/components/ModalCustomizeColumns.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/ModalCustomizeColumns.jsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Frame,
+  List,
+  Modal,
+  SageClassnames,
+  SageTokens,
+  Switch,
+  Toggle,
+} from '../../..';
+import { columns as tableColumns } from '../data-helper';
+
+export const ModalCustomizeColumns = ({ active, onExit }) => {
+  const [columns, setColumns] = useState(tableColumns);
+
+  const handleResetToDefault = () => {
+    // TODO: Dev: Add logic to restore default column configs
+  };
+
+  useEffect(() => {
+    // TODO: Dev: Wire to ensure column configs can affect table as desired.
+  }, [columns]);
+
+  return (
+    <Modal onExit={onExit} active={active}>
+      {/*
+        TODO: DSS: Width shown in mocks is smaller than possible with modal rn.
+          Per discussion with Design, need to add ability set modal size
+          in sync with system container sizes.
+      */}
+      <Modal.Header
+        title="Custom columns"
+        aside={(
+          <Button
+            color={Button.COLORS.SECONDARY}
+            iconOnly={true}
+            icon={SageTokens.ICONS.REMOVE}
+            onClick={onExit}
+            subtle={true}
+          >
+            Close
+          </Button>
+        )}
+      >
+        <p className={[SageClassnames.TYPE.BODY, SageClassnames.TYPE_COLORS.CHARCOAL_400]}>
+          Add, remove or reorder columns to customize your table’s layout.
+        </p>
+      </Modal.Header>
+      <Modal.Body gap={Modal.Body.GAP_OPTIONS.LG}>
+        {/*
+          TODO: DSS: List is outputting some scheme errors that should be cleaned up.
+        */}
+        <List
+          sortableConfigs={{ setList: setColumns }}
+          itemRenderer={({ id, name, excludable = true }) => (
+            <Frame direction={Frame.DIRECTIONS.HORIZONTAL} align={Frame.ALIGNMENTS.START_SPREAD}>
+              <p>{name}</p>
+              {excludable && (
+                <Switch
+                  checked={false}
+                  label="Switch label"
+                  name="customize-column-toggles"
+                  hideText={true}
+                  type={Toggle.TYPES.CHECKBOX}
+                  id={`${id}-toggle`}
+                  value="Demo"
+                />
+              )}
+            </Frame>
+          )}
+          items={columns}
+        />
+      </Modal.Body>
+      <Modal.Footer>
+        <Modal.FooterAside>
+          {/*
+            TODO: DSS: Need to ensure link/button style and tags all work as expected.
+            Here, we probably want the Link styling but need to render a `button`.
+          */}
+          <Button
+            color={Button.COLORS.SECONDARY}
+            onClick={handleResetToDefault}
+            subtle={true}
+          >
+            Reset to default
+          </Button>
+        </Modal.FooterAside>
+        <Button
+          color={Button.COLORS.PRIMARY}
+          onClick={onExit}
+        >
+          Apply
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ModalCustomizeColumns.defaultProps = {
+  active: false,
+  onExit: null,
+};
+
+ModalCustomizeColumns.propTypes = {
+  active: PropTypes.bool,
+  onExit: PropTypes.func,
+};

--- a/packages/sage-react/lib/mocks/payment-transactions/components/ModalCustomizeColumns.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/ModalCustomizeColumns.jsx
@@ -26,9 +26,12 @@ export const ModalCustomizeColumns = ({ active, onExit }) => {
   return (
     <Modal onExit={onExit} active={active}>
       {/*
-        TODO: DSS: Width shown in mocks is smaller than possible with modal rn.
+        TODO: DSS: Add container sizes as Modal size options.
+          Width shown in mocks is smaller than possible with modal rn.
           Per discussion with Design, need to add ability set modal size
           in sync with system container sizes.
+          https://kajabi.atlassian.net/browse/SAGE-753
+          DESIGN: Spec needed?
       */}
       <Modal.Header
         title="Custom columns"
@@ -51,6 +54,7 @@ export const ModalCustomizeColumns = ({ active, onExit }) => {
       <Modal.Body gap={Modal.Body.GAP_OPTIONS.LG}>
         {/*
           TODO: DSS: List is outputting some scheme errors that should be cleaned up.
+          https://kajabi.atlassian.net/browse/SAGE-749
         */}
         <List
           sortableConfigs={{ setList: setColumns }}
@@ -77,7 +81,8 @@ export const ModalCustomizeColumns = ({ active, onExit }) => {
         <Modal.FooterAside>
           {/*
             TODO: DSS: Need to ensure link/button style and tags all work as expected.
-            Here, we probably want the Link styling but need to render a `button`.
+              Here, we probably want the Link styling but need to render a `button`.
+              DESIGN spec needed?
           */}
           <Button
             color={Button.COLORS.SECONDARY}

--- a/packages/sage-react/lib/mocks/payment-transactions/components/ModalFilters.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/ModalFilters.jsx
@@ -121,9 +121,16 @@ export const ModalFilters = ({ active, onExit }) => {
         >
           {paymentCards.map(({ label, icon }) => (
             <Frame key={label} widthRatio="1" align={Frame.ALIGNMENTS.SPREAD_STRETCH}>
+              {/*
+                TODO: DSS: Need to add interactive feature to Card
+                  Temporary styling used here in the meantime
+                  https://kajabi.atlassian.net/browse/SAGE-761
+              */}
               <Card onClick={() => onChangeActiveCards(label)}>
                 <Icon
                   icon={icon}
+                  // TODO: Dev: Reduce this to just CHARCOAL_500
+                  //   after the above ticket is completed.
                   color={activeCards.includes(label)
                     ? Icon.COLORS.CHARCOAL_500
                     : Icon.COLORS.CHARCOAL_100}

--- a/packages/sage-react/lib/mocks/payment-transactions/components/ModalFilters.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/ModalFilters.jsx
@@ -1,0 +1,226 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Card,
+  Frame,
+  Icon,
+  Modal,
+  Panel,
+  SageClassnames,
+  SageTokens,
+} from '../../..';
+import {
+  currencies,
+  otherFilters,
+  paymentCards,
+  paymentTypes,
+  renderToggleGroup,
+  statuses,
+  timeframes,
+} from '../data-helper';
+
+export const ModalFilters = ({ active, onExit }) => {
+  const [filterCount] = useState(null);
+  const [activeCards, setActiveCards] = useState([]);
+  const [activeCurrencies, setActiveCurrencies] = useState([]);
+  const [activeOthers, setActiveOthers] = useState([]);
+  const [activePaymentTypes, setActivePaymentTypes] = useState([]);
+  const [activeStatuses, setActiveStatuses] = useState([]);
+  const [activeTimeframe, setActiveTimeframe] = useState([]);
+
+  const toggleMultipleValues = (value, arr, setArr) => {
+    if (arr.includes(value)) {
+      setArr(arr.filter((o) => o !== value));
+    } else {
+      setArr([...arr, value]);
+    }
+  };
+
+  const onChangeActiveCards = (payload) => toggleMultipleValues(
+    payload,
+    activeCards,
+    setActiveCards
+  );
+
+  const onChangeActiveCurrencies = (payload) => toggleMultipleValues(
+    payload,
+    activeCurrencies,
+    setActiveCurrencies,
+  );
+
+  const onChangeActiveOthers = (payload) => toggleMultipleValues(
+    payload,
+    activeOthers,
+    setActiveOthers,
+  );
+
+  const onChangeActivePaymentTypes = (payload) => toggleMultipleValues(
+    payload,
+    activePaymentTypes,
+    setActivePaymentTypes
+  );
+
+  const onChangeActiveStatuses = (payload) => toggleMultipleValues(
+    payload,
+    activeStatuses,
+    setActiveStatuses,
+  );
+
+  const onChangeActiveTimeframe = (payload) => setActiveTimeframe(payload);
+
+  const filterFields = [
+    {
+      title: 'Payment types',
+      fields: renderToggleGroup({
+        name: 'filter-by-payment-types',
+        items: paymentTypes.map(({ id, label }) => ({
+          checked: activePaymentTypes.includes(id),
+          id: `payment-types-${id}`,
+          label,
+          onChange: onChangeActivePaymentTypes,
+          value: id,
+        })),
+      }),
+    },
+    {
+      title: 'Status',
+      fields: renderToggleGroup({
+        name: 'filter-by-status',
+        items: statuses.map(({ id, label }) => ({
+          checked: activeStatuses.includes(id),
+          id: `status-${id}`,
+          label,
+          onChange: onChangeActiveStatuses,
+          value: id,
+        })),
+      }),
+    },
+    {
+      title: 'In the last...',
+      fields: renderToggleGroup({
+        name: 'filter-by-timeframe',
+        items: timeframes.map(({ id, label }) => ({
+          checked: activeTimeframe === id,
+          id: `timeframe-${id}`,
+          label,
+          onChange: onChangeActiveTimeframe,
+          value: id,
+        })),
+        type: 'radio',
+        useTwoColumns: false,
+      }),
+    },
+    {
+      title: 'Payment method',
+      fields: (
+        <Frame
+          direction={Frame.DIRECTIONS.HORIZONTAL}
+          gap={Frame.GAPS.SM}
+          align={Frame.ALIGNMENTS.CENTER_SPREAD}
+        >
+          {paymentCards.map(({ label, icon }) => (
+            <Frame key={label} widthRatio="1" align={Frame.ALIGNMENTS.SPREAD_STRETCH}>
+              <Card onClick={() => onChangeActiveCards(label)}>
+                <Icon
+                  icon={icon}
+                  color={activeCards.includes(label)
+                    ? Icon.COLORS.CHARCOAL_500
+                    : Icon.COLORS.CHARCOAL_100}
+                />
+                <span className={SageClassnames.TYPE.BODY_MED}>
+                  {label}
+                </span>
+              </Card>
+            </Frame>
+          ))}
+        </Frame>
+      ),
+    },
+    {
+      title: 'Currency type',
+      fields: renderToggleGroup({
+        name: 'filter-by-timeframe',
+        items: currencies.map(({ name, symbol }) => ({
+          checked: activeCurrencies.includes(name),
+          id: `currencies-${name.toLowerCase()}`,
+          label: `${symbol} ${name}`,
+          onChange: onChangeActiveCurrencies,
+          value: name,
+        })),
+      }),
+    },
+    {
+      title: 'Other filters',
+      fields: renderToggleGroup({
+        name: 'filter-by-timeframe',
+        items: otherFilters.map(({ id, label }) => ({
+          checked: activeOthers.includes(id),
+          id: `other-filters-${id}`,
+          label,
+          onChange: onChangeActiveOthers,
+          value: id,
+        })),
+      }),
+    },
+  ];
+
+  return (
+    <Modal
+      active={active}
+      allowScroll={true}
+      onExit={onExit}
+    >
+      <Modal.Header
+        title="Filters"
+        aside={(
+          <Button
+            color={Button.COLORS.SECONDARY}
+            iconOnly={true}
+            icon={SageTokens.ICONS.REMOVE}
+            onClick={onExit}
+            subtle={true}
+          >
+            Close
+          </Button>
+        )}
+      />
+      <Modal.Body gap={Modal.Body.GAP_OPTIONS.LG}>
+        {filterFields.map(({ title, fields }) => (
+          <Frame key={title}>
+            <h4>{title}</h4>
+            {fields}
+            <Panel.Divider />
+          </Frame>
+        ))}
+      </Modal.Body>
+      <Modal.Footer>
+        <Modal.FooterAside>
+          <Button
+            color={Button.COLORS.SECONDARY}
+            onClick={onExit}
+            subtle={true}
+          >
+            Cancel
+          </Button>
+        </Modal.FooterAside>
+        <Button
+          color={Button.COLORS.PRIMARY}
+          onClick={onExit}
+        >
+          Show {filterCount === null ? 'all' : filterCount} transactions
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ModalFilters.defaultProps = {
+  active: false,
+  onExit: null,
+};
+
+ModalFilters.propTypes = {
+  active: PropTypes.bool,
+  onExit: PropTypes.func,
+};

--- a/packages/sage-react/lib/mocks/payment-transactions/components/PriceField.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/PriceField.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Badge,
+  Icon,
+  Link,
+  Frame,
+  SageClassnames,
+  SageTokens,
+  Tooltip,
+} from '../../..';
+import {
+  currencies,
+  paymentCards,
+  statuses,
+} from '../data-helper';
+
+export const PriceField = ({
+  cardType,
+  price,
+  coupon,
+  currency,
+  status,
+}) => {
+  const { icon: cardIcon } = (
+    paymentCards.find(({ label }) => label.toLowerCase() === cardType)
+    || { icon: Icon.ICONS.CARD_GENERIC }
+  );
+
+  const currencyData = (
+    currencies.find(({ name }) => name === currency)
+    || currencies[0]
+  );
+
+  const {
+    name: currencyCode,
+    symbol: currencySymbol,
+  } = currencyData;
+
+  const badgeConfigs = (
+    statuses.find(({ id }) => id === status)
+    || statuses[0]
+  );
+
+  const couponIcon = coupon ? (
+    <Tooltip content={`Coupon: ${coupon.value}`}>
+      <Icon
+        color={Icon.COLORS.CHARCOAL_100}
+        icon={Icon.ICONS.COUPON}
+        label="Used a coupon"
+        size={Icon.SIZES.MD}
+      />
+    </Tooltip>
+  ) : (
+    <Icon
+      color={Icon.COLORS.WHITE}
+      icon={Icon.ICONS.BAN}
+      label="Did not use a coupon"
+      // TODO: DSS: Consider adding a `null` icon that can be used for placeholders like here
+      size={Icon.SIZES.MD}
+    />
+  );
+
+  return (
+    <Frame
+      align={Frame.ALIGNMENTS.CENTER_LEFT}
+      direction={Frame.DIRECTIONS.HORIZONTAL}
+      gap={Frame.GAPS.XS}
+      width={Frame.WIDTHS.FILL}
+    >
+      <Icon
+        color={SageTokens.COLOR_SLIDERS.CHARCOAL_500}
+        icon={cardIcon}
+        size={Icon.SIZES.XL}
+      />
+      <Frame
+        align={Frame.ALIGNMENTS.CENTER_RIGHT}
+        direction={Frame.DIRECTIONS.HORIZONTAL}
+        gap={Frame.GAPS['2XS']}
+        tag="span"
+        width={Frame.WIDTHS.FLEX}
+      >
+        <Link
+          // TODO: Dev: The following class can be used
+          //   in order to enact the correct hover effect on the row
+          //   once this PR is merged: https://github.com/Kajabi/sage-lib/pull/1499
+          // className={SageClassnames.LINK.TABLE_CELL_PRIMARY}
+          href="#TODO-dev-url-transaction-details"
+          removeUnderline={true}
+          // TODO: DSS: This property collides with `style` for providing CSS
+          style={Link.COLORS.SECONDARY}
+        >
+          {currencySymbol}
+          {price}
+        </Link>
+        <span className={SageClassnames.TYPE_COLORS.CHARCOAL_100}>
+          {currencyCode}
+        </span>
+      </Frame>
+      {couponIcon}
+      <Frame width="85px">
+        <Badge
+          color={badgeConfigs.badgeColor}
+          value={badgeConfigs.label}
+        />
+      </Frame>
+    </Frame>
+  );
+};
+
+PriceField.defaultProps = {
+  cardType: null,
+  price: '--',
+  coupon: null,
+  currency: 'USD',
+  status: 'success',
+};
+
+PriceField.propTypes = {
+  cardType: PropTypes.oneOf(paymentCards.map(({ label }) => label.toLowerCase())),
+  price: PropTypes.string,
+  coupon: PropTypes.shape({
+    value: PropTypes.string,
+  }),
+  currency: PropTypes.oneOf(currencies.map(({ name }) => name)),
+  status: PropTypes.oneOf(statuses.map(({ id }) => id)),
+};

--- a/packages/sage-react/lib/mocks/payment-transactions/components/PriceField.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/PriceField.jsx
@@ -56,7 +56,8 @@ export const PriceField = ({
       color={Icon.COLORS.WHITE}
       icon={Icon.ICONS.BAN}
       label="Did not use a coupon"
-      // TODO: DSS: Consider adding a `null` icon that can be used for placeholders like here
+      // TODO: DSS: Add `null` icon that can be used for placeholders like here
+      //   https://kajabi.atlassian.net/browse/SAGE-754
       size={Icon.SIZES.MD}
     />
   );
@@ -87,8 +88,11 @@ export const PriceField = ({
           // className={SageClassnames.LINK.TABLE_CELL_PRIMARY}
           href="#TODO-dev-url-transaction-details"
           removeUnderline={true}
-          // TODO: DSS: This property collides with `style` for providing CSS
           style={Link.COLORS.SECONDARY}
+          // TODO: DSS: Need to avoid using `style` as a prop name so we don't block inline styling.
+          //   Here this would have been useful to properly format
+          //   the size of this element in context.
+          //   https://kajabi.atlassian.net/browse/SAGE-750
         >
           {currencySymbol}
           {price}

--- a/packages/sage-react/lib/mocks/payment-transactions/components/index.js
+++ b/packages/sage-react/lib/mocks/payment-transactions/components/index.js
@@ -1,0 +1,3 @@
+export { ModalCustomizeColumns } from './ModalCustomizeColumns';
+export { ModalFilters } from './ModalFilters';
+export { PriceField } from './PriceField';

--- a/packages/sage-react/lib/mocks/payment-transactions/data-helper.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/data-helper.jsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import {
+  Badge,
+  Checkbox,
+  Frame,
+  Icon,
+  Radio,
+  Table,
+} from '../..';
+
+export const columns = [
+  {
+    id: 'transactions-column-price',
+    name: 'Price',
+    excludable: false,
+  },
+  {
+    id: 'transactions-column-type',
+    name: 'Transaction type',
+  },
+  {
+    id: 'transactions-column-name',
+    name: 'Name',
+  },
+  {
+    id: 'transactions-column-email',
+    name: 'Email address',
+    excludable: false,
+  },
+  {
+    id: 'transactions-column-offer-name',
+    name: 'Offer name',
+  },
+  {
+    id: 'transactions-column-date',
+    name: 'Date',
+  },
+];
+
+export const currencies = [
+  {
+    name: 'USD',
+    symbol: '$',
+  },
+  {
+    name: 'GBP',
+    symbol: '£',
+  },
+  {
+    name: 'KRW',
+    symbol: '₩',
+  },
+  {
+    name: 'EUR',
+    symbol: '€',
+  },
+  {
+    name: 'CAD',
+    symbol: '$',
+  },
+  {
+    name: 'JPY',
+    symbol: '¥',
+  },
+];
+
+export const otherFilters = [
+  {
+    id: 'used',
+    label: 'Coupon used',
+  }
+];
+
+export const paymentCards = [
+  {
+    label: 'Visa',
+    icon: Icon.ICONS.CARD_VISA,
+  },
+  {
+    label: 'Mastercard',
+    icon: Icon.ICONS.CARD_MASTERCARD,
+  },
+  {
+    label: 'AMEX',
+    icon: Icon.ICONS.CARD_AMEX,
+  },
+  {
+    label: 'Discover',
+    icon: Icon.ICONS.CARD_DISCOVER,
+  },
+];
+
+export const paymentTypes = [
+  {
+    id: 'single',
+    label: 'One-time payment',
+  },
+  {
+    id: 'subscription',
+    label: 'Subscription',
+  },
+  {
+    id: 'multi',
+    label: 'Multi-payment',
+  },
+];
+
+export const renderToggleGroup = ({
+  items,
+  name,
+  useTwoColumns = true,
+  type = 'checkbox',
+}) => {
+  let styles = {};
+  if (useTwoColumns) {
+    const halfItems = Math.ceil(items.length / 2);
+    styles = {
+      flexWrap: 'wrap',
+      height: `${halfItems * 24 + (halfItems - 1) * 16}px`
+    };
+  }
+
+  return (
+    <Frame
+      gap={Frame.GAPS.SM}
+      padding={Frame.PADDINGS.NONE}
+      tag="ul"
+      style={styles}
+    >
+      {items.map((configs) => (type === 'checkbox'
+        ? (
+          <Checkbox
+            name={name}
+            itemInList={true}
+            key={configs.id}
+            {...configs}
+          />
+        ) : (
+          <Radio
+            name={name}
+            itemInList={true}
+            key={configs.id}
+            {...configs}
+          />
+        )
+      ))}
+    </Frame>
+  );
+};
+
+export const statuses = [
+  {
+    id: 'success',
+    label: 'Successful',
+    badgeColor: Badge.COLORS.SUCCESS,
+  },
+  {
+    id: 'refund',
+    label: 'Refunded',
+    badgeColor: Badge.COLORS.DRAFT,
+  },
+  {
+    id: 'fail',
+    label: 'Failed',
+    badgeColor: Badge.COLORS.DANGER,
+  },
+];
+
+export const timeframes = [
+  {
+    id: 'month',
+    label: '30 days',
+  },
+  {
+    id: '3-month',
+    label: '3 months',
+  },
+  {
+    id: '6-month',
+    label: '6 months',
+  },
+  {
+    id: 'year',
+    label: '1 year',
+  },
+  {
+    id: 'custom',
+    label: 'Custom range',
+  }
+];
+
+export const transactionItemOptions = ({ id }) => [
+  {
+    id: `transaction-${id}-option-refund`,
+    label: 'Refund',
+  },
+  {
+    id: `transaction-${id}-option-send-receipt`,
+    label: 'Send receipt',
+  },
+  {
+    id: `transaction-${id}-option-details`,
+    label: 'View more details',
+  },
+];
+
+export const transactionPageOptions = ({ setShowCustomizeColumnsModal }) => [
+  {
+    id: 'header-action-export-transactions',
+    label: 'Export transactions ...',
+    // TODO: Dev: Wire in export action here
+  },
+  {
+    id: 'header-action-customize-columns',
+    label: 'Customize columns ...',
+    onClick: () => setShowCustomizeColumnsModal(true),
+  }
+];
+
+export const transactionsTableData = [
+  {
+    id: 1,
+    price: {
+      cardType: 'visa',
+      price: '9.95',
+      coupon: {
+        value: '25% off',
+      },
+      currency: 'USD',
+    },
+    type: 'One-time',
+    name: 'Tom Scott',
+    email: 'tomscott@gmail.com',
+    offerName: 'How Good is Your Pro...',
+    date: '12 minutes ago',
+  },
+  {
+    id: 2,
+    price: {
+      cardType: 'mastercard',
+      price: '12.95',
+      status: 'refund',
+      currency: 'EUR',
+    },
+    type: 'Multi-pay',
+    name: 'Annette Black',
+    email: 'gleason.yazmin@boyer.com',
+    offerName: 'What is Leadership',
+    date: 'Yesterday',
+  },
+  {
+    id: 3,
+    price: {
+      cardType: 'amex',
+      price: '99.99',
+      status: 'fail',
+      currency: 'JPY',
+    },
+    type: 'Subscription',
+    name: 'Tom Scott',
+    email: 'tomscott@gmail.com',
+    offerName: 'How Good is Your Pro...',
+    date: 'Last month',
+  }
+];
+
+export const transactionsTableSchema = {
+  price: {
+    label: 'Price',
+    dataType: Table.DATA_TYPES.HTML,
+  },
+  type: {
+    label: 'Type',
+  },
+  name: {
+    label: 'Name',
+  },
+  email: {
+    label: 'Email',
+  },
+  offerName: {
+    label: 'Offer name',
+  },
+  date: {
+    label: 'Date',
+    dataType: Table.DATA_TYPES.DATE,
+  },
+  options: {
+    label: '',
+    dataType: Table.DATA_TYPES.HTML,
+  }
+};


### PR DESCRIPTION
## Description

This PR adds mocks for the Transaction page.

For reviewers: Mocks like this are a stubbed version of the design mock to help us gauge what Sage can and cant't do, and to help give the Product team's a leg up in building things out effectively with Sage. As you review, consider the following:

- Does the mock align with the Figma design appropriately? Anything we missed from the mock?
- Does the approach used regarding Sage components make sense and seem like a good approach to provide to the team? Anything you'd like to suggest we do differently?
- When we found things that Sage couldn't yet do or had ideas about things we could improve, we added `TODO: DSS:` notes in the code and provided Jira tickets. Do you have any concerns about any of these?


## Screenshots

[Figma file](https://www.figma.com/file/8wkkXKHaOigsAl5Ye9vaKh/Transactions-page?node-id=3%3A185)

![Screen Shot 2022-07-18 at 2 58 37 PM](https://user-images.githubusercontent.com/17955295/179583906-de42ea36-7791-4c4f-97f4-82c776828da1.png)


## Testing in `sage-lib`

See http://localhost:4100/?path=/story/mocks-payments-transactions--index


## Testing in `kajabi-products`
1. (**N/A**) Add react mocks for Transactions page


## Related

https://kajabi.atlassian.net/browse/SAGE-732
