### PR TITLE
Link: Ensure nil is an allowed value on optional property url (replacemes #1525)

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_link.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_link.rb
@@ -10,6 +10,6 @@ class SageLink < SageComponent
     small: [:optional, TrueClass],
     style: [:optional, NilClass, Set.new(["primary", "neutral", "secondary", "danger"])],
     truncate: [:optional, TrueClass],
-    url: [:optional, String],
+    url: [:optional, NilClass, String],
   })
 end


### PR DESCRIPTION
## Description

This PR adds `nil` as a possible value to the optional `url` property. This addresses schema violations in `kp` where `nil` is being provided to this property.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`

1. (**MEDIUM**) Allow for `nil` as a value assigned to `SageLink.url`

## Related

Addresses spec failures from https://github.com/Kajabi/kajabi-products/pull/24254