### PR TITLE
[DSS-316]: Update indicator to match design spec

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -463,6 +463,7 @@ module ComponentsHelper
         react: "todo",
         responsive: "done",
         a11y: "done",
+        react_component_slug: "sage-indicator--default",
         figma_embed: "",
       },
       {

--- a/packages/sage-assets/lib/stylesheets/components/_indicator.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_indicator.scss
@@ -35,5 +35,5 @@ $-indicator-size: rem(6px);
 }
 
 .sage-indicator--current {
-  background-color: sage-color(primary, 300);
+  background-color: sage-color(charcoal, 400);
 }


### PR DESCRIPTION
## Description
Updates indicator to match design based on design audit.

> **Note** 
> The [design file](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/branch/typObw6n4rB0gvVpn8PfvC/%F0%9F%A7%A9-Sage-components?node-id=2697%3A22810&t=C97yOeb3SY12KP4F-1) calls the indicator `dotGroup`, but verified with design this is just a naming issue.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="166" alt="Screenshot 2023-03-23 at 2 58 20 PM" src="https://user-images.githubusercontent.com/1175111/227374665-0bb1ed2e-9207-4975-a606-165542140b13.png">|<img width="187" alt="Screenshot 2023-03-23 at 2 58 28 PM" src="https://user-images.githubusercontent.com/1175111/227374714-c15cc083-5f8f-438d-9bc9-57129767fde0.png">|


## Testing in `sage-lib`

**Rails/Docs**

- Navigate to [Indicator](http://localhost:4000/pages/component/indicator?tab=preview) 
- Verify the UI matches the [design spec](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/branch/typObw6n4rB0gvVpn8PfvC/%F0%9F%A7%A9-Sage-components?node-id=2697%3A22810&t=C97yOeb3SY12KP4F-1)
- Verify `React component` link now appears

**React/Storybook**

- Navigate to [Indicator](http://localhost:4100/?path=/docs/sage-indicator--default) 
- Verify the UI matches the [design spec](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/branch/typObw6n4rB0gvVpn8PfvC/%F0%9F%A7%A9-Sage-components?node-id=2697%3A22810&t=C97yOeb3SY12KP4F-1)


## Testing in `kajabi-products`
1. (**LOW**) Updates indicator component to match design spec. Styling only update.


## Related
DSS-316
