### PR TITLE
[SAGE-406] Deprecate Sage Table Striping

### DIFF
--- a/docs/app/views/examples/shared/_props.html.erb
+++ b/docs/app/views/examples/shared/_props.html.erb
@@ -2,7 +2,7 @@
   <%= sage_component SageCard, {} do %>
     <div class="sage-table-wrapper sage-table-wrapper--scroll">
       <div class="sage-table-wrapper__overflow">
-        <table class="sage-table sage-table--properties sage-table--striped docs-table">
+        <table class="sage-table sage-table--properties docs-table">
           <thead>
             <tr>
               <th>Property</th>

--- a/docs/app/views/examples/shared/_props_improved.html.erb
+++ b/docs/app/views/examples/shared/_props_improved.html.erb
@@ -1,19 +1,19 @@
 <% if defined?(props) %>
   <div class="<%= SageClassnames::GRID_CARD %>">
     <h3>Properties</h3>
-    <%= sage_table_for props, responsive: true, sortable: true, striped: true do | t | %>
+    <%= sage_table_for props, responsive: true, sortable: true do | t | %>
       <% t.column :name, label: "Name" do | c | %>
         <%= md("`#{c[:name]}`") %>
-      <% end %> 
+      <% end %>
       <% t.column :description, label: "Description" do | c | %>
         <%= md(c[:description], use_sage_type: true) %>
-      <% end %> 
+      <% end %>
       <% t.column :type, label: "Type" do | c | %>
         <%= md(c[:type]) %>
-      <% end %> 
+      <% end %>
       <% t.column :default, label: "Default" do | c | %>
         <%= md(c[:default]) %>
-      <% end %> 
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/docs/app/views/pages/container.html.erb
+++ b/docs/app/views/pages/container.html.erb
@@ -7,7 +7,7 @@
 )) %>
 <% end %>
 
-<%= sage_table_for SageTokens::CONTAINER_SPECS, striped: true, responsive: true do |t| %>
+<%= sage_table_for SageTokens::CONTAINER_SPECS, responsive: true do |t| %>
   <% t.column :container, label: "Container" do |c| %>
     <%= c[:name] %>
     <code><%= c[:alias] %></code>

--- a/docs/app/views/pages/gap.html.erb
+++ b/docs/app/views/pages/gap.html.erb
@@ -8,7 +8,6 @@
 <div class="<%= SageClassnames::TYPE_BLOCK %>">
   <p>The following gap tokens are used throughout Sage:</p>
   <%= sage_component SageTable, {
-    striped: true,
     headers: [
       "Token",
       "Value",

--- a/docs/app/views/pages/spacing.html.erb
+++ b/docs/app/views/pages/spacing.html.erb
@@ -8,7 +8,6 @@
 <div class="<%= SageClassnames::TYPE_BLOCK %>">
   <p>The following spacing tokens are used throughout Sage:</p>
   <%= sage_component SageTable, {
-    striped: true,
     headers: ["Token", "Value"],
     rows: sage_spacers,
   } %>

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -80,7 +80,7 @@ module SageTableHelper
   end
 
   class SageTableFor
-    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :striped, :reset_above, :reset_below
+    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :reset_above, :reset_below
     delegate :content_tag, :tag, to: :template
 
     def initialize(template, collection, opts={})
@@ -96,7 +96,6 @@ module SageTableHelper
       @responsive = opts[:responsive]
       @skip_headers = opts[:skip_headers]
       @sortable = opts[:sortable]
-      @striped = opts[:striped]
       @id = opts[:id]
       @columns = []
     end
@@ -133,7 +132,6 @@ module SageTableHelper
       table_classes = "sage-table"
       table_classes << " sage-table--condensed" if condensed
       table_classes << " sage-table--sortable" if sortable
-      table_classes << " sage-table--striped" if striped
       table_classes << " #{class_name}" if class_name
 
       content_tag "table", id: id, class: table_classes do

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -10,6 +10,5 @@ class SageTable < SageComponent
     responsive: [:optional, TrueClass],
     rows: [:optional, Array],
     selectable: [:optional, TrueClass],
-    striped: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -14,7 +14,6 @@ is_responsive = component.responsive.present? ? component.responsive : true
 
   <table class="
       sage-table
-      <%= "sage-table--striped" if component.striped %>
       <%= "sage-table--selectable" if component.selectable %>
       <%= "sage-table--condensed" if component.condensed %>
     "

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -32,7 +32,6 @@ $-table-overflow-indicator-opacity: 0.95;
 $-table-overflow-indicator-gradient: linear-gradient(90deg, $-table-overflow-indicator-color-start 0%, rgba($-table-overflow-indicator-color-end, $-table-overflow-indicator-opacity) 100%);
 
 // Other
-$-table-row-color-stripe: sage-color(grey, 200);
 $-table-row-color-hover: sage-color(grey, 100);
 $-table-cell-focus: sage-color(charcoal, 300);
 $-table-cell-truncate-width: 6.5em;
@@ -156,15 +155,6 @@ $-table-avatar-width: rem(32px);
     th {
       padding-top: $-table-cell-padding-xs;
       padding-bottom: $-table-cell-padding-xs;
-    }
-  }
-}
-
-// Alternating rows of striped colors
-.sage-table--striped {
-  tbody {
-    tr:nth-child(odd) {
-      background-color: $-table-row-color-stripe;
     }
   }
 }

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -40,7 +40,6 @@ export const Table = ({
   hasDataBeyondCurrentRows,
   headers,
   isResponsive,
-  isStriped,
   onSelectRowHook,
   resetAbove,
   resetBelow,
@@ -69,7 +68,6 @@ export const Table = ({
     'sage-table',
     {
       'sage-table--selectable': selectable,
-      'sage-table--striped': isStriped,
     }
   );
 
@@ -342,7 +340,6 @@ Table.defaultProps = {
   hasDataBeyondCurrentRows: false,
   headers: [],
   isResponsive: true,
-  isStriped: false,
   onSelectRowHook: null,
   resetAbove: false,
   resetBelow: false,
@@ -370,7 +367,6 @@ Table.propTypes = {
     PropTypes.shape({}),
   ]),
   isResponsive: PropTypes.bool,
-  isStriped: PropTypes.bool,
   onSelectRowHook: PropTypes.func,
   resetAbove: PropTypes.bool,
   resetBelow: PropTypes.bool,


### PR DESCRIPTION
## Description
The striped props & styling are being deprecated from Sage tables.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1333" alt="Screen Shot 2022-08-15 at 11 47 09 AM" src="https://user-images.githubusercontent.com/1175111/184696865-1a99a886-e83f-415b-a2f4-9c57133aaf50.png">|<img width="1331" alt="Screen Shot 2022-08-15 at 11 47 47 AM" src="https://user-images.githubusercontent.com/1175111/184696943-abf4cca7-db6d-4504-b994-3954b0ca79cc.png">|


## Testing in `sage-lib`

DOCS:

- Navigate to [docs site](http://localhost:4000/pages/index)
- Verify table striping no longer appears on [table component](http://localhost:4000/pages/component/table?tab=preview)
- Navigate to other components/pages and verify table striping does not appear. (e.g. property tab on component pages.)

STORYBOOK:
- Navigate to [table](http://localhost:4100/?path=/docs/sage-table--default)
- Verify `isStriped` prop no longer appears.


## Testing in `kajabi-products`
1. (**LOW**) Removes striped prop and styling related to table stripes from table components and docs site. Props and hard-coded styles were [previously removed from KP](https://github.com/Kajabi/kajabi-products/pull/24696), so no issues are expected.

## Related
https://kajabi.atlassian.net/browse/SAGE-406
