### PR TITLE
[DSS-252] - Checkbox - Firefox vertical alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -172,7 +172,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
     @include sage-icon-base(check, sm);
 
     $-checkbox-scale: 14 / 16;
-    transform: translate3d(-50%, -50%, 0) scale3d(#{$-checkbox-scale}, #{$-checkbox-scale}, #{$-checkbox-scale});
+    transform: translate3d(calc(-50% - 0.5px), calc(-50% - 0.5px), 0) scale3d(#{$-checkbox-scale}, #{$-checkbox-scale}, #{$-checkbox-scale});
     color: sage-color(white);
     font-weight: sage-font-weight(bold);
     opacity: 0;


### PR DESCRIPTION
## Description
On 1x displays the check in our checkboxes was sitting a little too low and a bit to the right. Moving them back half a pixel fixes the rounding issue on 1x displays without breaking anything in higher resolution environments. 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
Firefox
| DPR |  Before  |  After  |
|--|--------|--------|
| 1x |<img width="100" alt="CleanShot 2023-01-10 at 13 13 17@2x" src="https://user-images.githubusercontent.com/791670/211629982-612cd9a7-7b03-49f9-82ca-bebe42b60240.png">|![CleanShot 2023-01-10 at 13 06 41](https://user-images.githubusercontent.com/791670/211628968-65f522b2-4e32-4101-ba96-e33b7a8fc843.png)
| 2x(ish) |  <img width="111" alt="CleanShot 2023-01-10 at 13 06 11@2x" src="https://user-images.githubusercontent.com/791670/211629165-90971b49-457c-429b-9300-79771ef3350b.png">|<img width="101" alt="CleanShot 2023-01-10 at 13 06 50@2x" src="https://user-images.githubusercontent.com/791670/211629230-0b3807f0-dc47-4b5e-b0d3-efaf9d89060e.png">

Chrome
| DPR |  Before  |  After  |
|--|--------|--------|
| 1x | ![CleanShot 2023-01-10 at 13 10 56](https://user-images.githubusercontent.com/791670/211629484-274491ee-848b-4667-8f70-f96feca949c2.png)|![CleanShot 2023-01-10 at 13 12 18](https://user-images.githubusercontent.com/791670/211629753-a78c7064-406b-4ec4-a642-2d1f97e0b74e.png)
| 2x(ish)|<img width="110" alt="CleanShot 2023-01-10 at 13 11 32@2x" src="https://user-images.githubusercontent.com/791670/211629568-11410b5a-565d-4cc6-a22e-1a238b7b5d57.png">|<img width="115" alt="CleanShot 2023-01-10 at 13 12 01@2x" src="https://user-images.githubusercontent.com/791670/211629687-5fc3a67b-97c9-4697-9485-30b652c08485.png">


## Testing in `sage-lib`
1. Navigate to [Checkbox component](http://localhost:4000/pages/component/checkbox?tab=preview)
2. Confirm checkbox check displays in center of box

**Note:** Be sure to confirm multiple browsers


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update CSS for checkbox check to move it half a pixel up and to the left. This should only change subpixel rendering issues with the checkbox on certain displays to properly set check into center of checkbox.

## Related
[[DSS-252] Checkbox - Firefox vertical alignment](https://kajabi.atlassian.net/browse/DSS-252)

[DSS-252]: https://kajabi.atlassian.net/browse/DSS-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ