### PR TITLE
fix(copy-button): use new clipboard functions

### DIFF
--- a/packages/sage-system/lib/copy-button.js
+++ b/packages/sage-system/lib/copy-button.js
@@ -5,19 +5,59 @@ Sage.copyButton = (function() {
   // ==================================================
 
   function handleClick(ev) {
-    const str = ev.currentTarget.dataset.jsCopyButton;
-    const el = document.createElement('textarea');
-    el.value = str;
-    el.setAttribute('readonly', '');
-    el.setAttribute('class', 'visually-hidden');
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand('copy');
-    document.body.removeChild(el);
-    ev.currentTarget.focus();
-    Sage.toast.trigger({text:'Copied to clipboard'})
-  };
+    const strToCopy = ev.currentTarget.dataset.jsCopyButton;
 
+
+    if (navigator.clipboard) {
+      navigator.permissions.query({name: 'clipboard-write'}).then(result => {
+        if (result.state == 'granted' || result.state == 'prompt') {
+          navigator.clipboard.writeText(strToCopy)
+            .then(() => {
+              Sage.toast.trigger({text:'Copied to clipboard'})
+            })
+            .catch(err => {
+              Sage.toast.trigger({text:'Does not have access to clipboard'})
+            });
+        } else {
+          // Permission not granted, ask the user to grant it
+          navigator.permissions.request({name: 'clipboard-write'}).then(result => {
+            if (result.state == 'granted') {
+              navigator.clipboard.writeText(strToCopy)
+                .then(() => {
+                  Sage.toast.trigger({text:'Copied to clipboard'})
+                })
+                .catch(err => {
+                  const errMsg = 'Error writing text to clipboard: ' + err;
+                  Sage.toast.trigger({text: errMsg})
+                });
+              } else {
+                Sage.toast.trigger({text: 'Permission to write to clipboard denied'});
+              }
+            }).catch(err => {
+              const errMsg = 'Error requesting permission to write to clipboard: ' + err;
+              Sage.toast.trigger({text: errMsg})
+            });
+          }
+        }).catch(err => {
+          const errMsg = 'Error querying permission to write to clipboard: ' + err;
+          Sage.toast.trigger({text: errMsg})
+      });
+    } else {
+      // Fallback for Safari
+      const el = document.createElement('textarea');
+      el.value = strToCopy;
+      el.setAttribute('readonly', '');
+      el.setAttribute('class', 'visually-hidden');
+      document.body.appendChild(el);
+      el.select();
+
+      document.execCommand("copy");
+      document.body.removeChild(el);
+      Sage.toast.trigger({text:'Copied to clipboard'})
+    }
+
+    ev.currentTarget.focus();
+  };
 
   // ==================================================
   // Functions

--- a/packages/sage-system/lib/copy-button.js
+++ b/packages/sage-system/lib/copy-button.js
@@ -9,39 +9,14 @@ Sage.copyButton = (function() {
 
 
     if (navigator.clipboard) {
-      navigator.permissions.query({name: 'clipboard-write'}).then(result => {
-        if (result.state == 'granted' || result.state == 'prompt') {
-          navigator.clipboard.writeText(strToCopy)
-            .then(() => {
-              Sage.toast.trigger({text:'Copied to clipboard'})
-            })
-            .catch(err => {
-              Sage.toast.trigger({text:'Does not have access to clipboard'})
-            });
-        } else {
-          // Permission not granted, ask the user to grant it
-          navigator.permissions.request({name: 'clipboard-write'}).then(result => {
-            if (result.state == 'granted') {
-              navigator.clipboard.writeText(strToCopy)
-                .then(() => {
-                  Sage.toast.trigger({text:'Copied to clipboard'})
-                })
-                .catch(err => {
-                  const errMsg = 'Error writing text to clipboard: ' + err;
-                  Sage.toast.trigger({text: errMsg})
-                });
-              } else {
-                Sage.toast.trigger({text: 'Permission to write to clipboard denied'});
-              }
-            }).catch(err => {
-              const errMsg = 'Error requesting permission to write to clipboard: ' + err;
-              Sage.toast.trigger({text: errMsg})
-            });
-          }
-        }).catch(err => {
-          const errMsg = 'Error querying permission to write to clipboard: ' + err;
+      navigator.clipboard.writeText(strToCopy)
+        .then(() => {
+          Sage.toast.trigger({text:'Copied to clipboard'})
+        })
+        .catch(err => {
+          const errMsg = 'Error writing text to clipboard: ' + err;
           Sage.toast.trigger({text: errMsg})
-      });
+        });
     } else {
       // Fallback for Safari
       const el = document.createElement('textarea');


### PR DESCRIPTION
we still have a fallback to use execCommand for legacy browser support

JIRA Ticket: [DSS-388](https://kajabi.atlassian.net/browse/DSS-388)

## Description
It was discovered that the `copy-button` was not working in certain browsers (versions). The code implemented here addresses both current versions and legacy version support which falls back to using `execCommand('copy')`.


## Testing in `sage-lib`
1. Navigate to the Copy Button component on the documentation site. 
2. In each browser, Chrome (v111 and v112), Safari, and Firefox confirm that the functionality behaves as expected. 


## Testing in `kajabi-products`
1. (**HIGH**) Copy button is broken in Chrome version 112 or higher. Please check with all major browsers
   - [ ] Navigate [here](https://www.kajabi.test/admin/settings/account ), under Account Details, scroll to API Credentials under and confirm the copy-button
   - [ ] Navigate [here](https://app.kajabi.com/admin/settings/security) and click "Set up authenticator". Once you enter your password, you should see a copy button under the QR code. Confirm that it functions as expected. 




[DSS-388]: https://kajabi.atlassian.net/browse/DSS-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ