### PR TITLE
[DSS-240] Duplicate without user-selected canonical error

### DIFF
--- a/docs/app/views/application/_app_head_content.html.erb
+++ b/docs/app/views/application/_app_head_content.html.erb
@@ -10,6 +10,7 @@
   })(window,document,'script','dataLayer','GTM-T8W9NCJ');</script>
 <% end %>
 <%= stylesheet_pack_tag "docs" %>
+<link rel="canonical" href="<%= url_for(only_path: false) %>" />
 <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" type="image/png">
 <link href="/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
 <link href="/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">


### PR DESCRIPTION
## Description
Google search console is reporting pages on the docs site as duplicates due to the tabbed interface using params to display the different page content. 

There are concerns about this negatively affecting the [kajabi.com](http://kajabi.com/) domain as it relates to SEO.

In order to resolve the issue a [canonical](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) tag will be added to the `<head>` section of the documentation site.

## Screenshots
<img width="865" alt="Screen Shot 2022-12-06 at 11 27 25 AM" src="https://user-images.githubusercontent.com/1175111/206004127-78b8066b-5b10-4396-b67d-18e696b92947.png">

## Testing in `sage-lib`

- Navigate to any pages in the docs site ([http://localhost:4000/pages/index](http://localhost:4000/pages/index))
- Verify the rel="canonical" link tag displays with the proper URL (dev tools or view source).
- Verify navigation via tabs where applicable does not change the canonical URL in the link tag.


## Testing in `kajabi-products`
1. (**LOW**) Added canonical to docs site `<head>`. Documentation only updates, no effect on KP.


## Related
https://kajabi.atlassian.net/browse/DSS-240
