### PR TITLE
fix(listitem): address console errors related to proptype

### DIFF
--- a/packages/sage-react/lib/List/List.jsx
+++ b/packages/sage-react/lib/List/List.jsx
@@ -81,8 +81,8 @@ List.propTypes = {
       chosen: PropTypes.bool, // From react-sortablejs
       className: PropTypes.string,
       filtered: PropTypes.bool, // From react-sortablejs
-      id: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
-      moreActions: { ...OptionsDropdown.propTypes },
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      moreActions: PropTypes.shape({ ...OptionsDropdown.propTypes }),
       sortable: PropTypes.bool,
       selected: PropTypes.bool, // From react-sortablejs
     })

--- a/packages/sage-react/lib/List/ListItem.jsx
+++ b/packages/sage-react/lib/List/ListItem.jsx
@@ -49,7 +49,7 @@ ListItem.defaultProps = {
 ListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  id: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
-  moreActions: { ...OptionsDropdown.propTypes },
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  moreActions: PropTypes.shape({ ...OptionsDropdown.propTypes }),
   sortable: PropTypes.bool,
 };


### PR DESCRIPTION
## Description
ListItem component has a few errors in PropTypes declaration that are leading to console errors. This PR addresses the following:
* `id` should use `PropTypes.oneOfType`
* `moreActions` should wrap existing hash with `PropTypes.shape()`

## Testing in `sage-lib`
1. Navigate to http://localhost:4100/?path=/docs/sage-list--default
2. Inspect the page and view the console
3. Ensure the following errors are no longer showing

![Screen Shot 2022-07-29 at 1 41 41 PM](https://user-images.githubusercontent.com/24237393/181824152-3ae7c5fa-f77a-4dcd-804d-314ed1dbc36a.png)

## Testing in `kajabi-products`

1. (**LOW**) Console error

## Related
https://kajabi.atlassian.net/browse/SAGE-749
