### PR TITLE
docs(sage-component): add to the list of components on the rails doc site

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -13,6 +13,12 @@ module ComponentsHelper
     [
       # Sage Generated Components
       {
+        title: "sage_component",
+        description: "This serves as the base component for all Rails components",
+        rails: "done",
+        order: 1,
+      },
+      {
         title: "accordion",
         description: "The accordion component is used to show and hide sections of related content on a page.",
         scss: "done",
@@ -915,7 +921,7 @@ module ComponentsHelper
 
   # Sorts available components based on alphabet
   def sorted_sage_components
-    sage_components.sort_by { |h| h[:title] }
+    sage_components.sort_by { |h| [ ( h[:order] || 99 ), h[:title] ] }
   end
 
   # Archive of deprecated components

--- a/docs/app/views/examples/components/sage_component/_preview.html.erb
+++ b/docs/app/views/examples/components/sage_component/_preview.html.erb
@@ -1,0 +1,1 @@
+Nothing to see

--- a/docs/app/views/examples/components/sage_component/_props.html.erb
+++ b/docs/app/views/examples/components/sage_component/_props.html.erb
@@ -1,0 +1,36 @@
+<tr>
+  <td><%= md('`component_attributes`') %></td>
+  <td><%= md('Sets additional html attributes to the components inner element and not the outermost container.') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`content`') %></td>
+  <td><%= md('The internal content of the component') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`css_classes`') %></td>
+  <td><%= md('Set additional css classes on the outermost compnent container') %></td>
+  <td><%= md('String') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`html_attributes`') %></td>
+  <td><%= md('Sets html attributes to the outermost component container') %></td>
+  <td><%= md('Hash') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`spacer`') %></td>
+  <td><%= md('Adds margin spacing to the component') %></td>
+  <td><%= md('SageSchemas::SPACER') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
+  <td><%= md('`test_id`') %></td>
+  <td><%= md('Creates a `data-kjb-element` attribute based on the "id" supplied') %></td>
+  <td><%= md('string') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>

--- a/docs/app/views/examples/components/sage_component/_rules_do.html.erb
+++ b/docs/app/views/examples/components/sage_component/_rules_do.html.erb
@@ -1,0 +1,1 @@
+nothing at this time

--- a/docs/app/views/examples/components/sage_component/_rules_dont.html.erb
+++ b/docs/app/views/examples/components/sage_component/_rules_dont.html.erb
@@ -1,0 +1,1 @@
+nothing at this time


### PR DESCRIPTION
## Description
With the addition of a new prop to `SageComponent`, we need the ability to share the details with our customers. This will add the base `SageComponent` to the Rails doc site. 


## Screenshots
<img width="1594" alt="image" src="https://github.com/Kajabi/sage-lib/assets/1633290/0147034c-6600-4817-8485-66555967a1e6">


## Testing in `sage-lib`
1. Navigate to the Rails doc site e.g http://localhost:4000
2. Click on "Components", Sage Component should be the first component in the list. This was done intentionally since it serves as the base component for all Rails Sage components. 
3. Click on the `Props` tab, you should see the same details as the screenshot above.


## Testing in `kajabi-products`
No Impact


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
