### PR TITLE
[DSS-69]: Tabs: Filter Variant

### DIFF
--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -115,3 +115,34 @@
       ]
     }
   %>
+
+
+
+<h3 class="t-sage-heading-6">Filter style</h3>
+<div class="sage-tabs-container">
+  <%= sage_component SageTabs, {
+      id: "filter-tabs-example",
+      style: "filter",
+      items: [
+        {
+          text: "Current",
+          attributes: {
+            href: "//example.com/basic-test1",
+          },
+        },
+        {
+          text: "Past",
+          attributes: {
+            href: "//example.com/basic-test2"
+          },
+          active: true
+        },
+        {
+          text: "All",
+          attributes: {
+            href: "//example.com/basic-test3"
+          },
+        },
+      ]
+    }
+  %>

--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -116,8 +116,6 @@
     }
   %>
 
-
-
 <h3 class="t-sage-heading-6">Filter style</h3>
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {

--- a/docs/app/views/examples/components/tabs/_preview.html.erb
+++ b/docs/app/views/examples/components/tabs/_preview.html.erb
@@ -119,28 +119,28 @@
 <h3 class="t-sage-heading-6">Filter style</h3>
 <div class="sage-tabs-container">
   <%= sage_component SageTabs, {
-      id: "filter-tabs-example",
-      style: "filter",
-      items: [
-        {
-          text: "Current",
-          attributes: {
-            href: "//example.com/basic-test1",
-          },
+    id: "filter-tabs-example",
+    style: "filter",
+    items: [
+      {
+        text: "Current",
+        attributes: {
+          href: "//example.com/basic-test1",
         },
-        {
-          text: "Past",
-          attributes: {
-            href: "//example.com/basic-test2"
-          },
-          active: true
+      },
+      {
+        text: "Past",
+        attributes: {
+          href: "//example.com/basic-test2"
         },
-        {
-          text: "All",
-          attributes: {
-            href: "//example.com/basic-test3"
-          },
+        active: true
+      },
+      {
+        text: "All",
+        attributes: {
+          href: "//example.com/basic-test3"
         },
-      ]
-    }
-  %>
+      },
+    ]
+  }
+%>

--- a/docs/app/views/examples/components/tabs/_props.html.erb
+++ b/docs/app/views/examples/components/tabs/_props.html.erb
@@ -77,12 +77,12 @@ Array<{
 <tr>
   <td><%= md('`style`') %></td>
   <td><%= md('What kind of tab style to use. A simple style is default, but the `choice` setting enables a more complex Choice style (See Tab versus Choice components)') %></td>
-  <td><%= md('`nil` or `choice`') %></td>
+  <td><%= md('`nil` | `"choice` | `"filter"`') %></td>
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
   <td><%= md('`with_background`') %></td>
   <td><%= md('Determines whether to use the modification that has a `background-color`') %></td>
-  <td><%= md('`nil` or `choice`') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
 </tr>

--- a/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tabs.rb
@@ -9,7 +9,7 @@ class SageTabs < SageComponent
     permalink: [:optional, NilClass, TrueClass], # For Docs site use only.
     progressbar: [:optional, NilClass, TrueClass],
     stacked: [:optional, NilClass, TrueClass],
-    style: [:optional, NilClass, Set.new(["choice"])],
+    style: [:optional, NilClass, Set.new(["choice", "filter"])],
     with_background: [:optional, NilClass, TrueClass],
   })
 end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tabs.html.erb
@@ -10,6 +10,7 @@ gap = component.gap.present? ? component.gap : :sm
     <%= "sage-tabs--progressbar" if component.progressbar.present? && component.progressbar == true %>
     <%= "sage-tabs--align-items-center" if component.align_items_center.present? && component.align_items_center == true %>
     <%= "sage-tabs--choice" if component.style.present? && component.style === "choice" %>
+    <%= "sage-tabs--filter" if component.style.present? && component.style === "filter" %>
     <%= "sage-tabs--justify-#{component.justify}" if component.justify.present? %>
     <%= "sage-grid-gap-#{gap}" if gap %>
     <%= component.generated_css_classes %>

--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -27,7 +27,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
   transition: color map-get($sage-transitions, default), background-color map-get($sage-transitions, default), box-shadow map-get($sage-transitions, default);
 
   .sage-tabs--filter & {
-    padding: rem(6px) rem(14);
+    padding: rem(6px) rem(14px);
     background-color: sage-color(grey, 300);
     border-radius: sage-border(radius-x-large);
     @extend %t-sage-body-small-semi;

--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -26,10 +26,20 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
   text-decoration: none;
   transition: color map-get($sage-transitions, default), background-color map-get($sage-transitions, default), box-shadow map-get($sage-transitions, default);
 
+  .sage-tabs--filter & {
+    padding: rem(6px) rem(14);
+    background-color: sage-color(grey, 300);
+    border-radius: sage-border(radius-x-large);
+    @extend %t-sage-body-small-semi;
+  }
+
   @extend %t-sage-body-semi;
 
   &:hover {
     color: $-tab-color-active;
+    .sage-tabs--filter & {
+      background: sage-color(grey, 400);
+    }
   }
 
   &:focus {
@@ -37,6 +47,10 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
     outline: none;
     box-shadow: 0 0 0 4px sage-color(primary, 200);
     border-radius: sage-border(radius-small);
+
+    .sage-tabs--filter & {
+      border-radius: sage-border(radius-x-large);
+    }
 
     &::after {
       display: none;
@@ -46,6 +60,13 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
   &:active,
   &.sage-tab--active {
     color: $-tab-color-active;
+    .sage-tabs--filter & {
+      color: sage-color(white);
+      background: sage-color(charcoal, 400);
+      &::after {
+        display: none;
+      }
+    }
   }
 
   &:last-of-type {
@@ -66,7 +87,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
     border-top-left-radius: sage-border(radius-large);
     border-top-right-radius: sage-border(radius-large);
     background-clip: padding-box;
-    
+
     @extend %t-sage-body-xsmall-med;
 
     &::after {

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -34,6 +34,7 @@ export const Tabs = ({
     tabsClassName,
     {
       'sage-tabs--progressbar': tabStyle === TAB_STYLES.PROGRESSBAR,
+      'sage-tabs--filter': tabStyle === TAB_STYLES.FILTER,
       'sage-tabs--align-items-center': tabStyle === TAB_STYLES.CHOICE && alignItemsCenter,
       'sage-tabs--choice': tabStyle === TAB_STYLES.CHOICE,
       [`sage-tabs--layout-${tabLayout}`]: tabLayout,
@@ -78,7 +79,7 @@ export const Tabs = ({
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}
-            itemStyle={tabStyle === 'progressbar' ? 'tab' : tabStyle}
+            itemStyle={tabStyle === 'progressbar' || 'filter' ? 'tab' : tabStyle}
             key={id.toString()}
             onClick={handleClickTab}
             panelId={id}

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -79,7 +79,8 @@ export const Tabs = ({
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}
-            itemStyle={tabStyle === 'progressbar' ? 'tab' : tabStyle === 'filter' ? 'tab' : 'tab'}
+            itemStyle={tabStyle === 'progressbar' || 'filter' ? 'tab' : tabStyle}
+            itemStyle={tabStyle === 'progressbar' ? 'tab' : tabStyle === 'filter' ? 'tab' : tabStyle}
             key={id.toString()}
             onClick={handleClickTab}
             panelId={id}

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -79,7 +79,7 @@ export const Tabs = ({
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}
-            itemStyle={tabStyle === 'progressbar' || 'filter' ? 'tab' : tabStyle}
+            itemStyle={tabStyle === 'progressbar' ? 'tab' : tabStyle === 'filter' ? 'tab' : 'tab'}
             key={id.toString()}
             onClick={handleClickTab}
             panelId={id}

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -79,7 +79,6 @@ export const Tabs = ({
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}
-            itemStyle={tabStyle === 'progressbar' || 'filter' ? 'tab' : tabStyle}
             itemStyle={tabStyle === 'progressbar' ? 'tab' : tabStyle === 'filter' ? 'tab' : tabStyle}
             key={id.toString()}
             onClick={handleClickTab}

--- a/packages/sage-react/lib/Tabs/Tabs.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.jsx
@@ -58,6 +58,13 @@ export const Tabs = ({
     }
   };
 
+  const setTabStyle = (tabStyle) => {
+    if (tabStyle === TAB_STYLES.FILTER || tabStyle === TAB_STYLES.PROGRESSBAR) {
+      return 'tab';
+    }
+    return tabStyle;
+  };
+
   return (
     <div className={`sage-tabs-container ${className || ''}`}>
       <div className={tabsClassNames} role="tablist" {...rest}>
@@ -79,7 +86,7 @@ export const Tabs = ({
             disabled={disabled}
             icon={tabChoiceIcon}
             isActive={id === activeId}
-            itemStyle={tabStyle === 'progressbar' ? 'tab' : tabStyle === 'filter' ? 'tab' : tabStyle}
+            itemStyle={setTabStyle(tabStyle)}
             key={id.toString()}
             onClick={handleClickTab}
             panelId={id}
@@ -130,8 +137,8 @@ Tabs.defaultProps = {
   onChangeTabsHook: null,
   onClickTab: null,
   panesClassName: null,
-  tabLayout: TAB_LAYOUTS.DEFAULT,
-  tabStyle: TAB_STYLES.TAB,
+  tabLayout: Tabs.LAYOUTS.DEFAULT,
+  tabStyle: Tabs.STYLES.TAB,
   tabsClassName: null,
   useSeparator: false,
   withBackground: false,
@@ -140,15 +147,15 @@ Tabs.defaultProps = {
 Tabs.propTypes = {
   alignItemsCenter: PropTypes.bool,
   className: PropTypes.string,
-  gap: PropTypes.oneOf(Object.values(SageTokens.GRID_GAP_OPTIONS.SM)),
+  gap: PropTypes.oneOf(Object.values(SageTokens.GRID_GAP_OPTIONS)),
   initialActiveId: PropTypes.string,
   justify: PropTypes.oneOf(Object.values(Tabs.JUSTIFY_OPTIONS)),
   onChangeTabsHook: PropTypes.func,
   onClickTab: PropTypes.func,
   panesClassName: PropTypes.string,
-  tabLayout: PropTypes.oneOf(Object.values(TAB_LAYOUTS)),
+  tabLayout: PropTypes.oneOf(Object.values(Tabs.LAYOUTS)),
   tabs: PropTypes.arrayOf(tabsItemsPropTypes).isRequired,
-  tabStyle: PropTypes.oneOf(Object.values(TAB_STYLES)),
+  tabStyle: PropTypes.oneOf(Object.values(Tabs.STYLES)),
   tabsClassName: PropTypes.string,
   useSeparator: PropTypes.bool,
   withBackground: PropTypes.bool,

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -11,7 +11,9 @@ export default {
   argTypes: {
     ...selectArgs({
       tabLayout: Tabs.LAYOUTS,
-      tabStyle: Tabs.STYLES
+      tabStyle: Tabs.STYLES,
+      justify: Tabs.JUSTIFY_OPTIONS,
+      gap: SageTokens.GRID_GAP_OPTIONS,
     }),
   },
   args: {

--- a/packages/sage-react/lib/Tabs/Tabs.story.jsx
+++ b/packages/sage-react/lib/Tabs/Tabs.story.jsx
@@ -200,3 +200,26 @@ Background.args = {
   useSeparator: true,
   withBackground: true,
 };
+
+export const Filter = Template.bind({});
+Filter.args = {
+  tabs: [
+    {
+      id: 'filter-1',
+      label: 'Current',
+      href: '#'
+    },
+    {
+      id: 'filter-2',
+      label: 'Past',
+      href: '#'
+    },
+    {
+      id: 'filter-3',
+      label: 'All',
+      href: '#'
+    },
+  ],
+  initialActiveId: 'filter-2',
+  tabStyle: Tabs.STYLES.FILTER
+};

--- a/packages/sage-react/lib/Tabs/configs.js
+++ b/packages/sage-react/lib/Tabs/configs.js
@@ -27,6 +27,7 @@ export const TAB_LAYOUTS = {
 
 export const TAB_STYLES = {
   CHOICE: 'choice',
+  FILTER: 'filter',
   PROGRESSBAR: 'progressbar',
   TAB: 'tab',
 };


### PR DESCRIPTION
## Description
Adds filter style variant to tabs component in rails/react. This addition is to support product work.


## Screenshots

|  Filter tab variant  |
|--------|
|<img width="274" alt="Screen Shot 2022-09-12 at 3 34 29 PM" src="https://user-images.githubusercontent.com/1175111/189770180-bf263ef8-bf95-469f-9110-3029a90531be.png">|


## Testing in `sage-lib`

Docs site:
- Navigate to Tabs (http://localhost:4000/pages/component/tabs?tab=preview)
- Verify filter style tabs matches design spec.

Storybook:
- Navigate to Storybook (http://localhost:4100/?path=/docs/sage-tabs--default)
- Verify filter style tabs matches design spec.

## Testing in `kajabi-products`
1. (**LOW**) Adds filter style variant to tabs component. Not yet used in KP.


## Related
https://kajabi.atlassian.net/browse/DSS-69