### PR TITLE
[DSS-353] Panel Controls spec realignment

### DIFF
--- a/docs/app/views/examples/components/panel_controls/_preview.html.erb
+++ b/docs/app/views/examples/components/panel_controls/_preview.html.erb
@@ -120,9 +120,6 @@ actions_items = [
     <% content_for :sage_panel_controls_tabs do %>
       <%= tabs %>
     <% end %>
-    <% content_for :sage_panel_controls_tabs_dropdown do %>
-      <%= dropdown %>
-    <% end %>
     <% content_for :sage_panel_controls_toolbar do %>
       <%= search %>
     <% end %>

--- a/docs/lib/sage-frontend/stylesheets/docs/_checkbox.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_checkbox.scss
@@ -1,0 +1,19 @@
+/* ==================================================
+  ** _checkbox.scss
+
+  For Sage documentation use
+================================================== */
+
+.sage-checkbox {
+  &.sage-panel-controls__bulk-actions-checkbox {
+    .docs-panel & {
+      cursor: pointer;
+    }
+  }
+}
+
+.sage-checkbox__label {
+  .docs-panel .sage-panel-controls__bulk-actions--checked & {
+    pointer-events: none;
+  }
+}

--- a/docs/lib/sage-frontend/stylesheets/docs/index.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/index.scss
@@ -11,6 +11,7 @@
 @import "assistant";
 @import "colors";
 @import "text";
+@import "checkbox";
 @import "code";
 @import "snippet";
 @import "grid";

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -347,8 +347,7 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group &:not(:only-child) {
-    // hide duplicate borders
-    margin-left: -1px;
+    margin-left: rem(-1px); /* offset border overlap of multiple buttons */
   }
 
   .sage-panel-controls__toolbar-btn-group > &:first-child {

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -196,7 +196,6 @@ $-btn-loading-min-height: rem(36px);
 
     width: inherit;
     border-radius: inherit;
-    border-color: sage-color(grey, 400);
 
     &:hover {
       background-color: sage-color(white);
@@ -347,6 +346,11 @@ $-btn-loading-min-height: rem(36px);
     border-color: sage-color(grey, 500);
   }
 
+  .sage-panel-controls__toolbar-btn-group &:not(:only-child) {
+    // hide duplicate borders
+    margin-left: -1px;
+  }
+
   .sage-panel-controls__toolbar-btn-group > &:first-child {
     border-top-left-radius: sage-border(radius);
     border-bottom-left-radius: sage-border(radius);
@@ -374,6 +378,7 @@ $-btn-loading-min-height: rem(36px);
     margin-left: rem(-1px); /* offset border overlap of multiple buttons */
   }
 
+  .sage-panel-controls__toolbar > &:hover,
   .sage-toolbar__group > &:hover {
     z-index: sage-z-index(default, 1); /* raise button to display full border */
   }
@@ -582,9 +587,11 @@ a.sage-btn {
     border-color: sage-color(grey);
   }
 
+  &:disabled,
   &[aria-disabled="true"] {
     color: sage-color(charcoal, 100);
     background-color: sage-color(white);
+    border-color: sage-color(grey, 300);
   }
 
   &.sage-btn--subtle {

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -55,7 +55,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
     align-items: center;
     position: relative;
     z-index: sage-z-index(default);
-    padding: rem(10px) sage-spacing(sm);
+    padding: sage-spacing(xs) sage-spacing(sm);
     border: 0;
 
     .sage-panel-controls & {

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -60,11 +60,13 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
     .sage-panel-controls & {
       flex-flow: row;
+      height: auto;
     }
   }
 
   .sage-panel-controls__bulk-actions--checked & {
-    box-shadow: map-get($sage-toolbar-button-borders, default);
+    align-self: stretch;
+    border: 1px solid sage-color(grey, 500);
 
     &:first-child {
       border-top-left-radius: sage-border(radius);
@@ -78,8 +80,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
     &:hover {
       z-index: sage-z-index(default, 1);
-      box-shadow: map-get($sage-toolbar-button-borders, hover);
-      background-color: sage-color(grey, 200);
+      border-color: sage-color(charcoal, 100);
     }
 
     &:focus-within {
@@ -124,6 +125,7 @@ $-checkbox-focus-outline-color: sage-color(primary, 200);
 
   .sage-panel-controls__bulk-actions--checked & {
     display: unset;
+    padding-right: sage-spacing(sm);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -76,7 +76,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
       border-top-right-radius: sage-border(radius);
       border-bottom-right-radius: sage-border(radius);
     }
-   }
+  }
 
   .sage-panel-controls__bulk-actions--checked & {
     &:last-child {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -76,6 +76,13 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
       border-top-right-radius: sage-border(radius);
       border-bottom-right-radius: sage-border(radius);
     }
+   }
+
+  .sage-panel-controls__bulk-actions--checked & {
+    &:last-child {
+      // hide duplicate border
+      margin-left: -1px;
+    }
   }
 
   &.sage-dropdown--contained,
@@ -377,10 +384,6 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 .sage-dropdown__trigger--custom-width {
   width: var(--sage-dropdown-trigger-width, auto);
-}
-
-.sage-dropdown__trigger--select {
-  border-radius: sage-border(radius-medium);
 }
 
 .sage-btn--icon-right-caret-down::before {

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -80,8 +80,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
   .sage-panel-controls__bulk-actions--checked & {
     &:last-child {
-      // hide duplicate border
-      margin-left: -1px;
+      margin-left: rem(-1px); /* offset border overlap of multiple buttons */
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -159,6 +159,9 @@ $-search-icon: "::before";
     border-radius: inherit;
   }
 
+
+  .sage-panel-controls__toolbar &,
+  .sage-toolbar__group &,
   .sage-toolbar &,
   .sage-toolbar__group & {
     box-shadow: map-get($sage-toolbar-button-borders, default);

--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -159,12 +159,6 @@ $-search-icon: "::before";
     border-radius: inherit;
   }
 
-  .sage-panel-controls__toolbar & {
-    height: inherit;
-    padding-top: rem(10px);
-    padding-bottom: rem(10px);
-  }
-
   .sage-toolbar &,
   .sage-toolbar__group & {
     box-shadow: map-get($sage-toolbar-button-borders, default);


### PR DESCRIPTION
## Description
DSS-353

Addresses mismatched heights and borders in Panel Controls. Because this component has been deprecated, some styles were adapted from the Toolbar component.

Note that some hover/focus states will not be updated due to the number of sub-components and edge cases involved. A few may need adjustments on KP as well.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  |Before  |  After  |
|----|----|--------|
|Component|![panel-controls-before](https://user-images.githubusercontent.com/816579/222608967-960bf1c2-1dab-48f9-ae8e-9479f0920cf2.png)|![panel-controls-after](https://user-images.githubusercontent.com/816579/222608999-23e371c0-da8b-4fc0-ae4c-ba97c68d3820.png)|
|People list|![contacts-before](https://user-images.githubusercontent.com/816579/222609782-172f1aaa-e590-4cd3-86e9-6cd3356c936f.gif)|![contacts-after](https://user-images.githubusercontent.com/816579/222609821-63a2128a-653a-42a4-b03c-b54cfee61673.gif)|


## Testing in `sage-lib`
1. Navigate to the Panel Controls preview in [Rails](http://localhost:4000/pages/component/panel_controls?tab=preview) and [React](http://localhost:4100/?path=/docs/sage-panelcontrols--default)
2. Verify that heights of Panel Controls child components match


## Testing in `kajabi-products`
1. (**MED**) https://github.com/Kajabi/sage-lib/pull/1700 Style updates in Panel Controls: affects Button and Form Input heights and borders. Cosmetic changes only, no impact on functionality expected.
   - [ ] Contacts list (Contacts -> All Contacts)
   - [ ] Affilate Users (Sales -> Affiliates -> Users)


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
- DSS-300
