### PR TITLE
[DSS-241]:  Remove white background from input labels

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -458,7 +458,6 @@
 
     color: inherit;
     white-space: nowrap;
-    background-color: sage-color(white);
   }
 
   // TODO: add support for Simpleform classes


### PR DESCRIPTION
## Description
When adding form elements in areas that have a background that isn't white, the input labels appear with a white background. This is most likely a leftover background color from the previous (floating label) designs.

- FormInput
- FormSelect
- FormTextarea

## Screenshots

|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-12-07 at 8 50 01 AM](https://user-images.githubusercontent.com/1175111/206241424-f63a7ed3-7c69-4b36-bc7a-240ca864daf7.png)|![Screen Shot 2022-12-07 at 8 50 51 AM](https://user-images.githubusercontent.com/1175111/206241491-6c33fae3-de73-453d-a1ef-2dd1c6df7896.png)|



## Testing in `sage-lib`

- Navigate to [docs site](http://localhost:4000) and to the components listed above 
- Verify white background color is no longer applied to input labels.


## Testing in `kajabi-products`

1. (**LOW**) Removed white background color from form input labels.
   - [ ] Sanity check any pages with Sage form inputs.


## Related
https://kajabi.atlassian.net/browse/DSS-241