### PR TITLE
[Sage-279] Remove `clamp` mixin

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_chart_summary.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_chart_summary.scss
@@ -26,14 +26,14 @@
 
 .sage-chart-summary__caption {
   @extend %t-sage-body-xsmall-med;
-  @include clamp(1);
+  @include line-clamp(1);
 
   color: sage-color(charcoal, 100);
 }
 
 .sage-chart-summary__label {
   @extend %t-sage-body-small-med;
-  @include clamp(2);
+  @include line-clamp(2);
 
   color: sage-color(charcoal, 200);
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_utilities.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_utilities.scss
@@ -6,23 +6,6 @@
 
 
 ///
-/// Clamps an elements text to a maximum number of lines
-///
-/// @param {number} $lines Number of lines
-///
-/// @example scss - Basic usage
-///   .sage-box {
-///     @include clamp(2);
-///   }
-///
-@mixin clamp($lines: 2) {
-  display: -webkit-box; // stylelint-disable value-no-vendor-prefix
-  -webkit-line-clamp: $lines;
-  -webkit-box-orient: vertical; // stylelint-disable property-no-vendor-prefix
-  overflow: hidden;
-}
-
-///
 /// Adds a clearfix psuedo-element for use in containers that may include floated elements.
 /// Testing a new _item_.
 ///


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Removes clamp mixin from Sage.

There is a [separate PR](https://github.com/Kajabi/kajabi-products/pull/25026) to replace instances in `kp`.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
N/A


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Check that `clamp` is removed from Sage
- Check that any instances of `clamp` are replaced with `line-clamp`.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Removes clamp mixin from Sage.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[Sage-279](https://kajabi.atlassian.net/browse/SAGE-279)