### PR TITLE
[SAGE-185] Dropdown - rich text editor button style update

### DIFF
--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -331,14 +331,14 @@ demo_configs = [
   } %>
 </div>
 
-<h4>Disclosure Button - Icon Only</h4>
+<h4>Rich Text Editor Button</h4>
 <%= md("
   The disclosure button allows for an icon affordance.
 ", use_sage_type: true) %>
 <div>
   <%= sage_component SageButton, {
+    css_classes: "sage-btn--rich-text",
     value: "Add item",
-    disclosure: true,
     icon: { name: "add", style: "only" },
     attributes: {
       href: "#",
@@ -348,12 +348,13 @@ demo_configs = [
     style: "secondary",
   } %>
 </div>
-<h4>Disclosure Button - Icon Only small</h4>
+<h4>Rich Text Editor Disclosure Button</h4>
 <%= md("
   The disclosure button allows for an icon affordance to exist with hidden text.
 ", use_sage_type: true) %>
 <div>
   <%= sage_component SageButton, {
+    css_classes: "sage-btn--rich-text",
     value: "Add item",
     disclosure: true,
     small: true,

--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -106,14 +106,27 @@ custom_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Arrow</h3>
+<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Text and Arrow</h3>
 <%= sage_component SageDropdown, { items: menu_items } do %>
   <% content_for :sage_dropdown_trigger, flush: true do %>
     <%= sage_component SageButton, {
       disclosure: true,
-      icon: { name: "add", style: "only" },
+      style: "secondary",
+      value: "Text",
+      css_classes: "sage-btn--rich-text-disclosure",
+    } %>
+  <% end %>
+<% end %>
+
+<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Icon and Arrow</h3>
+<%= sage_component SageDropdown, { items: menu_items } do %>
+  <% content_for :sage_dropdown_trigger, flush: true do %>
+    <%= sage_component SageButton, {
+      disclosure: true,
+      icon: { name: "align-left", style: "only" },
       style: "secondary",
       value: "Add An Element",
+      css_classes: "sage-btn--rich-text-disclosure",
     } %>
   <% end %>
 <% end %>

--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -106,7 +106,7 @@ custom_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Text and Arrow</h3>
+<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Text</h3>
 <%= sage_component SageDropdown, { items: menu_items } do %>
   <% content_for :sage_dropdown_trigger, flush: true do %>
     <%= sage_component SageButton, {
@@ -118,7 +118,7 @@ custom_items = [
   <% end %>
 <% end %>
 
-<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Icon and Arrow</h3>
+<h3 class="t-sage-heading-6">Rich Text Editor Dropdown with Icon</h3>
 <%= sage_component SageDropdown, { items: menu_items } do %>
   <% content_for :sage_dropdown_trigger, flush: true do %>
     <%= sage_component SageButton, {

--- a/docs/app/views/examples/components/dropdown/_preview.html.erb
+++ b/docs/app/views/examples/components/dropdown/_preview.html.erb
@@ -113,7 +113,7 @@ custom_items = [
       disclosure: true,
       style: "secondary",
       value: "Text",
-      css_classes: "sage-btn--rich-text-disclosure",
+      css_classes: "sage-btn--rich-text",
     } %>
   <% end %>
 <% end %>
@@ -126,7 +126,7 @@ custom_items = [
       icon: { name: "align-left", style: "only" },
       style: "secondary",
       value: "Add An Element",
-      css_classes: "sage-btn--rich-text-disclosure",
+      css_classes: "sage-btn--rich-text",
     } %>
   <% end %>
 <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -437,8 +437,7 @@ $-btn-loading-min-height: rem(36px);
         background-color: sage-color(grey, 300);
       }
 
-      &.sage-btn--selected,
-      &:active {
+      &.sage-btn--selected {
         color: sage-color(white);
         background-color: sage-color(charcoal, 400);
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -422,29 +422,33 @@ $-btn-loading-min-height: rem(36px);
     &[class*="icon-only"].sage-btn--small::after {
       right: rem(12px);
     }
+  }
 
-    &.sage-btn--rich-text-disclosure {
-      padding: rem(10px) rem(32px) rem(10px) rem(8px);
-      border-radius: 6px;
-      border-width: 0;
+  &.sage-btn--rich-text {
+    padding: rem(8px) rem(32px) rem(8px) rem(8px);
+    border-radius: 6px;
+    border-width: 0;
+
+    &::after {
+      right: 7px;
+      font-size: 12px;
+    }
+
+    &:hover {
+      background-color: sage-color(grey, 300);
+    }
+
+    &.sage-btn--selected {
+      color: sage-color(white);
+      background-color: sage-color(charcoal, 400);
 
       &::after {
-        right: 7px;
-        font-size: 12px;
-      }
-
-      &:hover {
-        background-color: sage-color(grey, 300);
-      }
-
-      &.sage-btn--selected {
         color: sage-color(white);
-        background-color: sage-color(charcoal, 400);
-
-        &::after {
-          color: sage-color(white);
-        }
       }
+    }
+
+    &:not(.sage-btn--subtle):not(.sage-btn--disclosure) {
+      padding: rem(7px);
     }
   }
 
@@ -672,7 +676,7 @@ a.sage-btn {
           background-color: $value;
         }
       }
-  
+
       &:focus,
       &:active {
         border-color: transparent;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -431,7 +431,8 @@ $-btn-loading-min-height: rem(36px);
 
     &::after {
       right: 7px;
-      font-size: 12px;
+      font-size: 11px;
+      font-weight: sage-font-weight(bold);
     }
 
     &:hover {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -422,6 +422,31 @@ $-btn-loading-min-height: rem(36px);
     &[class*="icon-only"].sage-btn--small::after {
       right: rem(12px);
     }
+
+    &.sage-btn--rich-text-disclosure {
+      padding: rem(10px) rem(32px) rem(10px) rem(8px);
+      border-radius: 6px;
+      border-width: 0;
+
+      &::after {
+        right: 7px;
+        font-size: 12px;
+      }
+
+      &:hover {
+        background-color: sage-color(grey, 300);
+      }
+
+      &.sage-btn--selected,
+      &:active {
+        color: sage-color(white);
+        background-color: sage-color(charcoal, 400);
+
+        &::after {
+          color: sage-color(white);
+        }
+      }
+    }
   }
 
   // NOTE: Icon generation consolidated in `core/_icons.scss`

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -134,6 +134,15 @@
         &.sage-btn--small {
           padding: rem(12px) sage-spacing(sm) rem(12px) rem(12px);
         }
+
+        &.sage-btn--rich-text-disclosure {
+          padding: rem(10px) rem(12px) rem(10px) rem(8px);
+          border-radius: 6px;
+
+          &::after {
+            right: 15px;
+          }
+        }
         /* stylelint-enable max-nesting-depth */
       }
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -135,7 +135,7 @@
           padding: rem(12px) sage-spacing(sm) rem(12px) rem(12px);
         }
 
-        &.sage-btn--rich-text-disclosure {
+        &.sage-btn--rich-text {
           padding: rem(10px) rem(12px) rem(10px) rem(8px);
           border-radius: 6px;
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -141,6 +141,7 @@
 
           &::after {
             right: 15px;
+            font-size: 11px;
           }
         }
         /* stylelint-enable max-nesting-depth */

--- a/packages/sage-react/lib/Button/Button.story.jsx
+++ b/packages/sage-react/lib/Button/Button.story.jsx
@@ -92,14 +92,14 @@ Disclosure.args = {
 export const RichTextEditorWordsAndArrow = Template.bind({});
 RichTextEditorWordsAndArrow.args = {
   children: 'Text',
-  className: 'sage-btn--rich-text-disclosure',
+  className: 'sage-btn--rich-text',
   disclosure: true,
   color: Button.COLORS.SECONDARY
 };
 
 export const RichTextEditorIconAndArrow = Template.bind({});
 RichTextEditorIconAndArrow.args = {
-  className: 'sage-btn--rich-text-disclosure',
+  className: 'sage-btn--rich-text',
   disclosure: true,
   icon: SageTokens.ICONS.REMOVE,
   iconOnly: true,

--- a/packages/sage-react/lib/Button/Button.story.jsx
+++ b/packages/sage-react/lib/Button/Button.story.jsx
@@ -89,8 +89,17 @@ Disclosure.args = {
   color: Button.COLORS.SECONDARY
 };
 
-export const DisclosureIconOnly = Template.bind({});
-DisclosureIconOnly.args = {
+export const RichTextEditorWordsAndArrow = Template.bind({});
+RichTextEditorWordsAndArrow.args = {
+  children: 'Text',
+  className: 'sage-btn--rich-text-disclosure',
+  disclosure: true,
+  color: Button.COLORS.SECONDARY
+};
+
+export const RichTextEditorIconAndArrow = Template.bind({});
+RichTextEditorIconAndArrow.args = {
+  className: 'sage-btn--rich-text-disclosure',
   disclosure: true,
   icon: SageTokens.ICONS.REMOVE,
   iconOnly: true,

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -34,6 +34,7 @@ export const Dropdown = ({
   panelStateToken,
   panelType,
   triggerButtonSubtle,
+  triggerClassnames,
   triggerModifier,
   triggerWidth,
 }) => {
@@ -148,6 +149,7 @@ export const Dropdown = ({
         modifier={triggerModifier}
         onClickTrigger={onClickTrigger}
         subtleButton={triggerButtonSubtle}
+        triggerClassnames={triggerClassnames}
         width={triggerWidth}
       >
         {customTrigger}
@@ -202,6 +204,7 @@ Dropdown.defaultProps = {
   panelStateToken: null,
   panelType: null,
   triggerButtonSubtle: false,
+  triggerClassnames: '',
   triggerModifier: 'default',
   triggerWidth: null,
 };
@@ -229,6 +232,7 @@ Dropdown.propTypes = {
   panelType: PropTypes.oneOf(Object.values(Dropdown.PANEL_TYPES)),
   panelStateToken: PropTypes.string,
   triggerButtonSubtle: PropTypes.bool,
+  triggerClassnames: PropTypes.string,
   triggerModifier: PropTypes.string,
   triggerWidth: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -151,7 +151,6 @@ OptionMenu.decorators = [
   )
 ];
 
-
 export const DropdownMenuWithHeadings = () => (
   <BulkActionsStory />
 );

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -113,7 +113,7 @@ export const RichTextEditor = (args) => (
   <ToolbarDropdown
     options={defaultOptionsItems}
     isPinned={args.isPinned}
-    triggerClassnames="sage-btn--rich-text-disclosure"
+    triggerClassnames="sage-btn--rich-text"
     triggerButtonSubtle={false}
   />
 );
@@ -132,7 +132,7 @@ RichTextEditor.decorators = [
 
 export const RichTextEditorIconOnly = (args) => (
   <RichTextEditorDropdown
-    triggerClassnames="sage-btn--rich-text-disclosure"
+    triggerClassnames="sage-btn--rich-text"
     triggerButtonSubtle={false}
     options={defaultOptionsItems}
     isPinned={args.isPinned}

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -3,6 +3,7 @@ import { selectArgs } from '../story-support/helpers';
 import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
 import { OptionsDropdown } from './OptionsDropdown';
+import { RichTextEditorDropdown } from './RichEditorDropdown';
 import { ToolbarDropdown } from './ToolbarDropdown';
 import { defaultOptionsItems, sampleMenuItems } from './stories/story-helper';
 import { CustomItemsStory } from './stories/CustomItemsStory';
@@ -108,13 +109,18 @@ OptionMenu.decorators = [
   )
 ];
 
-export const IconOnlyMenuWithArrow = (args) => (
-  <ToolbarDropdown options={defaultOptionsItems} isPinned={args.isPinned} />
+export const RichTextEditor = (args) => (
+  <ToolbarDropdown
+    options={defaultOptionsItems}
+    isPinned={args.isPinned}
+    triggerClassnames="sage-btn--rich-text-disclosure"
+    triggerButtonSubtle={false}
+  />
 );
-IconOnlyMenuWithArrow.args = {
+RichTextEditor.args = {
   isPinned: false
 };
-IconOnlyMenuWithArrow.decorators = [
+RichTextEditor.decorators = [
   (Story) => (
     <>
       <div style={{ minHeight: 300 }}>
@@ -123,6 +129,28 @@ IconOnlyMenuWithArrow.decorators = [
     </>
   )
 ];
+
+export const RichTextEditorIconOnly = (args) => (
+  <RichTextEditorDropdown
+    triggerClassnames="sage-btn--rich-text-disclosure"
+    triggerButtonSubtle={false}
+    options={defaultOptionsItems}
+    isPinned={args.isPinned}
+  />
+);
+RichTextEditorIconOnly.args = {
+  isPinned: false
+};
+OptionMenu.decorators = [
+  (Story) => (
+    <>
+      <div style={{ minHeight: 300 }}>
+        <Story />
+      </div>
+    </>
+  )
+];
+
 
 export const DropdownMenuWithHeadings = () => (
   <BulkActionsStory />

--- a/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
@@ -13,6 +13,7 @@ export const DropdownTrigger = ({
   modifier,
   onClickTrigger,
   subtleButton,
+  triggerClassnames,
   width,
 }) => {
   const onClick = () => {
@@ -38,6 +39,7 @@ export const DropdownTrigger = ({
         ? React.cloneElement(children, { onClick })
         : (
           <DropdownTriggerDefault
+            className={triggerClassnames}
             disabled={disabled}
             disclosure={disclosure}
             icon={icon}
@@ -60,6 +62,7 @@ DropdownTrigger.defaultProps = {
   modifier: null,
   label: null,
   subtleButton: false,
+  triggerClassnames: '',
   width: null,
 };
 
@@ -73,5 +76,6 @@ DropdownTrigger.propTypes = {
   modifier: PropTypes.string,
   onClickTrigger: PropTypes.func.isRequired,
   subtleButton: PropTypes.bool,
+  triggerClassnames: PropTypes.string,
   width: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTriggerDefault.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerDefault.jsx
@@ -4,6 +4,7 @@ import { Button } from '../Button';
 import { SageTokens } from '../configs';
 
 export const DropdownTriggerDefault = ({
+  className,
   disabled,
   disclosure,
   icon,
@@ -13,6 +14,7 @@ export const DropdownTriggerDefault = ({
   subtle,
 }) => (
   <Button
+    className={className}
     color={Button.COLORS.SECONDARY}
     disabled={disabled}
     disclosure={disclosure}
@@ -27,6 +29,7 @@ export const DropdownTriggerDefault = ({
 );
 
 DropdownTriggerDefault.defaultProps = {
+  className: '',
   disabled: false,
   disclosure: false,
   isLabelVisible: true,
@@ -35,6 +38,7 @@ DropdownTriggerDefault.defaultProps = {
 };
 
 DropdownTriggerDefault.propTypes = {
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   disclosure: PropTypes.bool,
   onClick: PropTypes.func.isRequired,

--- a/packages/sage-react/lib/Dropdown/RichEditorDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/RichEditorDropdown.jsx
@@ -5,7 +5,7 @@ import { Dropdown } from './Dropdown';
 import { DropdownItemList } from './DropdownItemList';
 import { DROPDOWN_PANEL_SIZES, DROPDOWN_POSITIONS } from './configs';
 
-export const ToolbarDropdown = ({
+export const RichTextEditorDropdown = ({
   align,
   className,
   exitPanelHandler,
@@ -14,17 +14,18 @@ export const ToolbarDropdown = ({
   panelMaxWidth,
   panelSize,
   options,
-  triggerButtonSubtle,
   triggerClassnames,
+  triggerButtonSubtle,
 }) => (
   <Dropdown
     align={align}
     className={className}
     disclosure={true}
     exitPanelHandler={exitPanelHandler}
-    isLabelVisible={true}
+    icon={SageTokens.ICONS.ALIGN_LEFT}
+    isLabelVisible={false}
     isPinned={isPinned}
-    label="Text"
+    label="Add an element"
     onEscapeHook={onEscapeHook}
     panelMaxWidth={panelMaxWidth}
     panelSize={panelSize}
@@ -36,10 +37,10 @@ export const ToolbarDropdown = ({
   </Dropdown>
 );
 
-ToolbarDropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
-ToolbarDropdown.POSITIONS = DROPDOWN_POSITIONS;
+RichTextEditorDropdown.PANEL_SIZES = DROPDOWN_PANEL_SIZES;
+RichTextEditorDropdown.POSITIONS = DROPDOWN_POSITIONS;
 
-ToolbarDropdown.defaultProps = {
+RichTextEditorDropdown.defaultProps = {
   align: DROPDOWN_POSITIONS.DEFAULT,
   className: null,
   exitPanelHandler: (evt) => evt,
@@ -48,11 +49,11 @@ ToolbarDropdown.defaultProps = {
   panelMaxWidth: null,
   panelSize: DROPDOWN_PANEL_SIZES.DEFAULT,
   options: null,
-  triggerButtonSubtle: false,
   triggerClassnames: '',
+  triggerButtonSubtle: true,
 };
 
-ToolbarDropdown.propTypes = {
+RichTextEditorDropdown.propTypes = {
   align: PropTypes.oneOf(Object.values(DROPDOWN_POSITIONS)),
   className: PropTypes.string,
   exitPanelHandler: PropTypes.func,

--- a/packages/sage-react/lib/Dropdown/ToolbarDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/ToolbarDropdown.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
 import { DropdownItemList } from './DropdownItemList';
 import { DROPDOWN_PANEL_SIZES, DROPDOWN_POSITIONS } from './configs';


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update rich text editor disclosure button styles
- [x] allow custom class to dropdown trigger (React)

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Rails  |  React  |
|--------|--------|
|![Screen Shot 2022-10-19 at 8 08 08 AM](https://user-images.githubusercontent.com/1241836/196700268-46b02b28-27a8-48e3-a836-ec0aa96e4c74.png)|![Screen Shot 2022-10-19 at 8 09 05 AM](https://user-images.githubusercontent.com/1241836/196700294-1e1096e8-2715-4805-b21c-d34d4d10ddd1.png)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Rich Text Editor Dropdown
- [Rails](http://localhost:4000/pages/component/dropdown?tab=preview)
- [React](http://localhost:4100/?path=/docs/sage-dropdown--rich-text-editor-icon-only)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Style updates to the Rich Text Editor dropdown button.
   - [ ] Newsletters -> Newsletter
   - [ ] Theme Editor -> Sidebar updating a `Text` element


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [SAGE-185](https://kajabi.atlassian.net/browse/DSS-185)