### PR TITLE
PageHeading: Adjust React proptypes

### DIFF
--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -4,14 +4,14 @@ import classnames from 'classnames';
 import { Breadcrumbs } from '../Breadcrumbs';
 
 export const PageHeading = ({
-  actionItems,
+  actions,
   breadcrumbs,
   className,
   children,
   help,
   image,
   introText,
-  toolbarItems,
+  toolbar,
   secondaryText,
   ...rest
 }) => (
@@ -51,15 +51,15 @@ export const PageHeading = ({
         <img alt={image.alt || ''} src={image.src} />
       </div>
     )}
-    {toolbarItems && (
+    {toolbar && (
       <div className="sage-page-heading__toolbar">
-        {toolbarItems}
+        {toolbar}
       </div>
     )}
-    {actionItems && (
+    {actions && (
       <div className="sage-page-heading__actions">
         <div className="sage-page-heading__actions-inner">
-          {actionItems}
+          {actions}
         </div>
       </div>
     )}
@@ -72,18 +72,18 @@ export const PageHeading = ({
 );
 
 PageHeading.defaultProps = {
-  actionItems: null,
+  actions: null,
   breadcrumbs: null,
   className: '',
   help: null,
   image: {},
   introText: null,
-  toolbarItems: null,
+  toolbar: null,
   secondaryText: null,
 };
 
 PageHeading.propTypes = {
-  actionItems: PropTypes.node,
+  actions: PropTypes.node,
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
@@ -94,5 +94,5 @@ PageHeading.propTypes = {
   }),
   introText: PropTypes.string,
   secondaryText: PropTypes.string,
-  toolbarItems: PropTypes.node,
+  toolbar: PropTypes.node,
 };

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uuid from 'react-uuid';
 import classnames from 'classnames';
 import { Breadcrumbs } from '../Breadcrumbs';
 

--- a/packages/sage-react/lib/PageHeading/PageHeading.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.jsx
@@ -54,13 +54,13 @@ export const PageHeading = ({
     )}
     {toolbarItems && (
       <div className="sage-page-heading__toolbar">
-        {toolbarItems.map((tool) => <React.Fragment key={uuid()}>{tool}</React.Fragment>)}
+        {toolbarItems}
       </div>
     )}
     {actionItems && (
       <div className="sage-page-heading__actions">
         <div className="sage-page-heading__actions-inner">
-          {actionItems.map((action) => <React.Fragment key={uuid()}>{action}</React.Fragment>)}
+          {actionItems}
         </div>
       </div>
     )}
@@ -84,7 +84,7 @@ PageHeading.defaultProps = {
 };
 
 PageHeading.propTypes = {
-  actionItems: PropTypes.arrayOf(PropTypes.node),
+  actionItems: PropTypes.node,
   breadcrumbs: PropTypes.arrayOf(Breadcrumbs.itemPropTypes),
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
@@ -95,5 +95,5 @@ PageHeading.propTypes = {
   }),
   introText: PropTypes.string,
   secondaryText: PropTypes.string,
-  toolbarItems: PropTypes.arrayOf(PropTypes.node),
+  toolbarItems: PropTypes.node,
 };

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -13,23 +13,25 @@ export default {
         Page heading goes here
       </>
     ),
-    actionItems: [
-      <Button
-        color={Button.COLORS.SECONDARY}
-        icon={SageTokens.ICONS.PREVIEW_ON}
-        subtle={true}
-      >
-        Preview
-      </Button>,
-      <Button
-        color={Button.COLORS.PRIMARY}
-        icon={SageTokens.ICONS.CART}
-      >
-        Create
-      </Button>
-    ],
+    actionItems: (
+      <>
+        <Button
+          color={Button.COLORS.SECONDARY}
+          icon={SageTokens.ICONS.PREVIEW_ON}
+          subtle={true}
+        >
+          Preview
+        </Button>
+        <Button
+          color={Button.COLORS.PRIMARY}
+          icon={SageTokens.ICONS.CART}
+        >
+          Create
+        </Button>
+      </>
+    ),
     toolbarItems: null,
-  }
+  },
 };
 const Template = (args) => <PageHeading {...args} />;
 
@@ -69,29 +71,31 @@ PageHeadingWithThumbnail.args = {
 export const PageHeadingWithToolbarAndSecondaryText = Template.bind({});
 PageHeadingWithToolbarAndSecondaryText.args = {
   secondaryText: 'Secondary text here',
-  toolbarItems: [
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.CART}
-      subtle={true}
-    >
-      Preview
-    </Button>,
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.GEAR}
-      subtle={true}
-    >
-      Report
-    </Button>,
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.GEAR}
-      subtle={true}
-    >
-      Settings
-    </Button>
-  ],
+  toolbarItems: (
+    <>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.CART}
+        subtle={true}
+      >
+        Preview
+      </Button>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.GEAR}
+        subtle={true}
+      >
+        Report
+      </Button>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.GEAR}
+        subtle={true}
+      >
+        Settings
+      </Button>
+    </>
+  ),
 };
 
 export const AllItems = Template.bind({});

--- a/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
+++ b/packages/sage-react/lib/PageHeading/PageHeading.story.jsx
@@ -13,7 +13,7 @@ export default {
         Page heading goes here
       </>
     ),
-    actionItems: (
+    actions: (
       <>
         <Button
           color={Button.COLORS.SECONDARY}
@@ -30,7 +30,7 @@ export default {
         </Button>
       </>
     ),
-    toolbarItems: null,
+    toolbar: null,
   },
 };
 const Template = (args) => <PageHeading {...args} />;
@@ -71,7 +71,7 @@ PageHeadingWithThumbnail.args = {
 export const PageHeadingWithToolbarAndSecondaryText = Template.bind({});
 PageHeadingWithToolbarAndSecondaryText.args = {
   secondaryText: 'Secondary text here',
-  toolbarItems: (
+  toolbar: (
     <>
       <Button
         color={Button.COLORS.SECONDARY}
@@ -113,46 +113,50 @@ AllItems.args = {
       <HelpLink href="//example.com" target="_blank" rel="noopener" />
     </>
   ),
-  actionItems: [
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.PREVIEW_ON}
-      subtle={true}
-    >
-      Preview
-    </Button>,
-    <Button
-      color={Button.COLORS.PRIMARY}
-      icon={SageTokens.ICONS.CART}
-    >
-      Create
-    </Button>
-  ],
+  actions: (
+    <>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.PREVIEW_ON}
+        subtle={true}
+      >
+        Preview
+      </Button>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        icon={SageTokens.ICONS.CART}
+      >
+        Create
+      </Button>
+    </>
+  ),
   image: {
     src: 'https://via.placeholder.com/132x74',
     alt: 'Page heading demo image',
   },
-  toolbarItems: [
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.CART}
-      subtle={true}
-    >
-      Preview
-    </Button>,
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.GEAR}
-      subtle={true}
-    >
-      Report
-    </Button>,
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.GEAR}
-      subtle={true}
-    >
-      Settings
-    </Button>
-  ],
+  toolbar: (
+    <>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.CART}
+        subtle={true}
+      >
+        Preview
+      </Button>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.GEAR}
+        subtle={true}
+      >
+        Report
+      </Button>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        icon={SageTokens.ICONS.GEAR}
+        subtle={true}
+      >
+        Settings
+      </Button>
+    </>
+  ),
 };

--- a/packages/sage-react/lib/mocks/payment-transactions/Main.jsx
+++ b/packages/sage-react/lib/mocks/payment-transactions/Main.jsx
@@ -37,13 +37,13 @@ export const Main = () => {
       <PageHeading
         // TODO: DSS: `actionItems` should not be an array but just nodes as children.
         //   https://kajabi.atlassian.net/browse/SAGE-752
-        actionItems={[
+        actions={(
           <OptionsDropdown
             options={transactionPageOptions({ setShowCustomizeColumnsModal })}
             triggerButtonSubtle={false}
             align={OptionsDropdown.POSITIONS.RIGHT}
           />
-        ]}
+        )}
         className={SageClassnames.SPACERS.LG_BOTTOM}
       >
         Transactions


### PR DESCRIPTION
## Description

This PR adjusts the proptypes for actionItems and toolbarItems to be just nodes rather than an array of nodes in keeping with a more conventional approach to such props in React.

## Screenshots

No visual impact.

## Testing in `sage-lib`

See http://localhost:4100/?path=/story/sage-pageheading--default and other related stories to see no visual change in output.

## Testing in `kajabi-products`

1. (**LOW**) Adjust proptype setting for toolbarItems and actionItems to expect just a node rather than an array of nodes. This change does not create a breaking change as React still handles the array-based nodes, but [this corresponding PR](https://github.com/Kajabi/kajabi-products/pull/24747) patches related aspects in `kp` to avoid any console warnings or errors with mismatching proptypes.


## Related

[SAGE-752](https://kajabi.atlassian.net/browse/SAGE-752)