### PR TITLE
[DSS-421] Render `css_classes` on Rails Radio component 

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_radio.html.erb
@@ -26,6 +26,7 @@
       <%= "sage-radio--custom" if content_for :sage_radio_custom_content %>
       <%= component.has_border ? "sage-radio--has-border" : "" %>
       <%= component.has_error ? "sage-radio--error" : "" %>
+      <%= component.generated_css_classes %>
     "
     <%= component.generated_html_attributes.html_safe %>
   >


### PR DESCRIPTION
## Description
DSS-421

Enables the base Radio component in Rails to accept `css_classes`, currently restricted to `standalone` mode only.

## Screenshots
No visual changes


## Testing in `sage-lib`
1. Add a custom CSS class to any example in `docs/app/views/examples/components/radio/_preview.html.erb` 
2. Navigate to the Radio component in the Rails docs
3. Inspect the modified Radio button and verify that the custom class appears


## Testing in `kajabi-products`

1. (**HIGH**) Radio: enables custom CSS classes use with Rails component. No expected impact on existing implementations.
   - [ ] Coaching Programs -> scheduling details/scheduling integration type
   - [ ] Offer checkout editor -> Log in requirement settings


## Related
- COMM-3777
