### PR TITLE
[SAGE-783] Improve legibility of documentation site color token blocks

### DIFF
--- a/docs/app/views/pages/_color_values.html.erb
+++ b/docs/app/views/pages/_color_values.html.erb
@@ -2,31 +2,35 @@
   <div class="colors__block color-<%= color %>-100">
     <div class="colors__tokens">
       <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-        <h3>Classname Token</h3>
+        <h3 class="colors__tokens-heading">Classname Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames::TYPE_COLORS::#{color.upcase}_100"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames.TYPE_COLORS.#{color.upcase}_100"
           } %>
         </div>
       </div>
-      <div class="colors__hex-token"> 
-        <h3>Hex Token</h3>
+      <div class="colors__hex-token">
+        <h3 class="colors__tokens-heading">Hex Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens::COLOR_PALETTE::#{color.upcase}_100"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens.COLOR_PALETTE.#{color.upcase}_100"
           } %>
         </div>
@@ -36,31 +40,35 @@
   <div class="colors__block color-<%= color %>-200">
     <div class="colors__tokens">
       <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-        <h3>Classname Token</h3>
+        <h3 class="colors__tokens-heading">Classname Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames::TYPE_COLORS::#{color.upcase}_200"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames.TYPE_COLORS.#{color.upcase}_200"
           } %>
         </div>
       </div>
-      <div class="colors__hex-token"> 
-        <h3>Hex Token</h3>
+      <div class="colors__hex-token">
+        <h3 class="colors__tokens-heading">Hex Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens::COLOR_PALETTE::#{color.upcase}_200"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens.COLOR_PALETTE.#{color.upcase}_200"
           } %>
         </div>
@@ -70,31 +78,35 @@
   <div class="colors__block color-<%= color %>-300">
     <div class="colors__tokens">
       <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-        <h3>Classname Token</h3>
+        <h3 class="colors__tokens-heading">Classname Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames::TYPE_COLORS::#{color.upcase}_300"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames.TYPE_COLORS.#{color.upcase}_300"
           } %>
         </div>
       </div>
-      <div class="colors__hex-token"> 
-        <h3>Hex Token</h3>
+      <div class="colors__hex-token">
+        <h3 class="colors__tokens-heading">Hex Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens::COLOR_PALETTE::#{color.upcase}_300"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens.COLOR_PALETTE.#{color.upcase}_300"
           } %>
         </div>
@@ -104,31 +116,35 @@
   <div class="colors__block color-<%= color %>-400">
     <div class="colors__tokens">
       <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-        <h3>Classname Token</h3>
+        <h3 class="colors__tokens-heading">Classname Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames::TYPE_COLORS::#{color.upcase}_400"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames.TYPE_COLORS.#{color.upcase}_400"
           } %>
         </div>
       </div>
-      <div class="colors__hex-token"> 
-        <h3>Hex Token</h3>
+      <div class="colors__hex-token">
+        <h3 class="colors__tokens-heading">Hex Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens::COLOR_PALETTE::#{color.upcase}_400"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens.COLOR_PALETTE.#{color.upcase}_400"
           } %>
         </div>
@@ -138,31 +154,35 @@
   <div class="colors__block color-<%= color %>-500">
     <div class="colors__tokens">
       <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-        <h3>Classname Token</h3>
+        <h3 class="colors__tokens-heading">Classname Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames::TYPE_COLORS::#{color.upcase}_500"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames.TYPE_COLORS.#{color.upcase}_500"
           } %>
         </div>
       </div>
-      <div class="colors__hex-token"> 
-        <h3>Hex Token</h3>
+      <div class="colors__hex-token">
+        <h3 class="colors__tokens-heading">Hex Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens::COLOR_PALETTE::#{color.upcase}_500"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens.COLOR_PALETTE.#{color.upcase}_500"
           } %>
         </div>

--- a/docs/app/views/pages/_color_values_base.html.erb
+++ b/docs/app/views/pages/_color_values_base.html.erb
@@ -2,31 +2,35 @@
   <div class="colors__block color-<%= color %>-100">
     <div class="colors__tokens">
       <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-        <h4>Classname Token</h4>
+        <h3 class="colors__tokens-heading">Classname Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames::TYPE_COLORS::#{color.upcase}"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageClassnames.TYPE_COLORS.#{color.upcase}"
           } %>
         </div>
       </div>
-      <div class="colors__hex-token"> 
-        <h4>Hex Token</h4>
+      <div class="colors__hex-token">
+        <h3 class="colors__tokens-heading">Hex Token</h3>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens::COLOR_PALETTE::#{color.upcase}"
           } %>
         </div>
         <div>
           <%= sage_component SageCopyButton, {
             borderless: true,
+            css_classes: "colors__copy-btn",
             value: "SageTokens.COLOR_PALETTE.#{color.upcase}"
           } %>
         </div>

--- a/docs/app/views/pages/_color_values_neutral.html.erb
+++ b/docs/app/views/pages/_color_values_neutral.html.erb
@@ -3,31 +3,35 @@
     <div class="colors__block color-<%= color %>-<%= i %>00">
       <div class="colors__tokens">
         <div class="colors__classname-token <%= "#{SageClassnames::SPACERS::SM_BOTTOM}" %>">
-          <h3>Classname Token</h3>
+          <h3 class="colors__tokens-heading">Classname Token</h3>
           <div>
             <%= sage_component SageCopyButton, {
               borderless: true,
+              css_classes: "colors__copy-btn",
               value: "SageClassnames::TYPE_COLORS::#{color.upcase}_#{i}00"
             } %>
           </div>
           <div>
             <%= sage_component SageCopyButton, {
               borderless: true,
+              css_classes: "colors__copy-btn",
               value: "SageClassnames.TYPE_COLORS.#{color.upcase}_#{i}00"
             } %>
           </div>
         </div>
         <div class="colors__hex-token">
-          <h3>Hex Token</h3>
+          <h3 class="colors__tokens-heading">Hex Token</h3>
           <div>
             <%= sage_component SageCopyButton, {
               borderless: true,
+              css_classes: "colors__copy-btn",
               value: "SageTokens::COLOR_PALETTE::#{color.upcase}_#{i}00"
             } %>
           </div>
           <div>
             <%= sage_component SageCopyButton, {
               borderless: true,
+              css_classes: "colors__copy-btn",
               value: "SageTokens.COLOR_PALETTE.#{color.upcase}_#{i}00"
             } %>
           </div>

--- a/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
@@ -33,6 +33,15 @@
   }
 }
 
+.colors__tokens-heading,
+.colors__copy-btn,
+.colors__copy-btn::before {
+  .colors__classname-token &,
+  .colors__hex-token & {
+    color: inherit;
+  }
+}
+
 // build individual color blocks
 @each $name, $color in $sage-colors {
   @each $value, $map in $color {
@@ -47,12 +56,16 @@
         color: sage-color(charcoal, 500);
       }
 
-      @else if (lightness($hex) > 60) {
-        color: sage-color($name, 500);
+      @else if (($name == black) or ($name == charcoal)) {
+        color: sage-color(white);
+      }
+
+      @else if (lightness($hex) < 65) {
+        color: sage-color($name, 100);
       }
 
       @else {
-        color: sage-color(white);
+        color: sage-color($name, 400);
       }
 
       &::after {


### PR DESCRIPTION
## Description
[SAGE-783](https://kajabi.atlassian.net/browse/SAGE-783)

⚠️ This branch requires [SAGE-788](https://github.com/Kajabi/sage-lib/pull/1548), relying on the updated `borderless` copy button to inherit color values

Updates color token blocks listed on the Foundations -> Color page. Some values are currently illegible.
- colors other than grey, black, and white apply tints depending on the background lightness
- fixes skipped heading level warning


## Screenshots
|  |Before  |  After  |
|---|-----|--------|
|Charcoal|![before-charcoal](https://user-images.githubusercontent.com/816579/183787197-6b816aa8-f2d6-4e59-bc7e-1637fc9a2ee1.png)|![after-charcoal](https://user-images.githubusercontent.com/816579/183787206-b0205da5-1f74-416b-b39c-dd28eb46a9bf.png)|
|Success|![before-success](https://user-images.githubusercontent.com/816579/183787218-d0b81739-05dc-465d-8ca6-fdcb24e002d2.png)|![after-success](https://user-images.githubusercontent.com/816579/183787231-8300dd70-f5a7-4ed4-8e0a-153be63464ea.png)|
|Danger|![before-danger](https://user-images.githubusercontent.com/816579/183787245-b7c459b3-ffd8-4c81-ae9f-cf70c8b01b73.png)|![after-danger](https://user-images.githubusercontent.com/816579/183787254-25774158-ea17-4e2e-9095-5d7e30d312cb.png)|



## Testing in `sage-lib`
⚠️ This branch requires [SAGE-788](https://github.com/Kajabi/sage-lib/pull/1548), relying on the updated `borderless` copy button to inherit color values

1. View the [Foundations: Color page ](http://localhost:4000/pages/foundations/color)
2. Verify that the color blocks for each token are legible and function as expected


## Testing in `kajabi-products`
1. (**N/A**) Updated Foundations: Color page; documentation site only, no effect on KP


## Related
- Requires [SAGE-788](https://github.com/Kajabi/sage-lib/pull/1548)
