### PR TITLE
[Sage-761] Card - Add Interactivity

### DIFF
--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -48,6 +48,7 @@
 <%= sage_component SageCard, { interactive: true } do %>
   <%= sage_component SageCardBlock, { type_block: true } do %>
     <%= sage_component SageLink, {
+      css_classes: "sage-card__link--primary",
       label: "Sage Card",
       show_label: true,
       style: "primary",

--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -47,22 +47,12 @@
 
 <%= sage_component SageCard, { interactive: true } do %>
   <%= sage_component SageCardBlock, { type_block: true } do %>
-  <div>
     <%= sage_component SageLink, {
       label: "Sage Card",
       show_label: true,
       style: "primary",
       url: "https://bing.com"
     } %>
-    </div>
-    <div>
-    <%= sage_component SageLink, {
-      label: "Sage Card",
-      show_label: true,
-      style: "secondary",
-      url: "https://google.com"
-    } %>
-    </div>
     <p>
       An interactive card
     </p>

--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -51,7 +51,7 @@
       label: "Sage Card",
       show_label: true,
       style: "primary",
-      url: "https://bing.com"
+      url: "#"
     } %>
     <p>
       An interactive card

--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -45,6 +45,20 @@
   <% end %>
 <% end %>
 
+<%= sage_component SageCard, { interactive: true } do %>
+  <%= sage_component SageCardBlock, { type_block: true } do %>
+    <%= sage_component SageLink, {
+      label: "Sage Card",
+      show_label: true,
+      style: "secondary"
+    } %>
+    <%# <a href="#">Sage Card</a> %>
+    <p>
+      An interactive card
+    </p>
+  <% end %>
+<% end %>
+
 <%= sage_component SageCard, { border_dashed: true } do %>
   <%= sage_component SageCardBlock, { type_block: true } do %>
     <p>

--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -47,12 +47,22 @@
 
 <%= sage_component SageCard, { interactive: true } do %>
   <%= sage_component SageCardBlock, { type_block: true } do %>
+  <div>
     <%= sage_component SageLink, {
       label: "Sage Card",
       show_label: true,
-      style: "secondary"
+      style: "primary",
+      url: "https://bing.com"
     } %>
-    <%# <a href="#">Sage Card</a> %>
+    </div>
+    <div>
+    <%= sage_component SageLink, {
+      label: "Sage Card",
+      show_label: true,
+      style: "secondary",
+      url: "https://google.com"
+    } %>
+    </div>
     <p>
       An interactive card
     </p>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -23,6 +23,12 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`interactive`') %></td>
+  <td><%= md('Gives Card appropriate interactive states when Card links are present.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td colspan="4"><%= md('**Card List**') %></td>
 </tr>
 <tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card.rb
@@ -4,6 +4,6 @@ class SageCard < SageComponent
     compact: [:optional, TrueClass,],
     clear_bottom_padding: [:optional, TrueClass],
     clear_top_padding: [:optional, TrueClass],
-    interactive: [:optiona, TrueClass]
+    interactive: [:optional, TrueClass]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card.rb
@@ -4,5 +4,6 @@ class SageCard < SageComponent
     compact: [:optional, TrueClass,],
     clear_bottom_padding: [:optional, TrueClass],
     clear_top_padding: [:optional, TrueClass],
+    interactive: [:optiona, TrueClass]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
@@ -5,6 +5,7 @@
     <%= "sage-card--clear-padding-top" if component.clear_top_padding %>
     <%= "sage-card--clear-padding-bottom" if component.clear_bottom_padding %>
     <%= "sage-card--border-dashed" if component.border_dashed %>
+    <%= "sage-card--interactive" if component.interactive %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -46,6 +46,17 @@
 
 .sage-card--interactive {
   border: 0;
+
+  a:not(.sage-link--primary),
+  button:not(.sage-link--primary) {
+    z-index: sage-z-index(default, 2);
+    position: relative;
+
+    &::before,
+    &:hover::before {
+      box-shadow: none;
+    }
+  }
 }
 
 .sage-card__footer {

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -47,8 +47,18 @@
 .sage-card--interactive {
   border: 0;
 
-  a:not(.sage-link--primary),
-  button:not(.sage-link--primary) {
+  .sage-link.sage-card__link--primary {
+    // Remove when Link component is updated with new styles
+    color: sage-color(charcoal, 400);
+    text-decoration: none;
+
+    &:hover {
+      color: sage-color(charcoal, 500);
+    }
+  }
+
+  a:not(.sage-card__link--primary),
+  button:not(.sage-card__link--primary) {
     z-index: sage-z-index(default, 2);
     position: relative;
 

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -12,6 +12,24 @@
   width: 100%;
 }
 
+.sage-card--border-dashed {
+  border-color: sage-color(white);
+  @include sage-dashed-border(
+    $border-radius: sage-border(radius),
+    $color: sage-color(grey, 400),
+  );
+}
+
+.sage-card--clear-padding-top,
+.sage-card--clear-padding-both {
+  padding-top: 0;
+}
+
+.sage-card--clear-padding-bottom,
+.sage-card--clear-padding-both {
+  padding-bottom: 0;
+}
+
 .sage-card--compact {
   gap: sage-spacing(sm);
   padding: sage-spacing(sm);
@@ -26,22 +44,8 @@
   @include sage-grid-card;
 }
 
-.sage-card--clear-padding-top,
-.sage-card--clear-padding-both {
-  padding-top: 0;
-}
-
-.sage-card--clear-padding-bottom,
-.sage-card--clear-padding-both {
-  padding-bottom: 0;
-}
-
-.sage-card--border-dashed {
-  border-color: sage-color(white);
-  @include sage-dashed-border(
-    $border-radius: sage-border(radius),
-    $color: sage-color(grey, 400),
-  );
+.sage-card--interactive {
+  border: 0;
 }
 
 .sage-card__footer {

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -70,12 +70,59 @@ $-link-base-styles: (
 
   &:hover {
     color: sage-color(primary, 400);
+    cursor: pointer;
   }
 
   &:focus {
     color: sage-color(primary, 300);
 
     @include sage-focus-outline--update-color(sage-color(primary, 200));
+  }
+
+  .sage-card--interactive & {
+    position: static;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: sage-z-index(default, 1);
+      box-shadow: sage-border-interactive();
+      border-radius: sage-border(radius-medium);
+    }
+
+    &:hover::before {
+      box-shadow: sage-border-interactive(hover);
+    }
+
+    &:focus::before {
+      box-shadow: sage-border-interactive(focus);
+    }
+
+    &:active::before {
+      box-shadow: sage-border-interactive(selected);
+    }
+
+    &:invalid::before {
+      box-shadow: sage-border-interactive(error);
+    }
+
+    &:focus:invalid::before {
+      box-shadow: sage-border-interactive(error-focus);
+    }
+
+    &:focus::after {
+      border: 0;
+    }
+
+    &::after {
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -32,7 +32,7 @@ $-table-overflow-indicator-gradient: linear-gradient(
   90deg,
   $-table-overflow-indicator-color-start 0%,
   rgba($-table-overflow-indicator-color-end, $-table-overflow-indicator-opacity)
-    100%
+  100%
 );
 
 // Other

--- a/packages/sage-react/lib/Card/Card.jsx
+++ b/packages/sage-react/lib/Card/Card.jsx
@@ -21,6 +21,7 @@ export const Card = ({
   clearPaddingLeft,
   clearPaddingRight,
   clearPaddingTop,
+  interactive,
   loading,
   borderDashed,
   ...rest
@@ -35,6 +36,7 @@ export const Card = ({
       'sage-card--clear-padding-left': clearPaddingLeft,
       'sage-card--clear-padding-right': clearPaddingRight,
       'sage-card--clear-padding-top': clearPaddingTop,
+      'sage-card--interactive': interactive
     }
   );
 
@@ -66,6 +68,7 @@ Card.defaultProps = {
   clearPaddingLeft: false,
   clearPaddingRight: false,
   clearPaddingTop: false,
+  interactive: false,
   loading: false,
   borderDashed: false,
 };
@@ -78,6 +81,7 @@ Card.propTypes = {
   clearPaddingLeft: PropTypes.bool,
   clearPaddingRight: PropTypes.bool,
   clearPaddingTop: PropTypes.bool,
+  interactive: PropTypes.bool,
   loading: PropTypes.bool,
   borderDashed: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Card/Card.story.jsx
+++ b/packages/sage-react/lib/Card/Card.story.jsx
@@ -4,6 +4,7 @@ import { SageTokens } from '../configs';
 import { Button } from '../Button';
 import { Grid } from '../Grid';
 import { Icon } from '../Icon';
+import { Link } from '../Link';
 import { Card } from './Card';
 
 export default {
@@ -123,6 +124,14 @@ Default.args = {
     </>
   ),
 };
+
+export const InteractiveCard = () => (
+  <Card interactive={true}>
+    <Link href="//example.com">
+      Sage Card Link
+    </Link>
+  </Card>
+);
 
 export const CardHighlight = (args) => (
   <Grid container={Grid.CONTAINER_SIZES.XS}>

--- a/packages/sage-react/lib/Card/Card.story.jsx
+++ b/packages/sage-react/lib/Card/Card.story.jsx
@@ -127,7 +127,7 @@ Default.args = {
 
 export const InteractiveCard = () => (
   <Card interactive={true}>
-    <Link href="//example.com">
+    <Link className="sage-card__link--primary" href="//example.com">
       Sage Card Link
     </Link>
   </Card>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds new Card prop for interactivity.

The main/primary link or button in the Card should make the entire card clickable. When a secondary link is present, the `z-index` should elevate it above the primary link's hitbox to make it clickable.

[Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage-components?node-id=1667%3A23273)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
https://user-images.githubusercontent.com/14791307/185470449-e009f561-404a-4bdf-9e11-8cd27006caf3.mov




## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Card](http://localhost:4000/pages/component/card?tab=preview#)
- Check that entire Interactive Card is clickable with proper focus and hover states
- Add a second SageLink to `docs/app/views/examples/components/card/_preview.html.erb` line:56 and change style to `secondary`
- Ensure that secondary link is clickable

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds new Card prop for interactivity.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-761](https://kajabi.atlassian.net/browse/SAGE-761)