### PR TITLE
[DSS-45] Radio - Bordered Variant Update

### DIFF
--- a/docs/app/views/examples/components/radio/_preview.html.erb
+++ b/docs/app/views/examples/components/radio/_preview.html.erb
@@ -66,7 +66,11 @@
   has_border: true,
   label_text: "Bordered Option",
   required: true,
-} %>
+} do %>
+  <%= content_for :sage_radio_custom_content do %>
+    <div>Custom content</div>
+  <% end %>
+<% end %>
 
 <%= sage_component SageRadio, {
   caption: "caption text",

--- a/docs/app/views/examples/components/radio/_preview.html.erb
+++ b/docs/app/views/examples/components/radio/_preview.html.erb
@@ -68,7 +68,10 @@
   required: true,
 } do %>
   <%= content_for :sage_radio_custom_content do %>
-    <div>Custom content</div>
+    <%= sage_component SageBadge, {
+      value: "Published",
+      color: "published",
+    }%>
   <% end %>
 <% end %>
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -23,6 +23,7 @@
 <% else %>
   <div class="
       sage-radio
+      <%= "sage-radio--custom" if content_for :sage_radio_custom_content %>
       <%= component.has_border ? "sage-radio--has-border" : "" %>
       <%= component.has_error ? "sage-radio--error" : "" %>
     "

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -59,6 +59,7 @@ $-radio-focus-outline-color: currentColor;
       "radio label custom"
       "radio message custom"
       "radio message custom";
+    grid-template-columns: min-content 1fr auto;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -38,26 +38,27 @@ $-radio-focus-outline-color: currentColor;
   align-items: center;
   position: relative;
   column-gap: $-radio-gap-spacing;
+  grid-template-columns: min-content 1fr;
   
-  &.sage-radio--custom {
-    grid-template-areas:
-      "radio label"
-      "radio message"
-      "radio custom";
-  }
-
-  &.sage-radio--custom.sage-radio--has-border {
-    grid-template-areas:
-      "radio label custom"
-      "radio message custom"
-      "radio message custom";
-  }
-
   .sage-list & {
     margin-bottom: sage-spacing(card) / 2;
   }
 
   @include sage-form-toggle-parents;
+}
+
+.sage-radio--custom {
+  grid-template-areas:
+    "radio label"
+    "radio message"
+    "radio custom";
+  
+  &.sage-radio--has-border {
+    grid-template-areas:
+      "radio label custom"
+      "radio message custom"
+      "radio message custom";
+  }
 }
 
 .sage-radio--standalone {
@@ -66,6 +67,7 @@ $-radio-focus-outline-color: currentColor;
 
 .sage-radio--has-border:not(.sage-radio--standalone) {
   align-items: center;
+  column-gap: sage-spacing();
   padding: sage-spacing(card);
   border: sage-border();
   border-radius: sage-border(radius);
@@ -73,10 +75,6 @@ $-radio-focus-outline-color: currentColor;
 
 .sage-radio__caption {
   grid-area: message;
-
-  .sage-radio--has-border & {
-    margin-left: sage-spacing(lg);
-  }
 }
 
 .sage-radio__custom-content {
@@ -91,7 +89,6 @@ $-radio-focus-outline-color: currentColor;
   margin-left: 0;
 
   .sage-radio--has-border & {
-    margin-left: sage-spacing(lg);
     color: sage-color(charcoal, 400);
     font-weight: sage-font-weight(semibold);
 
@@ -216,7 +213,6 @@ $-radio-focus-outline-color: currentColor;
 
   &:not(.sage-radio--standalone) {
     .sage-radio--has-border & {
-      position: absolute;
       margin-top: 0;
     }
   }

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -29,6 +29,7 @@ $-radio-focus-outline-size: rem(3px);
 $-radio-focus-outline-width: 4;
 $-radio-focus-outline-color: currentColor;
 
+// stylelint-disable max-nesting-depth
 
 .sage-radio {
   display: grid;

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -20,7 +20,7 @@ $-radio-color-focus-outline-error: sage-color(red, 200);
 
 // Additional configurations
 $-radio-button-size: $sage-radio-size;
-$-radio-label-spacing: rem(12px);
+$-radio-gap-spacing: rem(12px);
 $-radio-transition: 0.15s ease-in-out;
 $-radio-selected-indicator-size: rem(7px);
 
@@ -31,10 +31,26 @@ $-radio-focus-outline-color: currentColor;
 
 
 .sage-radio {
+  display: grid;
+  grid-template-areas:
+    "radio label"
+    "radio message";
+  align-items: center;
   position: relative;
+  column-gap: $-radio-gap-spacing;
+  
+  &.sage-radio--custom {
+    grid-template-areas:
+      "radio label"
+      "radio message"
+      "radio custom";
+  }
 
-  &:not(.sage-radio--standalone) {
-    @include sage-form-toggle;
+  &.sage-radio--custom.sage-radio--has-border {
+    grid-template-areas:
+      "radio label custom"
+      "radio message custom"
+      "radio message custom";
   }
 
   .sage-list & {
@@ -56,13 +72,23 @@ $-radio-focus-outline-color: currentColor;
 }
 
 .sage-radio__caption {
+  grid-area: message;
+
   .sage-radio--has-border & {
     margin-left: sage-spacing(lg);
   }
 }
 
+.sage-radio__custom-content {
+  grid-area: custom;
+  justify-self: end;
+}
+
 .sage-radio__label {
   @include sage-form-toggle-label;
+
+  grid-area: label;
+  margin-left: 0;
 
   .sage-radio--has-border & {
     margin-left: sage-spacing(lg);
@@ -85,6 +111,7 @@ $-radio-focus-outline-color: currentColor;
 .sage-radio__input {
   @include sage-form-toggle-input;
 
+  grid-area: radio;
   z-index: sage-z-index(default, 1);
   height: $-radio-button-size;
   width: $-radio-button-size;
@@ -239,11 +266,4 @@ $-radio-focus-outline-color: currentColor;
 .sage-radio__message,
 .sage-radio__caption {
   @include sage-form-toggle-message;
-}
-
-.sage-radio__message,
-.sage-radio__caption,
-.sage-radio__custom-content {
-  margin-left: #{$-radio-button-size + $-radio-label-spacing};
-  margin-top: rem(2px);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -57,7 +57,6 @@ $-radio-focus-outline-color: currentColor;
   &.sage-radio--has-border {
     grid-template-areas:
       "radio label custom"
-      "radio message custom"
       "radio message custom";
     grid-template-columns: min-content 1fr auto;
   }

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -69,8 +69,14 @@ $-radio-focus-outline-color: currentColor;
   align-items: center;
   column-gap: sage-spacing();
   padding: sage-spacing(card);
-  border: sage-border();
+  box-shadow: sage-border-interactive();
   border-radius: sage-border(radius);
+
+  &:hover {
+    box-shadow: sage-border-interactive(hover);
+  }
+
+
 }
 
 .sage-radio__caption {
@@ -214,6 +220,11 @@ $-radio-focus-outline-color: currentColor;
   &:not(.sage-radio--standalone) {
     .sage-radio--has-border & {
       margin-top: 0;
+
+      &:checked + .sage-radio__label::after {
+        box-shadow: sage-border-interactive(selected);
+        border-radius: sage-border(radius);
+      }
     }
   }
 
@@ -234,7 +245,7 @@ $-radio-focus-outline-color: currentColor;
   }
 
   &.sage-radio--has-border:not(.sage-radio--standalone) {
-    border-color: $-radio-color-error;
+    box-shadow: sage-border-interactive(error);
   }
 
   .sage-radio__input {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates styling for bordered radio variant.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1262" alt="Screen Shot 2022-09-20 at 3 57 45 PM" src="https://user-images.githubusercontent.com/14791307/191363103-6a2d2d18-1e8f-42bb-a692-10a214a94a8e.png">|<img width="1254" alt="Screen Shot 2022-09-20 at 3 54 42 PM" src="https://user-images.githubusercontent.com/14791307/191363117-662c1db2-cde0-4a40-8342-1bb1b9fdfa74.png">
<img width="1258" alt="Screen Shot 2022-09-20 at 3 57 50 PM" src="https://user-images.githubusercontent.com/14791307/191363186-583a8ea3-5ac4-44c7-8c2d-9eb2dcc5ce12.png">|<img width="1258" alt="Screen Shot 2022-09-20 at 3 54 49 PM" src="https://user-images.githubusercontent.com/14791307/191363200-5ec68865-5338-4117-b59e-4c9f6f907efb.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- View [Radio](http://localhost:4000/pages/component/radio?tab=preview)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Updates styling for bordered radio variant.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-45](https://kajabi.atlassian.net/browse/DSS-45)