### PR TITLE
[DSS-189] - fix(sage-react:hero): add 'Hero' component to the list of exports

### DIFF
--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -28,6 +28,7 @@ export { FormSection } from './FormSection';
 export { Frame } from './Frame';
 export { Grid } from './Grid';
 export { HelpLink } from './HelpLink';
+export { Hero } from './Hero';
 export { Hint } from './Hint';
 export { Icon } from './Icon';
 export { IconCard } from './IconCard';


### PR DESCRIPTION
## Jira Ticket
[DSS-189](https://kajabi.atlassian.net/browse/DSS-189) 

## Description
A support request came in that identified that the `Hero` react component was no longer being exported. 


## Screenshots
N/A

