### PR TITLE
Icon: Remove deprecated icons from v7 and prior

### DIFF
--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -324,15 +324,6 @@ module SageTokens
     "warning-filled",
     "window-paragraph",
     "world",
-
-    # Deprecations
-    "beta", # DEPRECATE --> "lab"
-    "filters", # DEPRECATE --> "filter"?
-    "graph", # DEPRECATE --> "chart"
-    "list-details", # DEPRECATE --> "layout-list"
-    "list-stack", # DEPRECATE --> "rows"
-    "select", # DEPRECATE --> "enlarge"
-    "success", # DEPRECATE --> "headset"
   ]
 
   ICON_SIZES = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl"]

--- a/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
@@ -268,13 +268,6 @@ $sage-icons: (
 
   // Duplications/deprecations
   3-dot-menu: unicode(e952), // TODO: deprecate in favor of `dot-menu-horizontal`
-  beta: unicode(e97e), // TODO: deprecate in favor of `lab`
-  filters: unicode(e961), // TODO: deprecate in favor of `filter`
-  graph: unicode(e92f), // TODO: deprecate in favor of `chart`
-  list-details: unicode(e981), // TODO: deprecate in favor of `layout-list`
-  list-stack: unicode(e986), // TODO: deprecate in favor of `rows`
-  select: unicode(e95a), // TODO: deprecate in favor of `enlarge`
-  success: unicode(e971), // TODO: deprecate in favor of `headset`
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_icon.scss
@@ -265,9 +265,6 @@ $sage-icons: (
   warning-filled: unicode(e9e2),
   window-paragraph: unicode(e9e3),
   world: unicode(e9e4),
-
-  // Duplications/deprecations
-  3-dot-menu: unicode(e952), // TODO: deprecate in favor of `dot-menu-horizontal`
 );
 
 ///

--- a/packages/sage-react/lib/configs/tokens/icons.js
+++ b/packages/sage-react/lib/configs/tokens/icons.js
@@ -225,13 +225,4 @@ export const TOKENS_ICONS = {
   WARNING_FILLED: 'warning-filled',
   WINDOW_PARAGRAPH: 'window-paragraph',
   WORLD: 'world',
-
-  // Deprecations
-  BETA: 'beta',
-  FILTERS: 'filters',
-  GRAPH: 'graph',
-  LIST_DETAILS: 'list-details',
-  LIST_STACK: 'list-stack',
-  SELECT: 'select',
-  SUCCESS: 'success',
 };


### PR DESCRIPTION
## Description

This PR wraps up effort to deprecate some icons with new names to better match their content.

Background: In [SAGE-526](https://github.com/Kajabi/sage-lib/pull/1453) we updated a number of icons and marked a few more for deprecation. Then in [SAGE-699](https://github.com/Kajabi/kajabi-products/pull/24156) and [a quick follow-up](https://github.com/Kajabi/kajabi-products/pull/24983) we switched these deprecated icons on on `kp` favoring the newer names. This ticket now circles back to Sage to fully remove these deprecated icons from the docs site and tokens lists.

NOTE: A much older `3-dot-menu` icon listed in the `_icons.scss` file was also finally removed after being patched in the [follow-up to SAGE-699](https://github.com/Kajabi/kajabi-products/pull/24983).

## Screenshots

N/A -- deprecated icons removed from tokens lists.

| Deprecation | Replacement |
|---|---|
| `beta` | `lab` |
| `filters` | `filter` |
| `graph` | `chart` |
| `list-details` | `layout-list` |
| `list-stack` | `rows` |
| `select` | `enlarge` |
| `success` | `headset` |


## Testing in `sage-lib`

See Foundations > Icons for updated page that now no longer contains the deprecated icons listed above.


## Testing in `kajabi-products`

1. (**LOW**) Deprecated icons fully removed from Sage.


## Related

See description.
