### PR TITLE
[SAGE-788] Copy Button borderless css_classes attribute fix

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_copy_button.html.erb
@@ -1,6 +1,6 @@
 <% if component.borderless %>
   <%= sage_component SageButton, {
-    css_classes: "sage-copy-btn sage-copy-btn--borderless",
+    css_classes: "sage-copy-btn sage-copy-btn--borderless #{ component.generated_css_classes }",
     icon: { name: "copy", style: "right" },
     subtle: true,
     style: "secondary",


### PR DESCRIPTION
## Description
[SAGE-788](https://kajabi.atlassian.net/browse/SAGE-788)

When a Sage Copy Button has `borderless` enabled, custom CSS classes added will not render. This PR patches the `borderless` variant to pass through `generated_css_classes` to the underlying `SageButton`.


## Screenshots
No visual changes


## Testing in `sage-lib`
1. Navigate to the [Copy Text preview](http://localhost:4000/pages/component/copy_text?tab=preview)
2. Confirm that clicking either version of the Copy Button functions as expected
3. Modify `docs/app/views/examples/components/copy_text/_preview.html.erb`:15 to add a custom `css_classes` value
4. Verify that the class appears as expected on the element 


## Testing in `kajabi-products`
1. (**HIGH**) Sage Copy Button with `borderless` enabled has no current use in KP, but existing non-borderless instances should be checked. Two active areas in Superadmin:
   - [ ] SuperAdmin -> Accounts -> `<user account>` -> Affiliate Link
   - [ ] SuperAdmin -> Accounts -> `<suspended user account>` -> Affiliate Link


## Related
- [SAGE-783](https://kajabi.atlassian.net/browse/SAGE-783)
