### PR TITLE
[DSS-243] Add missing page title content

### DIFF
--- a/docs/app/views/application/_app_head_content.html.erb
+++ b/docs/app/views/application/_app_head_content.html.erb
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title><%= defined?(@title) ? "Sage | #{@title.titleize}" : "Sage Design System" %></title>
+<title><%= defined?(@title) ? "#{@title.titleize} | Sage Design System" : "Sage Design System" %></title>
 <link rel="preconnect" href="https://sage.kajabi-cdn.com" crossorigin>
 <% unless Rails.env.development? %>
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/docs/app/views/pages/color.html.erb
+++ b/docs/app/views/pages/color.html.erb
@@ -1,3 +1,7 @@
+<%# Used for page <title> %>
+<% @title = "Colors" %>
+
+
 <%= content_for :heading do %>
 <%= md(%(
 # Colors

--- a/docs/app/views/pages/design_principles.html.erb
+++ b/docs/app/views/pages/design_principles.html.erb
@@ -1,3 +1,7 @@
+
+<%# Used for page <title> %>
+<% @title = "Design Principles" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # Design Principles

--- a/docs/app/views/pages/grid.html.erb
+++ b/docs/app/views/pages/grid.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "12 Column Grid" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # The 12 Column Grid

--- a/docs/app/views/pages/grid_templates.html.erb
+++ b/docs/app/views/pages/grid_templates.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Grid Templates" %>
+
 <%
 grid_patterns = [
   {

--- a/docs/app/views/pages/icon.html.erb
+++ b/docs/app/views/pages/icon.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Icons" %>
+
 <%
 
 action_icons = [

--- a/docs/app/views/pages/reveal.html.erb
+++ b/docs/app/views/pages/reveal.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Reveal" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # Reveal

--- a/docs/app/views/pages/sandbox.html.erb
+++ b/docs/app/views/pages/sandbox.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Sandbox" %>
+
 <%= content_for :heading do %>
 <%= md("
 # Sandbox

--- a/docs/app/views/pages/search.html.erb
+++ b/docs/app/views/pages/search.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Search" %>
+
 <%= content_for :heading do %>
   <h1>Component Search</h1>
 <% end %>

--- a/docs/app/views/pages/spacing.html.erb
+++ b/docs/app/views/pages/spacing.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Spacing" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # Spacing

--- a/docs/app/views/pages/support.html.erb
+++ b/docs/app/views/pages/support.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Support" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # Support

--- a/docs/app/views/pages/truncation.html.erb
+++ b/docs/app/views/pages/truncation.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Truncation" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # Truncation

--- a/docs/app/views/pages/typography.html.erb
+++ b/docs/app/views/pages/typography.html.erb
@@ -1,3 +1,6 @@
+<%# Used for page <title> %>
+<% @title = "Typography" %>
+
 <%= content_for :heading do %>
 <%= md(%(
 # Typography


### PR DESCRIPTION
## Description
Many pages of the docs site currently have duplicate default page `<title>` content.

Page titles should be unique in order to prevent any duplicate title-related issues as it relates to SEO.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2022-12-08 at 4 32 40 PM](https://user-images.githubusercontent.com/1175111/206595655-74357767-57e8-49d5-9cc5-8fe361182a7b.png)|![Screen Shot 2022-12-08 at 4 32 03 PM](https://user-images.githubusercontent.com/1175111/206595693-7d3d2d84-d7ef-4fba-86ed-4cb2578ae7a8.png)|

## Testing in `sage-lib`

- Navigate to the [docs site](http://localhost:4000/)
- Check pages that have been updated have unique page titles instead of the default.


## Testing in `kajabi-products`

1. (**LOW**) Added unique page title content to prevent duplicates. Docs only update, no effect on KP.

## Related
https://kajabi.atlassian.net/browse/DSS-243
