### PR TITLE
[DSS-356] - Fix dropdown logic for safari

### DIFF
--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -182,9 +182,9 @@ Sage.dropdown = (function () {
     let direction = null;
 
     // Elements
+    const button = el;
     const panel = el.lastElementChild
     const win = panel.ownerDocument.defaultView;
-    const button = document.activeElement;
     const docEl = window.document.documentElement;
 
     panel.style.top = ''; // resets the style

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -194,7 +194,7 @@ Sage.dropdown = (function () {
     const panelDimensions = panel.getBoundingClientRect();
 
     const panelNewLoc = {
-      top: buttonDimensions.height + panelDimensions.height
+      top: ( buttonDimensions.height / 2 ) + panelDimensions.height
     }
 
     const viewport = {
@@ -219,7 +219,7 @@ Sage.dropdown = (function () {
     }
 
     if ( direction == 'above') {
-      panel.style.top = `-${panelNewLoc.top - 30}px`;
+      panel.style.top = `-${panelNewLoc.top}px`;
     }
   }
   function open(el) {

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -208,8 +208,9 @@ Sage.dropdown = (function () {
       bottom: (panelDimensions.top + win.pageYOffset)
     };
 
-    const enoughSpaceAbove = viewport.top < ( offset.top + getHeight(panel));
-    const enoughSpaceBelow = viewport.bottom > (offset.bottom + getHeight(panel));
+    const panelHeight = getHeight(panel);
+    const enoughSpaceAbove = viewport.top < ( offset.top + panelHeight);
+    const enoughSpaceBelow = viewport.bottom > (offset.bottom + panelHeight);
 
     if (!enoughSpaceBelow && enoughSpaceAbove) {
       direction = 'above';
@@ -218,7 +219,7 @@ Sage.dropdown = (function () {
     }
 
     if ( direction == 'above') {
-      panel.style.top = `-${panelNewLoc.top}px`;
+      panel.style.top = `-${panelNewLoc.top - 30}px`;
     }
   }
   function open(el) {


### PR DESCRIPTION


## Description
It was discovered that the `sage-dropdown` was broken when using Safari. 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|https://www.loom.com/share/6c862d9f2fe942f787eab8ad3a5fe075|https://www.loom.com/share/e17f6684dcac41809c5317d694c4fb98|

** NOTE:
updated After loom video with the changes made in the [commit](https://github.com/Kajabi/sage-lib/pull/1701/commits/5565cc69e0d416e1838ab7b7f00219e1a562c6a0), which addresses @monkeypox8 concern.

## Testing in `sage-lib`
1. Start up the library by running `yarn start`
2. Open up Safari 
3. Go to the doc site by navigating to `localhost:4000`
4. Navigate to `Components -> Dropdown` or click [here](http://localhost:4000/pages/component/dropdown?tab=preview)
5. Scroll down to get a button to be at the bottom of the viewport. 
6. Click the button, dropdown should show the panel above the trigger. 


## Testing in `kajabi-products`
1. Navigate to a page e.g Products. 
2. Have enough products on the page so that a dropdown would be forced to render above the trigger. 


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
