### PR TITLE
[DSS-281]: React Accordion icon misalignment 

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_loader.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_loader.scss
@@ -4,7 +4,6 @@
 /// @group sage
 ////
 
-
 $-loader-bar-bg-color: sage-color(grey, 500);
 $-loader-bar-height: rem(6px);
 $-loader-bar-speed: 1.2s;
@@ -15,13 +14,12 @@ $-loader-spinner-speed: 2s;
 $-loader-spinner-path-speed: 1.5s;
 
 .sage-loader {
-  position: relative;
-
   &:not(.visually-hidden) {
     display: flex;
     align-items: center;
     justify-content: center;
     flex-flow: column;
+    position: relative;
   }
 
   // visibility of the loader is toggled by setting data attribute "data-loading" to "true".
@@ -76,7 +74,8 @@ $-loader-spinner-path-speed: 1.5s;
 
   &::after {
     background-color: sage-color(primary, 300);
-    animation: loader-bar $-loader-bar-speed $-loader-bar-speed-delay linear infinite;
+    animation: loader-bar $-loader-bar-speed $-loader-bar-speed-delay linear
+      infinite;
   }
 }
 
@@ -93,7 +92,7 @@ $-loader-spinner-path-speed: 1.5s;
 }
 
 .sage-loader__spinner-path {
-  stroke-dasharray: 150,200;
+  stroke-dasharray: 150, 200;
   stroke-dashoffset: -10;
   stroke-linecap: round;
   stroke: sage-color(primary, 300);
@@ -110,7 +109,7 @@ $-loader-spinner-path-speed: 1.5s;
 }
 
 .sage-loader__success-path {
-  stroke-dasharray: 150,200;
+  stroke-dasharray: 150, 200;
   stroke-linecap: round;
   stroke: sage-color(sage, 300);
 }
@@ -153,15 +152,15 @@ $-loader-spinner-path-speed: 1.5s;
 
 @keyframes dash {
   0% {
-    stroke-dasharray: 1,200;
+    stroke-dasharray: 1, 200;
     stroke-dashoffset: 0;
   }
   50% {
-    stroke-dasharray: 89,200;
+    stroke-dasharray: 89, 200;
     stroke-dashoffset: -35;
   }
   100% {
-    stroke-dasharray: 89,200;
+    stroke-dasharray: 89, 200;
     stroke-dashoffset: -124;
   }
 }


### PR DESCRIPTION
## Description
Changes to the `.sage-loader` button broke accordions. I've rescoped our `position: relative;` on the `.sage-loader` styles to ensure any time the loader is `.visually-hidden` it defers to `position: absolute;`. 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="592" alt="CleanShot 2023-03-08 at 09 57 57@2x" src="https://user-images.githubusercontent.com/791670/223747405-986a31f9-9895-4abd-ad88-b87a90a15599.png">|<img width="581" alt="CleanShot 2023-03-08 at 09 57 08@2x" src="https://user-images.githubusercontent.com/791670/223747262-c3b0ba66-5163-4e92-8ee0-85d817935903.png">


## Testing in `sage-lib`
1. [Open Storybook and navigate to the Accordion component ](http://localhost:4100/?path=/story/sage-accordion--single-panel)
2. Confirm other instances of `.sage-loader` haven't regressed


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/**) Change should be scoped to only when loader is expected to be visually hidden but due to the many uses of `<Button>` there could be adverse effects
   - [ ] Examples include but are not limited to `Button`, `Banner`, `Alert`, etc...

## Related
[DSS-281: React Accordion has misaligned arrow](https://kajabi.atlassian.net/browse/DSS-281)