### PR TITLE
[DSS-250]: InputGroup Button Breaks Out When Error

### DIFF
--- a/docs/app/views/examples/components/input_group/_preview.html.erb
+++ b/docs/app/views/examples/components/input_group/_preview.html.erb
@@ -60,6 +60,38 @@
     } %>
   <% end %>
 
+
+  <%= sage_component SageInputGroup, {
+    group_id: "input-group-save-example2",
+    disabled: false,
+    has_button: true,
+    group_buttons: [{
+      icon: "",
+      text: "Save",
+      tooltip: true,
+      tooltip_position: "top",
+      tooltip_size: "",
+      tooltip_text: "Save",
+    }],
+    input_type: "text",
+    spacer: { top: :md }
+  } do %>
+    <%= sage_component SageFormInput, {
+      id: "input-group-save-field2",
+      max: "100",
+      min: "0",
+      input_type: "number",
+      input_mode: "numeric",
+      label_text: "Percentage",
+      placeholder: "Percentage",
+      required: false,
+      disabled: false,
+      has_error: true,
+      message_text: "this is an error message",
+      has_placeholder: false
+    } %>
+  <% end %>
+
   <h3 class="t-sage-heading-6">Input group with password reveal toggle and helper</h3>
 
   <%= sage_component SageInputGroup, {

--- a/packages/sage-assets/lib/stylesheets/components/_input_group.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_input_group.scss
@@ -84,3 +84,9 @@ $-input-group-pw-field-button-color-text-hover: sage-color(black);
     background-color: sage-color(grey, 200);
   }
 }
+
+.sage-input-group .sage-form-field--error {
+  + .sage-btn {
+    bottom: rem(29px);
+  }
+}


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
When an inputGroup component contains a button, the button position is incorrect when the input is in the error state. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2022-12-20 at 12 40 42 PM](https://user-images.githubusercontent.com/1175111/208768541-12ceaffc-33b6-4818-a65a-f15778c5c8b2.png)|![Screenshot 2022-12-20 at 12 41 14 PM](https://user-images.githubusercontent.com/1175111/208768573-dd770d03-3ff7-4112-859e-067c5026d968.png)|


|  KP Usage Example  |
|--------|
|![Screenshot 2022-12-20 at 1 22 05 PM](https://user-images.githubusercontent.com/1175111/208769438-f8a5fd8f-787c-4608-aa2d-432eb08e4aaf.png)|

## Testing in `sage-lib`
Navigate to [Input Group](http://localhost:4000/pages/component/input_group?tab=preview)
Verify button displays in the correct location in the error state preview


## Testing in `kajabi-products`
1. (**LOW**) Adjusting positioning of inputGroup button when input in error state.
   - [ ] Website &rarr; Pages &rarr; Page &rarr; Edit Details. 
   
## Related
https://kajabi.atlassian.net/browse/DSS-250