### PR TITLE
[DSS-295] Divider Component

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -262,7 +262,7 @@ module ComponentsHelper
         scss: "done",
         docs: "done",
         rails: "done",
-        react: "todo",
+        react: "done",
         responsive: "done",
         a11y: "doing",
         react_component_slug: "sage-divider--default",

--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -265,7 +265,7 @@ module ComponentsHelper
         react: "todo",
         responsive: "done",
         a11y: "doing",
-        react_component_slug: "",
+        react_component_slug: "sage-divider--default",
         figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FsMbtLUHSt2vfKgKjyQ3052%2F%25F0%259F%25A7%25A9-Sage-components%3Fnode-id%3D4553%253A21314%26t%3DKQqqiKDenhS3MD4k-1",
       },
       {

--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -257,6 +257,18 @@ module ComponentsHelper
         figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FsMbtLUHSt2vfKgKjyQ3052%2F%25F0%259F%25A7%25A9-Sage-components%3Fnode-id%3D2643%253A23062",
       },
       {
+        title: "divider",
+        description: "Use the divider to separate sections of content. You can also use them to override auto-layout padding.",
+        scss: "done",
+        docs: "done",
+        rails: "done",
+        react: "todo",
+        responsive: "done",
+        a11y: "doing",
+        react_component_slug: "",
+        figma_embed: "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FsMbtLUHSt2vfKgKjyQ3052%2F%25F0%259F%25A7%25A9-Sage-components%3Fnode-id%3D4553%253A21314%26t%3DKQqqiKDenhS3MD4k-1",
+      },
+      {
         title: "dot",
         description: "Dots provide a subtle color cue to place beside text or other elements.",
         scss: "done",

--- a/docs/app/views/examples/components/divider/_preview.html.erb
+++ b/docs/app/views/examples/components/divider/_preview.html.erb
@@ -1,0 +1,125 @@
+<h3>Horizontal</h3>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageDivider, {} %>
+<% end %>
+
+<h3>Vertical</h3>
+
+<%= sage_component SageCard, {} do %>
+  <div style="height: 200px;" class="sage-col--sm-hide">
+    <%= sage_component SageDivider, {
+      vertical: true,
+    } %>
+  </div>
+  <div class="sage-col--sm-show">
+    <%= sage_component SageHint, {
+      content: 'Vertical dividers are not displayed on small screens',
+      icon: "info-circle",
+    } %>
+  </div>
+<% end %>
+
+<div class="<%= SageClassnames::TYPE::BODY %>">
+  <h3>Offset</h3>
+  <p>Both horizontal and vertical dividers can be offset to create a full width/height bleed appearance.</p>
+</div>
+
+<%= sage_component SageCard, {
+  html_attributes: {
+    style: "height: 150px",
+  }
+} do %>
+  <%= sage_component SageDivider, {
+    offset: "md",
+  } %>
+<% end %>
+<%= sage_component SageCard, {} do %>
+  <div style="height: 200px;" class="sage-col--sm-hide">
+    <%= sage_component SageDivider, {
+      vertical: true,
+      offset: "md",
+    } %>
+  </div>
+  <div class="sage-col--sm-show">
+    <%= sage_component SageHint, {
+      content: 'Vertical dividers are not displayed on small screens',
+      icon: "info-circle",
+    } %>
+  </div>
+<% end %>
+
+<h3>Colors</h3>
+
+<%= sage_component SageDivider, {
+  color: "#000"
+} %>
+<%= sage_component SageDivider, {
+  color: SageTokens::COLOR_PALETTE[:SAGE_300],
+} %>
+<%= sage_component SageDivider, {
+  color: SageTokens::COLOR_PALETTE[:YELLOW_300],
+} %>
+<%= sage_component SageDivider, {
+  color: SageTokens::COLOR_PALETTE[:RED_300],
+} %>
+
+<h3>Layout Examples</h3>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardHeader, { title: "Divider w/o offset" } %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <%= sage_component SageDivider, {} %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <%= sage_component SageDivider, {} %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<% end %>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardHeader, { title: "Divider w/ offset" } %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <%= sage_component SageDivider, { offset: "md" } %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <%= sage_component SageDivider, { offset: "md" } %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<% end %>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardRow, { grid_template: "iti" } do %>
+    <%= sage_component SageAvatar, { size: "88px" } %>
+    <%= sage_component SageDivider, {
+      vertical: true,
+    } %>
+    <div>
+      <h4>Vertical divider w/o offset</h4>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+  <% end %>
+  <div class="sage-col--sm-show">
+    <%= sage_component SageHint, {
+      content: 'Vertical dividers are not displayed on small screens',
+      icon: "info-circle",
+    } %>
+  </div>
+<% end %>
+
+<%= sage_component SageCard, {} do %>
+  <%= sage_component SageCardRow, { grid_template: "iti" } do %>
+    <%= sage_component SageAvatar, { size: "88px" } %>
+    <%= sage_component SageDivider, {
+      vertical: true,
+      offset: "md",
+    } %>
+    <div>
+      <h4>Vertical divider w/ offset</h4>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+  <% end %>
+  <div class="sage-col--sm-show">
+    <%= sage_component SageHint, {
+      content: 'Vertical dividers are not displayed on small screens',
+      icon: "info-circle",
+    } %>
+  </div>
+<% end %>
+

--- a/docs/app/views/examples/components/divider/_props.html.erb
+++ b/docs/app/views/examples/components/divider/_props.html.erb
@@ -1,0 +1,20 @@
+<tr>
+  <td><%= md('`color`') %></td>
+  <td><%= md('Sets color of divider.') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`Grey-300`') %></td>
+</tr>
+
+<tr>
+  <td><%= md('`vertical`') %></td>
+  <td><%= md('Changes layout of divider to vertical.') %></td>
+  <td><%= md('Boolean') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+
+<tr>
+  <td><%= md('`offset`') %></td>
+  <td><%= md('Adds offset margin/padding to expand the width (horizontal) or the height (vertical) of divider. See [Spacing](../helpers/spacing) for token values.') %></td>
+  <td><%= md("`#{SageTokens::SPACER_SIZES.inspect()}`") %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/divider/_rules_do.html.erb
+++ b/docs/app/views/examples/components/divider/_rules_do.html.erb
@@ -1,0 +1,5 @@
+<!-- Uncomment when in use.
+<ul>
+  <li>Rules for what you should do with this component go here.</li>
+</ul>
+-->

--- a/docs/app/views/examples/components/divider/_rules_dont.html.erb
+++ b/docs/app/views/examples/components/divider/_rules_dont.html.erb
@@ -1,0 +1,5 @@
+<!-- Uncomment when in use.
+<ul>
+  <li>Rules for what you should not do with this component go here.</li>
+</ul>
+-->

--- a/docs/lib/sage_rails/app/sage_components/sage_divider.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_divider.rb
@@ -1,0 +1,7 @@
+class SageDivider < SageComponent
+  set_attribute_schema({
+    color: [:optional, NilClass, String],
+    vertical: [:optional, NilClass, TrueClass],
+    offset: [:optional, NilClass, SageSchemas::DIVIDER_OFFSET],
+  })
+end

--- a/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
@@ -12,6 +12,8 @@ module SageSchemas
 
   CONTAINER_SIZE = [:optional, NilClass, Set.new(SageTokens::CONTAINER_SIZES)]
 
+  DIVIDER_OFFSET = Set.new(SageTokens::SPACER_SIZES)
+
   GRID_GAP_OPTION = Set.new(SageTokens::GRID_GAP_OPTIONS)
 
   GRID_TEMPLATE = Set.new(SageTokens::GRID_TEMPLATES)

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_divider.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_divider.html.erb
@@ -1,0 +1,12 @@
+<hr
+  class="
+  sage-divider
+  <%= "sage-divider--vertical" if component.vertical %>
+  <%= "sage-divider-offset--#{component.offset}" if component.offset %>
+  <%= component.generated_css_classes %>
+  "
+  <% if component.color.present? %>
+    style="--sage-divider-background-color: <%= component.color %>"
+  <% end %>
+  <%= component.generated_html_attributes.html_safe %>
+/>

--- a/packages/sage-assets/lib/stylesheets/components/_divider.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_divider.scss
@@ -6,14 +6,14 @@
 
 .sage-divider {
   display: flex;
-  height: 1px;
+  height: rem(1px);
   width: 100%;
   margin: 0;
   background: var(--sage-divider-background-color, sage-color(grey, 300));
   border: 0;
 
   &--vertical {
-    width: 1px;
+    width: rem(1px);
     height: 100%;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_divider.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_divider.scss
@@ -1,0 +1,39 @@
+////
+/// divider
+///
+/// @group sage
+////
+
+.sage-divider {
+  display: flex;
+  height: 1px;
+  width: 100%;
+  margin: 0;
+  background: var(--sage-divider-background-color, sage-color(grey, 300));
+  border: 0;
+
+  &--vertical {
+    width: 1px;
+    height: 100%;
+  }
+}
+
+@each $offset-size, $offset in $sage-spacings {
+  $suffix: "-#{$offset-size}";
+
+  .sage-divider-offset-#{$suffix} {
+    margin: 0 (-$offset);
+    padding: 0 $offset;
+
+    &.sage-divider--vertical {
+      margin: (-$offset) 0;
+      padding: $offset 0;
+    }
+  }
+}
+
+@media (max-width: sage-breakpoint(sm-max)) {
+  .sage-divider--vertical {
+    display: none;
+  }
+}

--- a/packages/sage-assets/lib/stylesheets/components/_index.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_index.scss
@@ -18,6 +18,7 @@
 @import "copy_text";
 @import "data_card";
 @import "description";
+@import "divider";
 @import "dropdown";
 @import "dynamic_select";
 @import "empty_state";

--- a/packages/sage-react/lib/Divider/Divider.jsx
+++ b/packages/sage-react/lib/Divider/Divider.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SageTokens } from '../configs';
+import classnames from 'classnames';
+
+
+export const Divider = ({
+  className,
+  color,
+  vertical,
+  offset,
+
+  ...rest
+}) => {
+  const classNames = classnames(
+    'sage-divider',
+    className,
+    {
+      'sage-divider--vertical': vertical,
+      [`sage-divider-offset--${offset}`]: offset,
+    }
+  );
+
+  const style = {};
+
+  if (color) {
+    style['--sage-divider-background-color'] = color;
+  }
+
+  return (
+    <hr className={classNames} style={style} {...rest} />
+  );
+};
+
+Divider.defaultProps = {
+  color: SageTokens.COLOR_PALETTE.GREY_300,
+  vertical: null,
+  offset: null,
+};
+
+Divider.propTypes = {
+  color: PropTypes.string,
+  vertical: PropTypes.bool,
+  offset: PropTypes.oneOf(Object.values(SageTokens.SPACERS)),
+};

--- a/packages/sage-react/lib/Divider/Divider.jsx
+++ b/packages/sage-react/lib/Divider/Divider.jsx
@@ -1,20 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SageTokens } from '../configs';
 import classnames from 'classnames';
-
+import { SageTokens } from '../configs';
 
 export const Divider = ({
-  className,
   color,
   vertical,
   offset,
-
   ...rest
 }) => {
   const classNames = classnames(
     'sage-divider',
-    className,
     {
       'sage-divider--vertical': vertical,
       [`sage-divider-offset--${offset}`]: offset,

--- a/packages/sage-react/lib/Divider/Divider.spec.jsx
+++ b/packages/sage-react/lib/Divider/Divider.spec.jsx
@@ -1,0 +1,47 @@
+require("../test/testHelper");
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { Divider } from "./Divider";
+import { SageTokens } from "../configs";
+
+describe("Sage Divider", () => {
+  it("renders a custom color when provided", () => {
+    const props = {
+      color: `${SageTokens.COLORS.ORANGE_300}`,
+    };
+    render(<Divider {...props} />);
+
+    const divider = document.querySelector(".sage-divider");
+    const dividerStyleAttr = divider.getAttribute("style");
+
+    expect(dividerStyleAttr).toEqual(
+      `--sage-divider-background-color: ${props.color};`
+    );
+  });
+
+  it("renders vertical when vertical present", () => {
+    const props = {
+      vertical: true,
+    };
+    render(<Divider {...props} />);
+
+    const divider = document.querySelector(".sage-divider");
+    const dividerClass = divider.getAttribute("class");
+
+    expect(dividerClass).toContain("sage-divider--vertical");
+  });
+
+  it("renders offset when offset present", () => {
+
+    const props = {
+      offset: `${SageTokens.SPACERS.MD}`,
+    };
+    render(<Divider {...props} />);
+
+    const divider = document.querySelector(".sage-divider");
+    const dividerClassList = divider.classList;
+
+    expect(dividerClassList).toContainEqual(`sage-divider-offset--${props.offset}`);
+  });
+});

--- a/packages/sage-react/lib/Divider/Divider.spec.jsx
+++ b/packages/sage-react/lib/Divider/Divider.spec.jsx
@@ -1,47 +1,38 @@
-require("../test/testHelper");
+require('../test/testHelper');
 
-import React from "react";
-import { render } from "@testing-library/react";
-import { Divider } from "./Divider";
-import { SageTokens } from "../configs";
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Divider } from './Divider';
+import { SageTokens } from '../configs';
 
-describe("Sage Divider", () => {
-  it("renders a custom color when provided", () => {
+describe('Sage Divider', () => {
+  it('renders a custom color when provided', () => {
     const props = {
       color: `${SageTokens.COLORS.ORANGE_300}`,
     };
     render(<Divider {...props} />);
-
-    const divider = document.querySelector(".sage-divider");
-    const dividerStyleAttr = divider.getAttribute("style");
-
-    expect(dividerStyleAttr).toEqual(
-      `--sage-divider-background-color: ${props.color};`
-    );
+    const divider = document.querySelector('.sage-divider');
+    const dividerStyleAttr = divider.getAttribute('style');
+    expect(dividerStyleAttr).toEqual(`--sage-divider-background-color: ${props.color};`);
   });
 
-  it("renders vertical when vertical present", () => {
+  it('renders vertical when vertical present', () => {
     const props = {
       vertical: true,
     };
     render(<Divider {...props} />);
-
-    const divider = document.querySelector(".sage-divider");
-    const dividerClass = divider.getAttribute("class");
-
-    expect(dividerClass).toContain("sage-divider--vertical");
+    const divider = document.querySelector('.sage-divider');
+    const dividerClass = divider.getAttribute('class');
+    expect(dividerClass).toContain('sage-divider--vertical');
   });
 
-  it("renders offset when offset present", () => {
-
+  it('renders offset when offset present', () => {
     const props = {
       offset: `${SageTokens.SPACERS.MD}`,
     };
     render(<Divider {...props} />);
-
-    const divider = document.querySelector(".sage-divider");
+    const divider = document.querySelector('.sage-divider');
     const dividerClassList = divider.classList;
-
     expect(dividerClassList).toContainEqual(`sage-divider-offset--${props.offset}`);
   });
 });

--- a/packages/sage-react/lib/Divider/Divider.story.jsx
+++ b/packages/sage-react/lib/Divider/Divider.story.jsx
@@ -10,7 +10,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: ''
+        component: 'Use the divider to separate sections of content. You can also use them to override auto-layout padding.'
       },
     },
   },

--- a/packages/sage-react/lib/Divider/Divider.story.jsx
+++ b/packages/sage-react/lib/Divider/Divider.story.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { selectArgs } from '../story-support/helpers';
+import { SageTokens } from '../configs';
+import { Divider } from './Divider';
+
+export default {
+  title: 'Sage/Divider',
+  component: Divider,
+  // displays description on Docs tab
+  parameters: {
+    docs: {
+      description: {
+        component: ''
+      },
+    },
+  },
+  args: {
+    vertical: false,
+  },
+  argTypes: {
+    ...selectArgs({
+      offset: SageTokens.SPACERS
+    })
+  }
+};
+
+const Template = (args) => <Divider {...args} />;
+export const Default = Template.bind({});

--- a/packages/sage-react/lib/Divider/Divider.story.jsx
+++ b/packages/sage-react/lib/Divider/Divider.story.jsx
@@ -14,9 +14,6 @@ export default {
       },
     },
   },
-  args: {
-    vertical: false,
-  },
   argTypes: {
     ...selectArgs({
       offset: SageTokens.SPACERS
@@ -25,4 +22,48 @@ export default {
 };
 
 const Template = (args) => <Divider {...args} />;
+
 export const Default = Template.bind({});
+
+export const vertical = Template.bind({});
+vertical.args = {
+  vertical: true,
+};
+vertical.decorators = [
+  (Story) => (
+    <>
+      <div style={{ height: 250 }}>
+        {Story()}
+      </div>
+    </>
+  )
+];
+
+export const horizontalOffset = Template.bind({});
+horizontalOffset.args = {
+  offset: SageTokens.SPACERS.LG,
+};
+horizontalOffset.decorators = [
+  (Story) => (
+    <>
+      <div style={{ height: 150 }}>
+        {Story()}
+      </div>
+    </>
+  )
+];
+
+export const verticalOffset = Template.bind({});
+verticalOffset.args = {
+  vertical: true,
+  offset: SageTokens.SPACERS.LG,
+};
+verticalOffset.decorators = [
+  (Story) => (
+    <>
+      <div style={{ height: 150 }}>
+        {Story()}
+      </div>
+    </>
+  )
+];


### PR DESCRIPTION
## Description
Adds new Rails/React divider component to Sage.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Horz/Vert  |  Offset  |
|--------|--------|
|![Screenshot 2023-03-22 at 3 56 31 PM](https://user-images.githubusercontent.com/1175111/227057733-c96c3630-4235-4db4-b35e-d7d0bc645fcc.png)|![Screenshot 2023-03-22 at 4 06 55 PM](https://user-images.githubusercontent.com/1175111/227058344-c8cb1a83-3f34-45d1-9e71-ee48ec0a0bc6.png)|


## Testing in `sage-lib`

> **Note**
> Dear reviewers/testers, due to vertical dividers not playing nicely with responsive designs, the vertical variant will not be displayed on small screens. This is in agreement with our design partners. For the docs site, I've added a small message to the previews when the page is resized. More than happy to take another approach if anyone has any ideas.

**Rails/Docs**

- Navigate to [Divider](http://localhost:4000/pages/component/divider?tab=preview) 
- Verify the divider matches the [design spec](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/branch/typObw6n4rB0gvVpn8PfvC/%F0%9F%A7%A9-Sage-components?node-id=4553%3A21314&t=D6mnHEqSMZOaMATy-1)

**React/Storybook**

- Navigate to [Divider](http://localhost:4100/?path=/docs/sage-divider--default) 
- Verify the divider matches the [design spec](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/branch/typObw6n4rB0gvVpn8PfvC/%F0%9F%A7%A9-Sage-components?node-id=4553%3A21314&t=D6mnHEqSMZOaMATy-1)


## Testing in `kajabi-products`
1. (**LOW**) Adds new divider component to Sage. No effect on KP.

## Related
DSS-295
