### PR TITLE
[DSS-289] - Banner: The link text within the react component is hard-coded

### DIFF
--- a/packages/sage-react/lib/Banner/Banner.jsx
+++ b/packages/sage-react/lib/Banner/Banner.jsx
@@ -31,7 +31,12 @@ Banner.propTypes = {
   active: PropTypes.bool,
   bannerContext: PropTypes.string,
   dismissable: PropTypes.bool,
-  link: PropTypes.string,
+  link: PropTypes.shape({
+    href: PropTypes.string,
+    name: PropTypes.string,
+    rel: PropTypes.string,
+    target: PropTypes.string
+  }),
   text: PropTypes.string,
   type: PropTypes.oneOf(Object.values(BANNER_TYPES)),
 };

--- a/packages/sage-react/lib/Banner/Banner.story.jsx
+++ b/packages/sage-react/lib/Banner/Banner.story.jsx
@@ -22,7 +22,11 @@ export default {
   args: {
     active: true,
     dismissable: true,
-    link: '#',
+    link: {
+      name: 'test',
+      href: '#',
+      rel: 'no-opener'
+    },
     text: 'Alert description text',
     type: Banner.TYPES.DEFAULT,
   },

--- a/packages/sage-react/lib/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.jsx
@@ -86,7 +86,12 @@ BannerContent.propTypes = {
   className: PropTypes.string,
   dismissable: PropTypes.bool,
   id: PropTypes.string,
-  link: PropTypes.string,
+  link: PropTypes.shape({
+    href: PropTypes.string,
+    name: PropTypes.string,
+    rel: PropTypes.string,
+    target: PropTypes.string
+  }),
   text: PropTypes.string,
   type: PropTypes.oneOf(Object.values(BannerContent.TYPES)),
 };

--- a/packages/sage-react/lib/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.jsx
@@ -41,9 +41,11 @@ export const BannerContent = ({
         <Button
           className="sage-banner__link"
           subtle={true}
-          href="#"
+          href={link.href}
+          rel={link.rel}
+          target={link.target}
         >
-          banner link
+          {link.name}
         </Button>
       )}
 

--- a/packages/sage-react/lib/Banner/BannerContent.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.jsx
@@ -41,7 +41,7 @@ export const BannerContent = ({
         <Button
           className="sage-banner__link"
           subtle={true}
-          href={link.href}
+          href={link.href || '#'}
           rel={link.rel}
           target={link.target}
         >

--- a/packages/sage-react/lib/Banner/BannerContent.spec.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.spec.jsx
@@ -19,6 +19,26 @@ describe('Sage BannerContent', () => {
     expect(banner).toHaveTextContent('Banner Text');
   });
 
+  it('renders without a Link when no link prop is passed', () => {
+    render(<BannerContent />);
+
+    const bannerLink = document.querySelector('.sage-banner__link');
+    expect(bannerLink).toBeFalsy();
+  });
+
+  it('renders a Link when only one sub-prop is passed', () => {
+    const props = {
+      link: {
+        name: 'Banner Link',
+      },
+    };
+
+    render(<BannerContent {...props} />);
+
+    const bannerLink = document.querySelector('.sage-banner__link');
+    expect(bannerLink).toBeTruthy();
+  });
+
   it('renders a Link with all sub-props present', () => {
     const props = {
       link: {

--- a/packages/sage-react/lib/Banner/BannerContent.spec.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.spec.jsx
@@ -22,7 +22,7 @@ describe('Sage BannerContent', () => {
   it('renders without a Link when no link prop is passed', () => {
     render(<BannerContent />);
 
-    const bannerLink = document.querySelector('.sage-banner__link');
+    const bannerLink = document.querySelector('a.sage-banner__link');
     expect(bannerLink).toBeFalsy();
   });
 
@@ -30,12 +30,13 @@ describe('Sage BannerContent', () => {
     const props = {
       link: {
         name: 'Banner Link',
+        href: '#'
       },
     };
 
     render(<BannerContent {...props} />);
 
-    const bannerLink = document.querySelector('.sage-banner__link');
+    const bannerLink = document.querySelector('a.sage-banner__link');
     expect(bannerLink).toBeTruthy();
   });
 
@@ -51,7 +52,7 @@ describe('Sage BannerContent', () => {
 
     render(<BannerContent {...props} />);
 
-    const bannerLink = document.querySelector('.sage-banner__link');
+    const bannerLink = document.querySelector('a.sage-banner__link');
     expect(bannerLink).toBeTruthy();
     expect(bannerLink).toHaveTextContent('Banner Link');
     expect(bannerLink).toHaveAttribute('href', '#');
@@ -70,7 +71,7 @@ describe('Sage BannerContent', () => {
 
     render(<BannerContent {...props} />);
 
-    const bannerLink = document.querySelector('.sage-banner__link');
+    const bannerLink = document.querySelector('a.sage-banner__link');
     expect(bannerLink).toBeTruthy();
     expect(bannerLink).toHaveTextContent('Banner Link');
     expect(bannerLink).toHaveAttribute('href', '#');
@@ -85,7 +86,7 @@ describe('Sage BannerContent', () => {
 
     render(<BannerContent {...props} />);
 
-    const dismissButton = document.querySelector('.sage-banner__close');
+    const dismissButton = document.querySelector('button.sage-banner__close');
     expect(dismissButton).toBeTruthy();
     expect(dismissButton).toHaveTextContent('Dismiss');
   });

--- a/packages/sage-react/lib/Banner/BannerContent.spec.jsx
+++ b/packages/sage-react/lib/Banner/BannerContent.spec.jsx
@@ -12,17 +12,50 @@ describe('Sage BannerContent', () => {
 
     render(<BannerContent {...props} />);
 
-    screen.findByText('Banner Text');
+    screen.findByText('Banner test Text');
+
+    const banner = document.querySelector('.sage-banner');
+    expect(banner).toBeTruthy();
+    expect(banner).toHaveTextContent('Banner Text');
   });
 
-  it('renders a button when Link prop present', () => {
+  it('renders a Link with all sub-props present', () => {
     const props = {
-      link: 'banner link',
+      link: {
+        name: 'Banner Link',
+        href: '#',
+        target: '_blank',
+        rel: 'noopener',
+      },
     };
 
     render(<BannerContent {...props} />);
 
-    expect(screen.queryByRole('button', { class: 'sage-banner__link' }));
+    const bannerLink = document.querySelector('.sage-banner__link');
+    expect(bannerLink).toBeTruthy();
+    expect(bannerLink).toHaveTextContent('Banner Link');
+    expect(bannerLink).toHaveAttribute('href', '#');
+    expect(bannerLink).toHaveAttribute('target', '_blank');
+    expect(bannerLink).toHaveAttribute('rel', 'noopener');
+  });
+
+  it('renders a Link with all some-props present', () => {
+    const props = {
+      link: {
+        name: 'Banner Link',
+        href: '#',
+        target: '_blank',
+      },
+    };
+
+    render(<BannerContent {...props} />);
+
+    const bannerLink = document.querySelector('.sage-banner__link');
+    expect(bannerLink).toBeTruthy();
+    expect(bannerLink).toHaveTextContent('Banner Link');
+    expect(bannerLink).toHaveAttribute('href', '#');
+    expect(bannerLink).toHaveAttribute('target', '_blank');
+    expect(bannerLink).not.toHaveAttribute('rel');
   });
 
   it('renders a button when dismissable prop present', () => {
@@ -32,6 +65,8 @@ describe('Sage BannerContent', () => {
 
     render(<BannerContent {...props} />);
 
-    expect(screen.queryByRole('button', { text: 'Dismiss' }));
+    const dismissButton = document.querySelector('.sage-banner__close');
+    expect(dismissButton).toBeTruthy();
+    expect(dismissButton).toHaveTextContent('Dismiss');
   });
 });


### PR DESCRIPTION
## Description
Update prop to accept link shape with `href`, `rel`, `name`, and `target`.


## Testing in `sage-lib`
1. Run storybook
2. Open Banner page: http://localhost:4100/?path=/story/sage-banner--default
3. Inspect page and confirm props are populating as expected
4. Edit banner story to confirm props update as expected

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Change `link` prop for banner from string to shape accepting subprops
   - [ ] The only react banner I found when searching KP was on the Dashboard page, if that banner has no regressions, we should be good to go


## Related
[DSS-289 - Banner: The link text within the react component is hard-coded](https://kajabi.atlassian.net/browse/DSS-289)



[DSS-289]: https://kajabi.atlassian.net/browse/DSS-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ