### PR TITLE
[SAGE-759] SageTable caption position with `sage_table_for` helper

### DIFF
--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -233,7 +233,7 @@ This involves calling `sage_table_for` with a collection, and then using `t.colu
 **NOTE:** This is an MVP implementation based on a helper written earlier for `kajabi-products` and may not be fully aligned with SageTable. It is safe to use, but should be tracked against future updates.
 ") %>
 
-<%= sage_table_for people_data, selectable: true, sortable: true, responsive: true, caption: "Caption <strong>positioned above</strong>".html_safe, caption_side: "top" do |t| %>
+<%= sage_table_for people_data, selectable: true, sortable: true, responsive: true, caption: "Caption positioned above using `caption_side`".html_safe, caption_side: "top" do |t| %>
   <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
     <%= sage_component SageCheckbox, {
       label_text: 'Select row',

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -226,18 +226,14 @@ sample_table = {
 
 <h3>Using `sage_table_for`</h3>
 <%= md("
-As an alterative to directly calling the SageTable component,
-a helper variation is available that allows for formatting table columns
-in a more compositional fashion. This involves calling `sage_table_for` with a collection,
-and then using `t.column ... do |c|` blocks to provide templates for each column of data.
-See the \"Properties\" tab for documentation of the available parameters.
+As an alternative to directly calling the SageTable component, a helper variation is available that allows for formatting table columns in a more compositional fashion.
 
-**NOTE:** This is an MVP implementation based on a helper written earlier for `kajabi-products`
-and not completely aligned with SageTable yet.
-It is safe to use, but should be tracked against future updates.
+This involves calling `sage_table_for` with a collection, and then using `t.column ... do |c|` blocks to provide templates for each column of data. See the \"Properties\" tab for documentation of the available parameters.
+
+**NOTE:** This is an MVP implementation based on a helper written earlier for `kajabi-products` and may not be fully aligned with SageTable. It is safe to use, but should be tracked against future updates.
 ") %>
 
-<%= sage_table_for people_data, sortable: true, responsive: true, caption: "<p>Testing <b>stuff</b></p>".html_safe do |t| %>
+<%= sage_table_for people_data, selectable: true, sortable: true, responsive: true, caption: "<p>Caption <b>positioned below</b></p>".html_safe, caption_side: "top" do |t| %>
   <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
     <%= sage_component SageCheckbox, {
       label_text: 'Select row',

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -233,7 +233,7 @@ This involves calling `sage_table_for` with a collection, and then using `t.colu
 **NOTE:** This is an MVP implementation based on a helper written earlier for `kajabi-products` and may not be fully aligned with SageTable. It is safe to use, but should be tracked against future updates.
 ") %>
 
-<%= sage_table_for people_data, selectable: true, sortable: true, responsive: true, caption: "<p>Caption <b>positioned below</b></p>".html_safe, caption_side: "top" do |t| %>
+<%= sage_table_for people_data, selectable: true, sortable: true, responsive: true, caption: "Caption <strong>positioned above</strong>".html_safe, caption_side: "top" do |t| %>
   <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
     <%= sage_component SageCheckbox, {
       label_text: 'Select row',

--- a/docs/app/views/examples/components/table/_props.html.erb
+++ b/docs/app/views/examples/components/table/_props.html.erb
@@ -7,7 +7,7 @@
 <tr>
   <td><%= md('`caption_side`') %></td>
   <td><%= md('Sets the caption position for the component.') %></td>
-  <td><%= md('`"bottom"`, `"top"`') %></td>
+  <td><%= md('String: [`bottom` | `top`]') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -18,7 +18,7 @@
 </tr>
 <tr>
   <td><%= md('`has_borders`') %></td>
-  <td><%= md('When set to true, adds borders for cleaner readability.') %></td>
+  <td><%= md('When set to `true`, adds borders for cleaner readability.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -42,7 +42,9 @@
 </tr>
 <tr>
   <td><%= md('`responsive`') %></td>
-  <td><%= md('Allows the table to scroll horizontally without breaking its parent container. Requires the use of two containing elements: the parent with class `.sage-table-wrapper`, and a child with class `.sage-table-wrapper__overflow`.') %></td>
+  <td><%= md('Allows the table to scroll horizontally without breaking its parent container.
+
+  Requires the use of two containing elements: the parent with class `.sage-table-wrapper`, and a child with class `.sage-table-wrapper__overflow`.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
@@ -55,7 +57,7 @@
 <tr>
   <td><%= md('`selectable`') %></td>
   <td><%= md('Adds a background color when a user hovers over rows.') %></td>
-  <td><%= md('String:') %></td>
+  <td><%= md('Boolean') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
@@ -64,24 +66,29 @@
   </td>
 </tr>
 <tr>
-  <td><%= md('`collection`') %></td>
+  <td><%= md('`collection`') %><%= sage_component SageBadge, { color: "published", value: "required" } %></td>
   <td><%= md('A collection from which the table data will be formatted.') %></td>
   <td><%= md('Array of Objects') %></td>
-  <td><%= md('Required') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`options`') %></td>
   <td><%= md('
-  A set of options that match the following options from SageTable above:
+  Allows a **limited** subset of the properties listed above for Table:
 
+  - `caption`
+  - `caption_side`
   - `condensed`
+  - `has_borders`
   - `reset_above`
   - `reset_below`
   - `responsive`
 
-  Also available, unique to `sage_table_for`:
+  The following properties are **unique to `sage_table_for`**:
 
-  - `sortable` -- enables sorting links and direction indicators on sorted columns.
+  - `sortable` (Boolean): enables sorting links and direction indicators on sorted columns
+
+  - `skip_headers` (Boolean): table column headings are not rendered
 ') %></td>
   <td><%= md('See properties above') %></td>
   <td><%= md('Varies') %></td>
@@ -92,13 +99,15 @@
   </td>
 </tr>
 <tr>
-  <td><%= md('`attribute`') %></td>
+  <td><%= md('`attribute`') %><%= sage_component SageBadge, { color: "published", value: "required" } %></td>
   <td><%= md('
-  An alias/identifier for the column/attribute. While this does not have to align to a property from the collection itself,
-  if `sortable` is on, those that do align with collection property will result in a sortable link being rendered.
+  An alias/identifier for the column/attribute.
+
+  While this does not have to align to a property from the collection itself,
+  if `sortable` is enabled, those that do align with the collection property will result in a sortable link being rendered.
 ') %></td>
   <td><%= md('Symbol') %></td>
-  <td><%= md('Required') %></td>
+  <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`options`') %></td>
@@ -106,14 +115,14 @@
   A set of options for the columns including:
 
   - `align <"right" | "center" | nil>` -- Alignment direction for cells (body and header)
-  - `class_name <string>` -- CSS class name to render on body cells (not on header cell).
+  - `class_name (String)` -- CSS class name to render on body cells (not on header cell).
   - `data_type <"checkbox" | "avatar">` -- Special cell data types to apply some preset styling for special cases.
-  - `header_class <string>` -- CSS class name to render on header cells.
-  - `hide <{ sm: boolean, md: boolean, lg: boolean}>` -- Set only the desired breakpoint to `true` to hide a given columnn at and below that breakpoint.
-  - `label <string>` -- Content for the header of the column.
-  - `strong <boolean>` -- Renders cell with strong style: weight of 600 and darker color.
-  - `style <string>` -- style attributes to render on cells.
-  - `truncate <boolean>` -- Whether or not to truncate the cell if its content does not fit (rather than wrap).
+  - `header_class (String)` -- CSS class name to render on header cells.
+  - `hide <{ sm: (Boolean), md: (Boolean), lg: (Boolean)}>` -- Set only the desired breakpoint to `true` to hide a given columnn at and below that breakpoint.
+  - `label (String)` -- Content for the header of the column.
+  - `strong (Boolean)` -- Renders cell with strong style: weight of 600 and darker color.
+  - `style (String)` -- style attributes to render on cells.
+  - `truncate (Boolean)` -- Whether or not to truncate the cell if its content does not fit (rather than wrap).
 ') %></td>
   <td><%= md('Hash') %></td>
   <td><%= md('`nil`') %></td>

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -80,12 +80,13 @@ module SageTableHelper
   end
 
   class SageTableFor
-    attr_reader :caption, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :striped, :reset_above, :reset_below
+    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :striped, :reset_above, :reset_below
     delegate :content_tag, :tag, to: :template
 
     def initialize(template, collection, opts={})
       @template = template
       @caption = opts[:caption]
+      @caption_side = opts[:caption_side]
       @class_name = opts[:class_name]
       @condensed = opts[:condensed]
       @collection = collection
@@ -114,7 +115,7 @@ module SageTableHelper
       wrapper_classes << " sage-table-wrapper--reset-above" if reset_above
       wrapper_classes << " sage-table-wrapper--reset-below" if reset_below
       wrapper_classes << " sage-table-wrapper--scroll" if responsive
-      
+
       content_tag "div", class: wrapper_classes do
         if responsive
           content_tag "div", class: "sage-table-wrapper__overflow" do
@@ -142,7 +143,9 @@ module SageTableHelper
 
     def caption
       if @caption
-        content_tag "caption" do
+        caption_class = "sage-table__caption"
+        caption_class << " sage-table__caption--#{caption_side}" if caption_side
+        content_tag "caption", class: caption_class do
           @caption
         end
       else


### PR DESCRIPTION
## Description
- Adds the ability to position table captions when using the `sage_table_for` helper to generate tables
- Updated properties table, minor edits to wording and spelling corrections in documentation


## Screenshots
No visual changes


## Testing in `sage-lib`
1. Navigate to [Table](http://localhost:4000/pages/component/table?tab=preview) on your local docs site
2. Scroll to the "Using `sage_table_for`" example, and verify that the caption appears at the top of the table


## Testing in `kajabi-products`
1. (**LOW**) Adds ability to position table captions when using the `sage_table_for` helper to generate tables. No expected impact with current use 


## Related
- [SAGE-759](https://kajabi.atlassian.net/browse/SAGE-759)
