### PR TITLE
[DSS-210] Bug: Icon role not present

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -9,7 +9,7 @@ end
 
 %>
 <% if component.card_color.present? %>
-  <div class="sage-icon-background 
+  <div class="sage-icon-background
     <%= "sage-icon-background--#{component.card_color}" %>
     <%= "sage-icon-background--#{component.size}" if component.size.present? %>
     <%= "sage-icon-background--custom-size" if component.background_height || component.background_width %>
@@ -32,6 +32,7 @@ end
     "
     <% if component.label.present? %>
       aria-label="<%= component.label %>"
+      role="img"
     <% else %>
       aria-hidden=true
     <% end %>

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -43,6 +43,7 @@ export const Icon = ({
     attributes['aria-hidden'] = true;
   } else {
     attributes['aria-label'] = label;
+    attributes.role = 'img';
   }
 
   const renderIcon = () => (


### PR DESCRIPTION
## Description
Corrects [an accessibility violation](https://dequeuniversity.com/rules/axe/4.6/aria-allowed-attr?application=axeAPI) in the Icon component by adding `role="img"` when an `aria-label` is applied. This is only necessary because we're using an icon font, where the unicode character does not provide a useful label.

Note: see the [potential drawbacks to this patch](https://www.scottohara.me/blog/2019/06/10/no-fallback-drawback.html) when loading is interrupted

## Screenshots

![a11y-violation](https://user-images.githubusercontent.com/816579/236577310-24ba1b86-9b6d-4cf3-80e7-d7e51527c0fa.png)



## Testing in `sage-lib`
1. Navigate to the Icon component in Storybook
2. Open the Addon panel, and view the "Accessibility" tab
3. Verify there are no Violations listed
4. Navigate to the Icon component in the Rails docs
5. Inspect an icon with no visible label (`aria-label` only)
6. Confirm that `role="img"` has been applied to the component


## Testing in `kajabi-products`
1. (**HIGH**) Adds `role` attribute on uses of icons with labels. Accessibility-only, no visual or functional impact in `kajabi-products`.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
