### PR TITLE
[SAGE-779]: Sage dropdown and select alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -179,7 +179,7 @@ $-btn-loading-min-height: rem(36px);
 
     width: inherit;
     border-radius: inherit;
-    border-color: sage-color(grey, 500);
+    border-color: sage-color(grey, 400);
 
     &:hover {
       background-color: sage-color(white);

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -379,6 +379,16 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   width: var(--sage-dropdown-trigger-width, auto);
 }
 
+.sage-dropdown__trigger--select {
+  border-radius: sage-border(radius-medium);
+}
+
+.sage-btn--icon-right-caret-down::before {
+  .sage-dropdown__trigger--select & {
+    color: sage-color(charcoal, 100);
+  }
+}
+
 .sage-dropdown__trigger--select,
 .sage-dropdown__trigger--select-labeled {
   :not(.sage-dropdown--customized) > & {
@@ -431,3 +441,4 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown-combo {
   width: 100%;
 }
+

--- a/packages/sage-assets/lib/stylesheets/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_select.scss
@@ -51,7 +51,7 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
 }
 
 .sage-select__arrow::before {
-  @include sage-icon-base(down-small);
+  @include sage-icon-base(caret-down);
 
   align-items: center;
   height: $-select-height;


### PR DESCRIPTION
## Description
The dropdown and form select components have different arrow icons applied.
The border colors and radius also seem to be slightly different. 


## Screenshots

Updates styling of dropdown select variant to better match form select.
Adjust arrow within form select to match dropdown select (directed by design)

||  Before  |  After  |
|--------|--------|--------|
|Dropdown (border adjustments)|<img width="786" alt="Screen Shot 2022-08-04 at 4 11 26 PM" src="https://user-images.githubusercontent.com/1175111/182970620-63eb65cf-6847-43d2-b550-c479b871af9d.png">|<img width="786" alt="Screen Shot 2022-08-04 at 4 03 44 PM" src="https://user-images.githubusercontent.com/1175111/182969958-9a505e77-ff73-41f6-bd60-59f6ea15d350.png">|
|Select (arrow adjustments)|<img width="797" alt="Screen Shot 2022-08-04 at 4 11 36 PM" src="https://user-images.githubusercontent.com/1175111/182970680-eb19e6f5-e36c-467c-a911-b06337fc4089.png">|<img width="803" alt="Screen Shot 2022-08-04 at 4 12 30 PM" src="https://user-images.githubusercontent.com/1175111/182970698-20ae1764-4332-4311-ae6a-b8115fb76164.png">|


## Testing in `sage-lib`

DROPDOWN:
- Navigate to [Dropdown](http://localhost:4000/pages/component/dropdown?tab=preview)
- Verify border-color and border-radius now match form select

SELECT:
- Navigate to [Select](http://localhost:4000/pages/component/form_select?tab=preview)
- Verify the arrow now matches the dropdown (larger version)


## Testing in `kajabi-products`

1. (**LOW**) Updates styling of dropdown select variant and form select to better match. Styling only update.



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
