### PR TITLE
[Sage-674] Choice - Icon and Text Not Aligning

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -138,6 +138,10 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     align-self: start;
     margin-top: var(--icon-top-offset);
   }
+
+  @media (max-width: sage-breakpoint(xs-max)) {
+    display: block;
+  }
 }
 
 .sage-choice--radio {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Forces icon variation to wrap on smaller breakpoints.

*Note: This is a temporary solution intended to last until the Choice component is deprecated in favor of a catch-all Card component.

[Slack thread for option context](https://kajabi.slack.com/archives/C03GKQJHCLX/p1658259838755109)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="315" alt="Screen Shot 2022-07-25 at 11 25 25 AM" src="https://user-images.githubusercontent.com/14791307/180827700-abc22fdd-5b61-432b-9217-59ab27de3b37.png">|<img width="318" alt="Screen Shot 2022-07-25 at 11 04 39 AM" src="https://user-images.githubusercontent.com/14791307/180827715-8b2ebc31-34d0-484d-a3e7-8ad4f9e93ed3.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Choice](http://localhost:4000/pages/component/choice?tab=preview)
- Check that icon and text wrap on the extra small breakpoint

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Forces icon variation to wrap on smaller breakpoints.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-674](https://kajabi.atlassian.net/browse/SAGE-674)