### PR TITLE
[DSS-173] Add Google Analytics to Docs Site

### DIFF
--- a/docs/app/views/application/_ga_tracking.html.erb
+++ b/docs/app/views/application/_ga_tracking.html.erb
@@ -1,0 +1,7 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-238598709-2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-238598709-2');
+</script>

--- a/docs/app/views/layouts/application.html.erb
+++ b/docs/app/views/layouts/application.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= render "application/meta" %>
     <%= render "application/styles" %>
+    <%= unless Rails.env.development? %>
+      <%= render "application/ga_tracking" %>
+    <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <%= render "application/content_skip_link",

--- a/docs/app/views/layouts/breakout.html.erb
+++ b/docs/app/views/layouts/breakout.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= render "application/meta" %>
     <%= render "application/styles" %>
+    <% unless Rails.env.development? %>
+      <%= render "application/ga_tracking" %>
+    <% end %>
   </head>
   <body class="sage-page sage-docs sage-page--breakout">
     <%= render "application/content_skip_link",

--- a/docs/app/views/layouts/full_page.html.erb
+++ b/docs/app/views/layouts/full_page.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= render "application/meta" %>
     <%= render "application/styles" %>
+    <% unless Rails.env.development? %>
+      <%= render "application/ga_tracking" %>
+    <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <%= render "application/content_skip_link",

--- a/docs/app/views/layouts/home.html.erb
+++ b/docs/app/views/layouts/home.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= render "application/meta" %>
     <%= render "application/styles" %>
+    <% unless Rails.env.development? %>
+      <%= render "application/ga_tracking" %>
+    <% end %>
   </head>
   <body class="sage-docs docs-home">
     <%= render "application/content_skip_link",

--- a/docs/app/views/layouts/mocks.html.erb
+++ b/docs/app/views/layouts/mocks.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= render "application/meta" %>
     <%= render "application/styles" %>
+    <% unless Rails.env.development? %>
+      <%= render "application/ga_tracking" %>
+    <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <%= render "application/content_skip_link", link_id: "main-content" -%>

--- a/docs/app/views/layouts/sandbox.html.erb
+++ b/docs/app/views/layouts/sandbox.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= render "application/meta" %>
     <%= render "application/styles" %>
+    <% unless Rails.env.development? %>
+      <%= render "application/ga_tracking" %>
+    <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <%= render "application/content_skip_link",


### PR DESCRIPTION
## Description
Adds Google Analytics tracking to the Sage docs website.
The tracking code is added by including a render partial in various layout views.

## Screenshots
![Screen Shot 2022-09-28 at 2 25 01 PM](https://user-images.githubusercontent.com/1175111/192891628-e5824934-e705-48c2-b8d7-8cd5538b8101.png)

## Testing in `sage-lib`
**INSTALL CHROME EXTENSION:**
- Install Google Analytics Debugger ([extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en))

**EDIT LAYOUTS FILE:**
- Open `home.html.erb` in `docs/apps/views/layouts`
- Change or remove condition around `ga_tracking` partial

**VERIFY IN DEV TOOLS:**
- Navigate to [Sage Docs](http://localhost:4000/pages/index) 
- Open Chrome DevTools to Console
- Turn on the GA extension
- Refresh the page and verify ID matches `UA-238598709-2`

## Testing in `kajabi-products`
1. (**LOW**) Adds GA tracking to Sage docs website. No KP impact is expected.

## Related
https://kajabi.atlassian.net/browse/DSS-173
