### PR TITLE
Modal - Fullscreen Bottom Margin

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -240,7 +240,7 @@ $-modal-inner-size: sage-container(md);
 
   .sage-modal--fullscreen & {
     max-width: $-modal-fullscreen-max-width;
-    margin: $-modal-fullscreen-top-spacing auto 0 auto;
+    margin: $-modal-fullscreen-top-spacing auto sage-spacing() auto;
   }
 
   .sage-modal--scrollable & {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds bottom margin to fullscreen modal. Added to further match Figma specs for Product Creation Flow and prevent content from bumping against the bottom of the viewport.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
N/A

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Modal](http://localhost:4000/pages/component/modal?tab=preview)
- Click Fullscreen example
- Check that modal content now has `24px` of bottom margin

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds bottom margin to fullscreen modal.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
N/A