### PR TITLE
Add required prop to the sage-lib Select component

### DIFF
--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -12,6 +12,7 @@ export const Select = ({
   message,
   onChange,
   options,
+  required,
   value,
   ...rest
 }) => {
@@ -66,6 +67,7 @@ export const Select = ({
         placeholder={label}
         value={value}
         disabled={disabled}
+        required={required}
         {...rest}
       >
         {(label && includeLabelInOptions) && <option label={label} />}
@@ -96,6 +98,7 @@ Select.defaultProps = {
   message: null,
   onChange: (evt) => evt,
   options: [],
+  required: false,
   value: '',
 };
 
@@ -134,5 +137,6 @@ Select.propTypes = {
       }),
     ]),
   ),
+  required: Proptypes.bool,
   value: PropTypes.string,
 };

--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -137,6 +137,6 @@ Select.propTypes = {
       }),
     ]),
   ),
-  required: Proptypes.bool,
+  required: PropTypes.bool,
   value: PropTypes.string,
 };


### PR DESCRIPTION
## Description
Adds the "required" prop to the sage-lib Select component.
Allows for management of forms using the Select component via the FormValidation API.

No visual updates.
No impact to existing implementation as the default value is `false`. 

## Testing in `sage-lib`
N/A


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
