### PR TITLE
[DSS-198]  Update GA Scripts to Google Tag Manager

### DIFF
--- a/docs/app/views/application/_ga_tracking.html.erb
+++ b/docs/app/views/application/_ga_tracking.html.erb
@@ -1,7 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-238598709-2"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-238598709-2');
-</script>

--- a/docs/app/views/application/_gtm_tracking.html.erb
+++ b/docs/app/views/application/_gtm_tracking.html.erb
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-T8W9NCJ');</script>
+<!-- End Google Tag Manager -->

--- a/docs/app/views/application/_gtm_tracking_body.html.erb
+++ b/docs/app/views/application/_gtm_tracking_body.html.erb
@@ -1,0 +1,5 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8W9NCJ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+test
+<!-- End Google Tag Manager (noscript) -->

--- a/docs/app/views/application/_gtm_tracking_body.html.erb
+++ b/docs/app/views/application/_gtm_tracking_body.html.erb
@@ -1,5 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8W9NCJ"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-test
 <!-- End Google Tag Manager (noscript) -->

--- a/docs/app/views/layouts/application.html.erb
+++ b/docs/app/views/layouts/application.html.erb
@@ -1,16 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%= render "application/meta" %>
-    <%= render "application/styles" %>
     <% unless Rails.env.development? %>
       <%= render "application/gtm_tracking" %>
     <% end %>
+    <%= render "application/meta" %>
+    <%= render "application/styles" %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
-    <% unless Rails.env.development? %>
-      <%= render "application/gtm_tracking_body" %>
-    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>

--- a/docs/app/views/layouts/application.html.erb
+++ b/docs/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <%= render "application/styles" %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>

--- a/docs/app/views/layouts/application.html.erb
+++ b/docs/app/views/layouts/application.html.erb
@@ -4,10 +4,13 @@
     <%= render "application/meta" %>
     <%= render "application/styles" %>
     <% unless Rails.env.development? %>
-      <%= render "application/ga_tracking" %>
+      <%= render "application/gtm_tracking" %>
     <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>

--- a/docs/app/views/layouts/breakout.html.erb
+++ b/docs/app/views/layouts/breakout.html.erb
@@ -4,10 +4,13 @@
     <%= render "application/meta" %>
     <%= render "application/styles" %>
     <% unless Rails.env.development? %>
-      <%= render "application/ga_tracking" %>
+      <%= render "application/gtm_tracking" %>
     <% end %>
   </head>
   <body class="sage-page sage-docs sage-page--breakout">
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>

--- a/docs/app/views/layouts/breakout.html.erb
+++ b/docs/app/views/layouts/breakout.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%= render "application/meta" %>
-    <%= render "application/styles" %>
     <% unless Rails.env.development? %>
       <%= render "application/gtm_tracking" %>
     <% end %>
+    <%= render "application/meta" %>
+    <%= render "application/styles" %>
   </head>
   <body class="sage-page sage-docs sage-page--breakout">
     <% unless Rails.env.development? %>

--- a/docs/app/views/layouts/full_page.html.erb
+++ b/docs/app/views/layouts/full_page.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%= render "application/meta" %>
-    <%= render "application/styles" %>
     <% unless Rails.env.development? %>
       <%= render "application/gtm_tracking" %>
     <% end %>
+    <%= render "application/meta" %>
+    <%= render "application/styles" %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <% unless Rails.env.development? %>

--- a/docs/app/views/layouts/full_page.html.erb
+++ b/docs/app/views/layouts/full_page.html.erb
@@ -4,10 +4,13 @@
     <%= render "application/meta" %>
     <%= render "application/styles" %>
     <% unless Rails.env.development? %>
-      <%= render "application/ga_tracking" %>
+      <%= render "application/gtm_tracking" %>
     <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>

--- a/docs/app/views/layouts/home.html.erb
+++ b/docs/app/views/layouts/home.html.erb
@@ -4,10 +4,13 @@
     <%= render "application/meta" %>
     <%= render "application/styles" %>
     <% unless Rails.env.development? %>
-      <%= render "application/ga_tracking" %>
+      <%= render "application/gtm_tracking" %>
     <% end %>
   </head>
   <body class="sage-docs docs-home">
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>

--- a/docs/app/views/layouts/home.html.erb
+++ b/docs/app/views/layouts/home.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%= render "application/meta" %>
-    <%= render "application/styles" %>
     <% unless Rails.env.development? %>
       <%= render "application/gtm_tracking" %>
     <% end %>
+    <%= render "application/meta" %>
+    <%= render "application/styles" %>
   </head>
   <body class="sage-docs docs-home">
     <% unless Rails.env.development? %>

--- a/docs/app/views/layouts/mocks.html.erb
+++ b/docs/app/views/layouts/mocks.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%= render "application/meta" %>
-    <%= render "application/styles" %>
     <% unless Rails.env.development? %>
       <%= render "application/gtm_tracking" %>
     <% end %>
+    <%= render "application/meta" %>
+    <%= render "application/styles" %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <% unless Rails.env.development? %>

--- a/docs/app/views/layouts/mocks.html.erb
+++ b/docs/app/views/layouts/mocks.html.erb
@@ -4,10 +4,13 @@
     <%= render "application/meta" %>
     <%= render "application/styles" %>
     <% unless Rails.env.development? %>
-      <%= render "application/ga_tracking" %>
+      <%= render "application/gtm_tracking" %>
     <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link", link_id: "main-content" -%>
     <%= sage_component(SageHeader, {}) do %>
       <%= render "application/assistant" %>

--- a/docs/app/views/layouts/sandbox.html.erb
+++ b/docs/app/views/layouts/sandbox.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%= render "application/meta" %>
-    <%= render "application/styles" %>
     <% unless Rails.env.development? %>
       <%= render "application/gtm_tracking" %>
     <% end %>
+    <%= render "application/meta" %>
+    <%= render "application/styles" %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
     <% unless Rails.env.development? %>

--- a/docs/app/views/layouts/sandbox.html.erb
+++ b/docs/app/views/layouts/sandbox.html.erb
@@ -4,10 +4,13 @@
     <%= render "application/meta" %>
     <%= render "application/styles" %>
     <% unless Rails.env.development? %>
-      <%= render "application/ga_tracking" %>
+      <%= render "application/gtm_tracking" %>
     <% end %>
   </head>
   <%= sage_component(SageBody, { css_classes: "sage-docs" }) do %>
+    <% unless Rails.env.development? %>
+      <%= render "application/gtm_tracking_body" %>
+    <% end %>
     <%= render "application/content_skip_link",
       link_id: "main-content"
     -%>


### PR DESCRIPTION
## Description
To allow better event tracking in Google Analytics, the current GA script should be converted to use GTM. This PR switches out the current GA script for the GTM script.

## Screenshots
|  Markup  |  Tag Assistant  |
|--------|--------|
|![Screen Shot 2022-10-14 at 12 11 46 PM](https://user-images.githubusercontent.com/1175111/195924910-7601fd82-849c-4746-90b6-3b8fa9f19b28.png)|![Screen Shot 2022-10-14 at 12 12 21 PM](https://user-images.githubusercontent.com/1175111/195925044-735fec94-5811-44df-aa0d-6705296b3744.png)|


## Testing in `sage-lib`

- Remove prod conditional in `app/views/layouts/application.html.erb` (line 4 & 11)
- Navigate to the docs site.
- Verify GTM scripts display in the elements panel or verify with [Google tag assistant](https://chrome.google.com/webstore/detail/tag-assistant-legacy-by-g/kejbdjndbnbjgmefkgdddjlbokphdefk/related?hl=en)


## Testing in `kajabi-products`
1. (**LOW**) Converts GA script to use GTM for docs site. Documentation only updates, no effect on KP.

## Related
https://kajabi.atlassian.net/browse/DSS-198
