### PR TITLE
[DSS-336] Remove sass-rails gem

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,7 +6,6 @@ ruby "2.5.9"
 
 gem 'rails', '5.2.6.3'
 
-gem 'sass-rails', '~> 5.0', '>= 5.0.7'
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '~> 4.3', '>= 4.3.0'
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -176,17 +176,6 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     spring (1.3.3)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -198,7 +187,6 @@ GEM
     strscan (3.0.4)
     thor (1.1.0)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     timeout (0.3.1)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
@@ -233,7 +221,6 @@ DEPENDENCIES
   rouge
   rspec-rails (>= 4.0.1)
   sage_rails!
-  sass-rails (~> 5.0, >= 5.0.7)
   spring (= 1.3.3)
   uglifier (>= 1.3.0)
   web-console (~> 3.7, >= 3.7.0)
@@ -243,4 +230,4 @@ RUBY VERSION
    ruby 2.5.9p229
 
 BUNDLED WITH
-   2.3.14
+   2.3.26


### PR DESCRIPTION
## Description
Removes `sass-rails` gem. No longer necessary now that `sass` package is applied in `sage-assets`.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
1. (**LOW**) Removes deprecated `sass-rails` gem from repo. No impact on external sources.



## Related
- https://github.com/Kajabi/kajabi-products/pull/27957
