### PR TITLE
[Sage-753] Modal - Size Prop Based on Container

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -48,6 +48,14 @@
     <%= sage_component SageButton, {
       style: "primary",
       icon: { name: "launch", style: "right" },
+      value: "Modal with Size Option",
+      attributes: {
+        "data-js-modaltrigger": "cool-modal-size-option",
+      }
+    } %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
       value: "Spaced Modal",
       attributes: {
         "data-js-modaltrigger": "cool-modal-spaced",
@@ -231,6 +239,41 @@
         name: "danger",
         color: "red"
       },
+      title: "Example Modal"
+    } do %>
+      <% content_for :sage_header_aside do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          subtle: true,
+          value: "Close Modal",
+          icon: { name: "remove", style: "only" },
+          attributes: { "data-js-modal": true }
+        } %>
+      <% end %>
+
+      <%= sample_body_text %>
+
+      <% content_for :sage_footer do %>
+        <% content_for :sage_footer_aside do %>
+          <%= sage_component SageButton, {
+            style: "secondary",
+            subtle: true,
+            value: "Close Modal",
+            attributes: { "data-js-modal": true }
+          } %>
+        <% end %>
+        <%= sage_component SageButton, {
+          style: "primary",
+          icon: { name: "check", style: "left" },
+          value: "Take An Action",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%# Standard Modal with Size Option %>
+  <%= sage_component SageModal, { id: "cool-modal-size-option", size: "full" } do %>
+    <%= sage_component SageModalContent, {
       title: "Example Modal"
     } do %>
       <% content_for :sage_header_aside do %>

--- a/docs/lib/sage_rails/app/sage_components/sage_modal.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_modal.rb
@@ -12,6 +12,7 @@ class SageModal < SageComponent
     id: [:optional, NilClass, String],
     large: [:optional, TrueClass],
     remove_content_on_close: [:optional, TrueClass],
-    remote_url: [:optional, String]
+    remote_url: [:optional, String],
+    size: [:optional, Set.new(SageTokens::CONTAINER_SIZES)]
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal.html.erb
@@ -6,6 +6,7 @@
     <%= "sage-modal--no-blur" if component.disable_background_blur -%>
     <%= "sage-modal--no-background-dismiss" if component.disable_background_dismiss -%>
     <%= "sage-modal--scrollable" if component.allow_scroll %>
+    <%= "sage-modal--size-#{component.size}" if component.size %>
     <%= component.generated_css_classes %>
   "
   <%= "data-sage-animate" if component.animate.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -173,6 +173,13 @@ $-modal-inner-size: sage-container(md);
     @include overflow-scroll(y);
     padding: sage-spacing(xs) sage-spacing(3xs);
   }
+
+  @each $-key, $-value in $sage-containers {
+    .sage-modal--size-#{$-key} & {
+      width: sage-container($-key);
+      max-width: none;
+    }
+  }
 }
 
 .sage-modal__header {

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -6,7 +6,7 @@ import { ModalFooter } from './ModalFooter';
 import { ModalFooterAside } from './ModalFooterAside';
 import { ModalHeader } from './ModalHeader';
 import { ModalHeaderAside } from './ModalHeaderAside';
-import { MODAL_ANIMATION_PRESETS, MODAL_ANIMATION_DIRECTIONS } from './configs';
+import { MODAL_ANIMATION_PRESETS, MODAL_ANIMATION_DIRECTIONS, MODAL_CONTAINER_SIZES } from './configs';
 
 export const Modal = ({
   active,
@@ -21,6 +21,7 @@ export const Modal = ({
   id,
   large,
   onExit,
+  size,
   ...rest
 }) => {
   const classNames = classnames(
@@ -33,6 +34,7 @@ export const Modal = ({
       'sage-modal--fullscreen': fullScreen,
       'sage-modal--no-blur': disableBackgroundBlur,
       'sage-modal--no-background-dismiss': disableBackgroundDismiss,
+      [`sage-modal--size-${size}`]: size,
     }
   );
 
@@ -100,6 +102,7 @@ Modal.Header = ModalHeader;
 Modal.HeaderAside = ModalHeaderAside;
 Modal.ANIMATION_PRESETS = MODAL_ANIMATION_PRESETS;
 Modal.ANIMATION_DIRECTIONS = MODAL_ANIMATION_DIRECTIONS;
+Modal.SIZES = MODAL_CONTAINER_SIZES;
 
 Modal.defaultProps = {
   active: false,
@@ -114,6 +117,7 @@ Modal.defaultProps = {
   disableBackgroundBlur: false,
   disableBackgroundDismiss: false,
   onExit: (val) => val,
+  size: null,
 };
 
 Modal.propTypes = {
@@ -134,4 +138,5 @@ Modal.propTypes = {
   id: PropTypes.string,
   large: PropTypes.bool,
   onExit: PropTypes.func,
+  size: PropTypes.oneOf(Object.values(Modal.SIZES))
 };

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -237,3 +237,31 @@ export const Fullscreen = (args) => {
     </>
   );
 };
+
+export const ModalWithCustomSize = (args) => {
+  const [active, setActive] = useState(false);
+
+  const onExit = () => {
+    setActive(false);
+  };
+
+  return (
+    <>
+      <Button
+        color={Button.COLORS.PRIMARY}
+        onClick={() => setActive(true)}
+      >
+        Take An Action
+      </Button>
+      <Modal
+        active={active}
+        animation={{ direction: Modal.ANIMATION_DIRECTIONS.BOTTOM }}
+        onExit={onExit}
+        size={Modal.SIZES.FULL}
+        {...args}
+      >
+        <DefaultBody onExit={onExit} />
+      </Modal>
+    </>
+  );
+};

--- a/packages/sage-react/lib/Modal/configs.js
+++ b/packages/sage-react/lib/Modal/configs.js
@@ -23,3 +23,12 @@ export const MODAL_ANIMATION_PRESETS = {
   'data-sage-animate': true,
   'data-sage-animate-direction': MODAL_ANIMATION_DIRECTIONS.TOP
 };
+
+export const MODAL_CONTAINER_SIZES = {
+  XS: 'xs',
+  SM: 'sm',
+  MD: 'md',
+  LG: 'lg',
+  XL: 'xl',
+  FULL: 'full',
+};


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds a new prop `size` to allow for modal sizes based on container sizes.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="1572" alt="Screen Shot 2022-08-23 at 11 35 07 AM" src="https://user-images.githubusercontent.com/14791307/186213135-f1578c99-6256-4c87-a83c-34cbb2f422a9.png">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Modal](http://localhost:4000/pages/component/modal?tab=preview)
- Click "Modal with Size Option" button
- Check that modal container properly changes width to mapped container value

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds a new prop `size` to allow for modal sizes based on container sizes.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-753](https://kajabi.atlassian.net/browse/SAGE-753)