### PR TITLE
docs: update copy-text example verbiage

### DIFF
--- a/docs/app/views/examples/components/copy_text/_preview.html.erb
+++ b/docs/app/views/examples/components/copy_text/_preview.html.erb
@@ -1,5 +1,5 @@
 <h3 class="t-sage-heading-6">Copy Text (inline)</h3>
-<%= sage_component SageCopyText, { value: "me.ns.cloudflare.com", semibold: true } %>
+<%= sage_component SageCopyText, { value: "inline copy button example", semibold: true } %>
 
 <h3 class="t-sage-heading-6">Copy Text (block)</h3>
 <%= sage_component SageCopyTextCard, {} do %>
@@ -9,10 +9,10 @@
 <% end %>
 
 <h3 class="t-sage-heading-6">Copy Button</h3>
-<%= sage_component SageCopyButton, { value: "me.ns.cloudflare.com", semibold: true } %>
+<%= sage_component SageCopyButton, { value: "semi-bold copy example", semibold: true } %>
 
 <h3 class="t-sage-heading-6">Copy Button - Borderless</h3>
-<%= sage_component SageCopyButton, { borderless: true, value: "me.ns.cloudflare.com", semibold: true } %>
+<%= sage_component SageCopyButton, { borderless: true, value: "borderless copy", semibold: true } %>
 
 <h3 class="t-sage-heading-6">Copy Button (fill container)</h3>
-<%= sage_component SageCopyButton, { fill_container: true, value: "me.ns.cloudflare.com", semibold: true } %>
+<%= sage_component SageCopyButton, { fill_container: true, value: "fill container example", semibold: true } %>


### PR DESCRIPTION
Fixes: [DSS-393](https://kajabi.atlassian.net/browse/DSS-393)

## Description
Per a wish request from @monkeypox8, he wanted to update the verbiage on the Copy Text examples to be different.

## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://user-images.githubusercontent.com/1633290/235202345-edf8bb6f-8fb3-48db-92f2-f26f4769d566.png)|![image](https://user-images.githubusercontent.com/1633290/235202271-e963f358-8f66-487d-bc61-19c463f39988.png)|


## Testing in `sage-lib`
1. No testing required


## Testing in `kajabi-products`
No impact


[DSS-393]: https://kajabi.atlassian.net/browse/DSS-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ