### PR TITLE
[DSS-135] Alert - resolve secondary actions URL error

### DIFF
--- a/docs/app/views/examples/components/alert/_preview.html.erb
+++ b/docs/app/views/examples/components/alert/_preview.html.erb
@@ -1,13 +1,4 @@
 <%
-  sage_link = sage_component(SageLink, {
-    url: "#",
-    label: "Link",
-    launch: false,
-    help_link: false,
-    show_label: true,
-    style: "secondary",
-    remove_underline: true,
-  })
   demo_description =  "Make sure you know how these changes affect you."
   demo_primary_action = {
     value: "Primary action",
@@ -28,36 +19,66 @@ These also determine the icon that will appear by default.
   title: "A default alert",
   desc: demo_description,
   icon_name: "sage-icon-info-circle-filled",
-  primary_action: demo_primary_action,
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+  <% end %>
+<% end %>
 <%= sage_component SageAlert, {
   color: "info",
   title: "An informative alert",
   desc: demo_description,
   icon_name: "sage-icon-info-circle-filled",
-  primary_action: demo_primary_action,
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+  <% end %>
+<% end %>
 <%= sage_component SageAlert, {
   color: "success",
   title: "An informative alert",
   desc: demo_description,
   icon_name: "sage-icon-check-circle-filled",
-  primary_action: demo_primary_action,
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+  <% end %>
+<% end %>
 <%= sage_component SageAlert, {
   color: "warning",
   title: "Uh, oh! Here's a warning alert",
   desc: demo_description,
   icon_name: "sage-icon-danger-filled",
-  primary_action: demo_primary_action,
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+  <% end %>
+<% end %>
 <%= sage_component SageAlert, {
   color: "danger",
   title: "Look out! This alert means there's an error",
   desc: demo_description,
   icon_name: "sage-icon-warning-filled",
-  primary_action: demo_primary_action,
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+  <% end %>
+<% end %>
 
 <%= md("
 ### Alert actions
@@ -65,26 +86,38 @@ These also determine the icon that will appear by default.
 Alerts can include buttons and links for users to take further action.
 These include a single primary action button and one or more additional secondary actions.
 
-- The primary action implements a single hash that allows `value` and `attributes` similar to SageButton.
-- The secondary actions implements an array of hashes that each allow a `value` and a `url`.
 ", use_sage_type: true) %>
 <%= sage_component SageAlert, {
   color: "published",
   title: "Alert with all actions",
   desc: demo_description,
   icon_name: "sage-icon-check-circle-filled",
-  primary_action: demo_primary_action,
-  secondary_actions: [
-    {
-      value: "Link 1",
-      url: "#href-for-link-1"
-    },
-    {
-      value: "Link 2",
-      url: "#href-for-link-1"
-    },
-  ],
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+    <%= sage_component SageLink, {
+      url: "#href-for-link-1",
+      label: "Link 1",
+      launch: false,
+      help_link: false,
+      show_label: true,
+      style: "secondary",
+      remove_underline: true,
+    } %>
+    <%= sage_component SageLink, {
+      url: "#href-for-link-1",
+      label: "Link 2",
+      launch: false,
+      help_link: false,
+      show_label: true,
+      style: "secondary",
+      remove_underline: true,
+    } %>
+  <% end %>
+<% end %>
 
 
 <%= md("
@@ -102,14 +135,20 @@ You can listen for this event as it bubbles and respond as you see fit.
   desc: demo_description,
   dismissable: true,
   icon_name: "sage-icon-info-circle-filled",
-  primary_action: demo_primary_action,
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageButton, {
+      style: "primary",
+      value: "Primary action",
+    } %>
+  <% end %>
+<% end %>
 
 <%= md("
 ### Small Alerts
 
 The `small` variant of Alert can be used for smaller spaces or a more minimal presence.
-They support all other properties with the exception of `primary_action`; only `secondary_actions` are allowed.
+They support all other properties with the exception of buttons in the `sage_alerts_actions` slot; only links are allowed.
 ", use_sage_type: true) %>
 
 <%= sage_component SageAlert, {
@@ -118,17 +157,28 @@ They support all other properties with the exception of `primary_action`; only `
   small: true,
   dismissable: true,
   icon_name: "sage-icon-info-circle-filled",
-  secondary_actions: [
-    {
-      value: "Link 1",
-      url: "#href-for-link-1"
-    },
-    {
-      value: "Link 2",
-      url: "#href-for-link-1"
-    },
-  ],
-} %>
+} do %>
+  <% content_for :sage_alert_actions do %>
+    <%= sage_component SageLink, {
+      url: "#href-for-link-1",
+      label: "Link 1",
+      launch: false,
+      help_link: false,
+      show_label: true,
+      style: "secondary",
+      remove_underline: true,
+    } %>
+    <%= sage_component SageLink, {
+      url: "#href-for-link-1",
+      label: "Link 2",
+      launch: false,
+      help_link: false,
+      show_label: true,
+      style: "secondary",
+      remove_underline: true,
+    } %>
+  <% end %>
+<% end %>
 
 
 <script>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] update Rails demos to use `sage_alert_actions` in favor of `primary_actions` and `secondary_actions`

## Screenshots
![Screen Shot 2023-01-19 at 7 18 35 PM](https://user-images.githubusercontent.com/1241836/213597857-1dc92c79-3c2f-451c-b554-2b391818d309.png)



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the Rails Alert page and verify that there is no visual change:
- Local: http://localhost:4000/pages/component/alert?tab=preview
- Live: https://sage.kajabi.com/pages/component/alert?tab=preview

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) `Alert` documentation-only update


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [DSS-135](https://kajabi.atlassian.net/browse/DSS-135)

[DSS-135]: https://kajabi.atlassian.net/browse/DSS-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ