### PR TITLE
[DSS-448]: Button Border Correction (Follow Up)

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -514,6 +514,7 @@ a.sage-btn {
         &:hover {
           color: map-get($-style-type-configs, color);
           background-color: map-get($-style-type-configs, background-color);
+          border-color: map-get($-style-type-configs, border-color);
         }
       }
       @else if ($-style-type-name == focus) {
@@ -538,6 +539,7 @@ a.sage-btn {
 
         color: map-get($-style-type-configs, color);
         background-color: map-get($-style-type-configs, background-color);
+        border-color: map-get($-style-type-configs, border-color);
 
         .sage-toolbar > &,
         .sage-toolbar__group > & {


### PR DESCRIPTION
## Description
Updates provided in #1775 introduced a minor bug where the button border color displays incorrectly when placed in locations where the background color is not white.

These updates provide the fix that sets the border color correctly. This was initially overlooked since most buttons appear on a white background throughout the application.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1160" alt="Screenshot 2023-08-07 at 11 41 07 AM" src="https://github.com/Kajabi/sage-lib/assets/1175111/834723f9-2dab-4c2d-8230-f4ab119b51af">|<img width="1134" alt="Screenshot 2023-08-07 at 11 50 07 AM" src="https://github.com/Kajabi/sage-lib/assets/1175111/047f6e82-c9f8-45a7-9bf9-56e4396eb041">|

## Testing in `sage-lib`

- Navigate to [docs site](http://localhost:4000/pages/index).
- Verify hero button no longer has incorrect border color.
- Verify [buttons](http://localhost:4000/pages/component/button?tab=preview) render as expected.

## Testing in `kajabi-products`
1. (**LOW**) Adds missing button border color. Styling only adjustment as follow up to previous button adjustments.

## Related
https://kajabi.atlassian.net/browse/DSS-448
