### PR TITLE
[SAGE-239] Description: Update to latest spec

### DIFF
--- a/docs/app/views/examples/components/description/_preview.html.erb
+++ b/docs/app/views/examples/components/description/_preview.html.erb
@@ -152,3 +152,71 @@
     },
   ]
 } %>
+
+<h3>No Dividers</h3>
+<%= md(
+  "In some situations it is desired to remove the borders between items.
+  In such cases set `no_dividers: true`.
+  
+  NOTE: The example below shows a sample two-column layout where no dividers might be implemented.",
+  use_sage_type: true
+) %>
+<%= sage_component SageGridRow, {} do %>
+  <%= sage_component SageGridCol, { small: 12, medium: 6 } do %>
+    <%= sage_component SageDescription, {
+      no_dividers: true,
+      layout: "stacked",
+      items: [
+        {
+          title: "Name",
+          data: "Savannah Nguyen",
+        },
+        {
+          title: "Email",
+          data: "sara.cruz@example.com",
+        },
+        {
+          title: "Address",
+          data: %(
+            2715 Ash Dr. San Jose<br />
+            South Dakota, 83475
+          ).html_safe,
+        },
+      ]
+    } %>
+  <% end %>
+  <%= sage_component SageGridCol, { small: 12, medium: 6 } do %>
+    <%= sage_component SageDescription, {
+      no_dividers: true,
+      layout: "stacked",
+      items: [
+        {
+          title: "Offers",
+          data: %(
+            #{sage_component(SageLink, { label: "HTML & CSS Basics", style: "secondary", html_attributes: { href: "#" }})}<br />
+            #{sage_component(SageLink, { label: "Back to School Offer", style: "secondary", html_attributes: { href: "#" }})}<br />
+            #{sage_component(SageLink, { label: "CodeCamp Free Community", style: "secondary", html_attributes: { href: "#" }})}<br />
+          ).html_safe,
+          action: { value: "View all", attributes: { href: "#" } }
+        },
+        {
+          title: "Tags",
+          data: sage_component(SageLabelGroup, {
+            content: %(
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+              #{sage_component(SageTag, { value: "Lorem", show_dismiss: true })}
+            ).html_safe,
+          }),
+          action: { value: "View all", attributes: { href: "#" } }
+        },
+      ],
+    } %>
+  <% end %>
+<% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_description.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_description.scss
@@ -70,11 +70,11 @@ $-description-spacing: sage-spacing(sm);
   @extend %t-sage-body;
 
   grid-area: title;
-  color: sage-color(charcoal, 200);
+  color: sage-color(charcoal, 300);
 }
 
 .sage-description__data {
-  @extend %t-sage-body-med;
+  @extend %t-sage-body;
 
   grid-area: data;
   color: sage-color(charcoal, 400);

--- a/packages/sage-assets/lib/stylesheets/components/_description.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_description.scss
@@ -8,7 +8,7 @@ $-description-size: 1fr;
 $-description-action-var: var(--sage-description-action-width, #{$-description-size});
 $-description-title-var: var(--sage-description-title-width, #{$-description-size});
 $-description-spacing: sage-spacing(sm);
-$-description-no-divider-spacing: rem(48px);
+$-description-no-divider-spacing: sage-spacing(xl);
 
 .sage-description {
   display: flex;

--- a/packages/sage-assets/lib/stylesheets/components/_description.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_description.scss
@@ -8,6 +8,7 @@ $-description-size: 1fr;
 $-description-action-var: var(--sage-description-action-width, #{$-description-size});
 $-description-title-var: var(--sage-description-title-width, #{$-description-size});
 $-description-spacing: sage-spacing(sm);
+$-description-no-divider-spacing: rem(48px);
 
 .sage-description {
   display: flex;
@@ -17,7 +18,7 @@ $-description-spacing: sage-spacing(sm);
 }
 
 .sage-description--no-dividers {
-  gap: $-description-spacing;
+  gap: $-description-no-divider-spacing;
 }
 
 .sage-description__term-group {

--- a/packages/sage-react/lib/Description/Description.story.jsx
+++ b/packages/sage-react/lib/Description/Description.story.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Description } from './Description';
 import { Badge } from '../Badge';
+import { Tag } from '../Tag';
+import { Grid } from '../Grid';
+import { Link } from '../Link';
 import { Label } from '../Label';
 
 export default {
@@ -164,3 +167,86 @@ CustomTitleAndActionWidths.args = {
     },
   ]
 };
+
+export const NoDividers = () => (
+  <Grid.Row>
+    <Grid.Col small={12} medium={6}>
+      <Description
+        noDividers={true}
+        layout="stacked"
+        items={[
+          {
+            title: 'Name',
+            data: 'Savannah Nguyen',
+          },
+          {
+            title: 'Email',
+            data: 'sara.cruz@example.com',
+          },
+          {
+            title: 'Address',
+            data: (
+              <>
+                2715 Ash Dr. San Jose<br />
+                South Dakota, 83475
+              </>
+            ),
+          },
+        ]}
+      />
+    </Grid.Col>
+    <Grid.Col small={12} medium={6}>
+      <Description
+        noDividers={true}
+        layout="stacked"
+        items={[
+          {
+            title: 'Offers',
+            data: (
+              <>
+                <Link
+                  style={Link.COLORS.SECONDARY}
+                  href="#url"
+                >
+                  HTML &amp; CSS Basics
+                </Link>
+                <br />
+                <Link
+                  style={Link.COLORS.SECONDARY}
+                  href="#url"
+                >
+                  Back to School Offer
+                </Link>
+                <br />
+                <Link
+                  style={Link.COLORS.SECONDARY}
+                  href="#url"
+                >
+                  CodeCamp Free Community
+                </Link>
+              </>
+            ),
+            action: { value: 'View all', attributes: { href: '#' } }
+          },
+          {
+            title: 'Tags',
+            data: (
+              <Label.Group>
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+                <Tag value="Lorem" showDismiss={true} />
+              </Label.Group>
+            ),
+            action: { value: 'View all', attributes: { href: '#' } }
+          },
+        ]}
+      />
+    </Grid.Col>
+  </Grid.Row>
+);


### PR DESCRIPTION
## Description

**This PR is Draft while I seek Design confirmation of changes indicated here.**

[SAGE-239](https://kajabi.atlassian.net/browse/SAGE-239) suggests some spacing adjustments to Description. However, the ticket refers to the prior version of Sage. I used this ticket to instead double-check that Description is up to date with the [latest spec](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/Sage-components?node-id=2697%3A22580). I found a few small things to update:

- Type specs and colors: Term changed from `Charcoal 200` to `Charcoal 300` and Definition changed from `Body Med` to `Body`.
- For the `no_dividers` variant the spacing between items increased from `16px` to `48px`
- Added documentation examples of the `no_dividers` variant matching Figma example.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
| <img width="863" alt="Screen Shot 2022-09-06 at 11 10 17 AM" src="https://user-images.githubusercontent.com/17955295/188671093-c0cd02cb-e22c-439d-8baa-a921c3210f71.png"> | <img width="855" alt="Screen Shot 2022-09-06 at 11 09 09 AM" src="https://user-images.githubusercontent.com/17955295/188670945-69522b3c-8be9-43dd-b18d-1e299b741ea0.png"> |
| (no example) | <img width="861" alt="Screen Shot 2022-09-06 at 10 27 29 AM" src="https://user-images.githubusercontent.com/17955295/188670998-465cac67-da95-4e5f-8e60-f8dbc6a33948.png"> |

## Testing in `sage-lib`

- See http://localhost:4000/pages/component/description?tab=preview
- See http://localhost:4100/?path=/story/sage-description--no-dividers


## Testing in `kajabi-products`

1. (**LOW**) Adjust Description to latest design specs. This includes small type spec and color changes and spacing change on the `no_dividers` variant.


## Related

[SAGE-239](http://localhost:4100/?path=/story/sage-description--no-dividers)
