### PR TITLE
[SAGE-800] - React Button: Refactor `renderContent();` function 

### DIFF
--- a/packages/sage-react/lib/Button/Button.jsx
+++ b/packages/sage-react/lib/Button/Button.jsx
@@ -58,34 +58,13 @@ export const Button = React.forwardRef(({
     rest['aria-live'] = 'polite';
   }
 
-  const renderContent = () => {
-    if (iconOnly) {
-      return (
-        <span className="visually-hidden">
-          {children}
-        </span>
-      );
-    }
-
-    if (hasCustomContent) {
-      return (
-        <span
-          className={classnames(
-            'sage-btn__custom-content',
-            customContentClassName,
-          )}
-        >
-          {children}
-        </span>
-      );
-    }
-
-    return (
-      <span className="sage-btn__truncate-text">
-        {children}
-      </span>
-    );
-  };
+  let generatedClassNames = 'sage-btn__truncate-text';
+  if (iconOnly) {
+    generatedClassNames = 'visually-hidden';
+  }
+  if (hasCustomContent) {
+    generatedClassNames = classnames('sage-btn__custom-content', customContentClassName);
+  }
 
   if (isLink) { rest.suppressDefaultClass = true; }
 
@@ -100,7 +79,9 @@ export const Button = React.forwardRef(({
       onClick={onClick}
       {...rest}
     >
-      {renderContent()}
+      <span className={generatedClassNames}>
+        {children}
+      </span>
       {!hasCustomContent && (
         <Loader
           loading={loading}


### PR DESCRIPTION
## Description
The logic in the renderContent(); function is much more complex than needed. We can constantly export the span we’re expecting and only dynamically update the classes attached to the span for each use case.

In this PR I've cleaned up the logic of the button to only dynamically insert the correct class.


## Screenshots
No visual changes should be expected


## Testing in `sage-lib`
http://localhost:4100/?path=/docs/sage-button--standard


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Refactor logic to dynamically insert the correct class to the `<button>`'s internal `<span>`

## Related
[[SAGE-800] - React Button: Refactor renderContent(); function](https://kajabi.atlassian.net/browse/SAGE-800)

[SAGE-800]: https://kajabi.atlassian.net/browse/SAGE-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ