### PR TITLE
fix(react-button): suppressDefaultClass warning

### DIFF
--- a/packages/sage-react/lib/Button/Button.jsx
+++ b/packages/sage-react/lib/Button/Button.jsx
@@ -77,7 +77,7 @@ export const Button = React.forwardRef(({
       aria-disabled={isLink && disabled}
       disabled={!isLink && disabled}
       tag={isLink ? linkTag : null}
-      suppressDefaultClass={isLink}
+      {...(isLink ? { suppressDefaultClass: isLink } : {})}
       onClick={onClick}
       {...rest}
     >


### PR DESCRIPTION
## Description
Warning occurs when the property was being set on a HTML button

 The conditional fixes that by checking if it's a Link component

fix: DSS-374
