### PR TITLE
[DSS-157] Avatar - Custom Icon and Color

### DIFF
--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -90,7 +90,8 @@
 <div class="sage-avatar-wrapper">
   <%= sage_component SageAvatar, {
     badge: true,
-    badge_color: "black",
+    badge_foregroundColor: "yellow",
+    badge_backgroundColor: "#4232a8",
     badge_icon: "play-circle",
     size: "80px",
     image: {
@@ -101,8 +102,9 @@
   } %>
   <%= sage_component SageAvatar, {
     badge: true,
-    badge_color: "purple-300",
-    badge_icon: "super-admin",
+    badge_foregroundColor: "red-300",
+    badge_backgroundColor: "#fff",
+    badge_icon: "danger",
     size: "80px",
     image: {
       alt: "Court's profile image",

--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -102,8 +102,8 @@
   <%= sage_component SageAvatar, {
     badge: true,
     badge_color: "purple-300",
-    badge_icon: "megaphone",
-    size: "90px",
+    badge_icon: "super-admin",
+    size: "80px",
     image: {
       alt: "Court's profile image",
       src: "avatar/court.png",

--- a/docs/app/views/examples/components/avatar/_preview.html.erb
+++ b/docs/app/views/examples/components/avatar/_preview.html.erb
@@ -86,6 +86,32 @@
   } %>
 </div>
 
+<h3>Avatar Badges with Custom Color and Icon</h3>
+<div class="sage-avatar-wrapper">
+  <%= sage_component SageAvatar, {
+    badge: true,
+    badge_color: "black",
+    badge_icon: "play-circle",
+    size: "80px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+  <%= sage_component SageAvatar, {
+    badge: true,
+    badge_color: "purple-300",
+    badge_icon: "megaphone",
+    size: "90px",
+    image: {
+      alt: "Court's profile image",
+      src: "avatar/court.png",
+      id: "custom_id"
+    }
+  } %>
+</div>
+
 <h3>Custom Colors</h3>
 <div class="sage-avatar-wrapper">
   <%= sage_component SageAvatar, { size: "24px",  color: "purple" } %>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -12,8 +12,8 @@
 </tr>
 <tr>
   <td><%= md('`badge_foregroundColor`') %></td>
-  <td><%= md('Sets the badge icon stroke/fill color. If not set, will default to `primary-300`.') %></td>
-  <td><%= md("Hex color string or `#{SageTokens::COLORS.inspect()}`") %></td>
+  <td><%= md('Sets the badge icon stroke/fill color. Use `SageTokens::COLOR_SLIDER` for Sage system colors. If not set, will default to `primary-300`.') %></td>
+  <td><%= md('String') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>

--- a/docs/app/views/examples/components/avatar/_props.html.erb
+++ b/docs/app/views/examples/components/avatar/_props.html.erb
@@ -5,6 +5,24 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`badge_backgroundColor`') %></td>
+  <td><%= md('Sets the badge icon background color. Provide either a Sage color name or a custom Hex color value. Use `SageTokens::COLOR_PALETTE` for hex values from the full Sage color palette. If not set, will default to white.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`badge_foregroundColor`') %></td>
+  <td><%= md('Sets the badge icon stroke/fill color. If not set, will default to `primary-300`.') %></td>
+  <td><%= md("Hex color string or `#{SageTokens::COLORS.inspect()}`") %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
+  <td><%= md('`badge_icon`') %></td>
+  <td><%= md('Sets a Sage icon. If not set, will defaul to `check-circle-filled`.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`false`') %></td>
+</tr>
+<tr>
   <td><%= md('`color`') %></td>
   <td><%= md('
     This component uses the `--color` modifier to change the default

--- a/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
@@ -31,7 +31,8 @@ module SageSchemas
 
   AVATAR = {
     badge: [:optional, NilClass, TrueClass],
-    badge_color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
+    badge_foregroundColor: [:optional, NilClass, Set.new(SageSchemas::COLOR_SLIDER)],
+    badge_backgroundColor: [:optional, NilClass, Set.new(SageTokens::COLORS), String],
     badge_icon: [:optional, NilClass, SageSchemas::ICON],
     centered: [:optional, NilClass, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],

--- a/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
@@ -31,6 +31,8 @@ module SageSchemas
 
   AVATAR = {
     badge: [:optional, NilClass, TrueClass],
+    badge_color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
+    badge_icon: [:optional, NilClass, SageSchemas::ICON],
     centered: [:optional, NilClass, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLORS],
     image: [:optional, NilClass, { alt: [:optional, NilClass, String], src: String, id: [:optional, NilClass, String] }],

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -36,9 +36,9 @@ end
   <% if component.badge %>
     <div class="sage-avatar__badge">
       <%= sage_component SageIcon, {
-        icon: "check-circle-filled",
+        icon: component.badge_icon ? component.badge_icon : "check-circle-filled",
         size: badge_icon_size,
-        color: "primary-300",
+        color: component.badge_color ? component.badge_color : "primary-300",
       } %>
     </div>
   <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -26,6 +26,7 @@ end
     sage-avatar
     <%= "sage-avatar--#{component.color}" if component.color %>
     <%= "sage-avatar--centered" if component.centered %>
+    <%= "sage-avatar--custom-badge" if component.badge_icon || component.badge_color %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -26,7 +26,7 @@ end
     sage-avatar
     <%= "sage-avatar--#{component.color}" if component.color %>
     <%= "sage-avatar--centered" if component.centered %>
-    <%= "sage-avatar--custom-badge" if component.badge_icon || component.badge_color %>
+    <%= "sage-avatar--custom-badge" if component.badge_backgroundColor || component.badge_foregroundColor || component.badge_icon %>
     <%= component.generated_css_classes %>
   "
   <%= component.generated_html_attributes.html_safe %>
@@ -35,11 +35,18 @@ end
   <% end %>
 >
   <% if component.badge %>
-    <div class="sage-avatar__badge">
+    <div class="
+      sage-avatar__badge
+      <%= "sage-avatar__badge--custom-bg" if component.badge_backgroundColor %>
+      "
+      <% if component.badge_backgroundColor.present? %>
+        style="--badge-custom-bg-color: <%= component.badge_backgroundColor %>"
+      <% end %>
+    >
       <%= sage_component SageIcon, {
         icon: component.badge_icon ? component.badge_icon : "check-circle-filled",
         size: badge_icon_size,
-        color: component.badge_color ? component.badge_color : "primary-300",
+        color: component.badge_foregroundColor ? component.badge_foregroundColor : "primary-300",
       } %>
     </div>
   <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -160,6 +160,10 @@ $-avatar-group-item-sizes: (
   border-radius: sage-border(radius-round);
   border: rem(2px) solid sage-color(white);
 
+  &.sage-avatar__badge--custom-bg {
+    background-color: var(--badge-custom-bg-color);
+  }
+
   i {
     display: flex;
   }

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -163,6 +163,10 @@ $-avatar-group-item-sizes: (
   i {
     display: flex;
   }
+
+  .sage-avatar--custom-badge & {
+    border: 0;
+  }
 }
 
 .sage-avatar__initials {

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -70,8 +70,8 @@ export const Avatar = ({
       {badge && (
         <div
           className={badgeClassnames}
-          style={(badgeBackgroundColor && badgeBackgroundColor !== '') && ({
-            '--badge-custom-bg-color': badgeBackgroundColor
+          style={({
+            '--badge-custom-bg-color': badgeBackgroundColor || ''
           })}
         >
           <Icon

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -7,7 +7,8 @@ import { AVATAR_COLORS } from './configs';
 
 export const Avatar = ({
   badge,
-  badgeColor,
+  badgeBackgroundColor,
+  badgeForegroundColor,
   badgeIcon,
   className,
   centered,
@@ -22,8 +23,16 @@ export const Avatar = ({
     className,
     {
       'sage-avatar--centered': centered,
-      'sage-avatar--custom-badge': badgeColor || badgeIcon,
+      'sage-avatar--custom-badge': badgeBackgroundColor || badgeIcon || badgeForegroundColor,
       [`sage-avatar--${color}`]: color,
+    }
+  );
+
+  const badgeClassnames = classnames(
+    'sage-avatar__badge',
+    className,
+    {
+      'sage-avatar__badge--custom-bg': badgeBackgroundColor
     }
   );
 
@@ -59,10 +68,15 @@ export const Avatar = ({
   return (
     <div className={classNames} style={style} {...rest}>
       {badge && (
-        <div className="sage-avatar__badge">
+        <div
+          className={badgeClassnames}
+          style={(badgeBackgroundColor && badgeBackgroundColor !== '') && ({
+            '--badge-custom-bg-color': badgeBackgroundColor
+          })}
+        >
           <Icon
             icon={badgeIcon || Icon.ICONS.CHECK_CIRCLE_FILLED}
-            color={badgeColor || Icon.COLORS.PRIMARY_300}
+            color={badgeForegroundColor || Icon.COLORS.PRIMARY_300}
             size={setBadgeSize()}
           />
         </div>
@@ -81,7 +95,8 @@ Avatar.COLORS = AVATAR_COLORS;
 
 Avatar.defaultProps = {
   badge: false,
-  badgeColor: null,
+  badgeBackgroundColor: null,
+  badgeForegroundColor: null,
   badgeIcon: null,
   centered: false,
   className: '',
@@ -93,7 +108,8 @@ Avatar.defaultProps = {
 
 Avatar.propTypes = {
   badge: PropTypes.bool,
-  badgeColor: PropTypes.oneOf(Object.values(SageTokens.COLOR_SLIDERS)),
+  badgeBackgroundColor: PropTypes.string,
+  badgeForegroundColor: PropTypes.oneOf(Object.values(SageTokens.COLOR_SLIDERS)),
   badgeIcon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   centered: PropTypes.bool,
   className: PropTypes.string,

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { SageTokens } from '../configs';
 import { Icon } from '../Icon';
 import { AVATAR_COLORS } from './configs';
 
 export const Avatar = ({
   badge,
+  badgeColor,
+  badgeIcon,
   className,
   centered,
   color,
@@ -19,6 +22,7 @@ export const Avatar = ({
     className,
     {
       'sage-avatar--centered': centered,
+      'sage-avatar--custom-badge': badgeColor || badgeIcon,
       [`sage-avatar--${color}`]: color,
     }
   );
@@ -57,8 +61,8 @@ export const Avatar = ({
       {badge && (
         <div className="sage-avatar__badge">
           <Icon
-            icon={Icon.ICONS.CHECK_CIRCLE_FILLED}
-            color={Icon.COLORS.PRIMARY_300}
+            icon={badgeIcon || Icon.ICONS.CHECK_CIRCLE_FILLED}
+            color={badgeColor || Icon.COLORS.PRIMARY_300}
             size={setBadgeSize()}
           />
         </div>
@@ -77,6 +81,8 @@ Avatar.COLORS = AVATAR_COLORS;
 
 Avatar.defaultProps = {
   badge: false,
+  badgeColor: null,
+  badgeIcon: null,
   centered: false,
   className: '',
   color: AVATAR_COLORS.DEFAULT,
@@ -87,6 +93,8 @@ Avatar.defaultProps = {
 
 Avatar.propTypes = {
   badge: PropTypes.bool,
+  badgeColor: PropTypes.oneOf(Object.values(SageTokens.COLOR_SLIDERS)),
+  badgeIcon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   centered: PropTypes.bool,
   className: PropTypes.string,
   color: PropTypes.oneOf(Object.values(AVATAR_COLORS)),

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -70,9 +70,7 @@ export const Avatar = ({
       {badge && (
         <div
           className={badgeClassnames}
-          style={({
-            '--badge-custom-bg-color': badgeBackgroundColor || ''
-          })}
+          style={{ '--badge-custom-bg-color': badgeBackgroundColor || '' }}
         >
           <Icon
             icon={badgeIcon || Icon.ICONS.CHECK_CIRCLE_FILLED}

--- a/packages/sage-react/lib/Avatar/Avatar.spec.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.spec.jsx
@@ -1,0 +1,56 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SageTokens } from '../configs';
+import { Avatar } from './Avatar';
+
+describe('Sage Avatar', () => {
+  it('renders a badge icon when set', () => {
+    const defaultProps = {
+      badge: true,
+      size: '48px',
+    };
+
+    render(<Avatar {...defaultProps} />);
+    const badge = document.querySelector('.sage-avatar__badge');
+    expect(badge).not.toBeNull();
+  });
+
+  it('correctly updates the icon when set', () => {
+    const defaultProps = {
+      badge: true,
+      badgeIcon: SageTokens.ICONS.DANGER_FILLED,
+      size: '48px',
+    };
+
+    render(<Avatar {...defaultProps} />);
+    const badgeIcon = document.querySelector('.sage-icon');
+    expect(badgeIcon).not.toHaveClass('[class*="sage-icon-check-circle-filled-"');
+  });
+
+  it('correctly updates background color when set', () => {
+    const defaultProps = {
+      badge: true,
+      badgeBackgroundColor: '#262',
+      size: '48px',
+    };
+
+    render(<Avatar {...defaultProps} />);
+    const badge = document.querySelector('.sage-avatar__badge--custom-bg');
+    const badgeBackground = window.getComputedStyle(badge).getPropertyValue('--badge-custom-bg-color');
+    expect(badgeBackground).toEqual('#262');
+  });
+
+  it('correctly updates foreground color when set', () => {
+    const defaultProps = {
+      badge: true,
+      badgeForegroundColor: 'sage-300',
+      size: '48px',
+    };
+
+    render(<Avatar {...defaultProps} />);
+    const badgeIcon = document.querySelector('.sage-icon');
+    expect(badgeIcon).toHaveClass('t-sage--color-sage-300');
+  });
+});

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -18,7 +18,7 @@ export default {
   },
   argTypes: {
     ...selectArgs({
-      badgeColor: SageTokens.COLOR_SLIDERS,
+      badgeForegroundColor: SageTokens.COLOR_SLIDERS,
       badgeIcon: SageTokens.ICONS,
       color: Avatar.COLORS,
     })
@@ -34,7 +34,8 @@ WithBadge.args = { badge: true, size: '64px' };
 export const CustomBadge = Template.bind({});
 CustomBadge.args = {
   badge: true,
-  badgeColor: SageTokens.COLOR_SLIDERS.YELLOW_400,
+  badgeBackgroundColor: '#333',
+  badgeForegroundColor: 'red-200',
   badgeIcon: SageTokens.ICONS.DANGER_FILLED,
   size: '64px',
 };

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { selectArgs } from '../story-support/helpers';
+import { SageTokens } from '../configs';
 import { Avatar } from './Avatar';
+import { Icon } from '../Icon';
 
 export default {
   title: 'Sage/Avatar',
@@ -17,7 +19,9 @@ export default {
   },
   argTypes: {
     ...selectArgs({
-      color: Avatar.COLORS
+      badgeColor: SageTokens.COLOR_SLIDERS,
+      badgeIcon: SageTokens.ICONS,
+      color: Avatar.COLORS,
     })
   }
 };
@@ -27,3 +31,11 @@ export const Default = Template.bind({});
 
 export const WithBadge = Template.bind({});
 WithBadge.args = { badge: true, size: '64px' };
+
+export const CustomBadge = Template.bind({});
+CustomBadge.args = {
+  badge: true,
+  badgeColor: Icon.COLORS.YELLOW_300,
+  badgeIcon: Icon.ICONS.ARCHIVE,
+  size: '64px',
+};

--- a/packages/sage-react/lib/Avatar/Avatar.story.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { SageTokens } from '../configs';
 import { Avatar } from './Avatar';
-import { Icon } from '../Icon';
 
 export default {
   title: 'Sage/Avatar',
@@ -35,7 +34,7 @@ WithBadge.args = { badge: true, size: '64px' };
 export const CustomBadge = Template.bind({});
 CustomBadge.args = {
   badge: true,
-  badgeColor: Icon.COLORS.YELLOW_300,
-  badgeIcon: Icon.ICONS.ARCHIVE,
+  badgeColor: SageTokens.COLOR_SLIDERS.YELLOW_400,
+  badgeIcon: SageTokens.ICONS.DANGER_FILLED,
   size: '64px',
 };


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds props to allow for background and foreground (icon stroke/fill) color for badges. Attempting to provide a backwards compatible solution to not disturb what's already been used in `kp`.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
<img width="1022" alt="Screen Shot 2022-10-06 at 10 18 11 AM" src="https://user-images.githubusercontent.com/14791307/194352081-5f6ed150-06e1-4512-b241-62d26b8d7c0d.png">

https://user-images.githubusercontent.com/14791307/195883012-d0d0ecb1-656f-400e-9679-b6940c037789.mov



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- View Avatar in [Rails](http://localhost:4000/pages/component/avatar?tab=preview) and [React](http://localhost:4100/?path=/docs/sage-avatar--custom-badge)
- Check that new props work as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds props to allow for background and foreground (icon stroke/fill) color for badges.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-157](https://kajabi.atlassian.net/browse/DSS-157)