### PR TITLE
fix(error): error occurring locally with PropTypes.object()

### DIFF
--- a/packages/sage-react/lib/Description/Description.jsx
+++ b/packages/sage-react/lib/Description/Description.jsx
@@ -148,7 +148,7 @@ Description.propTypes = {
   className: PropTypes.string,
   items: PropTypes.arrayOf(PropTypes.shape({
     action: PropTypes.shape({
-      attributes: PropTypes.objectOf(PropTypes.object()),
+      attributes: PropTypes.shape({}),
       iconOnly: PropTypes.bool,
       value: PropTypes.string,
     }),


### PR DESCRIPTION
## Description
Error when running locally was discovered by @pixelflips...See slack [thread](https://kajabi.slack.com/archives/C03GKQJHCLX/p1661446048919509)


## Solution
It was identified that the propType `PropTypes.object()` caused the problem. So we changed that to `PropTypes.shape({})`.

```
Unexpected error while loading ./Card/Card.story.jsx: Calling PropTypes validators directly is not supported by the `prop-types` package. Use `PropTypes.checkPropTypes()` to call them. Read more at http://fb.me/use-check-prop-types
 Invariant Violation: Calling PropTypes validators directly is not supported by the `prop-types` package. Use `PropTypes.checkPropTypes()` to call them.```