### PR TITLE
Modal fade out update

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -100,7 +100,6 @@ $-modal-inner-size: sage-container(md);
     @media (max-width: sage-breakpoint(md-min)) {
       max-width: var(--sage-drawer-mobile-size);
     }
-
   }
 
   .sage-drawer.sage-drawer--compact & {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -48,8 +48,8 @@ $-modal-inner-size: sage-container(md);
   }
 
   &.sage-modal--is-closing {
-    opacity: 0;
     transition: opacity 0.15s ease-in-out;
+    opacity: 0;
   }
 
   &.sage-modal--fullscreen {

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -47,6 +47,11 @@ $-modal-inner-size: sage-container(md);
     opacity: 1;
   }
 
+  &.sage-modal--is-closing {
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+  }
+
   &.sage-modal--fullscreen {
     padding: 0;
   }
@@ -192,6 +197,7 @@ $-modal-inner-size: sage-container(md);
     }
   }
 }
+
 
 .sage-modal__header {
   display: grid;

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -198,7 +198,6 @@ $-modal-inner-size: sage-container(md);
   }
 }
 
-
 .sage-modal__header {
   display: grid;
   align-items: baseline;

--- a/packages/sage-react/lib/Drawer/Drawer.jsx
+++ b/packages/sage-react/lib/Drawer/Drawer.jsx
@@ -24,6 +24,7 @@ export const Drawer = ({
   footer,
   onExpandChange,
   id,
+  isClosing,
   onExit,
   showClose,
   size,
@@ -67,6 +68,7 @@ export const Drawer = ({
       className={classNames}
       disableBackgroundDismiss={disableBackgroundDismiss}
       id={id}
+      isClosing={isClosing}
       onExit={onExit}
       styles={{ ...localStyles }}
       style={{
@@ -121,6 +123,7 @@ Drawer.defaultProps = {
   expanded: false,
   expandedSize: null,
   footer: null,
+  isClosing: false,
   onExit: (val) => val,
   onExpandChange: (expanded) => expanded,
   showClose: true,
@@ -140,6 +143,7 @@ Drawer.propTypes = {
   expandedSize: PropTypes.string,
   footer: PropTypes.node,
   id: PropTypes.string.isRequired,
+  isClosing: PropTypes.bool,
   onExit: PropTypes.func,
   onExpandChange: PropTypes.func,
   showClose: PropTypes.bool,

--- a/packages/sage-react/lib/Drawer/Drawer.story.jsx
+++ b/packages/sage-react/lib/Drawer/Drawer.story.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Drawer } from './Drawer';
 import { SageClassnames, SageTokens } from '../configs';
 import { Button } from '../Button';
@@ -96,6 +96,7 @@ export const WiredExample = () => {
   const [drawerContents, setDrawerContents] = React.useState(null);
   const [drawerActive, setDrawerActive] = React.useState(true);
   const [drawerExpanded, setDrawerExpanded] = React.useState(false);
+  const [isClosing, setIsClosing] = useState(false);
 
   const drawerCustomHeader = (
     <Button
@@ -128,6 +129,14 @@ export const WiredExample = () => {
       </p>
     </>
   );
+
+  const onExit = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setDrawerActive(false);
+      setIsClosing(false);
+    }, 1000);
+  };
 
   const respondToDrawerExpandChange = (status) => {
     switch (status) {
@@ -164,7 +173,8 @@ export const WiredExample = () => {
       <Drawer
         active={drawerActive}
         expanded={drawerExpanded}
-        onExit={() => setDrawerActive(false)}
+        isClosing={isClosing}
+        onExit={onExit}
         onExpandChange={respondToDrawerExpandChange}
         customHeader={drawerCustomHeader}
         disableBackgroundDismiss={!drawerExpanded}

--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -19,6 +19,7 @@ export const Modal = ({
   disableBackgroundDismiss,
   fullScreen,
   id,
+  isClosing,
   large,
   onExit,
   size,
@@ -30,6 +31,7 @@ export const Modal = ({
     className,
     {
       'sage-modal--active': active,
+      'sage-modal--is-closing': isClosing,
       'sage-modal--scrollable': allowScroll,
       'sage-modal--large': large,
       'sage-modal--fullscreen': fullScreen,
@@ -120,6 +122,7 @@ Modal.defaultProps = {
   fullScreen: false,
   large: false,
   id: null,
+  isClosing: false,
   disableBackgroundBlur: false,
   disableBackgroundDismiss: false,
   onExit: (val) => val,
@@ -142,6 +145,7 @@ Modal.propTypes = {
   disableBackgroundDismiss: PropTypes.bool,
   fullScreen: PropTypes.bool,
   id: PropTypes.string,
+  isClosing: PropTypes.bool,
   large: PropTypes.bool,
   onExit: PropTypes.func,
   size: PropTypes.oneOf(Object.values(Modal.SIZES))

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -190,6 +190,8 @@ export const Wired = (args) => {
   const [active, setActive] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
+  // The onExit will need to be modified per instance to include this functionality
+  // in order to contain the fade out effect
   const onExit = () => {
     setIsClosing(true);
     setTimeout(() => {
@@ -210,7 +212,7 @@ export const Wired = (args) => {
         {...args}
         active={active}
         isClosing={isClosing}
-        animation={{ direction: Modal.ANIMATION_DIRECTIONS.BOTTOM }}
+        animation={false}
         onExit={onExit}
       >
         <DefaultBody onExit={onExit} />

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -188,9 +188,14 @@ Default.decorators = [
 
 export const Wired = (args) => {
   const [active, setActive] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
 
   const onExit = () => {
-    setActive(false);
+    setIsClosing(true);
+    setTimeout(() => {
+      setActive(false);
+      setIsClosing(false);
+    }, 1000);
   };
 
   return (
@@ -204,6 +209,7 @@ export const Wired = (args) => {
       <Modal
         {...args}
         active={active}
+        isClosing={isClosing}
         animation={{ direction: Modal.ANIMATION_DIRECTIONS.BOTTOM }}
         onExit={onExit}
       >

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -190,8 +190,6 @@ export const Wired = (args) => {
   const [active, setActive] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
-  // The onExit will need to be modified per instance to include this functionality
-  // in order to contain the fade out effect
   const onExit = () => {
     setIsClosing(true);
     setTimeout(() => {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] Add fadeout transition to Modal
- [x] Add fadeout transiton to drawer

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![modalFadeOutBefore](https://github.com/Kajabi/sage-lib/assets/1241836/6f40d448-65a5-4040-86ee-e26b972e251c)|![modalFadeOutAfter](https://github.com/Kajabi/sage-lib/assets/1241836/9a41fcf2-9fe0-45f3-9470-9f5a40b5c397)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Visit the [Modal](http://localhost:4100/?path=/story/sage-modal--wired) and select the wired variant. Verify that closing the modal fades out
Visit the [Drawer](http://localhost:4100/?path=/story/sage-drawer--wired-example) and select the wired variant. Verify that closing the modal fades out

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds a fadeout that must be opted into. No affect in `kp`


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
