### PR TITLE
[DSS-175] Add Google Analytics to Sassdocs

### DIFF
--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:sassdoc && yarn build:webpack",
     "build:webpack": "webpack --config webpack/webpack.prod.js",
     "build:webpack:watch": "yarn build:webpack --watch",
-    "build:sassdoc": "sassdoc lib/stylesheets",
+    "build:sassdoc": "sassdoc lib/stylesheets --config sassdoc-config.yaml",
     "build:sassdoc:watch": "nodemon -e scss --watch lib/stylesheets -x \"yarn run build:sassdoc\"",
     "build:watch": "npm-run-all -p build:webpack:watch build:sassdoc:watch",
     "preversion": "yarn run build",

--- a/packages/sage-assets/sassdoc-config.yaml
+++ b/packages/sage-assets/sassdoc-config.yaml
@@ -1,0 +1,1 @@
+googleAnalytics: UA-238598709-3


### PR DESCRIPTION
## Description
Adds Google Analytics tracking to the Sage Sassdocs website.
The tracking code is added by using a Sassdocs config file as outlined [here](http://sassdoc.com/configuration/) & [here](http://sassdoc.com/customising-the-view/#google-analytics).


## Screenshots
![Screen Shot 2022-09-28 at 12 49 34 PM](https://user-images.githubusercontent.com/1175111/192875471-ddfb4aa3-2a78-4500-809e-77eb37a0fbba.png)


## Testing in `sage-lib`
- Install Google Analytics Debugger ([extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en))
- Navigate to [Sage Sassdocs](http://localhost:4200/) 
- Open Chrome DevTools to Console
- Turn on the GA extension
- Refresh the page and verify ID matches `UA-238598709-3`


## Testing in `kajabi-products`
1. (**LOW**) Adds GA tracking to Sage Sassdocs website. No KP impact is expected.


## Related
https://kajabi.atlassian.net/browse/DSS-175
