### PR TITLE
Pagination: (React) Adjust default value of `pageCount` for improved use

### DIFF
--- a/packages/sage-react/lib/Pagination/Pagination.jsx
+++ b/packages/sage-react/lib/Pagination/Pagination.jsx
@@ -29,17 +29,17 @@ export const Pagination = ({
   pageSize,
   pageURLFn,
 }) => {
-  // Get a safe page count if possible:
+  // Get a safe page count:
   let localPageCount;
   switch (true) {
-    // We favor `pageCount` if it is not null.
-    case pageCount:
+    // We favor `pageCount` if it is a positive value.
+    case pageCount > 0:
       localPageCount = pageCount;
       break;
 
-    // Or, if both `itemsTotalCount` and `pageSize` are not null
+    // Or, if both `itemsTotalCount` and `pageSize` are positive values
     // we can calculate the page count.
-    case itemsTotalCount && pageSize:
+    case itemsTotalCount > 0 && pageSize > 0:
       localPageCount = Math.ceil(itemsTotalCount / pageSize);
       break;
 

--- a/packages/sage-react/lib/Pagination/Pagination.jsx
+++ b/packages/sage-react/lib/Pagination/Pagination.jsx
@@ -212,7 +212,7 @@ Pagination.defaultProps = {
   labels: null,
   maxPageButtons: 4,
   onClickPage: null,
-  pageCount: 1,
+  pageCount: null,
   pageCountPrefix: null,
   pageCountSuffix: null,
   pageSize: null,

--- a/packages/sage-react/lib/Pagination/Pagination.jsx
+++ b/packages/sage-react/lib/Pagination/Pagination.jsx
@@ -29,14 +29,24 @@ export const Pagination = ({
   pageSize,
   pageURLFn,
 }) => {
-  const canCalculatePageRange = itemsTotalCount > 0 && pageSize > 0;
+  // Get a safe page count if possible:
+  let localPageCount;
+  switch (true) {
+    // We favor `pageCount` if it is not null.
+    case pageCount:
+      localPageCount = pageCount;
+      break;
 
-  // Get a safe page count if possible
-  let localPageCount = pageCount;
-  if (!localPageCount && canCalculatePageRange) {
-    localPageCount = Math.ceil(itemsTotalCount / pageSize);
-  } else if (!localPageCount) {
-    localPageCount = 1;
+    // Or, if both `itemsTotalCount` and `pageSize` are not null
+    // we can calculate the page count.
+    case itemsTotalCount && pageSize:
+      localPageCount = Math.ceil(itemsTotalCount / pageSize);
+      break;
+
+    // But if all else fails we set page count to `1` .
+    default:
+      localPageCount = 1;
+      break;
   }
 
   // Determine markup properties

--- a/packages/sage-react/lib/Pagination/Pagination.story.jsx
+++ b/packages/sage-react/lib/Pagination/Pagination.story.jsx
@@ -7,14 +7,18 @@ export default {
   argTypes: {},
   args: {
     itemsNoun: 'Cactus',
-    itemsTotalCount: 505,
     currentPage: 1,
     // onClickPage: (num) => console.log('clicked', num),
-    pageCount: 15,
-    pageSize: 50,
+    pageCount: 12,
     pageURLFn: (page) => `//example.com/${page}`,
   }
 };
 const Template = (args) => <Pagination {...args} />;
 
-export const Default = Template.bind({});
+export const FromPageCount = Template.bind({});
+
+export const FromCalculatedPages = Template.bind({});
+FromCalculatedPages.args = {
+  pageSize: 50,
+  itemsTotalCount: 505,
+};


### PR DESCRIPTION
## Description

Per SAGE-751 description, React Pagination defaults `pageCount` to `1` which makes page calculation moot. By setting it to default of `null` it becomes dependent on the user to provide `pageCount` for a specific number of pages or to provide `itemsTotalCount` and `pageSize` for the page count to be calculated better.

## Screenshots

No visual changes.

## Testing in `sage-lib`

See the following for improved stories showing the two configuration options.

- http://localhost:4100/?path=/story/sage-pagination--from-page-count 
- http://localhost:4100/?path=/story/sage-pagination--from-calculated-pages


## Testing in `kajabi-products`

1. (**LOW**) Adjust default value for `pageCount` in React Pagination for easier configuration. Also audited existing uses of Pagination to ensure no breaking changes or impact on uses. 👍 


## Related

https://kajabi.atlassian.net/browse/SAGE-751
