### PR TITLE
fix(assistant): add width to branding

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_assistant.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_assistant.scss
@@ -25,6 +25,7 @@ $-assistant-search-placeholder-transition: color 0.15s ease-in-out, opacity 0.15
 
 .sage-assistant__branding {
   height: $-assistant-branding-height;
+  width: auto;
 
   @media (max-width: sage-breakpoint(sm-max)) {
     @include visually-hidden;


### PR DESCRIPTION
## Description
Updated SageAssistant branding CSS to include `width: auto` to fix skewing branding issue


## Screenshots
|  Before  |  After  |
|--------|--------|
| ![before-fix-super-admin](https://user-images.githubusercontent.com/24237393/223854868-5994ca3b-c14e-4c2e-a6cb-8d0d009875b8.png) | ![after-fix-super-admin](https://user-images.githubusercontent.com/24237393/223854919-69c2a65c-b0ca-4aad-8fcd-962898e94381.png) |
| ![before-sage-prod](https://user-images.githubusercontent.com/24237393/223854972-c3d580f8-1f70-447e-adfb-c3355e7859f5.png) | ![after-sage-local](https://user-images.githubusercontent.com/24237393/223855004-4a4bc871-b576-47f5-8089-6e45282a9159.png) |

## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/assistant?tab=preview
2. Verify the logo for the Assistant in the component view renders properly
3. Verify the logo for the Documentation site renders properly 

## Testing in `kajabi-products`
1. (**LOW**) Verify in Super Admin that the logo renders properly
