### PR TITLE
[DSS-242]: Update form input background to white

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_select.scss
@@ -48,6 +48,8 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
   align-items: center;
   grid-column: -1 / -2;
   grid-row: 2 / 3;
+  position: relative;
+  z-index: sage-z-index(default, 1);
 }
 
 .sage-select__arrow::before {
@@ -120,6 +122,7 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
 
     ~ .sage-select__arrow::before {
       color: sage-color(charcoal, 200);
+      opacity: 0.5;
     }
 
     @include placeholder {

--- a/packages/sage-assets/lib/stylesheets/components/_form_textarea.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_textarea.scss
@@ -20,7 +20,6 @@ $-textarea-min-height: rem(90px);
 
 // Colors
 $-textarea-color-default: sage-color(charcoal, 300);
-$-textarea-color-default-background: sage-color(white);
 
 .sage-textarea {
   @include sage-form-field-group;
@@ -48,7 +47,6 @@ $-textarea-color-default-background: sage-color(white);
   grid-area: field;
   min-height: $-textarea-min-height;
   height: $-textarea-height;
-  background: $-textarea-color-default-background;
 }
 
 .sage-textarea__info {

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -405,7 +405,7 @@
   box-shadow: sage-border-interactive(default);
   border: 0;
   border-radius: sage-border(radius-medium);
-  background: transparent;
+  background: sage-color(white);
   transition: map-get($sage-transitions, input);
   transition-property: border, box-shadow, color;
 
@@ -430,8 +430,6 @@
   }
 
   &:valid:not(:placeholder-shown) {
-    background: transparent; // Prevent some browsers from coloring the background on 'valid'
-
     @include placeholder {
       opacity: 0;
     }


### PR DESCRIPTION
## Description
When adding form inputs in areas that have a background that isn't white, the input appears with a transparent background. This may be a leftover background color from the previous (floating label) designs.

- FormInput
- FormSelect
- FormTextarea

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-12-07 at 12 34 45 PM](https://user-images.githubusercontent.com/1175111/206305067-88eb7359-9355-4d46-b0e5-80f93cb1935e.png)|![Screen Shot 2022-12-07 at 12 35 05 PM](https://user-images.githubusercontent.com/1175111/206305099-3ab142d8-5344-4184-a091-f84da836c002.png)|

## Testing in `sage-lib`

- Navigate to [docs site](http://localhost:4000) and to the components listed above 
- Verify white background color is applied to input fields.


## Testing in `kajabi-products`

1. (**LOW**) Removed white background color from form input labels.
   - [ ] Sanity check any pages with Sage form inputs for any visual changes. 

## Related
https://kajabi.atlassian.net/browse/DSS-242