### PR TITLE
[DSS-411]: fix(button): html_attributes getting escaped when rendered.

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_button.html.erb
@@ -21,7 +21,7 @@
   <% if component.spinner_on_submit.present? %>
     data-js-sage-spinner-on-submit="<%= component.spinner_on_submit %>"
   <% end %>
-  <%= component.generated_html_attributes.html_safe %>
+  <%= component.generated_html_attributes %>
 >
   <% if component.icon&.dig(:style) == "only" %>
     <span class="visually-hidden">


### PR DESCRIPTION
## Description
When binding a JSON string to a `data-attribute` using `html_attributes` on the Rails Sage Button, the JSON string is getting escaped incorrectly in the DOM.

See the `data-object` attribute in the screenshots below.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="902" alt="Screenshot 2023-06-20 at 2 23 10 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/9412d3e5-93a9-4a59-953b-dda01c432ba2">|<img width="896" alt="Screenshot 2023-06-20 at 2 23 26 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/3406057a-4f42-4ca2-a0e5-6bf780be80af">|


## Testing in `sage-lib`
Add the following code snippet to the sandbox.html.erb file and verify the data is passed to the attribute properly and no long incorrectly escaped.

```
<% def json_object
  {
    "Account" => 123,
    "User" => 123,
    "Name" => "phillip",
  }.to_json
end %>

<%= sage_component SageButton, {
  html_attributes: {
    "data-object": json_object,
  },
  value: "Click Me",
  style: "primary",
} %>
```

## Testing in `kajabi-products`
1. (**LOW**) Fixes incorrect escaping for button html_attributes. No effect is expected.
   - [ ] Quick sanity check of buttons across the admin.


## Related
DSS-411
