### PR TITLE
[DSS-376]: Add deprecation messaging to Catalog Item docs

### DIFF
--- a/docs/app/views/examples/components/catalog_item/_preview.html.erb
+++ b/docs/app/views/examples/components/catalog_item/_preview.html.erb
@@ -1,7 +1,14 @@
+<%= sage_component SageAlert, {
+  color: "warning",
+  title: "Deprecated",
+  desc:  "Catalog Item usage is no longer recommended. Please use the #{link_to "List component", "/pages/component/list"} instead to construct a similar experience or as a replacement option.".html_safe,
+  icon_name: "sage-icon-danger-filled",
+} %>
+
 <%= sage_component SageCardList, {} do %>
   <% 2.times do %>
     <%= sage_component SageCatalogItem, {
-      title: "Fun For All – The Children Call: Their Favorite Time Of Year",
+      title: "Fun For All - The Children Call: Their Favorite Time Of Year",
       image: "card-placeholder-sm.png",
       href: "#"
     } do %>


### PR DESCRIPTION
## Description
To encourage XF teams to move away from using the `Catalog Item` component, a message will be added to the documentation page with directions to use the `List` component. 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Deprecation Messaging/Alert  |
|--------|
|<img width="1154" alt="Screenshot 2023-03-30 at 9 54 15 AM" src="https://user-images.githubusercontent.com/1175111/228911046-decf92cc-b005-4c86-b6c2-b4d3c7f41832.png">|



## Testing in `sage-lib`

- Navigate to [Catalog Item](http://localhost:4000/pages/component/catalog_item?tab=preview)
- Verify deprecation messaging appears
- Verify link to List functions as expected



## Testing in `kajabi-products`

1. (**LOW**) Adds deprecation messaging to Catalog Item docs. Docs only update.


## Related
DSS-376
