### PR TITLE
fix(react-dropdown): max depth reached due to improper dependency added

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -150,7 +150,7 @@ export const Dropdown = ({
       window.removeEventListener('scroll', onUpdate);
       window.removeEventListener('resize', onUpdate);
     };
-  }, [wrapperRef, isActive, isPinned, onUpdate, positionElement]);
+  }, [wrapperRef, isActive, isPinned, onUpdate]);
 
   useEffect(() => {
     if (panelStateToken) {


### PR DESCRIPTION
## Description
There was a circular dependency added to the `useEffect` for when the dropdown panel would render. This would cause an insane amount of errors in the console, causing the browser to lock up. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|https://www.loom.com/share/51f278be8a684a029cba4d73a6a445a3|https://www.loom.com/share/2e27ed46fd17466ab4575e7edb2484ea|


## Testing in `sage-lib`
1. Go to Storybook site or copy this [link](http://localhost:4100/?path=/story/sage-dropdown-optionsdropdown--default)
2. Open the OptionsDropdown
3. No errors should occur.


## Testing in `kajabi-products`
1. Pull down branch and start the bridge
4. Open Kajabi Products to either Contacts or Funnels (Pipelines) page
5. Open one of the dropdowns 
6. You should not see any errors for `maxdepth reached`


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
