### PR TITLE
[DSS-352]: Replace Help link focus state legacy styles

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -8,6 +8,7 @@ $-link-color: sage-color(primary, 300);
 $-link-color-hover: sage-color(primary, 400);
 $-link-subtext-color: sage-color(charcoal, 200);
 $-link-subtext-color-hover: sage-color(charcoal, 400);
+$-link-help-icon-only-size: rem(20px);
 
 $-link-base-styles: (
   primary:(
@@ -198,8 +199,14 @@ $-link-base-styles: (
 }
 
 .sage-link--help-icon-only {
-  @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: 2px);
-  @include sage-focus-outline--update-color($-link-color);
+  @include sage-focus-outline(
+    $outline-offset-inline: 4px,
+    $outline-offset-block: 4px,
+    $outline-border-radius: sage-border(radius-round),
+  );
+  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  width: $-link-help-icon-only-size;
+  height: $-link-help-icon-only-size;
 }
 
 .sage-link--remove-underline {

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -8,7 +8,6 @@ $-link-color: sage-color(primary, 300);
 $-link-color-hover: sage-color(primary, 400);
 $-link-subtext-color: sage-color(charcoal, 200);
 $-link-subtext-color-hover: sage-color(charcoal, 400);
-$-link-help-icon-only-size: rem(20px);
 
 $-link-base-styles: (
   primary:(
@@ -199,14 +198,15 @@ $-link-base-styles: (
 }
 
 .sage-link--help-icon-only {
+  display: inline-flex;
+  align-items: center;
+  margin-left: sage-spacing(2xs);
   @include sage-focus-outline(
     $outline-offset-inline: 4px,
     $outline-offset-block: 4px,
     $outline-border-radius: sage-border(radius-round),
   );
   @include sage-focus-outline--update-color(sage-color(primary, 200));
-  width: $-link-help-icon-only-size;
-  height: $-link-help-icon-only-size;
 }
 
 .sage-link--remove-underline {


### PR DESCRIPTION
## Description
Updates legacy focus-related styles applied to help icon link.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
||  Before  |  After  |
|--------|--------|--------|
|Docs|![Screenshot 2023-03-06 at 10 09 59 AM](https://user-images.githubusercontent.com/1175111/223194771-b4267dad-1915-41d8-990a-a56e0954fa2e.png)|![Screenshot 2023-03-06 at 10 10 12 AM](https://user-images.githubusercontent.com/1175111/223194824-013bf0db-f3b7-4b91-b96d-80e41a0a2a47.png)|
|KP|![Screenshot 2023-03-06 at 9 31 23 AM](https://user-images.githubusercontent.com/1175111/223195020-8195fe89-8478-40fd-8878-6ee5fa50efbd.png)|![Screenshot 2023-03-06 at 9 30 45 AM](https://user-images.githubusercontent.com/1175111/223194896-b9795484-5ee5-45a1-abfa-1f527b20681e.png)|


## Testing in `sage-lib`

- Navigate to Page Heading
- Apply focus to help link in the "Page Heading with Help Link" section.
- Verify styling is updated and correct.


## Testing in `kajabi-products`
1. (**LOW**) Updates focus styling on help icon links. Styling only updates.
   - [ ] Products > All Products
   - [ ] Coupon > Edit Coupon


## Related
DSS-352
