### PR TITLE
Add transactions to mocks index

### DIFF
--- a/docs/app/helpers/mocks_helper.rb
+++ b/docs/app/helpers/mocks_helper.rb
@@ -38,6 +38,18 @@ module MocksHelper
   def sage_mocks
     [
       {
+        alias: "transaction_update",
+        jira_epic: "SAGE-730",
+        name: "Transactions Page Update",
+        no_custom_styles: true,
+        no_rails_js: true,
+        no_rails_partials: true,
+        no_rails_helper: true,
+        status: DOING,
+        storybook_path: '/docs/mocks-payments-transactions--index',
+        team: "Commerce",
+      },
+      {
         alias: "product_creation_wizard",
         jira_epic: "SAGE-39",
         name: "Product Creation Wizard",


### PR DESCRIPTION
## Description

This PR adds an entry to the main Mocks index data set for the Transactions mocks that should have been included in the mock PR #1523 

Card on mocks index for these mocks:

![Screen Shot 2022-07-25 at 10 38 00 AM](https://user-images.githubusercontent.com/17955295/180803473-6fbb8058-24b8-49d2-85b1-362f6225966f.png)


## Testing in `sage-lib`

See http://localhost:4000/pages/mocks and linked page http://localhost:4000/pages/mock/transaction_update

In production these will point to code, Storybook mocks, etc.


## Testing in `kajabi-products`

1. (**LOW**) Add entry for Transactions mock to mocks datasset

