### PR TITLE
[DSS-313] Tooltip - Allow handlers to pass to Tooltip Element

### DIFF
--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -10,6 +10,10 @@ import {
 
 export const Tooltip = ({
   children,
+  content,
+  position,
+  size,
+  theme,
   ...rest
 }) => {
   const [active, setActive] = useState(false);
@@ -31,9 +35,16 @@ export const Tooltip = ({
         onFocus: handleActivate,
         onMouseLeave: handleDeactivate,
         onBlur: handleDeactivate,
+        ...rest,
       }))}
       {active && ReactDOM.createPortal(
-        <TooltipElement parentDomRect={parentDomRect} {...rest} />,
+        <TooltipElement
+          content={content}
+          parentDomRect={parentDomRect}
+          position={position}
+          size={size}
+          theme={theme}
+        />,
         document.body
       )}
     </>
@@ -46,8 +57,15 @@ Tooltip.SIZES = TOOLTIP_SIZES;
 Tooltip.THEMES = TOOLTIP_THEMES;
 
 Tooltip.defaultProps = {
+  position: TOOLTIP_POSITIONS.DEFAULT,
+  size: TOOLTIP_SIZES.DEFAULT,
+  theme: TOOLTIP_THEMES.DEFAULT,
 };
 
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
+  content: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+  position: PropTypes.oneOf(Object.values(TOOLTIP_POSITIONS)),
+  size: PropTypes.oneOf(Object.values(TOOLTIP_SIZES)),
+  theme: PropTypes.oneOf(Object.values(TOOLTIP_THEMES)),
 };

--- a/packages/sage-react/lib/Tooltip/Tooltip.spec.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.spec.jsx
@@ -1,0 +1,29 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Button } from '../Button';
+import { Tooltip } from './Tooltip';
+
+const handleClick = jest.fn();
+
+describe('Sage Tooltip', () => {
+  it('properly handles an event when passed one', () => {
+    const defaultProps = {
+      children: (
+        <Button onClick={handleClick}>
+          Button
+        </Button>
+      ),
+      content: 'Hello world!',
+      position: Tooltip.POSITIONS.DEFAULT,
+      size: Tooltip.SIZES.DEFAULT,
+      theme: Tooltip.THEMES.DEFAULT,
+    };
+
+    render(<Tooltip {...defaultProps} />);
+    const button = screen.getByRole('button');
+    button.click();
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sage-react/lib/Tooltip/Tooltip.spec.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.spec.jsx
@@ -1,13 +1,46 @@
 require('../test/testHelper');
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Button } from '../Button';
 import { Tooltip } from './Tooltip';
 
-const handleClick = jest.fn();
-
 describe('Sage Tooltip', () => {
+  it('renders content when prop is set', () => {
+    const defaultProps = {
+      children: (
+        <Button>
+          button
+        </Button>
+      ),
+      content: 'tooltip text'
+    };
+    render(<Tooltip {...defaultProps} />);
+    const button = screen.getByRole('button');
+    fireEvent.mouseOver(button);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('tooltip text');
+  });
+
+  it('renders tooltip position properly', () => {
+    const defaultProps = {
+      children: (
+        <Button>
+          button
+        </Button>
+      ),
+      content: 'tooltip text',
+      position: Tooltip.POSITIONS.DEFAULT,
+    };
+    render(<Tooltip {...defaultProps} />);
+    const button = screen.getByRole('button');
+    fireEvent.mouseOver(button);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveClass('sage-tooltip--top');
+  });
+
+  const handleClick = jest.fn();
+
   it('properly handles an event when passed one', () => {
     const defaultProps = {
       children: (
@@ -15,10 +48,8 @@ describe('Sage Tooltip', () => {
           Button
         </Button>
       ),
-      content: 'Hello world!',
+      content: 'hello world',
       position: Tooltip.POSITIONS.DEFAULT,
-      size: Tooltip.SIZES.DEFAULT,
-      theme: Tooltip.THEMES.DEFAULT,
     };
 
     render(<Tooltip {...defaultProps} />);

--- a/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
@@ -25,7 +25,7 @@ export default {
   args: {
     children: (
       <Button>
-        I inherit Mouse &amp; Focus events 👋
+        I inherit Mouse, Focus, and other events 👋
       </Button>
     ),
     content: 'Hi, I provide more context for this element!',


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds functionality to allow handlers to be passed to the Tooltip element [per support request](https://kajabi.slack.com/archives/C01A424HY8Y/p1676489478957219) and [engineer input](https://github.com/Kajabi/sage-lib/pull/1688).

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [the Tooltip Story](packages/sage-react/lib/Tooltip/Tooltip.story.jsx)
- Add a click handler on line 27
- Navigate to [Tooltip](http://localhost:4100/?path=/docs/sage-tooltip--default)
- Check that click handler works properly

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**LOW**) Adds functionality to allow handlers to be passed to the Tooltip element per support request.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-313](https://kajabi.atlassian.net/browse/DSS-313)

[DSS-313]: https://kajabi.atlassian.net/browse/DSS-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ