### PR TITLE
[SAGE-764] Card/Panel Divider Color Updates

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -68,7 +68,7 @@
     top: 50%;
     width: 100%;
     height: 1px;
-    background: sage-color(grey, 400);
+    background: sage-color(grey, 300);
   }
   &::after {
     content: attr(data-divider-label);

--- a/packages/sage-assets/lib/stylesheets/components/_panel.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel.scss
@@ -40,7 +40,7 @@
     top: 50%;
     width: 100%;
     height: 1px;
-    background: sage-color(grey, 400);
+    background: sage-color(grey, 300);
   }
 
   &::after {


### PR DESCRIPTION
## Description
Card & Panel dividers have incorrect colors.
This PR updates the applied color to match card and panel border colors.


## Screenshots
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-07-28 at 10 19 08 AM](https://user-images.githubusercontent.com/1175111/181599519-fd032b29-beaf-4a1b-960f-078bfc020740.png)|![Screen Shot 2022-07-28 at 10 19 25 AM](https://user-images.githubusercontent.com/1175111/181599565-cb88226f-81e5-4ecc-ba5e-6308c413274a.png)|



## Testing in `sage-lib`
Navigate to [Panel](http://localhost:4000/pages/component/panel?tab=preview) and [Card](http://localhost:4000/pages/component/card?tab=preview)
Verify color of the divider now matches border colors.


## Testing in `kajabi-products`
1. (**LOW**) Updates divider color in panels and cards. Styling only adjustment.


## Related
https://kajabi.atlassian.net/browse/SAGE-764
