### PR TITLE
fix(dropdown): calculate the position of the dropdown panel

### DIFF
--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -167,8 +167,63 @@ Sage.dropdown = (function () {
     }
   }
 
+  function getHeight(el) {
+    const styles = window.getComputedStyle(el);
+    const height = el.offsetHeight;
+    const borderTopWidth = parseFloat(styles.borderTopWidth);
+    const borderBottomWidth = parseFloat(styles.borderBottomWidth);
+    const paddingTop = parseFloat(styles.paddingTop);
+    const paddingBottom = parseFloat(styles.paddingBottom);
+
+    return height - borderBottomWidth - borderTopWidth - paddingTop - paddingBottom;
+  }
+
+  function positionElement(el) {
+    let direction = null;
+
+    // Elements
+    const panel = el.lastElementChild
+    const win = panel.ownerDocument.defaultView;
+    const button = document.activeElement;
+    const docEl = window.document.documentElement;
+
+    panel.style.top = ''; // resets the style
+
+    // Dimensions
+    const buttonDimensions = button.getBoundingClientRect();
+    const panelDimensions = panel.getBoundingClientRect();
+
+    const panelNewLoc = {
+      top: buttonDimensions.height + panelDimensions.height
+    }
+
+    const viewport = {
+      top: docEl.scrollTop,
+      bottom: window.pageYOffset + docEl.clientHeight,
+    }
+
+    const offset = {
+      top: panelDimensions.top + win.pageYOffset,
+      left: panelDimensions.left + win.pageXOffset,
+      bottom: (panelDimensions.top + win.pageYOffset)
+    };
+
+    const enoughSpaceAbove = viewport.top < ( offset.top + getHeight(panel));
+    const enoughSpaceBelow = viewport.bottom > (offset.bottom + getHeight(panel));
+
+    if (!enoughSpaceBelow && enoughSpaceAbove) {
+      direction = 'above';
+    } else if (!enoughSpaceAbove && enoughSpaceBelow) {
+      direction = 'below';
+    }
+
+    if ( direction == 'above') {
+      panel.style.top = `-${panelNewLoc.top}px`;
+    }
+  }
   function open(el) {
     el.setAttribute("aria-expanded", "true");
+    positionElement(el);
     let focusableEls = el.querySelectorAll(SELECTOR_FOCUSABLE_ELEMENTS);
     SELECTOR_LAST_FOCUSED = document.activeElement;
     el.addEventListener("keydown", focusTrap.bind(focusableEls));


### PR DESCRIPTION
## JIRA
https://kajabi.atlassian.net/browse/DSS-60


## Description
The initial problem was when a dropdown would be invoked and render outside the viewport. This PR addresses that issue, by determining the available viewport space and renders accordingly.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
![image](https://user-images.githubusercontent.com/1633290/211913302-da0d73ec-a4e4-4b62-8f81-1076a1dd0a72.png)|![image](https://user-images.githubusercontent.com/1633290/211913611-2233befc-5f61-4a26-99c8-1e187dce5047.png)|

Loom: [here](https://www.loom.com/share/55ff74d24f134ac59d51f334cb53d146)

## Testing in `kajabi-products`
1. Turn the bridge on for Sage Lib to KP
2. Navigate to a few locations that use dropdown (a few examples below)
  - Products Index
  - Websites
3. Confirm behavior shown in loom video.


