### PR TITLE
[SAGE-517] Banner: Add storybook examples and update logic to pass active state through components

### DIFF
--- a/packages/sage-react/lib/Banner/Banner.jsx
+++ b/packages/sage-react/lib/Banner/Banner.jsx
@@ -6,20 +6,32 @@ import { BannerWrapper } from './BannerWrapper';
 import { BANNER_TYPES } from './configs';
 
 export const Banner = ({
+  active,
   bannerContext,
   ...rest
 }) => (
   (bannerContext !== null)
-    ? <BannerWrapper bannerContext={bannerContext} {...rest} />
-    : <BannerContent bannerContext={bannerContext} {...rest} />
+    ? <BannerWrapper bannerContext={bannerContext} active={active} {...rest} />
+    : <BannerContent bannerContext={bannerContext} active={active} {...rest} />
 );
 
 Banner.TYPES = BANNER_TYPES;
 
+// Defining all default props and prop types explicitly to populate story table
 Banner.defaultProps = {
-  bannerContext: null
+  active: false,
+  bannerContext: null,
+  dismissable: true,
+  link: null,
+  text: null,
+  type: Banner.TYPES.DEFAULT,
 };
 
 Banner.propTypes = {
-  bannerContext: PropTypes.string
+  active: PropTypes.bool,
+  bannerContext: PropTypes.string,
+  dismissable: PropTypes.bool,
+  link: PropTypes.string,
+  text: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BANNER_TYPES)),
 };

--- a/packages/sage-react/lib/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/Banner/Banner.story.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Banner } from './Banner';
+import { Button } from '../Button';
 
 export default {
   title: 'Sage/Banner',
@@ -15,14 +16,53 @@ export default {
     dismissable: true,
     link: '#',
     text: 'Alert description text',
-    type: Banner.TYPES.DEFAULT
+    type: Banner.TYPES.DEFAULT,
   },
 };
 
 const Template = (args) => <Banner {...args} />;
 export const Default = Template.bind({});
 
-export const InlineBanner = Template.bind({});
-InlineBanner.args = {
+export const DefaultInlineBanner = Template.bind({});
+DefaultInlineBanner.args = {
   bannerContext: 'sage-demo'
+};
+
+export const SecondaryInlineBanner = Template.bind({});
+SecondaryInlineBanner.args = {
+  bannerContext: 'sage-demo',
+  type: Banner.TYPES.SECONDARY
+};
+
+export const WarningInlineBanner = Template.bind({});
+WarningInlineBanner.args = {
+  bannerContext: 'sage-demo',
+  type: Banner.TYPES.WARNING
+};
+
+export const DangerInlineBanner = Template.bind({});
+DangerInlineBanner.args = {
+  bannerContext: 'sage-demo',
+  type: Banner.TYPES.DANGER
+};
+
+export const DefaultFixedBanner = (args) => {
+  const [active, setActive] = useState(false);
+
+  const onClick = () => {
+    setActive(true);
+  };
+
+  return (
+    <>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        onClick={onClick}
+      >
+        Display Banner
+      </Button>
+
+      <Banner {...args} active={active} />
+    </>
+  );
 };

--- a/packages/sage-react/lib/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.jsx
@@ -66,7 +66,7 @@ export const BannerContent = ({
 BannerContent.TYPES = BANNER_TYPES;
 
 BannerContent.defaultProps = {
-  active: null,
+  active: false,
   bannerContext: null,
   children: null,
   className: null,

--- a/packages/sage-react/lib/Banner/BannerWrapper.jsx
+++ b/packages/sage-react/lib/Banner/BannerWrapper.jsx
@@ -4,7 +4,15 @@ import classnames from 'classnames';
 import { BannerContent } from './BannerContent';
 
 export const BannerWrapper = ({
+  active,
   bannerContext,
+  children,
+  className,
+  dismissable,
+  id,
+  link,
+  text,
+  type,
   ...rest
 }) => {
   const classNames = classnames(
@@ -16,13 +24,25 @@ export const BannerWrapper = ({
 
   return (
     <div className={classNames}>
-      <BannerContent {...rest} />
+      <BannerContent
+        active={active}
+        bannerContext={bannerContext}
+        className={className}
+        dismissable={dismissable}
+        id={id}
+        link={link}
+        text={text}
+        type={type}
+        {...rest}
+      >
+        {children}
+      </BannerContent>
     </div>
   );
 };
 
 BannerWrapper.defaultProps = {
-  active: null,
+  active: false,
   bannerContext: null,
   children: null,
   className: null,


### PR DESCRIPTION
## Description
Update banner logic slightly and add more stories to bring storybook into parity with rails examples.

Note: Original issue noted in ticket is no longer relevant

## Screenshots
before|after
--|--
<img width="1041" alt="CleanShot 2022-08-12 at 16 00 42@2x" src="https://user-images.githubusercontent.com/791670/184434039-a309e6e1-951c-4d5b-9e77-8ec58bd1c435.png">|<img width="1047" alt="CleanShot 2022-08-12 at 16 00 31@2x" src="https://user-images.githubusercontent.com/791670/184434050-c65c0524-a164-4ace-98b3-ef487fc7d7b3.png">


## Testing in `sage-lib`
Open react app, check banner stories. 
http://localhost:4100/?path=/docs/sage-banner--default


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Updated logic for banner to pass active state into context and wrapper components
   - [x] Updated banner logic has been tested in storybook and confirmed through review and react component has minimal use


## Related
https://kajabi.atlassian.net/browse/SAGE-517
