### PR TITLE
[DSS-269] Deprecate slash operator use

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -42,7 +42,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
   }
 
   .sage-list & {
-    margin-bottom: sage-spacing(card) / 2;
+    margin-bottom: calc(#{sage-spacing(card)} / 2);
   }
 
   @include sage-form-toggle-parents;
@@ -171,7 +171,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
   &::after {
     @include sage-icon-base(check, sm);
 
-    $-checkbox-scale: 14 / 16;
+    $-checkbox-scale: calc(14 / 16);
     transform: translate3d(calc(-50% - 0.5px), calc(-50% - 0.5px), 0) scale3d(#{$-checkbox-scale}, #{$-checkbox-scale}, #{$-checkbox-scale});
     color: sage-color(white);
     font-weight: sage-font-weight(bold);

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -91,7 +91,7 @@ $-modal-inner-size: sage-container(md);
     @media (max-width: sage-breakpoint(sm-max)) {
       max-width: var(--sage-drawer-size);
     }
-    
+
     @media (max-width: sage-breakpoint(md-min)) {
       max-width: var(--sage-drawer-mobile-size);
     }
@@ -265,8 +265,8 @@ $-modal-inner-size: sage-container(md);
     overflow-y: auto;
     align-content: start;
     height: calc(100% - var(--sage-drawer-header-height, 24px) - #{3 * sage-spacing(md)}); // a customizable height value for the header area minus top and bottom padding and one gap between header and content (sage-spacing(md))
-    padding: 0 (sage-spacing(card) / 2);
-    margin: 0 (sage-spacing(card) / 2);
+    padding: 0 calc(#{sage-spacing(card)} / 2);
+    margin: 0 calc(#{sage-spacing(card)} / 2);
   }
 
   > :last-child {

--- a/packages/sage-assets/lib/stylesheets/components/_panel_figure.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_panel_figure.scss
@@ -53,7 +53,7 @@ $-panel-figure-default-background-color: sage-color(grey, 200);
 
   &.sage-panel__figure--aspect-ratio {
     img {
-      top: calc(50% + #{$-panel-figure-padding / 2});
+      top: calc(50% + (#{$-panel-figure-padding} / 2));
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -40,9 +40,9 @@ $-radio-focus-outline-color: currentColor;
   position: relative;
   column-gap: $-radio-gap-spacing;
   grid-template-columns: min-content 1fr;
-  
+
   .sage-list & {
-    margin-bottom: sage-spacing(card) / 2;
+    margin-bottom: calc(#{sage-spacing(card)} / 2);
   }
 
   @include sage-form-toggle-parents;
@@ -53,7 +53,7 @@ $-radio-focus-outline-color: currentColor;
     "radio label"
     "radio message"
     "radio custom";
-  
+
   &.sage-radio--has-border {
     grid-template-areas:
       "radio label custom"

--- a/packages/sage-assets/lib/stylesheets/components/_sidebar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_sidebar.scss
@@ -61,7 +61,7 @@ $-sidebar-top-offset: $sage-assistant-height;
   content: "";
   display: block;
   position: absolute;
-  top: sage-spacing(sm) / -1;
+  top: calc(-1 * #{sage-spacing(sm)});
   left: 0;
   right: 0;
   height: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -34,7 +34,7 @@ $-switch-toggle-size: rem(16px);
   color: $-switch-color-default-text;
 
   & + & {
-    margin-top: -(sage-spacing(card) / 2);
+    margin-top: calc(#{sage-spacing(card)} / -2);
   }
 
   &.sage-switch--has-border {
@@ -50,7 +50,7 @@ $-switch-toggle-size: rem(16px);
 
   .sage-list & {
     margin-top: 0;
-    margin-bottom: sage-spacing(card) / 2;
+    margin-bottom: calc(#{sage-spacing(card)} / 2);
   }
 
   @include sage-form-toggle-parents {

--- a/packages/sage-assets/lib/stylesheets/core/functions/_utilities.scss
+++ b/packages/sage-assets/lib/stylesheets/core/functions/_utilities.scss
@@ -127,7 +127,7 @@ $sage-rem-base-font-size: 16 !default;
 ///
 /// Replace `$search` with `$replace` in `$string`
 ///
-/// @author Hugo Giraudel
+/// @author Kitty Giraudel
 ///
 /// @param {string} $string - Initial string
 /// @param {string} $search - Substring to replace

--- a/packages/sage-assets/lib/stylesheets/core/functions/_utilities.scss
+++ b/packages/sage-assets/lib/stylesheets/core/functions/_utilities.scss
@@ -5,6 +5,9 @@
 ////
 
 
+// Import dart-sass math functions
+@use "sass:math";
+
 ///
 /// Parse a Morse code into a prescriptive object pattern that is used to create CSS for the code value.
 ///
@@ -74,9 +77,13 @@
 /// For use in cases where a theme has modified the root font-size to something other than the browser default.
 ///
 $sage-use-rem-conversion: true !default;
+$sage-rem-base-font-size: 16 !default;
 
 ///
-/// Converts an integer to a rem value based on 16 as the base size.
+/// Converts an integer to a rem value
+///
+/// We first convert the input to a unitless number, then divide by the base font size (default of 16) to obtain
+/// the equivalent ratio of rems. The resulting calculation is multiplied by `1rem` to "attach" the unit.
 ///
 /// @param {length} $value Length value, typically a `px` or `pt` that is to be converted to `rem`
 ///
@@ -95,7 +102,7 @@ $sage-use-rem-conversion: true !default;
 ///
 @function rem($value) {
   @if ($sage-use-rem-conversion) {
-    @return strip-unit($value) / 16 * 1rem;
+    @return math.div(strip-unit($value), $sage-rem-base-font-size) * 1rem;
   }
 
   @return $value;
@@ -103,6 +110,7 @@ $sage-use-rem-conversion: true !default;
 
 ///
 /// Strips non-numeric content from values
+/// See https://css-tricks.com/snippets/sass/strip-unit-function/
 ///
 /// @param {length} $number Length from which to strip a unit
 ///
@@ -110,7 +118,7 @@ $sage-use-rem-conversion: true !default;
 ///
 @function strip-unit($number) {
   @if type-of($number) == "number" and not unitless($number) {
-    @return $number / ($number * 0 + 1);
+    @return math.div($number, ($number * 0 + 1));
   }
 
   @return $number;

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -31,13 +31,13 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   @include sage-row();
 
   .sage-modal__content & {
-    padding: 0 (sage-spacing(card) / 2);
+    padding: 0 calc(#{sage-spacing(card)} / 2);
   }
 }
 
 .sage-row--stage {
-  margin-left: sage-spacing(stage) / -2;
-  margin-right: sage-spacing(stage) / -2;
+  margin-left: calc(#{sage-spacing(stage)} / -2);
+  margin-right: calc(#{sage-spacing(stage)} / -2);
 
   &:not(:last-child) {
     margin-bottom: sage-spacing(stage);
@@ -45,8 +45,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 }
 
 .sage-row--panel {
-  margin-left: sage-spacing(panel) / -2;
-  margin-right: sage-spacing(panel) / -2;
+  margin-left: calc(#{sage-spacing(panel)} / -2);
+  margin-right: calc(#{sage-spacing(panel)} / -2);
 
   &:not(:last-child) {
     margin-bottom: sage-spacing(panel);
@@ -54,8 +54,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 }
 
 .sage-row--card {
-  margin-left: sage-spacing(card) / -2;
-  margin-right: sage-spacing(card) / -2;
+  margin-left: calc(#{sage-spacing(card)} / -2);
+  margin-right: calc(#{sage-spacing(card)} / -2);
 
   &:not(:last-child) {
     margin-bottom: sage-spacing(card);
@@ -131,15 +131,15 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
     @include sage-col();
 
     .sage-row--stage > & {
-      padding: 0 (sage-spacing(stage) / 2);
+      padding: 0 calc(#{sage-spacing(stage)} / 2);
     }
 
     .sage-row--panel > & {
-      padding: 0 (sage-spacing(stage) / 2);
+      padding: 0 calc(#{sage-spacing(stage)} / 2);
     }
 
     .sage-row--card > & {
-      padding: 0 (sage-spacing(card) / 2);
+      padding: 0 calc(#{sage-spacing(card)} / 2);
     }
 
     .sage-modal &:first-child {
@@ -154,10 +154,12 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
 @media (min-width: $-grid-breakpoint-sm) {
   @for $i from 1 through $-grid-num-columns {
+    $-grid-col-width: calc((#{$i} * 100%) / #{$-grid-num-columns});
+
     .sage-col--sm-#{$i} {
       flex: 0 1 auto;
-      width: percentage($i / $-grid-num-columns);
-      max-width: percentage($i / $-grid-num-columns);
+      width: $-grid-col-width;
+      max-width: $-grid-col-width;
     }
   }
 }
@@ -171,16 +173,18 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
 @media (min-width: $-grid-breakpoint-md) {
   @for $i from 1 through $-grid-num-columns {
+    $-grid-col-width: calc((#{$i} * 100%) / #{$-grid-num-columns});
+
     .sage-col-#{$i} {
-      flex: 0 0 percentage($i / $-grid-num-columns);
-      width: percentage($i / $-grid-num-columns);
-      max-width: percentage($i / $-grid-num-columns);
+      flex: 0 0 $-grid-col-width;
+      width: $-grid-col-width;
+      max-width: $-grid-col-width;
     }
 
     .sage-col--md-#{$i} {
       flex: 0 0 auto;
-      width: percentage($i / $-grid-num-columns);
-      max-width: percentage($i / $-grid-num-columns);
+      width: $-grid-col-width;
+      max-width: $-grid-col-width;
     }
   }
 
@@ -198,10 +202,12 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 
 @media (min-width: $-grid-breakpoint-lg) {
   @for $i from 1 through $-grid-num-columns {
+    $-grid-col-width: calc((#{$i} * 100%) / #{$-grid-num-columns});
+
     .sage-col--lg-#{$i} {
       flex: 0 1 auto;
-      width: percentage($i / $-grid-num-columns);
-      max-width: percentage($i / $-grid-num-columns);
+      width: $-grid-col-width;
+      max-width: $-grid-col-width;
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/layout/_grid.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_grid.scss
@@ -4,9 +4,10 @@
 /// @group sage
 ////
 
-
 $-grid-gap: sage-spacing();
 $-grid-num-columns: 12;
+
+// Breakpoint assignments
 $-grid-breakpoint-sm: sage-breakpoint(sm-min);
 $-grid-breakpoint-sm-max: sage-breakpoint(sm-max);
 $-grid-breakpoint-md: sage-breakpoint(md-min);
@@ -14,6 +15,18 @@ $-grid-breakpoint-md-max: sage-breakpoint(md-max);
 $-grid-breakpoint-lg: sage-breakpoint(lg-min);
 $-grid-breakpoint-lg-max: sage-breakpoint(lg-max);
 $-grid-breakpoint-xl: sage-breakpoint(xl-min);
+
+// Row and column spacing assignments
+$-grid-row-stage-inline-margin: calc(#{sage-spacing(stage)} / -2);
+$-grid-row-stage-inline-padding: calc(#{sage-spacing(stage)} / 2);
+
+$-grid-row-panel-inline-margin: calc(#{sage-spacing(panel)} / -2);
+
+$-grid-row-card-inline-margin: calc(#{sage-spacing(card)} / -2);
+$-grid-row-card-inline-padding: calc(#{sage-spacing(card)} / 2);
+
+$-grid-col-gap-inline-margin: calc(#{$-grid-gap} / -2);
+$-grid-col-gap-inline-padding: calc(#{$-grid-gap} / 2);
 
 ///
 /// Rows
@@ -23,21 +36,21 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  margin-left: calc(#{$-grid-gap} / -2);
-  margin-right: calc(#{$-grid-gap} / -2);
+  margin-left: $-grid-col-gap-inline-margin;
+  margin-right: $-grid-col-gap-inline-margin;
 }
 
 .sage-row {
   @include sage-row();
 
   .sage-modal__content & {
-    padding: 0 calc(#{sage-spacing(card)} / 2);
+    padding: 0 $-grid-row-card-inline-padding;
   }
 }
 
 .sage-row--stage {
-  margin-left: calc(#{sage-spacing(stage)} / -2);
-  margin-right: calc(#{sage-spacing(stage)} / -2);
+  margin-left: $-grid-row-stage-inline-margin;
+  margin-right: $-grid-row-stage-inline-margin;
 
   &:not(:last-child) {
     margin-bottom: sage-spacing(stage);
@@ -45,8 +58,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 }
 
 .sage-row--panel {
-  margin-left: calc(#{sage-spacing(panel)} / -2);
-  margin-right: calc(#{sage-spacing(panel)} / -2);
+  margin-left: $-grid-row-panel-inline-margin;
+  margin-right: $-grid-row-panel-inline-margin;
 
   &:not(:last-child) {
     margin-bottom: sage-spacing(panel);
@@ -54,8 +67,8 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
 }
 
 .sage-row--card {
-  margin-left: calc(#{sage-spacing(card)} / -2);
-  margin-right: calc(#{sage-spacing(card)} / -2);
+  margin-left: $-grid-row-card-inline-margin;
+  margin-right: $-grid-row-card-inline-margin;
 
   &:not(:last-child) {
     margin-bottom: sage-spacing(card);
@@ -107,7 +120,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   flex: 0 0 100%;
   width: 100%;
   max-width: 100%;
-  padding: 0 calc(#{$-grid-gap} / 2);
+  padding: 0 $-grid-col-gap-inline-padding;
 }
 
 .sage-col {
@@ -115,7 +128,7 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   flex-basis: 0;
   width: 100%;
   max-width: 100%;
-  padding: 0 calc(#{$-grid-gap} / 2);
+  padding: 0 $-grid-col-gap-inline-padding;
 }
 
 .sage-col-auto {
@@ -130,16 +143,13 @@ $-grid-breakpoint-xl: sage-breakpoint(xl-min);
   .sage-col--xl-#{$i} {
     @include sage-col();
 
-    .sage-row--stage > & {
-      padding: 0 calc(#{sage-spacing(stage)} / 2);
-    }
-
+    .sage-row--stage > &,
     .sage-row--panel > & {
-      padding: 0 calc(#{sage-spacing(stage)} / 2);
+      padding: 0 $-grid-row-stage-inline-padding;
     }
 
     .sage-row--card > & {
-      padding: 0 calc(#{sage-spacing(card)} / 2);
+      padding: 0 $-grid-row-card-inline-padding;
     }
 
     .sage-modal &:first-child {


### PR DESCRIPTION
## Description
The standalone slash operator / for division in SCSS has been marked for removal, making it necessary to convert use in Sage as we move to DartSass. Per group discussions, we’re moving forward with `calc()` over the Sass-specific `math.div` where possible, in keeping with web standards.

> **Warning**
> Testing this branch in KP requires [these updates to the asset pipeline](https://github.com/Kajabi/kajabi-products/pull/26797) when running the bridge


### Utility functions
Utility functions have been updated to use `math.div`. `calc()` is not an option here due to the mixed interpolation when passing in unitless values.

Functions affected:
- `rem()`, used widely for `px` to `rem` conversion
- `strip-unit`: internal use only, required dependency for `rem()`

### Component updates
The following components replace the slash operator `/` with `calc()`:
- [12-col Grid](http://localhost:4000/pages/patterns/grid)
- [Checkbox](http://localhost:4000/pages/component/checkbox?tab=preview)/[Radio](http://localhost:4000/pages/component/radio?tab=preview)/[Switch](http://localhost:4000/pages/component/switch?tab=preview)
- [Modal](http://localhost:4100/?path=/story/sage-modal--wired)
- [Sidebar](http://localhost:4000/pages/component/sidebar?tab=preview)
- [Panel Figure](http://localhost:4000/pages/component/panel_figure?tab=preview)



## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
No visual changes.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
1. View the components listed above
2. Compare with https://sage.kajabi.com and confirm calculated values render as expected


## Testing in `kajabi-products`
1. (**HIGH**) Refactors value calculations in several highly used components and `rem` utility
   - [ ] Dashboard cards ("Opt-ins", "Sales", etc) and Site Settings: verify 12-column grid values render `width` and `max-width` values as expected


To fully test this with the bridge on, find a stylesheet in the asset pipeline (typically in `app/assets/stylesheets/`) that imports Sage `consumables`. At the top of the stylesheet (must be before importing `consumables`), apply one of the new, [dart-Sass only modules](https://sass-lang.com/documentation/modules). This should verify the updates in 1. the updated KP asset pipeline, and 2. the Sage updates in this branch 




## Related
- [DSS-269](https://kajabi.atlassian.net/browse/DSS-269)
- [STANDARD-368](https://github.com/Kajabi/kajabi-products/pull/26797)

[DSS-269]: https://kajabi.atlassian.net/browse/DSS-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ