### PR TITLE
Radio: Ensure storybook shows props and code

### DIFF
--- a/packages/sage-react/lib/Toggle/Radio.jsx
+++ b/packages/sage-react/lib/Toggle/Radio.jsx
@@ -1,13 +1,79 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Toggle } from './Toggle';
 
-export const Radio = (props) => (
-  <Toggle {...props} />
+export const Radio = ({
+  checked,
+  className,
+  customContent,
+  disabled,
+  hasBorder,
+  hasError,
+  id,
+  itemInList,
+  label,
+  message,
+  name,
+  onChange,
+  required,
+  standalone,
+  value,
+  ...rest
+}) => (
+  <Toggle
+    checked={checked}
+    className={className}
+    customContent={customContent}
+    disabled={disabled}
+    hasBorder={hasBorder}
+    hasError={hasError}
+    hideText={false}
+    id={id}
+    itemInList={itemInList}
+    label={label}
+    message={message}
+    name={name}
+    onChange={onChange}
+    partialSelection={false}
+    required={required}
+    standalone={standalone}
+    togglePosition={Toggle.POSITIONS.DEFAULT}
+    toggleStyle={Toggle.STYLES.DEFAULT}
+    type={Toggle.TYPES.RADIO}
+    value={value}
+    {...rest}
+  />
 );
 
 Radio.defaultProps = {
-  type: Toggle.TYPES.RADIO,
-  ...Toggle.defaultProps
+  checked: false,
+  className: null,
+  customContent: null,
+  disabled: false,
+  hasBorder: false,
+  hasError: false,
+  message: null,
+  onChange: (v) => v,
+  itemInList: false,
+  required: false,
+  standalone: false,
+  value: '',
 };
 
-Radio.propTypes = { ...Toggle.propTypes };
+Radio.propTypes = {
+  checked: PropTypes.bool,
+  className: PropTypes.string,
+  customContent: PropTypes.node,
+  disabled: PropTypes.bool,
+  hasBorder: PropTypes.bool,
+  hasError: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  itemInList: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  message: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  required: PropTypes.bool,
+  standalone: PropTypes.bool,
+  value: PropTypes.string
+};

--- a/packages/sage-react/lib/Toggle/Radio.story.jsx
+++ b/packages/sage-react/lib/Toggle/Radio.story.jsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { selectArgs } from '../story-support/helpers';
 import { Radio } from './Radio';
-import { Toggle } from './Toggle';
 
 export default {
   title: 'Sage/Radio',
@@ -14,19 +12,11 @@ export default {
       },
     },
   },
-  decorators: [(Story) => <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Story /></div>],
   args: {
     label: 'Radio',
-    type: Toggle.TYPES.RADIO,
     id: 'radio-1',
     name: 'radio-1',
-    hasBorder: false,
   },
-  argTypes: {
-    ...selectArgs({
-      type: Toggle.TYPES
-    })
-  }
 };
 
 const Template = (args) => <Radio {...args} />;

--- a/packages/sage-react/lib/Toggle/Radio.story.jsx
+++ b/packages/sage-react/lib/Toggle/Radio.story.jsx
@@ -27,11 +27,13 @@ export const BorderedRadio = (args) => {
   const items = [
     {
       label: 'Option 1',
+      id: 'bordered-option-1',
       value: 'option-1',
       checked: false,
     },
     {
       label: 'Option 2',
+      id: 'bordered-option-2',
       value: 'option-2',
       checked: false,
     }
@@ -74,18 +76,22 @@ export const MultipleRadios = (args) => {
   const items = [
     {
       label: 'Option 1',
+      id: 'multiple-option-1',
       value: 'option-1',
       checked: false,
     }, {
       label: 'Option 2',
+      id: 'multiple-option-2',
       value: 'option-2',
       checked: false,
     }, {
       label: 'Option 3',
+      id: 'multiple-option-3',
       value: 'option-3',
       checked: false,
     }, {
       label: 'Option 4',
+      id: 'multiple-option-4',
       value: 'option-4',
       checked: false,
     }


### PR DESCRIPTION
## Description

This PR adds props onto Radio to ensure the Storybook documentation is more useful to engineers.

## Screenshots

| | Before | After |
|---|---|---|
| Props table | ![Screen Shot 2022-10-05 at 10 01 15 AM](https://user-images.githubusercontent.com/17955295/194103792-01a4a595-87e0-4cd9-9456-c3fd1581d977.png) | ![Screen Shot 2022-10-05 at 11 29 35 AM](https://user-images.githubusercontent.com/17955295/194103889-ca20a3b7-e800-4840-a9f7-2735121b739c.png) |
| Show code | ![Screen Shot 2022-10-05 at 10 01 10 AM](https://user-images.githubusercontent.com/17955295/194103941-5a70b18f-1e17-42a3-813e-fd496ea31fbe.png) | ![Screen Shot 2022-10-05 at 11 29 29 AM](https://user-images.githubusercontent.com/17955295/194103972-e2012586-dd85-4de6-8c8c-d8fe96b95ebf.png) |


## Testing in `sage-lib`

- See http://localhost:4100/?path=/docs/sage-radio--default

## Testing in `kajabi-products`

1. (**LOW**) Improve documentation for React Radio component


## Related

https://kajabi.atlassian.net/browse/DSS-191
