### PR TITLE
[SAGE-787]: Sage docs broken links

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -21,7 +21,7 @@ module ComponentsHelper
         react: "todo",
         responsive: "todo",
         a11y: "todo",
-        react_component_slug: "sage-alert--default",
+        react_component_slug: "sage-alert--dismissable-alert",
         figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F9Km09NjlZHYWsMP7EGT8tI%2F%255BWIP%255D-Sage-3-%25E2%2580%2594-Admin-Components%3Fnode-id%3D6989%253A21570",
       },
       {
@@ -838,7 +838,7 @@ module ComponentsHelper
       },
       {
         title: "topbar",
-        description: "The Topbar sits above all page content and contains breadcrumbs and the user menu.", 
+        description: "The Topbar sits above all page content and contains breadcrumbs and the user menu.",
         scss: "done",
         rails: "done",
         react: "done",

--- a/docs/app/views/application/_sidebar.html.erb
+++ b/docs/app/views/application/_sidebar.html.erb
@@ -97,9 +97,11 @@
       }
     %>
     <%= sage_component SageNav, {
-      items: [
-        { link: pages_layout_path(sorted_sage_components[0][:title]), text: "LAYOUT TOOLS", items: layout_list },
-      ]
+      items: [{
+        link: pages_layout_path(sage_layouts_sorted[0][:title]),
+        text: "LAYOUT TOOLS",
+        items: layout_list
+      }]
     } %>
   <% end %>
   <% if current_page_components? %>

--- a/docs/app/views/examples/components/choice/_rules_dont.html.erb
+++ b/docs/app/views/examples/components/choice/_rules_dont.html.erb
@@ -1,3 +1,3 @@
 <%= md('
-- The `radio` type should only be used to conditionally render content. This component should not be used as a form field. In that case use the <a href=\"/pages/component/radio\"> Radio</a> component
+- The `radio` type should only be used to conditionally render content. This component should not be used as a form field. In that case use the [Radio](radio) component
 ', use_sage_type: true) %>


### PR DESCRIPTION
## Description
https://kajabi.atlassian.net/browse/SAGE-787

The following is a list of broken links on the docs site:

 - [Sage Container](https://sage-design-system.kajabi.com/pages/layout/container): LAYOUT TOOLS (in the sidebar)
 - [Sage Alert](https://sage-design-system.kajabi.com/pages/component/alert?tab=preview): REACT COMPONENT LINK BROKEN (next to tabs)
 - [Sage Choice](https://sage-design-system.kajabi.com/pages/component/choice?tab=rules): LINK IN DON'T SECTION BROKEN (Best Practices tab)

Devs pointed these out during pairing sessions so they should be updated to point to the correct locations.

## Screenshots
No visual changes are expected.

## Testing in `sage-lib`
Navigate to the pages listed above and verify links outlined are corrected.

## Testing in `kajabi-products`
1. (**LOW**) Fixes broken links on the docs site, no effect on KP.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
