### PR TITLE
[DSS-318] Textarea content prop not populating content

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_textarea.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_textarea.html.erb
@@ -6,7 +6,7 @@
   <%= component.generated_html_attributes.html_safe %>
 >
   <%# <textarea declaration needs to be on a single line. The line breaks bleeding into the <textarea> as content causing unexpected placeholder behavior %>
-  <textarea class="sage-textarea__field" id="<%= component.id %>"<%= " name=#{ component.name.present? ? component.name : component.id }" %> placeholder="<%= component.placeholder %>" <%= "disabled" if component.disabled -%>><%- component.content if component.content.present? -%></textarea>
+  <textarea class="sage-textarea__field" id="<%= component.id %>"<%= " name=#{ component.name.present? ? component.name : component.id }" %> placeholder="<%= component.placeholder %>" <%= "disabled" if component.disabled -%>><%= component.content if component.content.present? %></textarea>
   <%- if component.label_text.present? -%><label for="<%= component.id %>" class="sage-textarea__label"><%= component.label_text -%></label><% end -%>
   <% if component.message_text.present? %>
     <div class="sage-textarea__info">


### PR DESCRIPTION
## Description
Adjusts textarea to display `content` when it's passed into the Rails component.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2023-02-28 at 2 25 52 PM](https://user-images.githubusercontent.com/1175111/221997362-f293ac01-36e0-4dfd-86a7-b869afdea942.png)|![Screenshot 2023-02-28 at 2 25 30 PM](https://user-images.githubusercontent.com/1175111/221997406-e91a052a-121d-4d4d-8bc5-bcb2113d0758.png)|


## Testing in `sage-lib`

- Navigate to [Form Textarea](http://localhost:4000/pages/component/form_textarea?tab=preview)
- Verify content now displays in the last textarea.
- Update a content prop on another textarea and verify it appears as expected.



## Testing in `kajabi-products`
1. (**LOW**) Updates Textarea Component (Rails) to Display Content. No usage was found in KP so no effects are expected.



## Related
DSS-318
