### PR TITLE
[SAGE-780] `SageGrid` column class fix

### DIFF
--- a/docs/lib/sage_rails/app/helpers/sage_grid_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_grid_helper.rb
@@ -1,0 +1,29 @@
+module SageGridHelper
+  def grid_column_classes(col)
+    column_sizes = ["xlarge", "large", "medium", "small"]
+    column_classes = ""
+
+    if col.breakpoint.present? && col.size.present?
+      column_classes << "sage-col--#{col.breakpoint}-#{col.size}"
+    elsif !col.breakpoint.present? && col.size.present?
+      column_classes << "sage-col-#{col.size}"
+    # elsif !col.breakpoint.present? && !col.size.present? && grid_col_legacy(column_sizes)
+    #   grid_col_breakpoint_individual(col, column_classes)
+    else
+      column_classes << "sage-col"
+    end
+  end
+
+  private
+
+  def grid_col_legacy(col)
+    col.include?
+  end
+
+  def grid_col_breakpoint_individual(col, column_classes)
+    column_classes << " sage-col--xl-#{col.xlarge}" if col.xlarge.present?
+    column_classes << " sage-col--lg-#{col.large}" if col.large.present?
+    column_classes << " sage-col--md-#{col.medium}" if col.medium.present?
+    column_classes << " sage-col--sm-#{col.small}" if col.small.present?
+  end
+end

--- a/docs/lib/sage_rails/app/helpers/sage_grid_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_grid_helper.rb
@@ -1,29 +1,34 @@
 module SageGridHelper
   def grid_column_classes(col)
-    column_sizes = ["xlarge", "large", "medium", "small"]
     column_classes = ""
 
     if col.breakpoint.present? && col.size.present?
-      column_classes << "sage-col--#{col.breakpoint}-#{col.size}"
+      # if both breakpoint and sizing are provided
+      column_classes << "sage-col--#{col.breakpoint}-#{col.size} "
     elsif !col.breakpoint.present? && col.size.present?
-      column_classes << "sage-col-#{col.size}"
-    # elsif !col.breakpoint.present? && !col.size.present? && grid_col_legacy(column_sizes)
-    #   grid_col_breakpoint_individual(col, column_classes)
+      # or if only a size is provided, without a breakpoint
+      column_classes << "sage-col-#{col.size} "
+    elsif !col.breakpoint.present? && !col.size.present? && grid_col_legacy(col)
+      # or if a legacy individual breakpoint is provided
+      grid_col_breakpoint_individual(col, column_classes)
     else
-      column_classes << "sage-col"
+      # otherwise we display a default unsized column
+      column_classes << "sage-col "
     end
+
+    column_classes << col.generated_css_classes
   end
 
   private
 
   def grid_col_legacy(col)
-    col.include?
+    col.xlarge.present? || col.large.present? || col.medium.present? || col.small.present?
   end
 
   def grid_col_breakpoint_individual(col, column_classes)
-    column_classes << " sage-col--xl-#{col.xlarge}" if col.xlarge.present?
-    column_classes << " sage-col--lg-#{col.large}" if col.large.present?
-    column_classes << " sage-col--md-#{col.medium}" if col.medium.present?
-    column_classes << " sage-col--sm-#{col.small}" if col.small.present?
+    column_classes << "sage-col--xl-#{col.xlarge} " if col.xlarge.present?
+    column_classes << "sage-col--lg-#{col.large} " if col.large.present?
+    column_classes << "sage-col--md-#{col.medium} " if col.medium.present?
+    column_classes << "sage-col--sm-#{col.small} " if col.small.present?
   end
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
@@ -1,14 +1,7 @@
-<% has_infix = component.breakpoint || component.size || component.small || component.medium || component.large %>
-
 <div class="
-  <%= "sage-col" if !has_infix -%>
-  <%= "sage-col-#{component.size}" if component.size -%>
-  <%= "sage-col--#{component.breakpoint}-#{component.size}" if component.breakpoint && component.size -%>
-  <%= "sage-col--sm-#{component.small}" if component.small%>
-  <%= "sage-col--md-#{component.medium}" if component.medium%>
-  <%= "sage-col--lg-#{component.large}" if component.large%>
-  <%= "sage-col--xl-#{component.xlarge}" if component.xlarge%>
-  <%= component.generated_css_classes %>
-" <%= component.generated_html_attributes.html_safe %>>
+  <%= grid_column_classes(component) %>
+  <%= component.generated_css_classes %>"
+  <%= component.generated_html_attributes.html_safe %>
+>
   <%= component.content %>
 </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_grid_col.html.erb
@@ -1,7 +1,3 @@
-<div class="
-  <%= grid_column_classes(component) %>
-  <%= component.generated_css_classes %>"
-  <%= component.generated_html_attributes.html_safe %>
->
+<div class="<%= grid_column_classes(component) %>" <%= component.generated_html_attributes.html_safe %>>
   <%= component.content %>
 </div>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
[SAGE-780](https://kajabi.atlassian.net/browse/SAGE-780)

Addresses a bug in the 12-column grid when using Rails `SageGridCol` component by removing the duplicate `sage-col` class when a responsive breakpoint is provided. In certain cases, this caused irregular sizing issues due to conflicting media queries.

Most easily noticeable when the `lg` breakpoint is in use. For example, open the "Help & Feedback" modal in the KP sidebar, and note that the `sage-col--lg-6` columns follow the `sage-col-6` media query when resized.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![before-grid-col](https://user-images.githubusercontent.com/816579/186043101-16d06a05-43e9-4384-8278-a0a42c731549.png)|![after-grid-col](https://user-images.githubusercontent.com/816579/186043131-28925274-1011-4c22-ad6c-b9d3586d536d.png)|



## Testing in `sage-lib`
1. Navigate to the [Sage docs homepage](http://localhost:4000/pages/index)
2. Inspect any of the content columns (within `.docs-section`)
3. Confirm the grid columns are only rendering responsive grid column classes (ex. `sage-col--md-4`)


## Testing in `kajabi-products`
1. (**HIGH**) Modifies output of `SageGridCol` component
   - [ ] Website -> Blog posts -> Edit post 
   - [ ] Sidebar -> "Help & Feedback" modal



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
