### PR TITLE
[DSS-141] Radio/Checkbox Sizing Adjustments (20px -> 16px)

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -16,10 +16,10 @@ $-checkbox-color-disabled-border: sage-color(grey, 300);
 $-checkbox-color-disabled-checked: sage-color(charcoal, 100);
 $-checkbox-color-error: sage-color(red, 300);
 
-$-checkbox-size: rem(20px);
+$-checkbox-size: rem(16px);
 $-checkbox-label-spacing: rem(12px);
-$-checkbox-border-radius-inner: rem(6px);
-$-checkbox-border-radius-outer: rem(10px);
+$-checkbox-border-radius-inner: rem(4px);
+$-checkbox-border-radius-outer: rem(8px);
 $-checkbox-transition: 0.15s ease-in-out;
 
 $-checkbox-marker-border: rem(2px);
@@ -169,7 +169,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
   // Checkmark
   &::after {
-    @include sage-icon-base(check);
+    @include sage-icon-base(check, sm);
 
     $-checkbox-scale: 14 / 16;
     transform: translate3d(-50%, -50%, 0) scale3d(#{$-checkbox-scale}, #{$-checkbox-scale}, #{$-checkbox-scale});
@@ -282,7 +282,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
   }
 
   .sage-checkbox & {
-    margin-top: rem(2px);
+    margin-top: rem(4px);
   }
 
   &.sage-checkbox, // spcificity that should apply only to `--standalone` variation

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -195,7 +195,7 @@ $-radio-focus-outline-color: currentColor;
   }
 
   .sage-radio & {
-    margin-top: rem(2px);
+    margin-top: rem(4px);
   }
 
   .sage-sortable & {

--- a/packages/sage-assets/lib/stylesheets/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_variables.scss
@@ -78,7 +78,7 @@ $sage-radio-colors: (
 ///
 /// Radio button size
 ///
-$sage-radio-size: rem(20px);
+$sage-radio-size: rem(16px);
 
 ///
 /// Tab colors shared by components such as tabs and choices


### PR DESCRIPTION
## Description
Updates to radio and checkbox components to match design spec updates.
Changes sizing from 20px to 16px.


## Screenshots

||  Before  |  After  |
|--------|--------|--------|
|Checkbox|![Screen Shot 2022-09-16 at 9 20 01 AM](https://user-images.githubusercontent.com/1175111/190684854-1ab47e20-1da5-4798-8a8c-5564f59736d3.png)|![Screen Shot 2022-09-16 at 9 18 55 AM](https://user-images.githubusercontent.com/1175111/190684908-c50c324a-4bd5-45a3-afbe-665f073353f0.png)|
|Radio|![Screen Shot 2022-09-16 at 9 20 01 AM](https://user-images.githubusercontent.com/1175111/190684993-94f908f4-2ecc-496b-a7c9-80b9ce240fc3.png)|![Screen Shot 2022-09-16 at 9 18 55 AM](https://user-images.githubusercontent.com/1175111/190685049-f83a86ac-22be-4a6c-853c-4a92695c25e6.png)|


## Testing in `sage-lib`
**Rails:**

- Navigate to [Checkbox](http://localhost:4000/pages/component/checkbox?tab=preview) & [Radio](http://localhost:4000/pages/component/radio?tab=preview)
- Verify the new sizing updates outlined above.

**React:**

- Navigate to [Checkbox](http://localhost:4100/?path=/docs/sage-checkbox--default) & [Radio](http://localhost:4100/?path=/docs/sage-radio--default)
- Verify the new sizing updates outlined above.

## Testing in `kajabi-products`
1. (**LOW**) Updates sizes of checkbox and radio components to match design spec. Styling only adjustments.


## Related
https://kajabi.atlassian.net/browse/DSS-141
