### PR TITLE
Table: Ensure `responsive: false` turns off responsive features

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_table.html.erb
@@ -1,5 +1,6 @@
 <%
-is_responsive = component.responsive.present? ? component.responsive : true
+# NOTE: Default to `true` unless `component.responsive` is set to `false`
+is_responsive = component.responsive != false
 %>
 <div class="
   sage-table-wrapper


### PR DESCRIPTION
## Description

This PR patches some faulty logic within SageTable to ensure that when users set `responsive: false` the responsive features are indeed disabled.

## Screenshots

|  | Before | After |
|---|---|---|
| `responsive: true` or not set | 👍  ![Screen Shot 2022-10-03 at 12 04 42 PM](https://user-images.githubusercontent.com/17955295/193625638-8651a353-da6b-4e75-a484-74db363fa13b.png) |  👍 ![Screen Shot 2022-10-03 at 12 04 42 PM](https://user-images.githubusercontent.com/17955295/193625638-8651a353-da6b-4e75-a484-74db363fa13b.png) |
| `responsive: false` | ❌ ![Screen Shot 2022-10-03 at 12 04 42 PM](https://user-images.githubusercontent.com/17955295/193625638-8651a353-da6b-4e75-a484-74db363fa13b.png) |  👍 ![Screen Shot 2022-10-03 at 12 02 48 PM](https://user-images.githubusercontent.com/17955295/193625823-7edf35e2-4360-4072-aadb-b413bc1f1484.png) |

## Testing in `sage-lib`

See http://localhost:4000/pages/component/table?tab=preview for no regressions.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related

https://kajabi.atlassian.net/browse/DSS-158
