### PR TITLE
[SAGE-324] align rails and react spinner

### DIFF
--- a/packages/sage-react/lib/Toast/Toast.jsx
+++ b/packages/sage-react/lib/Toast/Toast.jsx
@@ -11,6 +11,7 @@ export const Toast = ({
   description,
   icon,
   isActive,
+  isDismissable,
   onDismiss,
   timeout,
   link,
@@ -37,12 +38,12 @@ export const Toast = ({
 
   // Auto dismiss when applicable
   useEffect(() => {
-    if (timeout && isActive) {
+    if (timeout && isActive && isDismissable) {
       setTimeout(() => {
         dismiss(true);
       }, timeout);
     }
-  }, [timeout, isActive]);
+  }, [timeout, isActive, isDismissable]);
 
   // Toggle dismissed when isActive changes
   useEffect(() => {
@@ -119,6 +120,7 @@ Toast.defaultProps = {
   description: null,
   icon: null,
   isActive: false,
+  isDismissable: true,
   onDismiss: (evt) => evt,
   timeout: 4500,
   link: null,
@@ -131,6 +133,7 @@ Toast.propTypes = {
   description: PropTypes.string,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   isActive: PropTypes.bool,
+  isDismissable: PropTypes.bool,
   onDismiss: PropTypes.func,
   timeout: PropTypes.oneOfType([
     PropTypes.number,

--- a/packages/sage-react/lib/Toast/Toast.spec.jsx
+++ b/packages/sage-react/lib/Toast/Toast.spec.jsx
@@ -1,0 +1,27 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Toast } from './Toast';
+
+import { TOAST_TYPES } from './configs';
+
+describe('Sage Toast', () => {
+  it('displays the Toast when isActive', () => {
+    const props = {
+      isactive: true
+    };
+
+    render(<Toast {...props} />);
+    screen.findByText('sage-loader__spinner');
+  });
+
+  it('displays the spinner while loading', () => {
+    const props = {
+      loading: TOAST_TYPES.LOADING
+    };
+
+    render(<Toast {...props} />);
+    screen.findByText('sage-toast');
+  });
+});

--- a/packages/sage-react/lib/Toast/Toast.spec.jsx
+++ b/packages/sage-react/lib/Toast/Toast.spec.jsx
@@ -1,7 +1,8 @@
 require('../test/testHelper');
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Toast } from './Toast';
 
 import { TOAST_TYPES } from './configs';
@@ -9,19 +10,94 @@ import { TOAST_TYPES } from './configs';
 describe('Sage Toast', () => {
   it('displays the Toast when isActive', () => {
     const props = {
-      isactive: true
+      isActive: true
     };
 
     render(<Toast {...props} />);
-    screen.findByText('sage-loader__spinner');
+    const wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).not.toBeNull();
   });
 
-  it('displays the spinner while loading', () => {
+  it('displays the danger toast', () => {
     const props = {
-      loading: TOAST_TYPES.LOADING
+      isActive: true,
+      type: TOAST_TYPES.DANGER
+    };
+    render(<Toast {...props} />);
+    const wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).toHaveClass('sage-toast--style-danger');
+  });
+
+  // it('displays the non dismissable toast', () => {
+  //   const props = {
+  //     isActive: true,
+  //     isDismissable: true,
+  //     timeout: 10000,
+  //     title: 'non dismissable toast title'
+  //   };
+
+  //   render(<Toast {...props} />);
+  //   let wrapper = document.querySelector('.sage-toast');
+  //   expect(wrapper).not.toBeNull();
+
+  //   waitForElementToBeRemoved(
+  //     screen.queryByText(props.title)
+  //   ).then(() =>
+  //     expect(wrapper).toBeNull()
+  //   );
+  // });
+
+  it('displays a toast win an internal link', () => {
+    const props = {
+      isActive: true,
+      link: {
+        href: '#',
+        text: 'link text'
+      }
     };
 
     render(<Toast {...props} />);
-    screen.findByText('sage-toast');
+    const wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).not.toBeNull();
+
+    const link = document.querySelector('.sage-toast__button');
+    expect(link).not.toBeNull();
+  });
+
+  it('dismisses the toast when dismissed', async () => {
+    const props = {
+      isActive: true,
+      isDismissable: false
+    };
+
+    const user = userEvent.setup();
+    render(<Toast {...props} />);
+    let wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).not.toBeNull();
+
+    await user.click(screen.getByRole('button'));
+    wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).toBeNull();
+  });
+
+  it('dismisses the toast on timeout', () => {
+    let callbackFired = false;
+    const props = {
+      isActive: true,
+      onDismiss: () => {
+        callbackFired = true;
+      },
+      title: 'toast that has a timeout'
+    };
+
+    render(<Toast {...props} />);
+    let wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).not.toBeNull();
+
+    waitForElementToBeRemoved(
+      screen.queryByText(props.title)
+    ).then(() =>
+      expect(callbackFired).toBeT()
+    );
   });
 });

--- a/packages/sage-react/lib/Toast/Toast.spec.jsx
+++ b/packages/sage-react/lib/Toast/Toast.spec.jsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { Toast } from './Toast';
 
 import { TOAST_TYPES } from './configs';
+import { SageTokens } from '../configs';
 
 describe('Sage Toast', () => {
   it('displays the Toast when isActive', () => {
@@ -28,24 +29,48 @@ describe('Sage Toast', () => {
     expect(wrapper).toHaveClass('sage-toast--style-danger');
   });
 
-  // it('displays the non dismissable toast', () => {
-  //   const props = {
-  //     isActive: true,
-  //     isDismissable: true,
-  //     timeout: 10000,
-  //     title: 'non dismissable toast title'
-  //   };
+  it('displays the loading toast', () => {
+    const props = {
+      isActive: true,
+      type: TOAST_TYPES.LOADING
+    };
+    render(<Toast {...props} />);
+    const wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).toHaveClass('sage-toast--style-loading');
+  });
 
-  //   render(<Toast {...props} />);
-  //   let wrapper = document.querySelector('.sage-toast');
-  //   expect(wrapper).not.toBeNull();
+  it('displays a custom icon', () => {
+    const props = {
+      isActive: true,
+      icon: SageTokens.ICONS.FLAG
+    };
+    render(<Toast {...props} />);
+    const wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).not.toBeNull();
 
-  //   waitForElementToBeRemoved(
-  //     screen.queryByText(props.title)
-  //   ).then(() =>
-  //     expect(wrapper).toBeNull()
-  //   );
-  // });
+    const icon = document.querySelector('.sage-toast__icon');
+    expect(icon).not.toBeNull();
+  });
+
+  it('displays the non dismissable toast', async () => {
+    const props = {
+      isActive: true,
+      isDismissable: false,
+      title: 'non dismissable toast title'
+    };
+
+    render(<Toast {...props} />);
+    let wrapper = document.querySelector('.sage-toast');
+    expect(wrapper).not.toBeNull();
+
+    // revisit this test if a failure occurs as this may be flakey
+    await waitForElementToBeRemoved(
+      screen.queryByText(props.title)
+    ).catch(() => {
+      wrapper = document.querySelector('.sage-toast');
+      return expect(wrapper).not.toBeNull();
+    });
+  });
 
   it('displays a toast win an internal link', () => {
     const props = {
@@ -84,6 +109,8 @@ describe('Sage Toast', () => {
     let callbackFired = false;
     const props = {
       isActive: true,
+      timeout: 3000,
+      isDismissable: true,
       onDismiss: () => {
         callbackFired = true;
       },
@@ -91,13 +118,14 @@ describe('Sage Toast', () => {
     };
 
     render(<Toast {...props} />);
-    let wrapper = document.querySelector('.sage-toast');
+    setTimeout(4000);
+    const wrapper = document.querySelector('.sage-toast');
     expect(wrapper).not.toBeNull();
 
     waitForElementToBeRemoved(
       screen.queryByText(props.title)
     ).then(() =>
-      expect(callbackFired).toBeT()
+      expect(callbackFired).toBeTruthy()
     );
   });
 });


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] align the rails and react loading spinner
- [x] create toast specs
- [x] create Toast stories
    - [x] Self Dismissing Toasts
    - [x] Danger Toasts
    - [x] Loading Toasts
    - [x] Toast with Link

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
#### Loading spinner
|  Rails  |  React  |
|--------|--------|
|![loading-rails](https://user-images.githubusercontent.com/1241836/190268416-3c09bffa-8685-4f9e-ac7c-70321acc4bf2.gif)|![loading-react](https://user-images.githubusercontent.com/1241836/190268432-9debe846-54b4-4843-86b5-8aeaa9d945ed.gif)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Toast views and verify that the loading spinner looks the same in Rails and React:
- [Rails](http://localhost:4000/pages/component/toast?tab=preview)
- [React](http://localhost:4100/?path=/story/sage-toast--loading-toasts)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Updates for styles of the spinner in the React component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-324](https://kajabi.atlassian.net/browse/SAGE-324)