### PR TITLE
[SAGE-757] Table - responsive updates

### DIFF
--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -110,6 +110,51 @@ sample_table = {
     }
   ]
 }
+
+table_dropdown_menu_items = [
+  {
+    attributes: { "href": "#" },
+    icon: "pen",
+    value: "Edit",
+  },
+  {
+    attributes: {
+      "href": "https://kajabi.com",
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "right",
+    },
+    icon: "pen",
+    modifiers: ["disabled"],
+    value: "Disabled link w/ tooltip",
+  },
+  {
+    attributes: { "href": "#" },
+    icon: "add",
+    style: "primary",
+    value: "New",
+  },
+  {
+    attributes: { "href": "#" },
+    icon: "url",
+    modifiers: ["border-before"],
+    value: "Share Element",
+  },
+  {
+    attributes: { "href": "#" },
+    icon: "remove-circle",
+    style: "danger",
+    value: "Take A Dangerous Action",
+  },
+  {
+    attributes: {
+      "data-js-tooltip": "Tooltip",
+      "data-js-tooltip-position": "right",
+    },
+    icon: "users",
+    modifiers: ["disabled"],
+    value: "Disabled w/ Tooltip",
+  }
+]
 %>
 
 <%= sage_component SageTable, {
@@ -435,7 +480,12 @@ This involves calling `sage_table_for` with a collection, and then using `t.colu
 **NOTE:** This is an MVP implementation based on a helper written earlier for `kajabi-products` and may not be fully aligned with SageTable. It is safe to use, but should be tracked against future updates.
 ") %>
 
-<%= sage_table_for people_data, selectable: true, sortable: true, responsive: true, caption: "Caption positioned above using `caption_side`".html_safe, caption_side: "top" do |t| %>
+<%= sage_table_for people_data,
+    selectable: true,
+    sortable: true,
+    responsive: true,
+    responsive_stack: true,
+    caption: "Caption positioned above using `caption_side`".html_safe, caption_side: "top" do |t| %>
   <% t.column :initials, label: "", data_type: "checkbox" do |c| %>
     <%= sage_component SageCheckbox, {
       label_text: 'Select row',
@@ -467,15 +517,15 @@ This involves calling `sage_table_for` with a collection, and then using `t.colu
     </span>
   <% end %>
 
-  <% t.column :price, label: "Price", style: "width: 140px", hide: { md: true } do |c| %>
+  <% t.column :price, label: "Price", hide: { md: true } do |c| %>
     <%= c[:price] %>
   <% end %>
 
-  <% t.column :amount, label: "Amount", style: "width: 100px", hide: { md: true } do |c| %>
+  <% t.column :amount, label: "Amount", hide: { md: true } do |c| %>
     <%= c[:amount] %>
   <% end %>
 
-  <% t.column :labels, label: "Labels", style: "width: 150px", hide: { sm: true } do |c| %>
+  <% t.column :labels, label: "Labels", hide: { sm: true } do |c| %>
     <% c[:labels].each do |label| %>
       <%= sage_component SageBadge, {
         value: label,
@@ -484,14 +534,14 @@ This involves calling `sage_table_for` with a collection, and then using `t.colu
     <% end %>
   <% end %>
 
-  <% t.column :status, label: "Status", style: "width: 100px", hide: { sm: true } do |c| %>
+  <% t.column :status, label: "Status", hide: { sm: true } do |c| %>
     <%= sage_component SageBadge, {
       value: c[:status].titlecase,
       color: c[:status],
       } %>
   <% end %>
 
-  <% t.column :actions, label: "Actions", style: "width: 100px" do |c| %>
+  <% t.column :actions, label: "Actions" do |c| %>
     <%= sage_component SageButtonGroup, { gap: :xs } do %>
       <%= sage_component SageButton, {
         subtle: true,

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -230,11 +230,12 @@ table_dropdown_menu_items = [
   ]
 } %>
 
-<h3 class="t-sage-heading-6">Table with checkbox selection</h3>
+<h3 class="t-sage-heading-6">Responsive "stacked" table with checkbox selection</h3>
 <%= sage_component SageTable, {
   caption: %(
-    People example
+    Set `responsive_stack` to enable the mobile "stacked" layout
   ),
+  caption_side: "bottom",
   has_leading_input: true,
   has_menu_options: true,
   headers: [
@@ -252,7 +253,7 @@ table_dropdown_menu_items = [
       %(
         #{sage_component(SageCheckbox, {
           id:"c331",
-          label_text: "Checkbox",
+          label_text: "Select row",
           checked: false,
           disabled: false,
           has_error: false,
@@ -288,7 +289,7 @@ table_dropdown_menu_items = [
       %(
         #{sage_component(SageCheckbox, {
           id:"c332",
-          label_text: "Checkbox",
+          label_text: "Select row",
           checked: false,
           disabled: false,
           has_error: false,
@@ -324,7 +325,7 @@ table_dropdown_menu_items = [
       %(
         #{sage_component(SageCheckbox, {
           id:"c333",
-          label_text: "Checkbox",
+          label_text: "Select row",
           checked: false,
           disabled: false,
           has_error: false,

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -123,6 +123,7 @@ sample_table = {
     "Revenue",
     "Status"
   ],
+  # responsive_stack: true,
   rows: [
     [
       %(
@@ -200,6 +201,7 @@ sample_table = {
     "Last activity",
     ""
   ],
+  responsive_stack: true,
   rows: [
     [
       %(

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -116,6 +116,82 @@ sample_table = {
   caption: %(
     Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
   ),
+  has_leading_input: true,
+  has_menu_options: true,
+  headers: [
+    "Name",
+    "Email",
+    "Revenue",
+    "Status"
+  ],
+  rows: [
+    [
+      %(
+        #{link_to "Frank Dux", "#", class: "sage-table-cell__link"}
+      ),
+      "fd@email.com",
+      "$275.43",
+      %(
+        #{sage_component(SageButton, {
+          value: "Icon only",
+          small: true,
+          style: "secondary",
+          subtle: true,
+          icon: {
+            style: "only",
+            name: "dot-menu-horizontal"
+          },
+          small: true
+        })})
+    ],
+    [
+      %(
+        #{link_to "Stinkmeaner", "#", class: "sage-table-cell__link"}
+      ),
+      "st@email.com",
+      "$775.43",
+      %(
+        #{sage_component(SageButton, {
+          value: "Icon only",
+          small: true,
+          style: "secondary",
+          subtle: true,
+          icon: {
+            style: "only",
+            name: "dot-menu-horizontal"
+          },
+          small: true
+        })})
+    ],
+    [
+      %(
+        #{link_to "Huey Freeman", "#", class: "sage-table-cell__link"}
+      ),
+      "hf@email.com",
+      "$1275.43",
+      %(
+        #{sage_component(SageButton, {
+          value: "Icon only",
+          small: true,
+          style: "secondary",
+          subtle: true,
+          icon: {
+            style: "only",
+            name: "dot-menu-horizontal"
+          },
+          small: true
+        })})
+    ],
+  ]
+} %>
+
+<h3 class="t-sage-heading-6">Table with checkbox selection</h3>
+<%= sage_component SageTable, {
+  caption: %(
+    Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
+  ),
+  has_leading_input: true,
+  has_menu_options: true,
   headers: [
     "Name",
     "Email",

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -116,7 +116,6 @@ sample_table = {
   caption: %(
     Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
   ),
-  has_leading_input: true,
   has_menu_options: true,
   headers: [
     "Name",
@@ -193,6 +192,7 @@ sample_table = {
   has_leading_input: true,
   has_menu_options: true,
   headers: [
+    "",
     "Name",
     "Email",
     "Revenue",
@@ -200,6 +200,16 @@ sample_table = {
   ],
   rows: [
     [
+      %(
+        #{sage_component(SageCheckbox, {
+          id:"c1",
+          label_text: "Checkbox",
+          checked: false,
+          disabled: false,
+          has_error: false,
+          partial_selection: true,
+          standalone: true
+        })}),
       %(
         #{link_to "Frank Dux", "#", class: "sage-table-cell__link"}
       ),
@@ -220,6 +230,16 @@ sample_table = {
     ],
     [
       %(
+        #{sage_component(SageCheckbox, {
+          id:"c1",
+          label_text: "Checkbox",
+          checked: false,
+          disabled: false,
+          has_error: false,
+          partial_selection: true,
+          standalone: true
+        })}),
+      %(
         #{link_to "Stinkmeaner", "#", class: "sage-table-cell__link"}
       ),
       "st@email.com",
@@ -238,6 +258,16 @@ sample_table = {
         })})
     ],
     [
+      %(
+        #{sage_component(SageCheckbox, {
+          id:"c1",
+          label_text: "Checkbox",
+          checked: false,
+          disabled: false,
+          has_error: false,
+          partial_selection: true,
+          standalone: true
+        })}),
       %(
         #{link_to "Huey Freeman", "#", class: "sage-table-cell__link"}
       ),
@@ -258,7 +288,6 @@ sample_table = {
     ],
   ]
 } %>
-
 
 <h3 class="t-sage-heading-6">Responsive table with borders</h3>
 <%= sage_component SageTable, {

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -114,7 +114,7 @@ sample_table = {
 
 <%= sage_component SageTable, {
   caption: %(
-    Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
+    Basic table
   ),
   has_menu_options: true,
   headers: [
@@ -187,7 +187,7 @@ sample_table = {
 <h3 class="t-sage-heading-6">Table with checkbox selection</h3>
 <%= sage_component SageTable, {
   caption: %(
-    Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
+    People example
   ),
   has_leading_input: true,
   has_menu_options: true,
@@ -195,14 +195,16 @@ sample_table = {
     "",
     "Name",
     "Email",
-    "Revenue",
-    "Status"
+    "Marketing Status",
+    "Added date",
+    "Last activity",
+    ""
   ],
   rows: [
     [
       %(
         #{sage_component(SageCheckbox, {
-          id:"c1",
+          id:"c331",
           label_text: "Checkbox",
           checked: false,
           disabled: false,
@@ -214,7 +216,14 @@ sample_table = {
         #{link_to "Frank Dux", "#", class: "sage-table-cell__link"}
       ),
       "fd@email.com",
-      "$275.43",
+      %(
+        #{sage_component(SageBadge, {
+          color: "locked",
+          value: "Subscribed",
+        })}
+      ),
+      "August 21, 2019",
+      "November 21, 2019",
       %(
         #{sage_component(SageButton, {
           value: "Icon only",
@@ -231,7 +240,7 @@ sample_table = {
     [
       %(
         #{sage_component(SageCheckbox, {
-          id:"c1",
+          id:"c332",
           label_text: "Checkbox",
           checked: false,
           disabled: false,
@@ -243,7 +252,14 @@ sample_table = {
         #{link_to "Stinkmeaner", "#", class: "sage-table-cell__link"}
       ),
       "st@email.com",
-      "$775.43",
+      %(
+        #{sage_component(SageBadge, {
+          color: "locked",
+          value: "Subscribed",
+        })}
+      ),
+      "December 18, 2019",
+      "February 16, 2021",
       %(
         #{sage_component(SageButton, {
           value: "Icon only",
@@ -260,7 +276,7 @@ sample_table = {
     [
       %(
         #{sage_component(SageCheckbox, {
-          id:"c1",
+          id:"c333",
           label_text: "Checkbox",
           checked: false,
           disabled: false,
@@ -272,7 +288,14 @@ sample_table = {
         #{link_to "Huey Freeman", "#", class: "sage-table-cell__link"}
       ),
       "hf@email.com",
-      "$1275.43",
+      %(
+        #{sage_component(SageBadge, {
+          color: "draft",
+          value: "Not subscribed",
+        })}
+      ),
+      "July 22, 2020",
+      "September 16, 2020",
       %(
         #{sage_component(SageButton, {
           value: "Icon only",
@@ -286,7 +309,7 @@ sample_table = {
           small: true
         })})
     ],
-  ]
+  ],
 } %>
 
 <h3 class="t-sage-heading-6">Responsive table with borders</h3>

--- a/docs/app/views/examples/components/table/_preview.html.erb
+++ b/docs/app/views/examples/components/table/_preview.html.erb
@@ -112,6 +112,78 @@ sample_table = {
 }
 %>
 
+<%= sage_component SageTable, {
+  caption: %(
+    Block cells can be used with anchor tags to link the entire cell, or <code>&lt;div&gt;</code> and <code>&lt;span&gt;</code> elements for content
+  ),
+  headers: [
+    "Name",
+    "Email",
+    "Revenue",
+    "Status"
+  ],
+  rows: [
+    [
+      %(
+        #{link_to "Frank Dux", "#", class: "sage-table-cell__link"}
+      ),
+      "fd@email.com",
+      "$275.43",
+      %(
+        #{sage_component(SageButton, {
+          value: "Icon only",
+          small: true,
+          style: "secondary",
+          subtle: true,
+          icon: {
+            style: "only",
+            name: "dot-menu-horizontal"
+          },
+          small: true
+        })})
+    ],
+    [
+      %(
+        #{link_to "Stinkmeaner", "#", class: "sage-table-cell__link"}
+      ),
+      "st@email.com",
+      "$775.43",
+      %(
+        #{sage_component(SageButton, {
+          value: "Icon only",
+          small: true,
+          style: "secondary",
+          subtle: true,
+          icon: {
+            style: "only",
+            name: "dot-menu-horizontal"
+          },
+          small: true
+        })})
+    ],
+    [
+      %(
+        #{link_to "Huey Freeman", "#", class: "sage-table-cell__link"}
+      ),
+      "hf@email.com",
+      "$1275.43",
+      %(
+        #{sage_component(SageButton, {
+          value: "Icon only",
+          small: true,
+          style: "secondary",
+          subtle: true,
+          icon: {
+            style: "only",
+            name: "dot-menu-horizontal"
+          },
+          small: true
+        })})
+    ],
+  ]
+} %>
+
+
 <h3 class="t-sage-heading-6">Responsive table with borders</h3>
 <%= sage_component SageTable, {
   has_borders: true,

--- a/docs/app/views/examples/components/table/_props.html.erb
+++ b/docs/app/views/examples/components/table/_props.html.erb
@@ -49,6 +49,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`responsive_stack`') %></td>
+  <td><%= md('Rearranges table content on small screen devices. Requires the use of table headers`.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`rows`') %></td>
   <td><%= md('Array of items to populate the table. These items are key/value pairs.') %></td>
   <td><%= md('Array') %></td>
@@ -83,12 +89,13 @@
   - `reset_above`
   - `reset_below`
   - `responsive`
+  - `responsive_stack`
 
   The following properties are **unique to `sage_table_for`**:
 
   - `sortable` (Boolean): enables sorting links and direction indicators on sorted columns
 
-  - `skip_headers` (Boolean): table column headings are not rendered
+  - `skip_headers` (Boolean): table column headings are not rendered. This cannot be used when `responsive_stack` is enabled
 ') %></td>
   <td><%= md('See properties above') %></td>
   <td><%= md('Varies') %></td>

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -215,6 +215,56 @@ module SageTableHelper
     table.contents
   end
 
+  def sage_table_classes(table)
+    table_classlist = "sage-table"
+
+    table_classlist << " sage-table--selectable" if table.selectable
+    table_classlist << " sage-table--condensed" if table.condensed
+    table_classlist << " sage-table--has-leading-input" if table.has_leading_input
+    table_classlist << " sage-table--has-menu-options" if table.has_menu_options
+
+    return table_classlist
+  end
+
+  def sage_table_wrapper_classes(table, is_responsive)
+    table_wrapper_classlist = "sage-table-wrapper"
+    table_wrapper_classlist << " sage-table-wrapper--reset-above" if table.reset_above
+    table_wrapper_classlist << " sage-table-wrapper--reset-below" if table.reset_below
+    table_wrapper_classlist << " sage-table-wrapper--scroll" if is_responsive
+
+    return table_wrapper_classlist
+  end
+
+  def sage_table_caption_classes(table)
+    table_caption_classlist = "sage-table__caption"
+
+    if table.caption_side
+      table_caption_classlist << " sage-table__caption--#{table.caption_side}"
+    end
+
+    return table_caption_classlist
+  end
+
+  def sage_table_row_classes(table)
+    table_row_classlist = ""
+
+    if table.selectable
+      table_row_classlist << "sage-table__row--selectable"
+    end
+
+    return table_row_classlist
+  end
+
+  def sage_table_cell_classes(table)
+    table_cell_classlist = ""
+
+    if table.has_borders
+      table_cell_classlist << "sage-table-cell--borders"
+    end
+
+    return table_cell_classlist
+  end
+
   def sage_table_sortable_header_link(label, attribute)
     current = attribute.to_s == sort_column
     asc = sort_direction == "asc"

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -222,6 +222,7 @@ module SageTableHelper
     table_classlist << " sage-table--condensed" if table.condensed
     table_classlist << " sage-table--has-leading-input" if table.has_leading_input
     table_classlist << " sage-table--has-menu-options" if table.has_menu_options
+    table_classlist << " sage-table--stack" if table.responsive_stack
 
     return table_classlist
   end

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -154,7 +154,8 @@ module SageTableHelper
     end
 
     def head
-      if skip_headers
+      # responsive_stack enforces use of headers
+      if skip_headers && !responsive_stack
         ""
       else
         content_tag "thead" do

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -80,7 +80,7 @@ module SageTableHelper
   end
 
   class SageTableFor
-    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :skip_headers, :reset_above, :reset_below
+    attr_reader :caption, :caption_side, :columns, :condensed, :template, :id, :class_name, :collection, :has_borders, :row_proc, :sortable, :responsive, :responsive_stack, :skip_headers, :reset_above, :reset_below
     delegate :content_tag, :tag, to: :template
 
     def initialize(template, collection, opts={})
@@ -94,6 +94,7 @@ module SageTableHelper
       @reset_above = opts[:reset_above]
       @reset_below = opts[:reset_below]
       @responsive = opts[:responsive]
+      @responsive_stack = opts[:responsive_stack]
       @skip_headers = opts[:skip_headers]
       @sortable = opts[:sortable]
       @id = opts[:id]
@@ -132,6 +133,7 @@ module SageTableHelper
       table_classes = "sage-table"
       table_classes << " sage-table--condensed" if condensed
       table_classes << " sage-table--sortable" if sortable
+      table_classes << " sage-table--stack" if responsive_stack
       table_classes << " #{class_name}" if class_name
 
       content_tag "table", id: id, class: table_classes do

--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -238,9 +238,7 @@ module SageTableHelper
   def sage_table_caption_classes(table)
     table_caption_classlist = "sage-table__caption"
 
-    if table.caption_side
-      table_caption_classlist << " sage-table__caption--#{table.caption_side}"
-    end
+    table_caption_classlist << " sage-table__caption--#{table.caption_side}" if table.caption_side
 
     return table_caption_classlist
   end
@@ -256,10 +254,10 @@ module SageTableHelper
   end
 
   def sage_table_cell_classes(table)
-    table_cell_classlist = ""
+    table_cell_classlist = "sage-table-cell"
 
     if table.has_borders
-      table_cell_classlist << "sage-table-cell--borders"
+      table_cell_classlist << " sage-table-cell--borders"
     end
 
     return table_cell_classlist

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -4,6 +4,8 @@ class SageTable < SageComponent
     caption_side: [:optional, NilClass, Set.new(["bottom", "top"])],
     condensed: [:optional, NilClass, TrueClass],
     has_borders: [:optional, NilClass, TrueClass],
+    has_leading_input: [:optional, NilClass, TrueClass],
+    has_menu_options: [:optional, NilClass, TrueClass],
     headers: [:optional, NilClass, Array],
     reset_above: [:optional, NilClass, TrueClass],
     reset_below: [:optional, NilClass, TrueClass],

--- a/docs/lib/sage_rails/app/sage_components/sage_table.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_table.rb
@@ -10,6 +10,7 @@ class SageTable < SageComponent
     reset_above: [:optional, NilClass, TrueClass],
     reset_below: [:optional, NilClass, TrueClass],
     responsive: [:optional, NilClass, TrueClass],
+    responsive_stack: [:optional, NilClass, TrueClass],
     rows: [:optional, NilClass, Array],
     selectable: [:optional, NilClass, TrueClass],
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -1,35 +1,24 @@
 <%
-is_responsive = true
-if component&.responsive == false
-  is_responsive = false
-end
+  # see `docs/lib/sage_rails/app/helpers/sage_table_helper.rb` for CSS class output logic
+  is_responsive = true
+  if component&.responsive == false
+    is_responsive = false
+  end
 %>
-<div class="
-  sage-table-wrapper
-  <%= "sage-table-wrapper--reset-above" if component.reset_above %>
-  <%= "sage-table-wrapper--reset-below" if component.reset_below %>
-  <%= "sage-table-wrapper--scroll" if is_responsive %>
+<div class="<%= sage_table_wrapper_classes(component, is_responsive) %>"
   <%= component.generated_css_classes %>
-">
+>
   <% if is_responsive %>
     <div class="sage-table-wrapper__overflow">
   <% end %>
 
-  <table class="
-      sage-table
-      <%= "sage-table--selectable" if component.selectable %>
-      <%= "sage-table--condensed" if component.condensed %>
-      <%= "sage-table--has-leading-input" if component.has_leading_input %>
-      <%= "sage-table--has-menu-options" if component.has_menu_options %>
-    "
+  <table
+    class="<%= sage_table_classes(component) %>"
     data-js-table
     <%= component.generated_html_attributes.html_safe %>
   >
     <% if component.caption.present? %>
-      <caption class="
-        sage-table__caption
-        <%= "sage-table__caption--#{component.caption_side}" if component.caption_side %>
-      ">
+      <caption class="<%= sage_table_caption_classes(component) %>">
         <%= component.caption.html_safe %>
       </caption>
     <% end %>
@@ -55,10 +44,10 @@ end
     <tbody>
       <% if component.rows.present? %>
         <% component.rows.each do | row | %>
-          <tr class="<%= "sage-table__row--selectable" if component.selectable %>">
+          <tr class="<%= sage_table_row_classes(component) %>">
             <% if row.is_a? Array %>
               <% row.each do | cell | %>
-                <td class="<%= "sage-table-cell--borders" if component.has_borders %>"
+                <td class="<%= sage_table_cell_classes(component) %>"
                   <% cell[:html_attributes].each do | key, value | %>
                     <%= "#{key}=#{value}" %>
                   <% end if cell&.is_a?(Hash) && cell[:html_attributes].present? %>
@@ -68,7 +57,7 @@ end
               <% end %>
             <% elsif row.is_a? Object or row.is_a? Hash %>
               <% row.each do | key, value | %>
-                <td class="<%= "sage-table-cell--borders" if component.has_borders %>"
+                <td class="<%= sage_table_cell_classes(component) %>"
                   data-cell-key="<%= key %>"
                   <% value[:html_attributes].each do | k, v | %>
                     <%= "#{k}=#{v}" %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -19,6 +19,8 @@ end
       sage-table
       <%= "sage-table--selectable" if component.selectable %>
       <%= "sage-table--condensed" if component.condensed %>
+      <%= "sage-table--has-leading-input" if component.has_leading_input %>
+      <%= "sage-table--has-menu-options" if component.has_menu_options %>
     "
     data-js-table
     <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -26,7 +26,8 @@
       <thead>
         <tr>
           <% component.headers.each do | header | %>
-            <th
+            <% table_header_element = header.to_s.strip.empty? ? "td" : "th" %>
+            <<%= table_header_element %>
               class="
                 sage-table__header
                 <%= "sage-table__header--#{header[:data_type]}" if header&.is_a?(Hash) && header[:data_type].present? %>
@@ -36,7 +37,7 @@
               <% end if header&.is_a?(Hash) && header[:html_attributes].present? %>
             >
               <%= header&.is_a?(Hash) ? header[:value].html_safe : header.html_safe %>
-            </th>
+            </<%= table_header_element %>>
           <% end %>
         </tr>
       </thead>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -20,6 +20,7 @@ end
       <%= "sage-table--selectable" if component.selectable %>
       <%= "sage-table--condensed" if component.condensed %>
     "
+    data-js-table
     <%= component.generated_html_attributes.html_safe %>
   >
     <% if component.caption.present? %>

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -18,10 +18,10 @@ $-table-caption-font-size: "%t-sage-body-small";
 $-table-caption-alignment: center;
 $-table-cell-font-color: sage-color(charcoal, 200);
 $-table-cell-font-color-strong: sage-color(charcoal, 400);
-$-table-cell-type-spec: "%t-sage-body-small-med";
-$-table-cell-type-spec-strong: "%t-sage-body-small-semi";
+$-table-cell-type-spec: "%t-sage-body-small";
+$-table-cell-type-spec-strong: "%t-sage-body-small-med";
 $-table-heading-font-color: sage-color(charcoal, 500);
-$-table-heading-type-spec: "%t-sage-body-small-semi";
+$-table-heading-type-spec: "%t-sage-body-small-med";
 
 // Overflow gradient
 $-table-overflow-indicator-width: sage-spacing(sm);
@@ -311,7 +311,9 @@ $-table-avatar-width: rem(32px);
 }
 
 .sage-table-cell__link {
-  color: $-table-cell-font-color;
+  @extend #{$-table-cell-type-spec-strong};
+
+  color: $-table-cell-font-color-strong;
   text-decoration: none;
 
   &:focus,
@@ -342,5 +344,102 @@ $-table-avatar-width: rem(32px);
   .sage-table-cell__block &,
   .sage-table-cell__link & {
     margin-left: 0.5em;
+  }
+}
+
+@media screen and (max-width: sage-breakpoint(sm-max)) {
+  .sage-table {
+    thead {
+      tr,
+      &::after {
+        display: none;
+      }
+    }
+
+    tbody tr {
+      position: relative;
+
+      td:last-of-type {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+      }
+    }
+
+    td {
+      padding: rem(6px) 0;
+    }
+  }
+
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr,
+  caption {
+    display: block;
+  }
+
+  tr {
+    padding: rem(16px) rem(18px);
+    border: sage-border(default);
+    border-radius: sage-border(radius);
+
+    & + & {
+      margin-top: sage-spacing(sm);
+    }
+  }
+
+  td {
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-gap: 1em 0.5em;
+    justify-content: space-between;
+  }
+
+  td:nth-of-type(4)::before,
+  td:nth-of-type(5)::before {
+    text-align: left;
+  }
+
+  // TODO UXD - QUINTON - find scalable solution
+  td:nth-child(1)::before {
+    content: "Name: ";
+    display: none;
+  }
+
+  td:nth-child(2)::before {
+    content: "Email: ";
+  }
+
+  td:nth-child(3)::before {
+    content: "Labels: ";
+  }
+
+  td:nth-child(4)::before {
+    content: "Status: ";
+  }
+
+  td:nth-child(5)::before {
+    content: "Status: ";
+  }
+
+  td:nth-child(6)::before {
+    content: "Status: ";
+  }
+
+  td:nth-child(7)::before {
+    content: "Status: ";
+  }
+
+  td:last-child::before {
+    display: none;
+  }
+}
+
+@media screen and (min-width: sage-breakpoint(md-min)) {
+  .sage-table td::before {
+    display: none;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -360,15 +360,35 @@ $-table-avatar-width: rem(32px);
 
 @media screen and (max-width: sage-breakpoint(sm-max)) {
   .sage-table--stack {
-    thead {
-      tr,
-      &::after {
-        @include visually-hidden;
-      }
+    thead tr {
+      @include visually-hidden;
+    }
+
+    thead::after {
+      display: none;
+    }
+
+    tbody,
+    tbody td,
+    tbody tr {
+      display: block;
     }
 
     tbody tr {
+      padding: #{$-table-stack-row-padding-block} #{$-table-stack-row-padding-inline};
       position: relative;
+      border: sage-border(default);
+      border-radius: sage-border(radius);
+
+      & + & {
+        margin-top: #{$-table-stack-row-padding-block};
+      }
+    }
+
+    tbody td {
+      display: grid;
+      grid-template-columns: 1fr repeat(#{$-table-stack-cell-max-children}, auto);
+      padding: rem(6px) 0;
     }
 
     .sage-table-cell__heading--responsive {
@@ -382,32 +402,6 @@ $-table-avatar-width: rem(32px);
         top: #{$-table-stack-row-padding-block};
         right: #{$-table-stack-row-padding-inline};
       }
-    }
-
-    td {
-      padding: rem(6px) 0;
-    }
-
-    // table,
-    tbody,
-    tbody td,
-    tbody tr {
-      display: block;
-    }
-
-    tbody tr {
-      padding: #{$-table-stack-row-padding-block} #{$-table-stack-row-padding-inline};
-      border: sage-border(default);
-      border-radius: sage-border(radius);
-
-      & + & {
-        margin-top: #{$-table-stack-row-padding-block};
-      }
-    }
-
-    tbody td {
-      display: grid;
-      grid-template-columns: 1fr repeat(#{$-table-stack-cell-max-children}, auto);
     }
 
     // table cell overrides

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -38,6 +38,7 @@ $-table-overflow-indicator-gradient: linear-gradient(
 // Responsive stacked table
 $-table-stack-row-padding-block: rem(18px);
 $-table-stack-row-padding-inline: rem(20px);
+$-table-stack-row-margin-block: rem(15); // UXD TODO: confirm size with design
 $-table-stack-cell-max-children: 4;
 
 // Other
@@ -359,6 +360,10 @@ $-table-avatar-width: rem(32px);
 }
 
 @media screen and (max-width: sage-breakpoint(sm-max)) {
+  .sage-table-wrapper__overflow--stack::after {
+    opacity: 0;
+  }
+
   .sage-table--stack {
     thead tr {
       @include visually-hidden;
@@ -375,14 +380,11 @@ $-table-avatar-width: rem(32px);
     }
 
     tbody tr {
-      padding: #{$-table-stack-row-padding-block} #{$-table-stack-row-padding-inline};
       position: relative;
+      padding: #{$-table-stack-row-padding-block} #{$-table-stack-row-padding-inline};
+      margin-bottom: #{$-table-stack-row-margin-block};
       border: sage-border(default);
       border-radius: sage-border(radius);
-
-      & + & {
-        margin-top: #{$-table-stack-row-padding-block};
-      }
     }
 
     tbody td {
@@ -411,20 +413,8 @@ $-table-avatar-width: rem(32px);
     }
 
     .sage-table-cell--avatar,
-    .sage-table--has-menu-options td:last-child::before {
+    &.sage-table--has-menu-options td:last-child::before {
       display: none;
-    }
-  }
-}
-
-@media screen and (min-width: sage-breakpoint(md-min)) {
-  .sage-table td::before {
-    display: none;
-  }
-
-  .sage-table--has-leading-input {
-    tbody td:first-child {
-      width: rem(44px);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -273,6 +273,10 @@ $-table-avatar-width: rem(32px);
   max-width: $-table-cell-truncate-width;
 }
 
+.sage-table-cell__heading--responsive {
+  display: none;
+}
+
 .sage-table-cell--checkbox {
   width: $-table-checkbox-width;
 }
@@ -350,16 +354,21 @@ $-table-avatar-width: rem(32px);
 }
 
 @media screen and (max-width: sage-breakpoint(sm-max)) {
-  .sage-table {
+  .sage-table--stack {
     thead {
       tr,
       &::after {
-        display: none;
+        @include visually-hidden;
       }
     }
 
     tbody tr {
       position: relative;
+    }
+
+    .sage-table-cell__heading--responsive {
+      display: inline-block;
+      align-items: center;
     }
 
     &.sage-table--has-menu-options {
@@ -373,121 +382,88 @@ $-table-avatar-width: rem(32px);
     td {
       padding: rem(6px) 0;
     }
-  }
 
-  table,
-  thead,
-  tbody,
-  th,
-  td,
-  tr,
-  caption {
-    display: block;
-  }
-
-  tr {
-    padding: rem(16px) rem(18px);
-    border: sage-border(default);
-    border-radius: sage-border(radius);
-
-    & + & {
-      margin-top: sage-spacing(sm);
-    }
-  }
-
-  td {
-    display: grid;
-    grid-template-columns: auto auto;
-    grid-gap: 1em 0.5em;
-    justify-content: space-between;
-  }
-
-  td:nth-of-type(4)::before,
-  td:nth-of-type(5)::before {
-    text-align: left;
-  }
-
-  // TODO UXD - QUINTON - find scalable solution
-  td::before {
-    color: sage-color(charcoal, 200);
-  }
-  td:nth-child(1)::before {
-    content: "Name ";
-    display: none;
-  }
-
-  td:nth-child(2)::before {
-    content: "Email ";
-  }
-
-  td:nth-child(3)::before {
-    content: "Labels ";
-  }
-
-  td:nth-child(4)::before {
-    content: "Status ";
-  }
-
-  td:nth-child(5)::before {
-    content: "Status ";
-  }
-
-  td:nth-child(6)::before {
-    content: "Status ";
-  }
-
-  td:nth-child(7)::before {
-    content: "Status ";
-  }
-
-  .sage-table--has-menu-options td:last-child::before {
-    display: none;
-  }
-
-  .sage-table--has-leading-input {
-    td:nth-child(2) {
-      margin-left: sage-spacing(sm);
+    // table,
+    thead,
+    tbody,
+    th,
+    td,
+    tr,
+    caption {
+      display: block;
     }
 
-    td:nth-child(-n+2) {
-      display: inline-flex;
+    tr {
+      padding: rem(16px) rem(18px);
+      border: sage-border(default);
+      border-radius: sage-border(radius);
+
+      & + & {
+        margin-top: sage-spacing(sm);
+      }
     }
 
-    td:nth-child(n+3) {
-      margin-left: rem(40px);
+    td {
+      display: grid;
+      grid-template-columns: auto auto;
+      grid-gap: 1em 0.5em;
+      justify-content: space-between;
     }
 
-    td:nth-child(2)::before {
-      content: "Name ";
+    // td:nth-of-type(4)::before,
+    // td:nth-of-type(5)::before {
+    //   text-align: left;
+    // }
+
+    .sage-table--has-menu-options td:last-child::before {
       display: none;
     }
 
-    td:nth-child(3)::before {
-      content: "Email ";
-    }
+    .sage-table--has-leading-input {
+      td:nth-child(2) {
+        margin-left: sage-spacing(sm);
+      }
 
-    td:nth-child(4)::before {
-      content: "Labels ";
-    }
+      td:nth-child(-n+2) {
+        display: inline-flex;
+      }
 
-    td:nth-child(5)::before {
-      content: "Status ";
-    }
+      td:nth-child(n+3) {
+        margin-left: rem(40px);
+      }
 
-    td:nth-child(6)::before {
-      content: "Status ";
-    }
+      td:nth-child(2)::before {
+        content: "Name ";
+        display: none;
+      }
 
-    td:nth-child(7)::before {
-      content: "Status ";
-    }
+      td:nth-child(3)::before {
+        content: "Email ";
+      }
 
-    td:nth-child(8)::before {
-      content: "Status ";
-    }
+      td:nth-child(4)::before {
+        content: "Labels ";
+      }
 
-    td:last-child::before {
-      display: none;
+      td:nth-child(5)::before {
+        content: "Status ";
+      }
+
+      td:nth-child(6)::before {
+        content: "Status ";
+      }
+
+      td:nth-child(7)::before {
+        content: "Status ";
+      }
+
+      td:nth-child(8)::before {
+        content: "Status ";
+      }
+
+      td:last-child::before {
+        display: none;
+      }
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -65,7 +65,7 @@ $-table-avatar-width: rem(32px);
       @extend #{$-table-heading-type-spec};
 
       padding: $-table-padding;
-      color: $-table-cell-focus;
+      color: $-table-cell-font-color;
     }
 
     th {
@@ -408,42 +408,98 @@ $-table-avatar-width: rem(32px);
   }
 
   // TODO UXD - QUINTON - find scalable solution
+  td::before {
+    color: sage-color(charcoal, 200);
+  }
   td:nth-child(1)::before {
-    content: "Name: ";
+    content: "Name ";
     display: none;
   }
 
   td:nth-child(2)::before {
-    content: "Email: ";
+    content: "Email ";
   }
 
   td:nth-child(3)::before {
-    content: "Labels: ";
+    content: "Labels ";
   }
 
   td:nth-child(4)::before {
-    content: "Status: ";
+    content: "Status ";
   }
 
   td:nth-child(5)::before {
-    content: "Status: ";
+    content: "Status ";
   }
 
   td:nth-child(6)::before {
-    content: "Status: ";
+    content: "Status ";
   }
 
   td:nth-child(7)::before {
-    content: "Status: ";
+    content: "Status ";
   }
 
-  td:last-child::before {
+  .sage-table--has-menu-options td:last-child::before {
     display: none;
+  }
+
+  .sage-table--has-leading-input {
+    td:nth-child(2) {
+      margin-left: sage-spacing(sm);
+    }
+
+    td:nth-child(-n+2) {
+      display: inline-flex;
+    }
+
+    td:nth-child(n+3) {
+      margin-left: rem(40px);
+    }
+
+    td:nth-child(2)::before {
+      content: "Name ";
+      display: none;
+    }
+
+    td:nth-child(3)::before {
+      content: "Email ";
+    }
+
+    td:nth-child(4)::before {
+      content: "Labels ";
+    }
+
+    td:nth-child(5)::before {
+      content: "Status ";
+    }
+
+    td:nth-child(6)::before {
+      content: "Status ";
+    }
+
+    td:nth-child(7)::before {
+      content: "Status ";
+    }
+
+    td:nth-child(8)::before {
+      content: "Status ";
+    }
+
+    td:last-child::before {
+      display: none;
+    }
   }
 }
 
 @media screen and (min-width: sage-breakpoint(md-min)) {
   .sage-table td::before {
     display: none;
+  }
+
+  .sage-table--has-leading-input {
+    tbody td:first-child {
+      width: rem(44px);
+    }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -423,53 +423,6 @@ $-table-avatar-width: rem(32px);
     .sage-table--has-menu-options td:last-child::before {
       display: none;
     }
-
-    .sage-table--has-leading-input {
-      td:nth-child(2) {
-        margin-left: sage-spacing(sm);
-      }
-
-      td:nth-child(-n+2) {
-        display: inline-flex;
-      }
-
-      td:nth-child(n+3) {
-        margin-left: rem(40px);
-      }
-
-      td:nth-child(2)::before {
-        content: "Name ";
-        display: none;
-      }
-
-      td:nth-child(3)::before {
-        content: "Email ";
-      }
-
-      td:nth-child(4)::before {
-        content: "Labels ";
-      }
-
-      td:nth-child(5)::before {
-        content: "Status ";
-      }
-
-      td:nth-child(6)::before {
-        content: "Status ";
-      }
-
-      td:nth-child(7)::before {
-        content: "Status ";
-      }
-
-      td:nth-child(8)::before {
-        content: "Status ";
-      }
-
-      td:last-child::before {
-        display: none;
-      }
-    }
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -333,10 +333,12 @@ $-table-avatar-width: rem(32px);
 }
 
 .sage-table-cell--borders {
-  border-bottom: sage-border();
-
   tr:last-child & {
     border-bottom: 0;
+  }
+
+  @media screen and (min-width: sage-breakpoint(md-min)) {
+    border-bottom: sage-border();
   }
 }
 
@@ -358,7 +360,9 @@ $-table-avatar-width: rem(32px);
 
     tbody tr {
       position: relative;
+    }
 
+    &.sage-table--has-menu-options {
       td:last-of-type {
         position: absolute;
         top: 1rem;

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -35,6 +35,11 @@ $-table-overflow-indicator-gradient: linear-gradient(
   100%
 );
 
+// Responsive stacked table
+$-table-stack-row-padding-block: rem(18px);
+$-table-stack-row-padding-inline: rem(20px);
+$-table-stack-cell-max-children: 4;
+
 // Other
 $-table-row-color-hover: sage-color(grey, 100);
 $-table-cell-focus: sage-color(charcoal, 300);
@@ -367,15 +372,15 @@ $-table-avatar-width: rem(32px);
     }
 
     .sage-table-cell__heading--responsive {
-      display: inline-block;
+      display: inline-flex;
       align-items: center;
     }
 
     &.sage-table--has-menu-options {
       td:last-of-type {
         position: absolute;
-        top: 1rem;
-        right: 1rem;
+        top: #{$-table-stack-row-padding-block};
+        right: #{$-table-stack-row-padding-inline};
       }
     }
 
@@ -394,27 +399,27 @@ $-table-avatar-width: rem(32px);
     }
 
     tr {
-      padding: rem(16px) rem(18px);
+      padding: #{$-table-stack-row-padding-block} #{$-table-stack-row-padding-inline};
       border: sage-border(default);
       border-radius: sage-border(radius);
 
       & + & {
-        margin-top: sage-spacing(sm);
+        margin-top: #{$-table-stack-row-padding-block};
       }
     }
 
     td {
       display: grid;
-      grid-template-columns: auto auto;
-      grid-gap: 1em 0.5em;
-      justify-content: space-between;
+      grid-template-columns: 1fr repeat(#{$-table-stack-cell-max-children}, auto);
     }
 
-    // td:nth-of-type(4)::before,
-    // td:nth-of-type(5)::before {
-    //   text-align: left;
-    // }
+    // table cell overrides
+    .sage-table-cell--truncate,
+    .sage-table-cell__truncated-content {
+      max-width: none;
+    }
 
+    .sage-table-cell--avatar,
     .sage-table--has-menu-options td:last-child::before {
       display: none;
     }

--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -389,16 +389,13 @@ $-table-avatar-width: rem(32px);
     }
 
     // table,
-    thead,
     tbody,
-    th,
-    td,
-    tr,
-    caption {
+    tbody td,
+    tbody tr {
       display: block;
     }
 
-    tr {
+    tbody tr {
       padding: #{$-table-stack-row-padding-block} #{$-table-stack-row-padding-inline};
       border: sage-border(default);
       border-radius: sage-border(radius);
@@ -408,7 +405,7 @@ $-table-avatar-width: rem(32px);
       }
     }
 
-    td {
+    tbody td {
       display: grid;
       grid-template-columns: 1fr repeat(#{$-table-stack-cell-max-children}, auto);
     }

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -38,6 +38,8 @@ export const Table = ({
   className,
   hasBorders,
   hasDataBeyondCurrentRows,
+  hasLeadingInput,
+  hasMenuOptions,
   headers,
   isResponsive,
   onSelectRowHook,
@@ -68,6 +70,8 @@ export const Table = ({
     'sage-table',
     {
       'sage-table--selectable': selectable,
+      'sage-table--has-leading-input': hasLeadingInput,
+      'sage-table--has-menu-options': hasMenuOptions,
     }
   );
 
@@ -338,6 +342,8 @@ Table.defaultProps = {
   className: null,
   hasBorders: false,
   hasDataBeyondCurrentRows: false,
+  hasLeadingInput: false,
+  hasMenuOptions: false,
   headers: [],
   isResponsive: true,
   onSelectRowHook: null,
@@ -358,6 +364,8 @@ Table.propTypes = {
   className: PropTypes.string,
   hasBorders: PropTypes.bool,
   hasDataBeyondCurrentRows: PropTypes.bool,
+  hasLeadingInput: PropTypes.bool,
+  hasMenuOptions: PropTypes.bool,
   // Headers provide a simpler alternative to schema
   headers: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.oneOfType([

--- a/packages/sage-react/lib/Table/Table.story.jsx
+++ b/packages/sage-react/lib/Table/Table.story.jsx
@@ -81,10 +81,15 @@ Default.decorators = [
     </>
   )
 ];
+Default.args = {
+  selectable: false
+};
 
 export const TableWithRichContent = Template.bind({});
 TableWithRichContent.args = {
+  hasMenuOptions: true,
   rows: domains,
+  selectable: false,
   schema: {
     domain: {
       label: 'Domain',
@@ -106,6 +111,37 @@ TableWithRichContent.decorators = [
     <>
       <Panel>
         {Story()}
+      </Panel>
+    </>
+  )
+];
+
+export const TableWithRichContentAndCheckbox = Template.bind({});
+TableWithRichContentAndCheckbox.args = {
+  rows: domains,
+  hasLeadingInput: true,
+  hasMenuOptions: true,
+  schema: {
+    domain: {
+      label: 'Domain',
+      dataType: Table.DATA_TYPES.STRING,
+    },
+    status: {
+      label: 'Status',
+      dataType: Table.DATA_TYPES.LABEL,
+    },
+    options: {
+      label: '',
+      dataType: Table.DATA_TYPES.HTML,
+    },
+  }
+};
+
+TableWithRichContentAndCheckbox.decorators = [
+  (Story) => (
+    <>
+      <Panel>
+        <Story />
       </Panel>
     </>
   )

--- a/packages/sage-react/lib/Table/sample-data/domains.jsx
+++ b/packages/sage-react/lib/Table/sample-data/domains.jsx
@@ -16,11 +16,11 @@ export const domains = [
       <Button
         color={Button.COLORS.SECONDARY}
         subtle={true}
-        onClick={() => console.log('do something!')} // eslint-disable-line
-        icon={SageTokens.ICONS.PEN}
+        onClick={() => console.log('temp button, not dropdown')} // eslint-disable-line
+        icon={SageTokens.ICONS.DOT_MENU_HORIZONTAL}
         iconOnly={true}
       >
-        Edit
+        Open Menu
       </Button>
     ),
   },
@@ -36,11 +36,11 @@ export const domains = [
       <Button
         color={Button.COLORS.SECONDARY}
         subtle={true}
-        onClick={() => console.log('go somewhere!')} // eslint-disable-line
-        icon={SageTokens.ICONS.CARET_RIGHT}
+        onClick={() => console.log('temp button, not dropdown')} // eslint-disable-line
+        icon={SageTokens.ICONS.DOT_MENU_HORIZONTAL}
         iconOnly={true}
       >
-        View Settings
+        Open Menu
       </Button>
     ),
   },

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -47,7 +47,7 @@ Sage.table = (function() {
     };
 
     tables.forEach(table => {
-      const headers = table.querySelectorAll('thead th');
+      const headers = table.querySelectorAll('.sage-table__header');
       const rows = table.querySelectorAll('tbody tr');
       const tableHeadings = [];
 
@@ -102,12 +102,9 @@ Sage.table = (function() {
 
   function addTableAria() {
     const tableItems = [
-      { items: 'table', role: 'table' },
-      { items: 'thead, tbody, tfoot', role: 'rowgroup' },
-      { items: 'tr', role: 'row' },
-      { items: 'td', role: 'cell' },
-      { items: 'th', role: 'columnheader' },
-      { items: 'th[scope=row]', role: 'rowheader' },
+      { items: 'tbody', role: 'rowgroup' },
+      { items: 'tbody tr', role: 'row' },
+      { items: 'tbody td', role: 'cell' },
     ];
 
     tableItems.map((item) => setAriaRole(item));

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -56,6 +56,41 @@ Sage.table = (function() {
     }
   }
 
+  // https://adrianroselli.com/2018/02/tables-css-display-properties-and-aria.html
+  // https://adrianroselli.com/2018/05/functions-to-add-aria-to-tables-and-lists.html
+  function AddTableARIA() {
+    try {
+      var allTables = document.querySelectorAll('table');
+      for (var i = 0; i < allTables.length; i++) {
+        allTables[i].setAttribute('role','table');
+      }
+      var allRowGroups = document.querySelectorAll('thead, tbody, tfoot');
+      for (var i = 0; i < allRowGroups.length; i++) {
+        allRowGroups[i].setAttribute('role','rowgroup');
+      }
+      var allRows = document.querySelectorAll('tr');
+      for (var i = 0; i < allRows.length; i++) {
+        allRows[i].setAttribute('role','row');
+      }
+      var allCells = document.querySelectorAll('td');
+      for (var i = 0; i < allCells.length; i++) {
+        allCells[i].setAttribute('role','cell');
+      }
+      var allHeaders = document.querySelectorAll('th');
+      for (var i = 0; i < allHeaders.length; i++) {
+        allHeaders[i].setAttribute('role','columnheader');
+      }
+      // this accounts for scoped row headers
+      var allRowHeaders = document.querySelectorAll('th[scope=row]');
+      for (var i = 0; i < allRowHeaders.length; i++) {
+        allRowHeaders[i].setAttribute('role','rowheader');
+      }
+      // caption role not needed as it is not a real role and
+      // browsers do not dump their own role with display block
+    } catch (e) {
+      console.log("AddTableARIA(): " + e);
+    }
+  }
 
   // reset classes on elements
   function removeActiveStyle(arr, className) {
@@ -70,8 +105,10 @@ Sage.table = (function() {
       sortEvents();
     }
     if (document.querySelector('.sage-table--sortable') !== null) {
-      // ResponsiveCellHeaders(SELECTOR_TABLE);
+      ResponsiveCellHeaders(SELECTOR_TABLE);
     }
+
+    AddTableARIA();
   }
 
 

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -1,4 +1,10 @@
 Sage.table = (function() {
+  // ==================================================
+  // Variables
+  // ==================================================
+
+  // const SELECTOR_TABLE = "[data-js-table]";
+  const SELECTOR_TABLE = ".sage-table";
 
   // ==================================================
   // Functions
@@ -24,6 +30,32 @@ Sage.table = (function() {
     });
   }
 
+  function ResponsiveCellHeaders(elem) {
+    var THarray = [];
+    var table = document.querySelector(SELECTOR_TABLE);
+    var ths = table.getElementsByTagName("th");
+    for (var i = 0; i < ths.length; i++) {
+      var headingText = ths[i].innerHTML;
+      THarray.push(headingText);
+    }
+    var styleElm = document.createElement("style"),
+      styleSheet;
+    document.head.appendChild(styleElm);
+    styleSheet = styleElm.sheet;
+    for (var i = 0; i < THarray.length; i++) {
+      styleSheet.insertRule(
+        "" +
+          elem +
+          " td:nth-child(" +
+          (i + 1) +
+          ')::before {content:"' +
+          THarray[i] +
+          ': ";}',
+        styleSheet.cssRules.length
+      );
+    }
+  }
+
 
   // reset classes on elements
   function removeActiveStyle(arr, className) {
@@ -36,6 +68,9 @@ Sage.table = (function() {
   function init() {
     if (document.querySelector('.sage-table--sortable') !== null) {
       sortEvents();
+    }
+    if (document.querySelector('.sage-table--sortable') !== null) {
+      // ResponsiveCellHeaders(SELECTOR_TABLE);
     }
   }
 

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -33,26 +33,29 @@ Sage.table = (function() {
   // TODO: Q: do this for each table
   function ResponsiveCellHeaders(elem) {
     var THarray = [];
-    var table = document.querySelector(SELECTOR_TABLE);
-    var ths = table.getElementsByTagName("th");
-    for (var i = 0; i < ths.length; i++) {
-      var headingText = ths[i].innerHTML.trim();
-      THarray.push(headingText);
-    }
-    var styleElm = document.createElement("style"),
-      styleSheet;
-    document.head.appendChild(styleElm);
-    styleSheet = styleElm.sheet;
-    for (var i = 0; i < THarray.length; i++) {
-      styleSheet.insertRule(
-        "" +
-          elem +
-          " td:nth-child(" +
-          (i + 1) +
-          ')::before { content:"' + THarray[i] + ': ";}',
-        styleSheet.cssRules.length
-      );
-    }
+    var tables = document.querySelectorAll(SELECTOR_TABLE);
+    tables.forEach(table => {
+      // var table = document.querySelector(SELECTOR_TABLE);
+      var ths = table.getElementsByTagName("th");
+      for (var i = 0; i < ths.length; i++) {
+        var headingText = ths[i].innerHTML.trim();
+        THarray.push(headingText);
+      }
+      var styleElm = document.createElement("style"),
+        styleSheet;
+      document.head.appendChild(styleElm);
+      styleSheet = styleElm.sheet;
+      for (var i = 0; i < THarray.length; i++) {
+        styleSheet.insertRule(
+          "" +
+            elem +
+            " td:nth-child(" +
+            (i + 1) +
+            ')::before { content:"' + THarray[i] + ': ";}',
+          styleSheet.cssRules.length
+        );
+      }
+    })
   }
 
   // https://adrianroselli.com/2018/02/tables-css-display-properties-and-aria.html

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -5,6 +5,7 @@ Sage.table = (function() {
 
   // const SELECTOR_TABLE = "[data-js-table]";
   const SELECTOR_TABLE = ".sage-table";
+  const MOBILE_TABLE_MAX_WIDTH = "767"; // SM_MAX
 
   // ==================================================
   // Functions
@@ -58,40 +59,29 @@ Sage.table = (function() {
     })
   }
 
-  // https://adrianroselli.com/2018/02/tables-css-display-properties-and-aria.html
-  // https://adrianroselli.com/2018/05/functions-to-add-aria-to-tables-and-lists.html
-  function AddTableARIA() {
-    try {
-      var allTables = document.querySelectorAll('table');
-      for (var i = 0; i < allTables.length; i++) {
-        allTables[i].setAttribute('role','table');
-      }
-      var allRowGroups = document.querySelectorAll('thead, tbody, tfoot');
-      for (var i = 0; i < allRowGroups.length; i++) {
-        allRowGroups[i].setAttribute('role','rowgroup');
-      }
-      var allRows = document.querySelectorAll('tr');
-      for (var i = 0; i < allRows.length; i++) {
-        allRows[i].setAttribute('role','row');
-      }
-      var allCells = document.querySelectorAll('td');
-      for (var i = 0; i < allCells.length; i++) {
-        allCells[i].setAttribute('role','cell');
-      }
-      var allHeaders = document.querySelectorAll('th');
-      for (var i = 0; i < allHeaders.length; i++) {
-        allHeaders[i].setAttribute('role','columnheader');
-      }
-      // this accounts for scoped row headers
-      var allRowHeaders = document.querySelectorAll('th[scope=row]');
-      for (var i = 0; i < allRowHeaders.length; i++) {
-        allRowHeaders[i].setAttribute('role','rowheader');
-      }
-      // caption role not needed as it is not a real role and
-      // browsers do not dump their own role with display block
-    } catch (e) {
-      console.log("AddTableARIA(): " + e);
-    }
+  function applyAriaRoles(args) {
+    // expects an object of the form { items: "<selector(s)>", role: "<role to represent>" }
+    // based on:
+    // https://adrianroselli.com/2018/02/tables-css-display-properties-and-aria.html
+    // https://adrianroselli.com/2018/05/functions-to-add-aria-to-tables-and-lists.html
+    const group = document.querySelectorAll(args.items);
+
+    group.forEach(el => {
+      el.setAttribute('role', args.role);
+    })
+  }
+
+  function addTableAria() {
+    const tableItems = [
+      { items: 'table', role: 'table' },
+      { items: 'thead, tbody, tfoot', role: 'rowgroup' },
+      { items: 'tr', role: 'row' },
+      { items: 'td', role: 'cell' },
+      { items: 'th', role: 'columnheader' },
+      { items: 'th[scope=row]', role: 'rowheader' },
+    ];
+
+    tableItems.map((item) => applyAriaRoles(item));
   }
 
   // reset classes on elements
@@ -106,11 +96,10 @@ Sage.table = (function() {
     if (document.querySelector('.sage-table--sortable') !== null) {
       sortEvents();
     }
-    if (document.querySelector('.sage-table--sortable') !== null) {
+    if (document.querySelector(SELECTOR_TABLE) !== null && window.innerWidth <= MOBILE_TABLE_MAX_WIDTH) {
+      addTableAria();
       ResponsiveCellHeaders(SELECTOR_TABLE);
     }
-
-    AddTableARIA();
   }
 
 

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -49,7 +49,10 @@ Sage.table = (function() {
     tables.forEach(table => {
       const headers = table.querySelectorAll('.sage-table__header');
       const rows = table.querySelectorAll('tbody tr');
+      const tableWrapper = table.parentElement;
       const tableHeadings = [];
+
+      tableWrapper.classList.add("sage-table-wrapper__overflow--stack");
 
       // populate an array with each table's headers
       headers.forEach(header => {
@@ -102,6 +105,7 @@ Sage.table = (function() {
 
   function addTableAria() {
     const tableItems = [
+      { items: 'thead th', role: 'columnheader' },
       { items: 'tbody', role: 'rowgroup' },
       { items: 'tbody tr', role: 'row' },
       { items: 'tbody td', role: 'cell' },

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -3,8 +3,7 @@ Sage.table = (function() {
   // Variables
   // ==================================================
 
-  // const SELECTOR_TABLE = "[data-js-table]";
-  const SELECTOR_TABLE = ".sage-table";
+  const RESPONSIVE_TABLE = ".sage-table--stack";
   const MOBILE_TABLE_MAX_WIDTH = "767"; // SM_MAX
 
   // ==================================================
@@ -31,31 +30,55 @@ Sage.table = (function() {
     });
   }
 
-  // TODO: Q: do this for each table
+  // create alternative table headings for responsive "stacked" tables
   function ResponsiveCellHeaders(elem) {
-    var THarray = [];
-    var tables = document.querySelectorAll(SELECTOR_TABLE);
+    const tables = document.querySelectorAll(RESPONSIVE_TABLE);
+
+    const cellHeaderTemplate = (textLabel) => {
+      const cellHeader = document.createElement('span');
+
+      cellHeader.classList.add('sage-table-cell__heading--responsive');
+      cellHeader.innerText = textLabel.trim(); // trim whitespace just in case
+
+      // content must be hidden from screen readers since it duplicates table headers
+      cellHeader.setAttribute('aria-hidden', true);
+
+      return cellHeader;
+    };
+
     tables.forEach(table => {
-      // var table = document.querySelector(SELECTOR_TABLE);
-      var ths = table.getElementsByTagName("th");
-      for (var i = 0; i < ths.length; i++) {
-        var headingText = ths[i].innerHTML.trim();
-        THarray.push(headingText);
-      }
-      var styleElm = document.createElement("style"),
-        styleSheet;
-      document.head.appendChild(styleElm);
-      styleSheet = styleElm.sheet;
-      for (var i = 0; i < THarray.length; i++) {
-        styleSheet.insertRule(
-          "" +
-            elem +
-            " td:nth-child(" +
-            (i + 1) +
-            ')::before { content:"' + THarray[i] + ': ";}',
-          styleSheet.cssRules.length
-        );
-      }
+      const headers = table.querySelectorAll('thead th');
+      const rows = table.querySelectorAll('tbody tr');
+      const tableHeadings = [];
+
+      // populate an array with each table's headers
+      headers.forEach(header => {
+        const label = header.textContent.trim();
+        tableHeadings.push(label);
+      })
+
+      rows.forEach(row => {
+        if (!row.hasChildNodes()) return; // skip empty rows
+
+        const cells = Array.from(row.children);
+
+        // add header text to each cell
+        const updatedCells = cells.map((cell, i) => {
+          if (!tableHeadings[i].length) return; // skip empty headers
+
+          const newHeader = cellHeaderTemplate(tableHeadings[i]);
+          cell.prepend(newHeader);
+        });
+
+        // look for cells with positioned content
+        cells.forEach((cell) => {
+          const checkboxes = cell.querySelectorAll(".sage-checkbox");
+
+          if (checkboxes.length) {
+            cell.classList.add('sage-table-cell--checkbox');
+          }
+        })
+      })
     })
   }
 
@@ -68,7 +91,7 @@ Sage.table = (function() {
 
     group.forEach(el => {
       el.setAttribute('role', args.role);
-    })
+    });
   }
 
   function addTableAria() {
@@ -96,9 +119,9 @@ Sage.table = (function() {
     if (document.querySelector('.sage-table--sortable') !== null) {
       sortEvents();
     }
-    if (document.querySelector(SELECTOR_TABLE) !== null && window.innerWidth <= MOBILE_TABLE_MAX_WIDTH) {
+    if (document.querySelector(RESPONSIVE_TABLE) !== null && window.innerWidth <= MOBILE_TABLE_MAX_WIDTH) {
       addTableAria();
-      ResponsiveCellHeaders(SELECTOR_TABLE);
+      ResponsiveCellHeaders(RESPONSIVE_TABLE);
     }
   }
 

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -70,19 +70,25 @@ Sage.table = (function() {
           cell.prepend(newHeader);
         });
 
-        // look for cells with positioned content
+        // find cells with special cases (positioned content, multiple children)
         cells.forEach((cell) => {
           const checkboxes = cell.querySelectorAll(".sage-checkbox");
+          const badges = cell.querySelectorAll(".sage-badge");
+          const containers = cell.querySelectorAll("div");
 
           if (checkboxes.length) {
             cell.classList.add('sage-table-cell--checkbox');
+          }
+
+          if (badges.length || containers.length) {
+            cell.classList.add('sage-table-cell--group');
           }
         })
       })
     })
   }
 
-  function applyAriaRoles(args) {
+  function setAriaRole(args) {
     // expects an object of the form { items: "<selector(s)>", role: "<role to represent>" }
     // based on:
     // https://adrianroselli.com/2018/02/tables-css-display-properties-and-aria.html
@@ -104,7 +110,7 @@ Sage.table = (function() {
       { items: 'th[scope=row]', role: 'rowheader' },
     ];
 
-    tableItems.map((item) => applyAriaRoles(item));
+    tableItems.map((item) => setAriaRole(item));
   }
 
   // reset classes on elements

--- a/packages/sage-system/lib/table.js
+++ b/packages/sage-system/lib/table.js
@@ -30,12 +30,13 @@ Sage.table = (function() {
     });
   }
 
+  // TODO: Q: do this for each table
   function ResponsiveCellHeaders(elem) {
     var THarray = [];
     var table = document.querySelector(SELECTOR_TABLE);
     var ths = table.getElementsByTagName("th");
     for (var i = 0; i < ths.length; i++) {
-      var headingText = ths[i].innerHTML;
+      var headingText = ths[i].innerHTML.trim();
       THarray.push(headingText);
     }
     var styleElm = document.createElement("style"),
@@ -48,9 +49,7 @@ Sage.table = (function() {
           elem +
           " td:nth-child(" +
           (i + 1) +
-          ')::before {content:"' +
-          THarray[i] +
-          ': ";}',
+          ')::before { content:"' + THarray[i] + ': ";}',
         styleSheet.cssRules.length
       );
     }


### PR DESCRIPTION
## Description
Repurposes table markup for a "stacked" visual layout on small screens.

- Table structure semantics are affected when setting `display`. Each default `role` has been added back in with JS.
- We're using JS to duplicate table header (`th`) text into each individual cell `td` as `span` elements. The actual table headers are visually hidden but remain readable for screen readers, keeping existing semantics/relationship with cells intact.


### Requirements:
- `responsive_stack` property must be enabled
- Existing `is_responsive` property can still be set independently, and will take effect on larger screen sizes **OR** when mobile stack content overflows its container
- JS runs on **page load/init only** to minimize reflow. The expectation being that users will not switch between multiple viewports, so adding a listener for resize should not be needed

### Current assumptions:
- headers are _required_ for tables
- cells will have a **max** of 4 children
  - example: multiple tags/badges within a cell
- truncated text is disabled on mobile
  - `max-width` set on truncated text causes issue with cell width layout
- some specific content will always be hidden when "stacked"
  - avatars: use varying nested containers


#### TODOs
- [ ] Design: confirm moving row selection checkbox (in table header) to bulk actions
- [x] Design: confirm patterns:
  - [x] does this apply to *all* tables, or only special cases?
  - [x] if all tables, strict rules will be needed to enforce markup order/structure
  - [x] verify [overflow approach](https://github.com/Kajabi/sage-lib/pull/1573/files#r1040334638)
- [ ] account for React `headers` schema override 
- [ ] investigate simplified use of dropdowns with `sage_table_for` - requires nested string(s)/schema
- [ ] investigate "action" column container for checkbox, avatar, options content


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  |Before  |  After  |
|-----|---|--------|
|Standard table|![rails](https://user-images.githubusercontent.com/816579/206273929-5fd323a9-8f5e-40b3-bdf2-ddadf92fb7ec.png)|![after-table-stack](https://user-images.githubusercontent.com/816579/206274018-d7cc21be-2a67-4c4c-a82f-403674880a46.png)|
|Using `sage_table_for`|![before-table-for](https://user-images.githubusercontent.com/816579/206274058-5c67161a-70d4-45fa-a1c7-89b78479a578.png)|![after-table-for-stack](https://user-images.githubusercontent.com/816579/206274082-02bb7e78-a3c1-4ebf-af01-0c1d548c338f.png)|




## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the table view and verify that the mobile view aligns with the design spec
- [Rails](http://localhost:4000/pages/component/table?tab=preview)
- [React](http://localhost:4100/?path=/docs/sage-table--default)

## Testing in `kajabi-products`

⚠️ Note: when testing the responsive view using browser devtools, you must refresh the page after resizing (see description above, under Requirements)

1. (**HIGH**) Update mobile styles for Table.
   - [ ] People Page


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-757](https://kajabi.atlassian.net/browse/SAGE-757)