### PR TITLE
[DSS-238]:  Dropdown - Rich Text Editor Menu (text and icon) Stories aren't responding to controls being changed

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -92,27 +92,6 @@ MenuWithArrow.decorators = [
   )
 ];
 
-export const RichTextEditor = (args) => (
-  <ToolbarDropdown
-    options={defaultOptionsItems}
-    isPinned={args.isPinned}
-    triggerClassnames="sage-btn--rich-text"
-    triggerButtonSubtle={false}
-  />
-);
-RichTextEditor.args = {
-  isPinned: false
-};
-RichTextEditor.decorators = [
-  (Story) => (
-    <>
-      <div style={{ minHeight: 300 }}>
-        { Story() }
-      </div>
-    </>
-  )
-];
-
 export const RichTextEditorIconOnly = (args) => (
   <ToolbarEditorDropdown
     triggerClassnames="sage-btn--rich-text"

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -45,9 +45,7 @@ export default {
     panelMaxWidth: null,
     panelSize: Dropdown.PANEL_SIZES.DEFAULT,
     triggerButtonSubtle: false,
-    children: (
-      <Dropdown.ItemList items={sampleMenuItems} />
-    ),
+
     exitPanelHandler: (data) => {
       if (data.handler) {
         data.handler();
@@ -56,7 +54,11 @@ export default {
   }
 };
 
-const Template = (args) => <Dropdown {...args} />;
+const Template = (args) => (
+  <Dropdown {...args}>
+    <Dropdown.ItemList items={sampleMenuItems} />
+  </Dropdown>
+);
 
 export const Default = Template.bind({});
 

--- a/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.story.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { SageTokens } from '../configs';
 import { Dropdown } from './Dropdown';
-import { ToolbarEditorDropdown } from './ToolbarEditorDropdown';
-import { ToolbarDropdown } from './ToolbarDropdown';
-import { defaultOptionsItems, sampleMenuItems } from './stories/story-helper';
+import { sampleMenuItems } from './stories/story-helper';
 import { CustomItemsStoryTemplate } from './stories/CustomItemsStory';
 import { CustomPanelStoryTemplate } from './stories/CustomPanelStory';
 import { BulkActionsStoryTemplate } from './stories/BulkActionsStory';
@@ -89,27 +87,6 @@ MenuWithArrow.decorators = [
     <div style={{ minHeight: 450 }}>
       { Story() }
     </div>
-  )
-];
-
-export const RichTextEditorIconOnly = (args) => (
-  <ToolbarEditorDropdown
-    triggerClassnames="sage-btn--rich-text"
-    triggerButtonSubtle={false}
-    options={defaultOptionsItems}
-    isPinned={args.isPinned}
-  />
-);
-RichTextEditorIconOnly.args = {
-  isPinned: false
-};
-RichTextEditorIconOnly.decorators = [
-  (Story) => (
-    <>
-      <div style={{ minHeight: 300 }}>
-        { Story() }
-      </div>
-    </>
   )
 ];
 

--- a/packages/sage-react/lib/Dropdown/OptionsDropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/OptionsDropdown.story.jsx
@@ -33,9 +33,6 @@ export default {
     panelMaxWidth: null,
     panelSize: Dropdown.PANEL_SIZES.DEFAULT,
     triggerButtonSubtle: false,
-    children: (
-      <Dropdown.ItemList items={sampleMenuItems} />
-    ),
     exitPanelHandler: (data) => {
       if (data.handler) {
         data.handler();
@@ -44,7 +41,11 @@ export default {
   }
 };
 
-const Template = (args) => <OptionsDropdown options={defaultOptionsItems} {...args} />;
+const Template = (args) => (
+  <OptionsDropdown options={defaultOptionsItems} {...args}>
+    <Dropdown.ItemList items={sampleMenuItems} />
+  </OptionsDropdown>
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/packages/sage-react/lib/Dropdown/ToolbarDropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/ToolbarDropdown.story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Dropdown } from './Dropdown';
 import { ToolbarDropdown } from './ToolbarDropdown';
+import { ToolbarEditorDropdown } from './ToolbarEditorDropdown';
 import { defaultOptionsItems, sampleMenuItems } from './stories/story-helper';
 
 export default {
@@ -63,6 +64,27 @@ RichTextEditor.args = {
   isPinned: false
 };
 RichTextEditor.decorators = [
+  (Story) => (
+    <>
+      <div style={{ minHeight: 300 }}>
+        { Story() }
+      </div>
+    </>
+  )
+];
+
+export const RichTextEditorIconOnly = (args) => (
+  <ToolbarEditorDropdown
+    triggerClassnames="sage-btn--rich-text"
+    triggerButtonSubtle={false}
+    options={defaultOptionsItems}
+    isPinned={args.isPinned}
+  />
+);
+RichTextEditorIconOnly.args = {
+  isPinned: false
+};
+RichTextEditorIconOnly.decorators = [
   (Story) => (
     <>
       <div style={{ minHeight: 300 }}>

--- a/packages/sage-react/lib/Dropdown/ToolbarDropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/ToolbarDropdown.story.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { Dropdown } from './Dropdown';
+import { ToolbarDropdown } from './ToolbarDropdown';
+import { defaultOptionsItems, sampleMenuItems } from './stories/story-helper';
+
+export default {
+  title: 'Sage/Dropdown/ToolbarDropdown',
+  component: ToolbarDropdown,
+  // displays description on Docs tab
+  parameters: {
+    docs: {
+      description: {
+        component: 'Sage dropdown.'
+      },
+    },
+  },
+  decorators: [(Story) => <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{ Story() }</div>],
+  subcomponents: {
+    'Dropdown.ItemList': Dropdown.ItemList,
+    Dropdown
+  },
+  argTypes: {
+    ...selectArgs({
+      align: Dropdown.POSITIONS,
+      panelSize: Dropdown.PANEL_SIZES
+    }),
+  },
+  args: {
+    align: Dropdown.POSITIONS.DEFAULT,
+    className: null,
+    isPinned: false,
+    panelMaxWidth: null,
+    panelSize: Dropdown.PANEL_SIZES.DEFAULT,
+    triggerButtonSubtle: false,
+    children: (
+      <Dropdown.ItemList items={sampleMenuItems} />
+    ),
+    exitPanelHandler: (data) => {
+      if (data.handler) {
+        data.handler();
+      }
+    }
+  }
+};
+
+const Template = (args) => <ToolbarDropdown options={defaultOptionsItems} {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  isPinned: false
+};
+
+export const RichTextEditor = (args) => (
+  <ToolbarDropdown
+    options={defaultOptionsItems}
+    isPinned={args.isPinned}
+    triggerClassnames="sage-btn--rich-text"
+    triggerButtonSubtle={false}
+  />
+);
+RichTextEditor.args = {
+  isPinned: false
+};
+RichTextEditor.decorators = [
+  (Story) => (
+    <>
+      <div style={{ minHeight: 300 }}>
+        { Story() }
+      </div>
+    </>
+  )
+];

--- a/packages/sage-react/lib/Dropdown/ToolbarDropdown.story.jsx
+++ b/packages/sage-react/lib/Dropdown/ToolbarDropdown.story.jsx
@@ -34,9 +34,6 @@ export default {
     panelMaxWidth: null,
     panelSize: Dropdown.PANEL_SIZES.DEFAULT,
     triggerButtonSubtle: false,
-    children: (
-      <Dropdown.ItemList items={sampleMenuItems} />
-    ),
     exitPanelHandler: (data) => {
       if (data.handler) {
         data.handler();
@@ -45,7 +42,11 @@ export default {
   }
 };
 
-const Template = (args) => <ToolbarDropdown options={defaultOptionsItems} {...args} />;
+const Template = (args) => (
+  <ToolbarDropdown options={defaultOptionsItems} {...args}>
+    <Dropdown.ItemList items={sampleMenuItems} />
+  </ToolbarDropdown>
+);
 
 export const Default = Template.bind({});
 Default.args = {


### PR DESCRIPTION
## Description
1. Create story for ToolbarDropdown and move Rich Text Editor examples into new story
2. Clean up story references to `Dropdown.ItemList` to fix controls parsing issue

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1252" alt="CleanShot 2022-12-12 at 11 38 23@2x" src="https://user-images.githubusercontent.com/791670/207102040-c5c6f50a-471a-4b68-9ed2-ba6f7960afcc.png">|<img width="1272" alt="CleanShot 2022-12-12 at 11 38 04@2x" src="https://user-images.githubusercontent.com/791670/207102165-865fb2f0-26d7-4f49-bb5a-8d23c339f930.png">
<img width="1251" alt="CleanShot 2022-12-12 at 11 38 28@2x" src="https://user-images.githubusercontent.com/791670/207102147-16f588cb-e997-467c-a6b6-8dac19c82840.png">|<img width="1268" alt="CleanShot 2022-12-12 at 11 38 09@2x" src="https://user-images.githubusercontent.com/791670/207102099-2516368d-5035-43f9-8b50-d6e588224d17.png">
<img width="1158" alt="CleanShot 2022-12-12 at 11 36 33@2x" src="https://user-images.githubusercontent.com/791670/207101680-abdf99df-f7b1-4995-a952-9de14a5cfcae.png">|<img width="1025" alt="CleanShot 2022-12-12 at 11 36 06@2x" src="https://user-images.githubusercontent.com/791670/207101690-2a49abc6-fcf7-4794-ac63-e59b1e1d6f3a.png">


## Testing in `sage-lib`
### Rich Text Editor Story Updates
1. Open new Toolbar Story: http://localhost:4100/?path=/story/sage-dropdown-toolbardropdown--default
2. Confirm new controls for toolbar stories
3. Confirm correct functionality for toolbar stories

### Storybook Controls Fix
1. Navigate to Dropdown Story: http://localhost:4100/?path=/story/sage-dropdown--default
2. Confirm story controls don't blow out (as shown in final row of Screenshots table)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Move stories for Rich Text Editor to fix storybook examples
2. (**LOW**) Update how `Dropdown`, `ToolbarDropdown`, `ToolbarEditorDropdown`, and `OptionsDropdown` components reference `Dropdown.ItemList`