### PR TITLE
Next version bump

### DIFF
--- a/docs/app/views/examples/components/card/_preview.html.erb
+++ b/docs/app/views/examples/components/card/_preview.html.erb
@@ -45,6 +45,21 @@
   <% end %>
 <% end %>
 
+<%= sage_component SageCard, { interactive: true } do %>
+  <%= sage_component SageCardBlock, { type_block: true } do %>
+    <%= sage_component SageLink, {
+      css_classes: "sage-card__link--primary",
+      label: "Sage Card",
+      show_label: true,
+      style: "primary",
+      url: "#"
+    } %>
+    <p>
+      An interactive card
+    </p>
+  <% end %>
+<% end %>
+
 <%= sage_component SageCard, { border_dashed: true } do %>
   <%= sage_component SageCardBlock, { type_block: true } do %>
     <p>

--- a/docs/app/views/examples/components/card/_props.html.erb
+++ b/docs/app/views/examples/components/card/_props.html.erb
@@ -23,6 +23,12 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`interactive`') %></td>
+  <td><%= md('Gives Card appropriate interactive states when Card links are present.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td colspan="4"><%= md('**Card List**') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/shared/_props.html.erb
+++ b/docs/app/views/examples/shared/_props.html.erb
@@ -2,7 +2,7 @@
   <%= sage_component SageCard, {} do %>
     <div class="sage-table-wrapper sage-table-wrapper--scroll">
       <div class="sage-table-wrapper__overflow">
-        <table class="sage-table sage-table--properties sage-table--striped docs-table">
+        <table class="sage-table sage-table--properties docs-table">
           <thead>
             <tr>
               <th>Property</th>

--- a/docs/app/views/examples/shared/_props_improved.html.erb
+++ b/docs/app/views/examples/shared/_props_improved.html.erb
@@ -1,19 +1,19 @@
 <% if defined?(props) %>
   <div class="<%= SageClassnames::GRID_CARD %>">
     <h3>Properties</h3>
-    <%= sage_table_for props, responsive: true, sortable: true, striped: true do | t | %>
+    <%= sage_table_for props, responsive: true, sortable: true do | t | %>
       <% t.column :name, label: "Name" do | c | %>
         <%= md("`#{c[:name]}`") %>
-      <% end %> 
+      <% end %>
       <% t.column :description, label: "Description" do | c | %>
         <%= md(c[:description], use_sage_type: true) %>
-      <% end %> 
+      <% end %>
       <% t.column :type, label: "Type" do | c | %>
         <%= md(c[:type]) %>
-      <% end %> 
+      <% end %>
       <% t.column :default, label: "Default" do | c | %>
         <%= md(c[:default]) %>
-      <% end %> 
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/docs/app/views/pages/container.html.erb
+++ b/docs/app/views/pages/container.html.erb
@@ -7,7 +7,7 @@
 )) %>
 <% end %>
 
-<%= sage_table_for SageTokens::CONTAINER_SPECS, striped: true, responsive: true do |t| %>
+<%= sage_table_for SageTokens::CONTAINER_SPECS, responsive: true do |t| %>
   <% t.column :container, label: "Container" do |c| %>
     <%= c[:name] %>
     <code><%= c[:alias] %></code>

--- a/docs/app/views/pages/gap.html.erb
+++ b/docs/app/views/pages/gap.html.erb
@@ -8,7 +8,6 @@
 <div class="<%= SageClassnames::TYPE_BLOCK %>">
   <p>The following gap tokens are used throughout Sage:</p>
   <%= sage_component SageTable, {
-    striped: true,
     headers: [
       "Token",
       "Value",

--- a/docs/app/views/pages/spacing.html.erb
+++ b/docs/app/views/pages/spacing.html.erb
@@ -8,7 +8,6 @@
 <div class="<%= SageClassnames::TYPE_BLOCK %>">
   <p>The following spacing tokens are used throughout Sage:</p>
   <%= sage_component SageTable, {
-    striped: true,
     headers: ["Token", "Value"],
     rows: sage_spacers,
   } %>

--- a/docs/config/environments/production.rb
+++ b/docs/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -80,7 +80,7 @@ module SageTableHelper
   end
 
   class SageTableFor
-    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :striped, :reset_above, :reset_below
+    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :reset_above, :reset_below
     delegate :content_tag, :tag, to: :template
 
     def initialize(template, collection, opts={})
@@ -96,7 +96,6 @@ module SageTableHelper
       @responsive = opts[:responsive]
       @skip_headers = opts[:skip_headers]
       @sortable = opts[:sortable]
-      @striped = opts[:striped]
       @id = opts[:id]
       @columns = []
     end
@@ -133,7 +132,6 @@ module SageTableHelper
       table_classes = "sage-table"
       table_classes << " sage-table--condensed" if condensed
       table_classes << " sage-table--sortable" if sortable
-      table_classes << " sage-table--striped" if striped
       table_classes << " #{class_name}" if class_name
 
       content_tag "table", id: id, class: table_classes do

--- a/docs/lib/sage_rails/app/sage_components/sage_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_card.rb
@@ -4,5 +4,6 @@ class SageCard < SageComponent
     compact: [:optional, TrueClass,],
     clear_bottom_padding: [:optional, TrueClass],
     clear_top_padding: [:optional, TrueClass],
+    interactive: [:optional, TrueClass]
   })
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -10,6 +10,5 @@ class SageTable < SageComponent
     responsive: [:optional, TrueClass],
     rows: [:optional, Array],
     selectable: [:optional, TrueClass],
-    striped: [:optional, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_card.html.erb
@@ -5,6 +5,7 @@
     <%= "sage-card--clear-padding-top" if component.clear_top_padding %>
     <%= "sage-card--clear-padding-bottom" if component.clear_bottom_padding %>
     <%= "sage-card--border-dashed" if component.border_dashed %>
+    <%= "sage-card--interactive" if component.interactive %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -14,7 +14,6 @@ is_responsive = component.responsive.present? ? component.responsive : true
 
   <table class="
       sage-table
-      <%= "sage-table--striped" if component.striped %>
       <%= "sage-table--selectable" if component.selectable %>
       <%= "sage-table--condensed" if component.condensed %>
     "

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -12,6 +12,24 @@
   width: 100%;
 }
 
+.sage-card--border-dashed {
+  border-color: sage-color(white);
+  @include sage-dashed-border(
+    $border-radius: sage-border(radius),
+    $color: sage-color(grey, 400),
+  );
+}
+
+.sage-card--clear-padding-top,
+.sage-card--clear-padding-both {
+  padding-top: 0;
+}
+
+.sage-card--clear-padding-bottom,
+.sage-card--clear-padding-both {
+  padding-bottom: 0;
+}
+
 .sage-card--compact {
   gap: sage-spacing(sm);
   padding: sage-spacing(sm);
@@ -26,22 +44,29 @@
   @include sage-grid-card;
 }
 
-.sage-card--clear-padding-top,
-.sage-card--clear-padding-both {
-  padding-top: 0;
-}
+.sage-card--interactive {
+  border: 0;
 
-.sage-card--clear-padding-bottom,
-.sage-card--clear-padding-both {
-  padding-bottom: 0;
-}
+  .sage-link.sage-card__link--primary {
+    // Remove when Link component is updated with new styles
+    color: sage-color(charcoal, 400);
+    text-decoration: none;
 
-.sage-card--border-dashed {
-  border-color: sage-color(white);
-  @include sage-dashed-border(
-    $border-radius: sage-border(radius),
-    $color: sage-color(grey, 400),
-  );
+    &:hover {
+      color: sage-color(charcoal, 500);
+    }
+  }
+
+  a:not(.sage-card__link--primary),
+  button:not(.sage-card__link--primary) {
+    z-index: sage-z-index(default, 2);
+    position: relative;
+
+    &::before,
+    &:hover::before {
+      box-shadow: none;
+    }
+  }
 }
 
 .sage-card__footer {

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -70,12 +70,59 @@ $-link-base-styles: (
 
   &:hover {
     color: sage-color(primary, 400);
+    cursor: pointer;
   }
 
   &:focus {
     color: sage-color(primary, 300);
 
     @include sage-focus-outline--update-color(sage-color(primary, 200));
+  }
+
+  .sage-card--interactive & {
+    position: static;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: sage-z-index(default, 1);
+      box-shadow: sage-border-interactive();
+      border-radius: sage-border(radius-medium);
+    }
+
+    &:hover::before {
+      box-shadow: sage-border-interactive(hover);
+    }
+
+    &:focus::before {
+      box-shadow: sage-border-interactive(focus);
+    }
+
+    &:active::before {
+      box-shadow: sage-border-interactive(selected);
+    }
+
+    &:invalid::before {
+      box-shadow: sage-border-interactive(error);
+    }
+
+    &:focus:invalid::before {
+      box-shadow: sage-border-interactive(error-focus);
+    }
+
+    &:focus::after {
+      border: 0;
+    }
+
+    &::after {
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -10,6 +10,7 @@ $-modal-padding-y: sage-spacing(md);
 $-modal-margin-lg: 6vh;
 $-modal-margin-xl: 8vh;
 $-modal-header-image-size: rem(28px);
+$-modal-fullscreen-max-width: rem(1440px);
 $-modal-fullscreen-top-spacing: rem(104px);
 $-modal-inner-size: sage-container(md);
 
@@ -238,7 +239,8 @@ $-modal-inner-size: sage-container(md);
   margin: $-modal-padding-y $-modal-padding-x;
 
   .sage-modal--fullscreen & {
-    margin-top: $-modal-fullscreen-top-spacing;
+    max-width: $-modal-fullscreen-max-width;
+    margin: $-modal-fullscreen-top-spacing auto 0 auto;
   }
 
   .sage-modal--scrollable & {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -188,7 +188,6 @@ $-modal-inner-size: sage-container(md);
     margin: 0;
     padding: sage-spacing(sm) $-modal-padding-x;
     background-color: sage-color(white);
-    box-shadow: sage-shadow(sm);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -240,7 +240,7 @@ $-modal-inner-size: sage-container(md);
 
   .sage-modal--fullscreen & {
     max-width: $-modal-fullscreen-max-width;
-    margin: $-modal-fullscreen-top-spacing auto 0 auto;
+    margin: $-modal-fullscreen-top-spacing auto sage-spacing() auto;
   }
 
   .sage-modal--scrollable & {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -10,7 +10,7 @@ $-modal-padding-y: sage-spacing(md);
 $-modal-margin-lg: 6vh;
 $-modal-margin-xl: 8vh;
 $-modal-header-image-size: rem(28px);
-$-modal-fullscreen-max-width: rem(1440px);
+$-modal-fullscreen-max-width: sage-container(full);
 $-modal-fullscreen-top-spacing: rem(104px);
 $-modal-inner-size: sage-container(md);
 

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -4,7 +4,6 @@
 /// @group sage
 ////
 
-
 // Borders and sizing
 $-table-header-border: rem(1px) solid sage-color(grey, 300);
 $-table-cell-padding-xs: sage-spacing(xs);
@@ -29,18 +28,21 @@ $-table-overflow-indicator-width: sage-spacing(sm);
 $-table-overflow-indicator-color-start: rgba(255, 255, 255, 0);
 $-table-overflow-indicator-color-end: sage-color(white);
 $-table-overflow-indicator-opacity: 0.95;
-$-table-overflow-indicator-gradient: linear-gradient(90deg, $-table-overflow-indicator-color-start 0%, rgba($-table-overflow-indicator-color-end, $-table-overflow-indicator-opacity) 100%);
+$-table-overflow-indicator-gradient: linear-gradient(
+  90deg,
+  $-table-overflow-indicator-color-start 0%,
+  rgba($-table-overflow-indicator-color-end, $-table-overflow-indicator-opacity)
+    100%
+);
 
 // Other
-$-table-row-color-stripe: sage-color(grey, 200);
-$-table-row-color-hover: sage-color(primary, 100);
+$-table-row-color-hover: sage-color(grey, 100);
 $-table-cell-focus: sage-color(charcoal, 300);
 $-table-cell-truncate-width: 6.5em;
 $-table-sort-indicator-width: rem(5px);
 $-table-sort-indicator-direction: rem(7px);
 $-table-checkbox-width: rem(20px);
 $-table-avatar-width: rem(32px);
-
 
 // stylelint-disable selector-max-compound-selectors, max-nesting-depth, selector-no-qualifying-type
 
@@ -127,15 +129,6 @@ $-table-avatar-width: rem(32px);
     th {
       padding-top: $-table-cell-padding-xs;
       padding-bottom: $-table-cell-padding-xs;
-    }
-  }
-}
-
-// Alternating rows of striped colors
-.sage-table--striped {
-  tbody {
-    tr:nth-child(odd) {
-      background-color: $-table-row-color-stripe;
     }
   }
 }
@@ -229,7 +222,7 @@ $-table-avatar-width: rem(32px);
   .sage-panel & {
     @include overflow-scroll();
     overflow-y: visible;
-    max-width: calc(100% + #{ 2 * sage-spacing(md)});
+    max-width: calc(100% + #{2 * sage-spacing(md)});
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -32,7 +32,7 @@ $-table-overflow-indicator-gradient: linear-gradient(
   90deg,
   $-table-overflow-indicator-color-start 0%,
   rgba($-table-overflow-indicator-color-end, $-table-overflow-indicator-opacity)
-    100%
+  100%
 );
 
 // Other

--- a/packages/sage-assets/lib/stylesheets/layout/_page.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_page.scss
@@ -23,6 +23,6 @@ $-banner-height-offset: map-get($sage-banner-heights, default);
   margin-bottom: sage-spacing();
 }
 
-.sage-page__has-open-modal {
+.sage-page--has-open-modal {
   overflow-y: hidden;
 }

--- a/packages/sage-react/lib/Banner/Banner.jsx
+++ b/packages/sage-react/lib/Banner/Banner.jsx
@@ -6,20 +6,32 @@ import { BannerWrapper } from './BannerWrapper';
 import { BANNER_TYPES } from './configs';
 
 export const Banner = ({
+  active,
   bannerContext,
   ...rest
 }) => (
   (bannerContext !== null)
-    ? <BannerWrapper bannerContext={bannerContext} {...rest} />
-    : <BannerContent bannerContext={bannerContext} {...rest} />
+    ? <BannerWrapper bannerContext={bannerContext} active={active} {...rest} />
+    : <BannerContent bannerContext={bannerContext} active={active} {...rest} />
 );
 
 Banner.TYPES = BANNER_TYPES;
 
+// Defining all default props and prop types explicitly to populate story table
 Banner.defaultProps = {
-  bannerContext: null
+  active: false,
+  bannerContext: null,
+  dismissable: true,
+  link: null,
+  text: null,
+  type: Banner.TYPES.DEFAULT,
 };
 
 Banner.propTypes = {
-  bannerContext: PropTypes.string
+  active: PropTypes.bool,
+  bannerContext: PropTypes.string,
+  dismissable: PropTypes.bool,
+  link: PropTypes.string,
+  text: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(BANNER_TYPES)),
 };

--- a/packages/sage-react/lib/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/Banner/Banner.story.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Banner } from './Banner';
+import { Button } from '../Button';
 
 export default {
   title: 'Sage/Banner',
@@ -15,14 +16,53 @@ export default {
     dismissable: true,
     link: '#',
     text: 'Alert description text',
-    type: Banner.TYPES.DEFAULT
+    type: Banner.TYPES.DEFAULT,
   },
 };
 
 const Template = (args) => <Banner {...args} />;
 export const Default = Template.bind({});
 
-export const InlineBanner = Template.bind({});
-InlineBanner.args = {
+export const DefaultInlineBanner = Template.bind({});
+DefaultInlineBanner.args = {
   bannerContext: 'sage-demo'
+};
+
+export const SecondaryInlineBanner = Template.bind({});
+SecondaryInlineBanner.args = {
+  bannerContext: 'sage-demo',
+  type: Banner.TYPES.SECONDARY
+};
+
+export const WarningInlineBanner = Template.bind({});
+WarningInlineBanner.args = {
+  bannerContext: 'sage-demo',
+  type: Banner.TYPES.WARNING
+};
+
+export const DangerInlineBanner = Template.bind({});
+DangerInlineBanner.args = {
+  bannerContext: 'sage-demo',
+  type: Banner.TYPES.DANGER
+};
+
+export const DefaultFixedBanner = (args) => {
+  const [active, setActive] = useState(false);
+
+  const onClick = () => {
+    setActive(true);
+  };
+
+  return (
+    <>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        onClick={onClick}
+      >
+        Display Banner
+      </Button>
+
+      <Banner {...args} active={active} />
+    </>
+  );
 };

--- a/packages/sage-react/lib/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.jsx
@@ -66,7 +66,7 @@ export const BannerContent = ({
 BannerContent.TYPES = BANNER_TYPES;
 
 BannerContent.defaultProps = {
-  active: null,
+  active: false,
   bannerContext: null,
   children: null,
   className: null,

--- a/packages/sage-react/lib/Banner/BannerWrapper.jsx
+++ b/packages/sage-react/lib/Banner/BannerWrapper.jsx
@@ -4,7 +4,15 @@ import classnames from 'classnames';
 import { BannerContent } from './BannerContent';
 
 export const BannerWrapper = ({
+  active,
   bannerContext,
+  children,
+  className,
+  dismissable,
+  id,
+  link,
+  text,
+  type,
   ...rest
 }) => {
   const classNames = classnames(
@@ -16,13 +24,25 @@ export const BannerWrapper = ({
 
   return (
     <div className={classNames}>
-      <BannerContent {...rest} />
+      <BannerContent
+        active={active}
+        bannerContext={bannerContext}
+        className={className}
+        dismissable={dismissable}
+        id={id}
+        link={link}
+        text={text}
+        type={type}
+        {...rest}
+      >
+        {children}
+      </BannerContent>
     </div>
   );
 };
 
 BannerWrapper.defaultProps = {
-  active: null,
+  active: false,
   bannerContext: null,
   children: null,
   className: null,

--- a/packages/sage-react/lib/Card/Card.jsx
+++ b/packages/sage-react/lib/Card/Card.jsx
@@ -21,6 +21,7 @@ export const Card = ({
   clearPaddingLeft,
   clearPaddingRight,
   clearPaddingTop,
+  interactive,
   loading,
   borderDashed,
   ...rest
@@ -35,6 +36,7 @@ export const Card = ({
       'sage-card--clear-padding-left': clearPaddingLeft,
       'sage-card--clear-padding-right': clearPaddingRight,
       'sage-card--clear-padding-top': clearPaddingTop,
+      'sage-card--interactive': interactive
     }
   );
 
@@ -66,6 +68,7 @@ Card.defaultProps = {
   clearPaddingLeft: false,
   clearPaddingRight: false,
   clearPaddingTop: false,
+  interactive: false,
   loading: false,
   borderDashed: false,
 };
@@ -78,6 +81,7 @@ Card.propTypes = {
   clearPaddingLeft: PropTypes.bool,
   clearPaddingRight: PropTypes.bool,
   clearPaddingTop: PropTypes.bool,
+  interactive: PropTypes.bool,
   loading: PropTypes.bool,
   borderDashed: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Card/Card.story.jsx
+++ b/packages/sage-react/lib/Card/Card.story.jsx
@@ -4,6 +4,7 @@ import { SageTokens } from '../configs';
 import { Button } from '../Button';
 import { Grid } from '../Grid';
 import { Icon } from '../Icon';
+import { Link } from '../Link';
 import { Card } from './Card';
 
 export default {
@@ -123,6 +124,14 @@ Default.args = {
     </>
   ),
 };
+
+export const InteractiveCard = () => (
+  <Card interactive={true}>
+    <Link className="sage-card__link--primary" href="//example.com">
+      Sage Card Link
+    </Link>
+  </Card>
+);
 
 export const CardHighlight = (args) => (
   <Grid container={Grid.CONTAINER_SIZES.XS}>

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ModalBody } from './ModalBody';
@@ -35,6 +35,14 @@ export const Modal = ({
       'sage-modal--no-background-dismiss': disableBackgroundDismiss,
     }
   );
+
+  useEffect(() => {
+    if (active) {
+      document.body.classList.add('sage-page--has-open-modal');
+    }
+
+    return () => { document.body.classList.remove('sage-page--has-open-modal'); };
+  });
 
   let animationAttributes = {};
 

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -40,7 +40,6 @@ export const Table = ({
   hasDataBeyondCurrentRows,
   headers,
   isResponsive,
-  isStriped,
   onSelectRowHook,
   resetAbove,
   resetBelow,
@@ -69,7 +68,6 @@ export const Table = ({
     'sage-table',
     {
       'sage-table--selectable': selectable,
-      'sage-table--striped': isStriped,
     }
   );
 
@@ -342,7 +340,6 @@ Table.defaultProps = {
   hasDataBeyondCurrentRows: false,
   headers: [],
   isResponsive: true,
-  isStriped: false,
   onSelectRowHook: null,
   resetAbove: false,
   resetBelow: false,
@@ -370,7 +367,6 @@ Table.propTypes = {
     PropTypes.shape({}),
   ]),
   isResponsive: PropTypes.bool,
-  isStriped: PropTypes.bool,
   onSelectRowHook: PropTypes.func,
   resetAbove: PropTypes.bool,
   resetBelow: PropTypes.bool,

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -11,7 +11,7 @@ Sage.modal = (function() {
   const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = "data-js-modal-remove-content-on-close";
   const SELECTOR_MODAL_CLOSE = "data-js-modal-close";
   const SELECTOR_MODALTRIGGER = "data-js-modaltrigger";
-  const SELECTOR_PAGE_HAS_OPEN_MODAL = "sage-page__has-open-modal";
+  const SELECTOR_PAGE_HAS_OPEN_MODAL = "sage-page--has-open-modal";
   const SELECTOR_FOCUSABLE_ELEMENTS = "a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type='text']:not([disabled]), input[type='radio']:not([disabled]), input[type='checkbox']:not([disabled]), select:not([disabled])";
   const MODAL_ACTIVE_CLASS = "sage-modal--active";
   const EVENT_CLOSEALL = "sage.modal.closeAll";


### PR DESCRIPTION
- (**HIGH**) kajabi/sage-lib#1559 Modal - adds class to <body> when modal a modal is open.
    - [ ] Creation Wizard
    - [ ] Pipelines Blueprint pages
- (**LOW**) kajabi/sage-lib#1551 Removes the drop shadow on the modal header within the fullscreen variation.
- (**LOW**) kajabi/sage-lib#1554 Updated logic for banner to pass active state into context and wrapper components 
- (**LOW**) kajabi/sage-lib#1557 Adds a max width for modal content to center content on fullscreen variation.
- (**LOW**) kajabi/sage-lib#1556 Removes striped prop and styling related to table stripes from table components and docs site. Props and hard-coded styles were [previously removed from KP](https://github.com/Kajabi/kajabi-products/pull/24696), so no issues are expected.
- (**LOW**) kajabi/sage-lib#1563 Adds bottom margin to fullscreen modal.
- (**LOW**) kajabi/sage-lib#1537 Adds new Card prop for interactivity.
