### PR TITLE
[DSS-183]: Storybook Components Not Displaying Code Examples

### DIFF
--- a/packages/sage-react/lib/FormSection/FormSection.story.jsx
+++ b/packages/sage-react/lib/FormSection/FormSection.story.jsx
@@ -25,10 +25,8 @@ const Template = (args) => <FormSection {...args} />;
 export const Default = Template.bind({});
 Default.decorators = [
   (Story) => (
-    <>
-      <div style={{ width: '75%', marginLeft: 'auto', marginRight: 'auto' }}>
-        <Story />
-      </div>
-    </>
+    <div style={{ width: '75%', marginLeft: 'auto', marginRight: 'auto' }}>
+      {Story()}
+    </div>
   )
 ];

--- a/packages/sage-react/lib/IconCard/IconCard.story.jsx
+++ b/packages/sage-react/lib/IconCard/IconCard.story.jsx
@@ -27,7 +27,7 @@ Default.decorators = [
   (Story) => (
     <>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <Story />
+        {Story()}
       </div>
     </>
   )

--- a/packages/sage-react/lib/Loader/Loader.story.jsx
+++ b/packages/sage-react/lib/Loader/Loader.story.jsx
@@ -26,7 +26,7 @@ Default.decorators = [
     <>
       <Grid container={Grid.CONTAINER_SIZES.MD}>
         <Card>
-          <Story />
+          {Story()}
         </Card>
       </Grid>
     </>

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -47,11 +47,7 @@ Default.decorators = [
     <>
       <div
         style={{
-          height: '100vh',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: '100%'
+          height: '450px',
         }}
       >
         {Story()}

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -54,7 +54,7 @@ Default.decorators = [
           width: '100%'
         }}
       >
-        <Story />
+        {Story()}
       </div>
     </>
   )

--- a/packages/sage-react/lib/Select/Select.story.jsx
+++ b/packages/sage-react/lib/Select/Select.story.jsx
@@ -4,7 +4,7 @@ import { Select } from './Select';
 export default {
   title: 'Sage/Select',
   component: Select,
-  decorators: [(Story) => <div style={{ width: 300, marginLeft: 'auto', marginRight: 'auto' }}><Story /></div>],
+  decorators: [(Story) => <div style={{ width: 300, marginLeft: 'auto', marginRight: 'auto' }}>{Story()}</div>],
   args: {
     label: 'Select',
     id: 'field-1',

--- a/packages/sage-react/lib/Table/Table.story.jsx
+++ b/packages/sage-react/lib/Table/Table.story.jsx
@@ -51,7 +51,7 @@ Default.decorators = [
   (Story) => (
     <>
       <Panel>
-        <Story />
+        {Story()}
       </Panel>
       <div className={`${SageClassnames.TYPE_BLOCK} ${SageClassnames.SPACERS.LG_TOP}`}>
         <p>NOTE: Wiring the select all checkbox requires the following:</p>
@@ -97,7 +97,7 @@ TableWithRichContent.decorators = [
   (Story) => (
     <>
       <Panel>
-        <Story />
+        {Story()}
       </Panel>
     </>
   )

--- a/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
@@ -6,7 +6,7 @@ import { Tooltip } from './Tooltip';
 export default {
   title: 'Sage/Tooltip',
   component: Tooltip,
-  decorators: [(Story) => <div style={{ padding: 100, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Story /></div>],
+  decorators: [(Story) => <div style={{ padding: 100, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{Story()}</div>],
   argTypes: {
     ...selectArgs({
       position: Tooltip.POSITIONS,

--- a/packages/sage-react/lib/Topbar/Topbar.story.jsx
+++ b/packages/sage-react/lib/Topbar/Topbar.story.jsx
@@ -78,7 +78,7 @@ Default.decorators = [
       >
         Show Topbar
       </Button>
-      <Story />
+      {Story()}
     </>
   )
 ];

--- a/packages/sage-react/lib/Type/Type.story.jsx
+++ b/packages/sage-react/lib/Type/Type.story.jsx
@@ -67,7 +67,7 @@ Default.decorators = [
   (Story) => (
     <>
       <Grid container={Grid.CONTAINER_SIZES.SM}>
-        <Story />
+        {Story()}
       </Grid>
     </>
   )

--- a/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
@@ -18,7 +18,7 @@ Default.decorators = [
   (Story) => (
     <>
       <Grid container={Grid.CONTAINER_SIZES.MD}>
-        <Story />
+        {Story()}
       </Grid>
     </>
   )


### PR DESCRIPTION
## Description
Code examples for the following components do not display properly in Storybook.
Most are returning `<No Display Name />` instead of markup.

- FormSection
- IconCard
- Loader
- Popover
- Select
- Table
- Tooltip
- Topbar
- Type
- UploadCard

Updates included using the `{Story()}` function when using decorators in the component story.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="984" alt="Screen Shot 2022-10-03 at 4 01 03 PM" src="https://user-images.githubusercontent.com/1175111/193700761-5568cecc-5ac5-4f12-aee8-ee1ab09d1c07.png">|<img width="967" alt="Screen Shot 2022-10-03 at 4 00 33 PM" src="https://user-images.githubusercontent.com/1175111/193700785-e3ea0b74-f443-4eef-b7db-10a2af21379d.png">|

## Testing in `sage-lib`
Navigate to [Storybook](http://localhost:4100/)
Visit each component listed above.
Verify code examples now display on Docs tab.


## Testing in `kajabi-products`
1. (**LOW**) Fixes code examples not displaying in Storybook. Documentation update only, no effect on KP expected.


## Related
https://kajabi.atlassian.net/browse/DSS-183
