### PR TITLE
fix(alert): grid template areas

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_alert.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_alert.html.erb
@@ -4,6 +4,7 @@
     <%= "sage-alert--#{component.color}" if component.color %>
     <%= "sage-alert--dismissable" if component.dismissable %>
     <%= "sage-alert--small" if component.small %>
+    <%= "sage-alert--actions" if component.primary_action or component.secondary_actions or content_for? :sage_alert_actions  %>
     <%= component.generated_css_classes %>
   "
   data-js-alert="true"

--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -37,9 +37,7 @@ $-alert-icon-colors: (
 .sage-alert {
   display: grid;
   grid-template-columns: auto 1fr;
-  grid-template-areas:
-    "icon copy"
-    ".    actions";
+  grid-template-areas: "icon copy";
   gap: sage-spacing(sm);
   padding: sage-spacing();
   margin-bottom: sage-spacing();
@@ -50,11 +48,21 @@ $-alert-icon-colors: (
     margin-bottom: 0;
   }
 
+  &.sage-alert--actions {
+    grid-template-areas:
+      "icon copy"
+      ".    actions";
+  }
+
   &.sage-alert--dismissable {
     grid-template-columns: auto 1fr auto;
-    grid-template-areas:
-      "icon copy    close"
-      ".    actions .";
+    grid-template-areas: "icon copy    close";
+
+    &.sage-alert--actions {
+      grid-template-areas:
+        "icon copy    close"
+        ".    actions .";
+    }
   }
 }
 
@@ -74,6 +82,14 @@ $-alert-icon-colors: (
   &.sage-alert--dismissable {
     grid-template-columns: auto 1fr auto auto;
     grid-template-areas: "icon copy actions close";
+
+    &.sage-alert--actions {
+      grid-template-areas: "icon copy actions close";
+    }
+  }
+
+  &.sage-alert--actions {
+    grid-template-areas: "icon copy actions";
   }
 }
 

--- a/packages/sage-react/lib/Alert/Alert.jsx
+++ b/packages/sage-react/lib/Alert/Alert.jsx
@@ -28,6 +28,7 @@ export const Alert = ({
       [`sage-alert--${color}`]: color,
       'sage-alert--dismissable': dismissable,
       'sage-alert--small': small,
+      'sage-alert--actions': actions !== null,
     }
   );
 

--- a/packages/sage-react/lib/Alert/Alert.story.jsx
+++ b/packages/sage-react/lib/Alert/Alert.story.jsx
@@ -31,8 +31,46 @@ export default {
 
 const Template = (args) => <Alert {...args} />;
 
+export const Default = Template.bind({});
+Default.args = {
+  description: 'This is a default alert with only the required attributes',
+  title: null,
+  titleAddon: null,
+};
+
+export const DefaultWithActions = Template.bind({});
+DefaultWithActions.args = {
+  description: 'This is a default alert with only the required attributes',
+  title: null,
+  titleAddon: null,
+  actions: (
+    <>
+      <Button
+        className={Alert.PRIMARY_ACTION_CLASSNAME}
+        color={Button.COLORS.PRIMARY}
+      >
+        Get unlimited pages
+      </Button>
+      <Link
+        href="//example.com"
+        suppressDefaultClass
+      >
+        Check Usage
+      </Link>
+    </>
+  )
+};
+
 export const DismissableAlert = Template.bind({});
 DismissableAlert.args = {
+  description: 'Body duis rhoncus neque, sed nulla sed quis fames. Eu eu ut at odio ultrices orci varius habitant. Tempor vulputate in nisl massa eget id.',
+  color: Alert.COLORS.DEFAULT,
+  dismissable: true,
+  onClickDismiss: () => console.log('clicked to dismiss'), // eslint-disable-line
+};
+
+export const DismissableAlertWithActions = Template.bind({});
+DismissableAlertWithActions.args = {
   description: 'Body duis rhoncus neque, sed nulla sed quis fames. Eu eu ut at odio ultrices orci varius habitant. Tempor vulputate in nisl massa eget id.',
   color: Alert.COLORS.DEFAULT,
   dismissable: true,
@@ -95,5 +133,3 @@ SmallAlert.args = {
   ),
   small: true,
 };
-
-export const Accessible = () => <Alert color={Alert.COLORS.DEFAULT}>Accessible button</Alert>;


### PR DESCRIPTION
Jira Ticket:  https://kajabi.atlassian.net/browse/DSS-405

## Description
When the Alert has no actions, the additional row was still being displayed. This is not the intended behavior. 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
![image](https://github.com/Kajabi/sage-lib/assets/1633290/2ca0e11a-bf5e-46a7-b1a5-6078648dba97)|
![image](https://github.com/Kajabi/sage-lib/assets/1633290/753b0828-ffbe-4311-8320-9a38ae5008f5)


## Testing in `sage-lib`
1. Navigate to Storybook -> Alert
2. Verify that there is no additional row added when the alert has no Actions. 


## Testing in `kajabi-products`
I need to find a location in the app that has an Alert with no action buttons. At this time I'm unaware of it. I'll try to update prior to merging.

