### PR TITLE
[DSS-156] Tag - Image Variant

### DIFF
--- a/docs/app/views/examples/components/tag/_preview.html.erb
+++ b/docs/app/views/examples/components/tag/_preview.html.erb
@@ -1,8 +1,18 @@
 <%= md("**Note:** The Tag component is meant to be interactive. If you are looking for a non-interactive Tag-like component, consider the #{link_to("Badge", pages_component_path("badge"))} component.") %>
-<%= sage_component SagePanelBlock, {} do %>
+<%= sage_component SagePanelStack, {} do %>
 	<h3 class="t-sage-heading-6">Default</h3>
 	<%= sage_component SageTag, {
 		value: "Label",
+		show_dismiss: true,
+		dismiss_attributes: {
+			"data-js-copy-button": "Label"
+		}
+	} %>
+
+	<h3 class="t-sage-heading-6">Image Variant</h3>
+	<%= sage_component SageTag, {
+		value: "Label",
+		image: "avatar/koray_okumus.png",
 		show_dismiss: true,
 		dismiss_attributes: {
 			"data-js-copy-button": "Label"

--- a/docs/app/views/examples/components/tag/_props.html.erb
+++ b/docs/app/views/examples/components/tag/_props.html.erb
@@ -5,6 +5,12 @@
   <td><%= md('`nil`') %></td>
 </tr>
 <tr>
+  <td><%= md('`image`') %></td>
+  <td><%= md('Adds a presentational image to the left of the label.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`show_dismiss`') %></td>
   <td><%= md('Determines whether the close button renders or not.') %></td>
   <td><%= md('Boolean') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_tag.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_tag.rb
@@ -1,6 +1,7 @@
 class SageTag < SageComponent
   set_attribute_schema({
     dismiss_attributes: [:optional, NilClass, Hash],
+    image: [:optional, NilClass, String],
     show_dismiss: [:optional, NilClass, TrueClass],
     value: String,
   })

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tag.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tag.html.erb
@@ -1,7 +1,7 @@
 <span
   class="
     sage-tag
-    <%= "sage-tag--image" if component.image %>
+    <%= "sage-tag--has-image" if component.image %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tag.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tag.html.erb
@@ -2,6 +2,7 @@
   class="sage-tag <%= component.generated_css_classes %>"
   <%= component.generated_html_attributes.html_safe %>
 >
+  <%= image_tag component.image, alt: "", class: "sage-tag__image", "role": "presentation" if component.image %>
   <span class="sage-tag__value"><%= component.value %></span>
   <% if component.show_dismiss %>
     <%= sage_component SageButton, {

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_tag.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_tag.html.erb
@@ -1,5 +1,9 @@
 <span
-  class="sage-tag <%= component.generated_css_classes %>"
+  class="
+    sage-tag
+    <%= "sage-tag--image" if component.image %>
+    <%= component.generated_css_classes %>
+  "
   <%= component.generated_html_attributes.html_safe %>
 >
   <%= image_tag component.image, alt: "", class: "sage-tag__image", "role": "presentation" if component.image %>

--- a/packages/sage-assets/lib/stylesheets/components/_tag.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tag.scss
@@ -4,6 +4,7 @@
 /// @group sage
 ////
 
+$-tag-image-size: sage-spacing();
 $-tag-button-color: sage-color(charcoal, 200);
 $-tag-button-icon-size: rem(18px);
 $-tag-button-icon-mobile-size: rem(24px);
@@ -20,6 +21,13 @@ $-tag-button-icon-mobile-size: rem(24px);
   &:hover {
     background-color: sage-color(grey, 400);
   }
+}
+
+.sage-tag__image {
+  width: $-tag-image-size;
+  height: $-tag-image-size;
+  margin-right: sage-spacing(xs);
+  border-radius: sage-border(radius-round);
 }
 
 .sage-tag__button.sage-btn--subtle {

--- a/packages/sage-assets/lib/stylesheets/components/_tag.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tag.scss
@@ -4,7 +4,7 @@
 /// @group sage
 ////
 
-$-tag-image-size: sage-spacing();
+$-tag-image-size: rem(24px);
 $-tag-button-color: sage-color(charcoal, 500);
 $-tag-button-icon-size: rem(18px);
 $-tag-button-icon-mobile-size: rem(24px);
@@ -23,7 +23,7 @@ $-tag-button-icon-mobile-size: rem(24px);
   }
 }
 
-.sage-tag--image {
+.sage-tag--has-image {
   padding-left: sage-spacing(2xs);
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_tag.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tag.scss
@@ -5,12 +5,12 @@
 ////
 
 $-tag-image-size: sage-spacing();
-$-tag-button-color: sage-color(charcoal, 200);
+$-tag-button-color: sage-color(charcoal, 500);
 $-tag-button-icon-size: rem(18px);
 $-tag-button-icon-mobile-size: rem(24px);
 
 .sage-tag {
-  @extend %t-sage-body-small-med;
+  @extend %t-sage-body-small-semi;
 
   display: inline-flex;
   align-items: center;
@@ -21,6 +21,10 @@ $-tag-button-icon-mobile-size: rem(24px);
   &:hover {
     background-color: sage-color(grey, 400);
   }
+}
+
+.sage-tag--image {
+  padding-left: sage-spacing(2xs);
 }
 
 .sage-tag__image {

--- a/packages/sage-assets/lib/stylesheets/components/_tag.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tag.scss
@@ -30,7 +30,7 @@ $-tag-button-icon-mobile-size: rem(24px);
 .sage-tag__image {
   width: $-tag-image-size;
   height: $-tag-image-size;
-  margin-right: sage-spacing(xs);
+  margin: sage-spacing(2xs) sage-spacing(xs) sage-spacing(2xs) sage-spacing(2xs);
   border-radius: sage-border(radius-round);
 }
 

--- a/packages/sage-react/lib/Tag/Tag.jsx
+++ b/packages/sage-react/lib/Tag/Tag.jsx
@@ -7,6 +7,7 @@ import { SageTokens } from '../configs';
 export const Tag = ({
   className,
   dismissAttributes,
+  image,
   showDismiss,
   value
 }) => {
@@ -16,6 +17,7 @@ export const Tag = ({
     <span
       className={classNames}
     >
+      <img src={image} alt="" role="presentation" />
       <span className="sage-tag__value">
         {value}
       </span>
@@ -39,12 +41,14 @@ export const Tag = ({
 Tag.defaultProps = {
   className: null,
   dismissAttributes: null,
+  image: null,
   showDismiss: false,
 };
 
 Tag.propTypes = {
   className: PropTypes.string,
   dismissAttributes: PropTypes.shape({}),
+  image: PropTypes.string,
   showDismiss: PropTypes.bool,
   value: PropTypes.string.isRequired,
 };

--- a/packages/sage-react/lib/Tag/Tag.jsx
+++ b/packages/sage-react/lib/Tag/Tag.jsx
@@ -11,7 +11,13 @@ export const Tag = ({
   showDismiss,
   value
 }) => {
-  const classNames = classnames('sage-tag', className);
+  const classNames = classnames(
+    'sage-tag',
+    className,
+    {
+      'sage-tag--has-image': image,
+    }
+  );
 
   return (
     <span

--- a/packages/sage-react/lib/Tag/Tag.jsx
+++ b/packages/sage-react/lib/Tag/Tag.jsx
@@ -23,7 +23,9 @@ export const Tag = ({
     <span
       className={classNames}
     >
-      <img className="sage-tag__image" src={image} alt="" role="presentation" />
+      {image && (
+        <img className="sage-tag__image" src={image} alt="" role="presentation" />
+      )}
       <span className="sage-tag__value">
         {value}
       </span>

--- a/packages/sage-react/lib/Tag/Tag.jsx
+++ b/packages/sage-react/lib/Tag/Tag.jsx
@@ -23,7 +23,7 @@ export const Tag = ({
     <span
       className={classNames}
     >
-      <img src={image} alt="" role="presentation" />
+      <img className="sage-tag__image" src={image} alt="" role="presentation" />
       <span className="sage-tag__value">
         {value}
       </span>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds image variation for the Tag component.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="467" alt="Screen Shot 2022-09-28 at 2 37 49 PM" src="https://user-images.githubusercontent.com/14791307/192875293-bd3e5ee2-ed8e-49ae-b4cb-34d26e966185.png">



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View [Tag](http://localhost:4000/pages/component/tag?tab=preview)
- Check that component matches Figma specs

### React
- View [Tag](http://localhost:4100/?path=/docs/sage-tag--default)
- Check that component matches Figma specs

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds image variation for the Tag component.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-156](https://kajabi.atlassian.net/browse/DSS-156)