### PR TITLE
SAGE-754 - Icon: Add `"NULL"` icon for placeholder needs

### DIFF
--- a/docs/app/views/examples/components/icon/_props.html.erb
+++ b/docs/app/views/examples/components/icon/_props.html.erb
@@ -36,7 +36,10 @@
 </tr>
 <tr>
   <td><%= md('`icon`') %><%= sage_component SageBadge, { color: "published", value: "required" } %></td>
-  <td><%= md('Which icon to display. See Sage Icons under "Design."') %></td>
+  <td><%= md('
+    Which icon to display. See Sage Icons under "Figma Design."
+    Note: `null` is also available to place an empty space icon
+  ') %></td>
   <td><%= md('`String` for desired icon.') %></td>
   <td><%= md('--') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -250,6 +250,7 @@ module SageTokens
     "move-right",
     "multi-pay",
     "newsletter",
+    "null",
     "one-off-session",
     "one-time",
     "package",

--- a/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
@@ -191,6 +191,7 @@ $sage-icons: (
   move-right: unicode(e99a),
   multi-pay: unicode(e99b),
   newsletter: unicode(e99c),
+  "null": "",
   one-off-session: unicode(e99d),
   one-time: unicode(e99e),
   package: unicode(e99f),

--- a/packages/sage-react/lib/Icon/Icon.story.jsx
+++ b/packages/sage-react/lib/Icon/Icon.story.jsx
@@ -59,3 +59,10 @@ CustomBackgroundSizeCircular.args = {
   backgroundHeight: '48px',
   size: Icon.SIZES.LG
 };
+export const NullIcon = Template.bind({});
+NullIcon.args = {
+  cardColor: 'draft',
+  circular: true,
+  backgroundHeight: '48px',
+  icon: Icon.ICONS.NULL,
+};

--- a/packages/sage-react/lib/configs/tokens/icons.js
+++ b/packages/sage-react/lib/configs/tokens/icons.js
@@ -151,6 +151,7 @@ export const TOKENS_ICONS = {
   MOVE_RIGHT: 'move-right',
   MULTI_PAY: 'multi-pay',
   NEWSLETTER: 'newsletter',
+  NULL: 'null',
   ONE_OFF_SESSION: 'one-off-session',
   ONE_TIME: 'one-time',
   PACKAGE: 'package',


### PR DESCRIPTION
## Description
Addition of empty null icon to act as a placeholder for instances where icon spacing is needed but no icon is expected.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Rails  |  React  |
|--------|--------|
![CleanShot 2022-08-23 at 10 55 37@2x](https://user-images.githubusercontent.com/791670/186191251-cb7e93ef-7416-49b8-9c20-bbcd50d4e95a.png)|<img width="153" alt="CleanShot 2022-08-23 at 10 33 53@2x" src="https://user-images.githubusercontent.com/791670/186185971-bfee26a2-327a-45ff-ab56-83789aa67bb4.png">


## Testing in `sage-lib`
http://localhost:4000/pages/foundations/icon
http://localhost:4100/?path=/docs/sage-icon--null-icon

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Addition of new empty null icon
   - [ ] Change should be benign


## Related
[SAGE-754 - Icon: Add `"NULL"` icon for placeholder needs](https://kajabi.atlassian.net/browse/SAGE-754)