### PR TITLE
[DSS-268] Tooltip TypeError

### DIFF
--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -50,7 +50,7 @@ Sage.tooltip = (function() {
 
   // Removes tooltip from DOM
   function removeTooltip(evt) {
-    if (!evt.target.hasAttribute(DATA_ATTR) || !document.querySelector(SELECTOR)) return;
+    if (!evt.target.hasAttribute(DATA_ATTR) || !document.querySelector(SELECTOR) || evt.target.dataset.jsTooltip === "")  return;
 
     window.requestAnimationFrame(function() {
       document.body.removeChild(document.querySelector(`.${TOOLTIP_CLASS}`));

--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -50,7 +50,7 @@ Sage.tooltip = (function() {
 
   // Removes tooltip from DOM
   function removeTooltip(evt) {
-    if (!evt.target.hasAttribute(DATA_ATTR) || !document.querySelector(SELECTOR) || evt.target.dataset.jsTooltip === "")  return;
+    if (!evt.target.hasAttribute(DATA_ATTR) || !document.querySelector(SELECTOR) || !evt.target.dataset.jsTooltip)  return;
 
     window.requestAnimationFrame(function() {
       document.body.removeChild(document.querySelector(`.${TOOLTIP_CLASS}`));


### PR DESCRIPTION
## Description
Tooltips (RAILS) throw a JS error on `mouseout` when the `data-js-tooltip` attribute contains no text.

These errors are showing up extensively in KP and are being reported through Sentry.

`Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'.`



## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![2023-01-12 11 12 02](https://user-images.githubusercontent.com/1175111/212161115-4a3309c0-7167-4537-98eb-71b192926c1a.gif)|![2023-01-12 11 12 50](https://user-images.githubusercontent.com/1175111/212161163-ebc1819b-5cfc-41f1-92de-831c73ee605d.gif)|


## Testing in `sage-lib`
- Navigate to [Tooltips](http://localhost:4000/pages/component/tooltip?tab=preview)
- Open & modify the tooltip preview file (`docs/app/views/examples/components/tooltip/_preview.html.erb`) and set the text to an empty string.
- Test the modified tooltip and verify the JS error no longer shows in the dev console.



## Testing in `kajabi-products`

1. (**LOW**) Tooltip adjustment to address JS error when data attribute is empty.


## Related
https://kajabi.atlassian.net/browse/DSS-268
