### PR TITLE
[DSS-363]: Carousel buttons non-functional in React

### DIFF
--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -84,7 +84,7 @@ export const Carousel = ({
           disabled={arrowPrevDisabled}
           icon="caret-left"
           id="prev"
-          onClickCallback={() => handlePrevArrowClick}
+          onClickCallback={() => handlePrevArrowClick()}
         />
         <div className="sage-carousel__sizer">
           <div className="sage-carousel__carousel">
@@ -95,7 +95,7 @@ export const Carousel = ({
           disabled={arrowNextDisabled}
           icon="caret-right"
           id="next"
-          onClickCallback={() => handleNextArrowClick}
+          onClickCallback={() => handleNextArrowClick()}
         />
       </div>
       {!looping && (


### PR DESCRIPTION
## Description
The Previous/Next button action in the React version of the Carousel does not function.


## Screenshots

|Carousel|
|--------|
|![2023-03-28 16 02 45](https://user-images.githubusercontent.com/1175111/228386305-e7ee5329-a6e1-4214-843a-956c5a9d6143.gif)|


## Testing in `sage-lib`
Navigate to [Carousel](http://localhost:4100/?path=/docs/sage-carousel--default)
Verify next and prev arrow now function


## Testing in `kajabi-products`
1. (**LOW**) Bug fix for Carousel arrows in React component.


## Related
DSS-363
