### PR TITLE
[SAGE-740] Sidebar/Content Background Color Updates

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_sidebar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_sidebar.scss
@@ -21,7 +21,6 @@ $-sidebar-top-offset: $sage-assistant-height;
   height: calc(100% - #{$-sidebar-top-offset});
   width: sage-sidebar(xl);
   background: $-sidebar-color-background;
-  border-right: sage-border();
   box-shadow: sage-shadow();
   overscroll-behavior-y: contain;
   transition: transform 0.2s ease-out, opacity 0.15s ease-in-out;

--- a/packages/sage-assets/lib/stylesheets/layout/_content.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_content.scss
@@ -12,7 +12,5 @@
   // Ladera Integration Note:
   // X-padding of 32px (`sage-spacing(lg)`) matches Ladera's `.content` wrapper padding value of `$spacing-outer`
   padding: sage-spacing() sage-spacing(lg);
-
-  background: sage-color(grey, 300);
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Description
Due to the recently rolled-out redesign, the background colors of the sidebar and content areas were updated in the Admin. These same updates need to be applied within the superAdmin.

- Content: Should have a white/transparent background.
- Sidebar:  Should become #f9fafa `sage-color(grey, 100);`

These adjustments require updates to the `.sage-content` & `.sage-sidebar` styling.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1782" alt="Screen Shot 2022-08-22 at 2 41 46 PM" src="https://user-images.githubusercontent.com/1175111/186028963-288c6164-5ecf-4e64-98b1-7aace169c0e6.png">|<img width="1778" alt="Screen Shot 2022-08-22 at 2 43 04 PM" src="https://user-images.githubusercontent.com/1175111/186029016-fda17d67-132f-4510-8106-446bd80db27c.png">|

## Testing in `sage-lib`
- Navigate to the [Sage Docs Site](http://localhost:4000/pages/index)
- Navigate through pages in the top nav
- Verify sidebar background color is correct (`#f9fafa` / `sage-color(grey, 100);`)
- Verify content area background is correct (white)

## Testing in `kajabi-products`
1. (**LOW**) Adjustments to the sidebar and content colors to match the recent redesign. Styling only update.
   - [ ] SuperAdmin - verify sidebar and content areas have correct background colors.
   - [ ] Affiliates - verify login/sign up/forgot password pages have white background.


## Related
https://kajabi.atlassian.net/browse/SAGE-740
