### PR TITLE
[DSS-429]: fix(button): Adjust border to correct button height differences

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -495,7 +495,6 @@ $-btn-loading-min-height: rem(36px);
 /* stylelint-disable selector-no-qualifying-type */
 a.sage-btn {
   text-decoration: none;
-  border-color: transparent;
 }
 /* stylelint-enable selector-no-qualifying-type */
 
@@ -603,10 +602,6 @@ a.sage-btn {
     background-color: sage-color(white);
     border-color: sage-color(grey, 300);
   }
-
-  &.sage-btn--subtle {
-    border: 0;
-  }
 }
 
 .sage-btn--subtle {
@@ -616,6 +611,7 @@ a.sage-btn {
   padding: 0;
   box-shadow: none;
   border-radius: sage-border(radius);
+  border: 0;
 
   &:focus {
     box-shadow: none;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -27,25 +27,30 @@ $-btn-base-styles: (
     default: (
       color: sage-color(white),
       background-color: sage-color(primary, 300),
+      border-color: sage-color(primary, 300),
       ring-color: sage-color(primary, 200),
     ),
     hover: (
       color: sage-color(white),
       background-color: sage-color(primary, 400),
+      border-color: sage-color(primary, 400),
     ),
     focus: (
       color: sage-color(white),
       background-color: sage-color(primary, 300),
+      border-color: sage-color(primary, 300),
     ),
     disabled: (
       color: sage-color(primary, 200),
       background-color: sage-color(primary, 100),
+      border-color: sage-color(primary, 100),
     )
   ),
   primary: (
     default: (
       color: sage-color(white),
       background-color: sage-color(charcoal, 400),
+      border-color: sage-color(charcoal, 400),
       ring-color: sage-color(primary, 200),
     ),
     hover: (
@@ -55,10 +60,12 @@ $-btn-base-styles: (
     focus: (
       color: sage-color(white),
       background-color: sage-color(charcoal, 400),
+      border-color: sage-color(charcoal, 400),
     ),
     disabled: (
       color: sage-color(charcoal, 100),
       background-color: sage-color(grey, 300),
+      border-color: sage-color(grey, 300),
     )
   ),
   secondary: (
@@ -84,6 +91,7 @@ $-btn-base-styles: (
     default: (
       color: sage-color(white),
       background-color: sage-color(red, 300),
+      border-color: sage-color(red, 300),
       ring-color: sage-color(red, 200),
     ),
     hover: (
@@ -93,10 +101,12 @@ $-btn-base-styles: (
     focus: (
       color: sage-color(white),
       background-color: sage-color(red, 300),
+      border-color: sage-color(red, 300),
     ),
     disabled: (
       color: sage-color(red, 200),
       background-color: sage-color(red, 100),
+      border-color: sage-color(red, 100),
     )
   ),
 );
@@ -170,7 +180,8 @@ $-btn-loading-min-height: rem(36px);
   justify-self: flex-start;
   padding: $-btn-base-padding-block $-btn-base-padding-inline;
   text-align: left; // Prevents text alignment issue when inner text is truncated
-  border: 0;
+  border-width: 1px;
+  border-style: solid;
   border-radius: $-btn-border-radius;
   transition: $-btn-transition;
   transition-property: border, background-color, box-shadow;
@@ -307,6 +318,7 @@ $-btn-loading-min-height: rem(36px);
     height: rem(38px);
     background-color: sage-color(white);
     box-shadow: rem(-1px) 0 0 0 sage-color(grey, 400);
+    border-color: transparent;
 
     @include sage-focus-outline--update-color(transparent);
 
@@ -315,7 +327,7 @@ $-btn-loading-min-height: rem(36px);
     }
 
     &:focus {
-      box-shadow: 0 0 0 rem(2px) sage-color(primary, 300);
+      @include sage-focus-ring;
     }
   }
 
@@ -335,6 +347,7 @@ $-btn-loading-min-height: rem(36px);
   .sage-toolbar__group > .sage-input ~ &.sage-btn--primary,
   .sage-toolbar__group > .sage-search ~ &.sage-btn--primary {
     box-shadow: 0 0 0 1px sage-color(charcoal, 400);
+    border-color: transparent;
   }
 
   .sage-toolbar__group .sage-dropdown__trigger > & {
@@ -482,6 +495,7 @@ $-btn-loading-min-height: rem(36px);
 /* stylelint-disable selector-no-qualifying-type */
 a.sage-btn {
   text-decoration: none;
+  border-color: transparent;
 }
 /* stylelint-enable selector-no-qualifying-type */
 
@@ -508,6 +522,7 @@ a.sage-btn {
         &:active {
           color: map-get($-style-type-configs, color);
           background-color: map-get($-style-type-configs, background-color);
+          border-color: map-get($-style-type-configs, border-color);
         }
       }
       @else if ($-style-type-name == disabled) {
@@ -515,6 +530,7 @@ a.sage-btn {
         &[aria-disabled="true"] {
           color: map-get($-style-type-configs, color);
           background-color: map-get($-style-type-configs, background-color);
+          border-color: map-get($-style-type-configs, border-color);
           box-shadow: none;
         }
       }
@@ -633,7 +649,7 @@ a.sage-btn {
     &.sage-btn--#{$-style-name} {
       color: map-get($-styles, default);
       background-color: transparent;
-
+      border-color: transparent;
       &::after {
         border-color: transparent;
       }
@@ -728,6 +744,7 @@ a.sage-btn {
     @include sage-focus-outline--update-color(sage-color(white));
 
     color: sage-color(grey, 200);
+    border-color: transparent;
 
     &:hover {
       color: sage-color(white);


### PR DESCRIPTION
## Description
Design noticed that due to the border applied to a secondary button, its height is 2px more than the other buttons.

This is not highly noticeable until the secondary is placed next to another button.

These updates correct the border on other buttons to resolve the height differences.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="508" alt="Screenshot 2023-08-01 at 1 59 39 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/21d5466a-758d-4953-b2d8-c3bcdacc9c1a">|<img width="556" alt="Screenshot 2023-08-01 at 1 59 08 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/730f310c-e524-43e3-b157-94067c782e87">|


> [!IMPORTANT]  
> The "before" screenshot above shows the difference in the height of the buttons. The secondary is 42px whereas the others (e.g. accent, primary, danger) are 40px.


## Testing in `sage-lib`

- Navigate to [Buttons](http://localhost:4000/pages/component/button?tab=preview)
- Verify Button heights now match. (e.g. Secondary is the same height as Accent)
- Verify subtle and icon-only buttons still render/function as expected.
- Verify hover, focus, and active states still function as expected.
- Spot-check other components that may use buttons.


## Testing in `kajabi-products`

1. (**MEDIUM**) Adjust button borders to correct a mismatch in overall button height.
   - [ ] These are styling-only changes, but a sanity check should be performed to check for any unexpected issues.


## Related
https://kajabi.atlassian.net/browse/DSS-429
