### PR TITLE
feat: add component attributes to sage_form_select component

### DIFF
--- a/docs/app/views/examples/components/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/form_select/_preview.html.erb
@@ -145,4 +145,34 @@
   ]
 } %>
 
+<script>
+  const handleOnChange = (consoles) => {
+    var selectedText = consoles.options[consoles.selectedIndex].innerHTML;
+    var selectedVal = consoles.value;
+    alert("Selected Text: " + selectedText + " Value: " + selectedVal);
+  }
+</script>
+<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Example on how to pass additional attributes to the component</h3>
+<%= sage_component SageFormSelect, {
+  name: "Consoles",
+  component_attributes: {
+    onChange: "handleOnChange(this)",
+    "my-attribute": "hello"
+  },
+  select_options: [
+    {
+      text: "X-Box",
+      value: "x-box"
+    },
+    {
+      text: "PlayStation",
+      value: "playstation"
+    },
+    {
+      text: "Nintendo Switch",
+      value: "switch"
+    },
+  ]
+} %>
+
 <p><strong>Note:</strong> For a fully styled dropdown selector, see the Dropdown component.</p>

--- a/docs/lib/sage_rails/app/sage_components/sage_component.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_component.rb
@@ -7,6 +7,7 @@ class SageComponent
 
   ATTRIBUTE_SCHEMA = {
     test_id: [:optional, NilClass, String],
+    component_attributes: [:optional, NilClass, Hash],
     html_attributes: [:optional, NilClass, Hash],
     spacer: [:optional, NilClass, SageSchemas::SPACER],
     css_classes: [:optional, NilClass, String],
@@ -15,6 +16,10 @@ class SageComponent
 
   def generated_css_classes
     @generated_css_classes ||= ""
+  end
+
+  def generated_component_attributes
+    @generated_component_attributes ||= ""
   end
 
   def generated_html_attributes
@@ -52,6 +57,24 @@ class SageComponent
     @spacer = spacer_hash
     spacer_hash.each do |key, value|
       generated_css_classes << " sage-spacer-#{key}#{(value != :md and value != "md") ? "-#{value}" : ""}"
+    end
+  end
+
+  # SageComponent Custom Event Attributes
+  #   Accepts a :component_attributes has that generates the additional
+  #   attributes on the element and not the parent container.
+  #
+  #   USAGE:
+  #   sage_component <CLASSNAME>, { component_attributes: { "onChange": "handleChange(this)" } }
+  #   sage_component <CLASSNAME>, { component_attributes: { "onChange": "alert('hello world')" } }
+  def component_attributes
+    @component_attributes ||= {}
+  end
+
+  def component_attributes=(component_attributes_hash)
+    @component_attributes = component_attributes_hash
+    component_attributes_hash.each do |key, value|
+      generated_component_attributes << " #{key}=\"#{value.to_s}\""
     end
   end
 

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
@@ -17,6 +17,7 @@
     name="<%= select_id %>"
     id="<%= select_id %>"
     <%= "disabled" if component.disabled %>
+    <%= component.generated_component_attributes.html_safe %>
   >
     <% if component.select_options.present? %>
       <% component.select_options.each do |option| %>


### PR DESCRIPTION
## Description
Per discussion in Slack, see [here](https://kajabi.slack.com/archives/C01A424HY8Y/p1690384266736959) for more details; it was requested to have the ability to add or subscribe to `onChange` events for the `sage_form_select` component in Rails. 

fixes: https://kajabi.atlassian.net/browse/DSS-444

## Testing in `sage-lib`
1. Navigate to `Form Select` in your local instance of the Doc Site e.g  http://localhost:4000/pages/component/form_select?tab=preview
2. Scroll to the bottom and interact with the select titled `Example on how to pass additional attributes to the component`
3. Click on the Code Tab to see how to implement it.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
