### PR TITLE
[DSS-305] Design complete: Button group update

### DIFF
--- a/docs/app/views/examples/components/button/_preview.html.erb
+++ b/docs/app/views/examples/components/button/_preview.html.erb
@@ -224,7 +224,7 @@ demo_configs = [
     external: false,
     launch: false,
     help_link: false,
-    remove_underline: false,
+    remove_underline: true,
     show_label: true,
     style: "secondary"
   } %>
@@ -243,7 +243,7 @@ demo_configs = [
     external: false,
     launch: false,
     help_link: false,
-    remove_underline: false,
+    remove_underline: true,
     show_label: true,
     style: "secondary"
   } %>

--- a/packages/sage-react/lib/Button/ButtonGroup.story.jsx
+++ b/packages/sage-react/lib/Button/ButtonGroup.story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Button } from './Button';
 import { ButtonGroup } from './ButtonGroup';
+import { Link } from '../Link'
 
 export default {
   title: 'Sage/Button Group',
@@ -34,3 +35,17 @@ export default {
 const Template = (args) => <ButtonGroup {...args} />;
 
 export const Default = Template.bind({});
+
+export const withLink = () => {
+  return (
+    <>
+      <ButtonGroup align="space-between">
+        <Link href="#" removeUnderline style="secondary">Link</Link>
+        <ButtonGroup gap="md">
+          <Button color={Button.COLORS.PRIMARY}>Foo</Button>
+          <Button color={Button.COLORS.SECONDARY}>Bar</Button>
+        </ButtonGroup>
+      </ButtonGroup>
+    </>
+  );
+};

--- a/packages/sage-react/lib/Button/ButtonGroup.story.jsx
+++ b/packages/sage-react/lib/Button/ButtonGroup.story.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { selectArgs } from '../story-support/helpers';
 import { Button } from './Button';
 import { ButtonGroup } from './ButtonGroup';
-import { Link } from '../Link'
+import { Link } from '../Link';
 
 export default {
   title: 'Sage/Button Group',
@@ -36,16 +36,12 @@ const Template = (args) => <ButtonGroup {...args} />;
 
 export const Default = Template.bind({});
 
-export const withLink = () => {
-  return (
-    <>
-      <ButtonGroup align="space-between">
-        <Link href="#" removeUnderline style="secondary">Link</Link>
-        <ButtonGroup gap="md">
-          <Button color={Button.COLORS.PRIMARY}>Foo</Button>
-          <Button color={Button.COLORS.SECONDARY}>Bar</Button>
-        </ButtonGroup>
-      </ButtonGroup>
-    </>
-  );
-};
+export const WithLink = () => (
+  <ButtonGroup align="space-between">
+    <Link href="http://example.com" removeUnderline style={Link.COLORS.SECONDARY}>Link</Link>
+    <ButtonGroup gap="md">
+      <Button color={Button.COLORS.PRIMARY}>Foo</Button>
+      <Button color={Button.COLORS.SECONDARY}>Bar</Button>
+    </ButtonGroup>
+  </ButtonGroup>
+);


### PR DESCRIPTION
## Description
Documentation update based on a request from Design audit.

- Removes underline from ButtonGroup previews (Rails).
- Adds an example of ButtonGroup with Link (Storybook/React).

## Testing in `sage-lib`

Rails/Docs:

- Navigate to [Button](http://localhost:4000/pages/component/button?tab=preview)
- Verify links in ButtonGroup section have no underline.

React/Storybook:

- Navigate to [ButtonGroup](http://localhost:4100/?path=/docs/sage-button-group--default)
- Verify an example with a link exists.


## Testing in `kajabi-products`
1. (**LOW**) Documentation updates for ButtonGroup. No effect on KP.


## Related
DSS-305
