### PR TITLE
Simplify Rails Alert docs

### DIFF
--- a/docs/app/views/examples/components/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/alert/_preview.html.erb
@@ -27,30 +27,35 @@ These also determine the icon that will appear by default.
   color: "default",
   title: "A default alert",
   desc: demo_description,
+  icon_name: "sage-icon-info-circle-filled",
   primary_action: demo_primary_action,
 } %>
 <%= sage_component SageAlert, {
   color: "info",
   title: "An informative alert",
   desc: demo_description,
+  icon_name: "sage-icon-info-circle-filled",
   primary_action: demo_primary_action,
 } %>
 <%= sage_component SageAlert, {
   color: "success",
   title: "An informative alert",
   desc: demo_description,
+  icon_name: "sage-icon-check-circle-filled",
   primary_action: demo_primary_action,
 } %>
 <%= sage_component SageAlert, {
   color: "warning",
   title: "Uh, oh! Here's a warning alert",
   desc: demo_description,
+  icon_name: "sage-icon-warning-filled",
   primary_action: demo_primary_action,
 } %>
 <%= sage_component SageAlert, {
   color: "danger",
   title: "Look out! This alert means there's an error",
   desc: demo_description,
+  icon_name: "sage-icon-danger-filled",
   primary_action: demo_primary_action,
 } %>
 

--- a/docs/app/views/examples/components/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/alert/_preview.html.erb
@@ -48,14 +48,14 @@ These also determine the icon that will appear by default.
   color: "warning",
   title: "Uh, oh! Here's a warning alert",
   desc: demo_description,
-  icon_name: "sage-icon-warning-filled",
+  icon_name: "sage-icon-danger-filled",
   primary_action: demo_primary_action,
 } %>
 <%= sage_component SageAlert, {
   color: "danger",
   title: "Look out! This alert means there's an error",
   desc: demo_description,
-  icon_name: "sage-icon-danger-filled",
+  icon_name: "sage-icon-warning-filled",
   primary_action: demo_primary_action,
 } %>
 

--- a/docs/app/views/examples/components/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/alert/_preview.html.erb
@@ -72,6 +72,7 @@ These include a single primary action button and one or more additional secondar
   color: "published",
   title: "Alert with all actions",
   desc: demo_description,
+  icon_name: "sage-icon-check-circle-filled",
   primary_action: demo_primary_action,
   secondary_actions: [
     {
@@ -100,6 +101,7 @@ You can listen for this event as it bubbles and respond as you see fit.
   title: "This nifty alert can be dismissed",
   desc: demo_description,
   dismissable: true,
+  icon_name: "sage-icon-info-circle-filled",
   primary_action: demo_primary_action,
 } %>
 
@@ -115,6 +117,7 @@ They support all other properties with the exception of `primary_action`; only `
   desc: demo_description,
   small: true,
   dismissable: true,
+  icon_name: "sage-icon-info-circle-filled",
   secondary_actions: [
     {
       value: "Link 1",

--- a/docs/app/views/examples/components/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/alert/_preview.html.erb
@@ -1,6 +1,6 @@
 <%
   sage_link = sage_component(SageLink, {
-   url: "#",
+    url: "#",
     label: "Link",
     launch: false,
     help_link: false,
@@ -8,281 +8,120 @@
     style: "secondary",
     remove_underline: true,
   })
-%>
-<h3>Dismissable Alert</h3>
-<!-- Default -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "default",
-  title: "Our privacy policy has changed",
-  title_addon: "(as of November 11, 2021)",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-info-circle-filled",
-  dismissable: true,
-  primary_action: {
-    value: "Primary",
-    test_id: "primary_action",
-  },
-  secondary_actions: [
-    {
-      value: "Link",
-      url: "#",
-    },
-    {
-      value: "Another link",
-      url: "#"
-    },
-  ],
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-<!-- Info -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "info",
-  title: "Our privacy policy has changed",
-  title_addon: "(as of November 11, 2021)",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-info-circle-filled",
-  dismissable: true,
-  primary_action: {
-    value: "Primary",
-    test_id: "primary_action",
-  },
-  secondary_actions: [
-    {
-      value: "Link",
-      url: "#"
-    },
-    {
-      value: "Another link",
-      url: "#"
-    },
-  ],
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Success -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "published",
-  title: "Account settings updated",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-check-circle-filled",
-  dismissable: true,
-  primary_action: {
-    value: "Primary - Link",
+  demo_description =  "Make sure you know how these changes affect you."
+  demo_primary_action = {
+    value: "Primary action",
     attributes: {
-      href: "#element-button"
+      href: "#href-for-primary-action"
     },
-  },
-  secondary_actions: [
-    {
-      value: "Secondary - Link",
-      url: "#element-button"
-    },
-  ],
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Warning -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "warning",
-  title: "Exceeded product amount limit",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-warning-filled",
-  dismissable: true,
-  primary_action: {
-    value: "Primary - Link",
-    attributes: {
-      href: "#element-button"
-    },
-  }, 
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Danger -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "danger",
-  title: "App outage tonight at 12am",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-danger-filled",
-  dismissable: true,
-  primary_action: {
-    value: "Primary"
   }
-} %>
+%>
 
-<h3>Non-Dismissable Alert (no close button)</h3>
+<%= md("
+### Alert colors
 
-<!-- Default -->
+Alerts can be implemented in a few different colors.
+These also determine the icon that will appear by default.
+", use_sage_type: true) %>
 <%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
   color: "default",
-  title: "Our privacy policy has changed",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-info-circle-filled",
-  primary_action: {
-    value: "Primary"
-  },
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Info -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "info",
-  title: "Our privacy policy has changed",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-info-circle-filled",
-  primary_action: {
-    value: "Primary"
-  },
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Success -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "published",
-  title: "Account settings updated",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-check-circle-filled",
-  primary_action: {
-    value: "Primary"
-  },
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Warning -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "warning",
-  title: "Exceeded product amount limit",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-warning-filled",
-  primary_action: {
-    value: "Primary"
-  },
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Danger -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: "2xs" },
-  color: "danger",
-  title: "App outage tonight at 12am",
-  desc: "Make sure you know how these changes affect you. Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-danger-filled",
-  primary_action: {
-    value: "Primary"
-  },
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<h3>Small Alerts</h3>
-
-<!-- Default -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: :md },
-  color: "default",
-  desc: "Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-info-circle-filled",
-  small: true,
-  dismissable: true,
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Info -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: :md },
-  color: "info",
-  desc: "Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-info-circle-filled",
-  small: true,
-  dismissable: true,
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Success -->
-<%= sage_component SageAlert, {
-  spacer: { bottom: :md },
-  color: "published",
-  desc: "Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-check-circle-filled",
-  small: true,
-  dismissable: true,
+  title: "A default alert",
+  desc: demo_description,
+  primary_action: demo_primary_action,
 } %>
-
-<!-- Warning -->
 <%= sage_component SageAlert, {
-  spacer: { bottom: :md },
+  color: "info",
+  title: "An informative alert",
+  desc: demo_description,
+  primary_action: demo_primary_action,
+} %>
+<%= sage_component SageAlert, {
+  color: "success",
+  title: "An informative alert",
+  desc: demo_description,
+  primary_action: demo_primary_action,
+} %>
+<%= sage_component SageAlert, {
   color: "warning",
-  desc: "Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-warning-filled",
-  small: true,
-} do %>
-  <% content_for :sage_alert_actions do %>
-    <%= sage_link %>
-  <% end %>
-<% end %>
-
-<!-- Danger -->
+  title: "Uh, oh! Here's a warning alert",
+  desc: demo_description,
+  primary_action: demo_primary_action,
+} %>
 <%= sage_component SageAlert, {
-  spacer: { bottom: :md },
   color: "danger",
-  desc: "Make sure you know how these changes affect you.",
-  icon_name: "sage-icon-danger-filled",
-  small: true,
+  title: "Look out! This alert means there's an error",
+  desc: demo_description,
+  primary_action: demo_primary_action,
 } %>
 
 <%= md("
-### Events
+### Alert actions
+
+Alerts can include buttons and links for users to take further action.
+These include a single primary action button and one or more additional secondary actions.
+
+- The primary action implements a single hash that allows `value` and `attributes` similar to SageButton.
+- The secondary actions implements an array of hashes that each allow a `value` and a `url`.
+", use_sage_type: true) %>
+<%= sage_component SageAlert, {
+  color: "published",
+  title: "Alert with all actions",
+  desc: demo_description,
+  primary_action: demo_primary_action,
+  secondary_actions: [
+    {
+      value: "Link 1",
+      url: "#href-for-link-1"
+    },
+    {
+      value: "Link 2",
+      url: "#href-for-link-1"
+    },
+  ],
+} %>
+
+
+<%= md("
+### Dismissable Alerts
+
+Alerts can be implemented in a few different colors.
+These also determine the icon that will appear by default.
 
 Alerts emit a custom event, `sage.alert.dismiss` when the dismiss button is clicked.
 You can listen for this event as it bubbles and respond as you see fit.
 ", use_sage_type: true) %>
+<%= sage_component SageAlert, {
+  color: "info",
+  title: "This nifty alert can be dismissed",
+  desc: demo_description,
+  dismissable: true,
+  primary_action: demo_primary_action,
+} %>
+
+<%= md("
+### Small Alerts
+
+The `small` variant of Alert can be used for smaller spaces or a more minimal presence.
+They support all other properties with the exception of `primary_action`; only `secondary_actions` are allowed.
+", use_sage_type: true) %>
+
+<%= sage_component SageAlert, {
+  color: "default",
+  desc: demo_description,
+  small: true,
+  dismissable: true,
+  secondary_actions: [
+    {
+      value: "Link 1",
+      url: "#href-for-link-1"
+    },
+    {
+      value: "Link 2",
+      url: "#href-for-link-1"
+    },
+  ],
+} %>
+
 
 <script>
 (function() {

--- a/docs/app/views/examples/components/alert/_props.html.erb
+++ b/docs/app/views/examples/components/alert/_props.html.erb
@@ -46,7 +46,6 @@ primary_action: {
 Array<{
   value: String,
   url: String,
-  html_attributes,
 }>
 ```')
     %>

--- a/docs/app/views/examples/components/alert/_props.html.erb
+++ b/docs/app/views/examples/components/alert/_props.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td><%= md('`color`') %></td>
-  <td><%= md('Applies color to alert. Options include `info`, `success`, `warning`, `danger`, `approaching`, `exceeded`, `reached` ') %></td>
-  <td><%= md('`"info"`, `"success"`, `"warning"`, `"danger"`, `"approaching"`, `"exceeded"`, `"reached"`') %></td>
-  <td><%= md('`nil`') %></td>
+  <td><%= md('Applies a color theme and a corresponding default icon.') %></td>
+  <td><%= md('`"default"`, `"info"`, `"success"`, `"warning"`, `"danger"`, `"approaching"`, `"exceeded"`, `"reached"`') %></td>
+  <td><%= md('`"default"`') %></td>
 </tr>
 <tr>
   <td><%= md('`desc`') %></td>
@@ -24,7 +24,7 @@
 </tr>
 <tr>
   <td><%= md('`primary_action`') %></td>
-  <td><%= md('Creates a custom primary action button for the Alert.') %></td>
+  <td><%= md('Creates a primary action for the alert. See SageButton.') %></td>
   <td>
     <%= md('```
 primary_action: {
@@ -40,12 +40,13 @@ primary_action: {
 </tr>
 <tr>
   <td><%= md('`secondary_actions`') %></td>
-  <td><%= md('An array of optional secondary actions.') %></td>
+  <td><%= md('An array of optional secondary actions. See SageLink.') %></td>
   <td>
     <%= md('```
 Array<{
   value: String,
   url: String,
+  html_attributes,
 }>
 ```')
     %>


### PR DESCRIPTION
## Description

This PR simplifies the Alert docs pages as follows:

- [x] Reduces redundancy; not all colors need to be shown for every example set.
- [x] Adds/revises sections:
   - [x] Dismissible alerts
   - [x] Alert actions
   - [x] Small alerts

NOTE: Once #1599 is merged this will be rebased and set to point to `develop` to be merged there once approved.

## Screenshots

| Before | After |
|---|---|
| ![Screen Shot 2022-09-27 at 10 47 23 AM](https://user-images.githubusercontent.com/17955295/192559548-87ccb6fb-0ec9-42fc-9263-12c45af4e19c.png) ![Screen Shot 2022-09-27 at 10 47 42 AM](https://user-images.githubusercontent.com/17955295/192559602-c8b1f9e5-0539-4652-8543-bcb576f1be0f.png) ![Screen Shot 2022-09-27 at 10 47 58 AM](https://user-images.githubusercontent.com/17955295/192559692-4030ed6f-295b-4097-8e8c-e3dd4d2fa5c1.png) ![Screen Shot 2022-09-27 at 10 48 06 AM](https://user-images.githubusercontent.com/17955295/192559759-83d62624-9d52-4000-b36b-88cb16ab714b.png) | ![Screen Shot 2022-09-27 at 10 42 03 AM](https://user-images.githubusercontent.com/17955295/192557999-7cdd152e-9857-4196-973a-7d00dc28e958.png) ![Screen Shot 2022-09-27 at 10 42 19 AM](https://user-images.githubusercontent.com/17955295/192558031-77bc2026-042c-4438-b395-120c4d21a2e6.png) ![Screen Shot 2022-09-27 at 10 42 29 AM](https://user-images.githubusercontent.com/17955295/192558064-5e6074ca-5693-49d4-bcbf-1bee9598cdd0.png) |


## Testing in `sage-lib`

See http://localhost:4000/pages/component/alert?tab=preview


## Testing in `kajabi-products`

1. (**LOW**) Documentation updates to Alert page


## Related

https://kajabi.atlassian.net/browse/DSS-168
