### PR TITLE
[SAGE-795] Transactions table hover behavior

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_table.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_table.scss
@@ -204,7 +204,6 @@ $-table-avatar-width: rem(32px);
 // Wrapper div required for responsive tables
 .sage-table-wrapper {
   position: relative;
-  z-index: sage-z-index(default, 1);
 
   .sage-panel & {
     margin-left: -1 * $-table-cell-padding-panel;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] resolve issue related to abnormal dropdown hover  behavior

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![table-z-index](https://user-images.githubusercontent.com/1241836/188761500-cd3bb415-e78d-4ed7-990b-fab8fb68ec40.gif)|![table-z-index-after](https://user-images.githubusercontent.com/1241836/188761503-7f11231d-7b03-4397-93b1-30bde2fc11d4.gif)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify that the tables not longer have a `z-index` on `sage-table-wrapper`
- [Rails](http://localhost:4000/pages/component/table?tab=preview)
- [React](http://localhost:4100/?path=/docs/sage-table--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->

Click on Sales > Payments > Click the dropdown > then click on a field in the table to close the dropdown

1. (**MEDIUM**) Removed the `z-index` from `SageTable`.
   - [ ] Transactions page


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-795](https://kajabi.atlassian.net/browse/SAGE-795)