### PR TITLE
Data Card: Add alignment to data card to prevent spread

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_data_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_data_card.scss
@@ -170,4 +170,5 @@ $-data-card-padding: sage-spacing(xs);
   grid-auto-columns: auto;
   overflow-x: auto;
   width: 100%;
+  justify-content: start;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_data_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_data_card.scss
@@ -169,6 +169,6 @@ $-data-card-padding: sage-spacing(xs);
   grid-auto-flow: column;
   grid-auto-columns: auto;
   overflow-x: auto;
-  width: 100%;
   justify-content: start;
+  width: 100%;
 }


### PR DESCRIPTION
## Description

This PR adds `justify-content: start` to Data Card scroll container to help ensure better alignment when there are only a few groups. Before, the groups would stretch to fill the space but now the pack in closer.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| <img width="866" alt="Screen Shot 2022-07-20 at 11 01 10 AM" src="https://user-images.githubusercontent.com/17955295/180016400-ca108fa7-8895-4b13-ae85-dd41ae586f38.png"> | <img width="867" alt="Screen Shot 2022-07-20 at 11 01 18 AM" src="https://user-images.githubusercontent.com/17955295/180016430-bb1f65a0-efe0-4348-868b-51b5b4158e64.png"> |

## Testing in `sage-lib`

See http://localhost:4000/pages/component/data_card and experiment with removing `.sage-data-card` items from within each group until only a few remain to observe the improved alignment.

## Testing in `kajabi-products`

1. (**LOW**) Improved alignment for Data Card groups in scrolling containers


## Related

https://kajabi.atlassian.net/browse/SAGE-566
