### PR TITLE
[DSS-328] Upload Card - Layout Update

### DIFF
--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -1,28 +1,72 @@
-<h3 class="t-sage-heading-6">Initial State</h3>
+<%
+  dropdown_menu_items = [
+    {
+      value: "Upload file",
+    }, {
+      value: "Select recent file",
+    },
+  ]
+
+  dropdown_menu_remove = {
+    icon: "remove-circle",
+    style: "danger",
+    value: "Take A Dangerous Action",
+  }
+%>
+
+<h3 class="t-sage-heading-6">Default State (no file selected)</h3>
 <%= sage_component SageUploadCard, {
+  id: "upload-card-default",
   selection_label: "Select file",
   selection_subtext: "Recommended dimensions or file size requirements",
 } %>
+
 
 <h3 class="t-sage-heading-6">Selected File State</h3>
 
 <%= sage_component SageUploadCard, {
   accepted_files: [
-    {name: "contacts.csv"},
+    {name: "my-image-file.jpg"},
   ],
   file_selected: true,
+  selection_preview: "https://placekitten.com/600",
+  id: "upload-card-selected",
   selection_label: "Edit file",
   selection_subtext: "Recommended dimensions or file size requirements",
 } %>
+
+<h3 class="t-sage-heading-6">Dropdown actions</h3>
+
+<%= sage_component SageUploadCard, {
+  accepted_files: [
+    {name: "my-image-file.jpg"},
+  ],
+  file_selected: true,
+  id: "upload-card-dropdown"
+} do %>
+  <% content_for :sage_upload_card_actions do %>
+    <%= sage_component SageDropdown, { items: dropdown_menu_items } do %>
+      <% content_for :sage_dropdown_trigger, flush: true do %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          icon: { name: "caret-down", style: "right" },
+          value: "Select filezzzz",
+        } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
 
 <h3 class="t-sage-heading-6">Error State</h3>
 
 <%= sage_component SageUploadCard, {
   has_error: true,
+  id: "upload-card-error",
   selection_label: "Select a file",
   selection_subtext: "Recommended dimensions or file size requirements",
   errors: [
-    {text: "This is the error message."},
+    {text: "This is an error message."},
   ]
 } %>
 

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -17,7 +17,11 @@
 <%= sage_component SageUploadCard, {
   id: "upload-card-default",
   selection_label: "Select file",
-} %>
+} do %>
+  <% content_for :sage_upload_card_instructions do %>
+    <p>Upload a JPEG sdbfksbfkjb</p>
+  <% end %>
+<% end %>
 
 <h3>Selected File State</h3>
 
@@ -31,10 +35,9 @@
   accepted_file_types: ["image/jpg"],
   selection_preview: "https://placekitten.com/360",
   id: "upload-card-selected",
-  selection_label: "Edit file"
 } do %>
   <% content_for :sage_upload_card_instructions do %>
-    <p>Upload a JPEG</p>
+    <p>Upload a JPEG this is a test</p>
   <% end %>
 <% end %>
 
@@ -108,6 +111,7 @@
   ],
   file_selected: true,
   has_error: true,
+  id: "upload-card-selected-error",
   selection_label: "Replace file",
   selection_subtext: "Recommended dimensions or file size requirements",
   errors: [

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -1,6 +1,6 @@
 <h3 class="t-sage-heading-6">Initial State</h3>
 <%= sage_component SageUploadCard, {
-  selection_label: "Select a file",
+  selection_label: "Select file",
   selection_subtext: "Recommended dimensions or file size requirements",
 } %>
 
@@ -11,7 +11,7 @@
     {name: "contacts.csv"},
   ],
   file_selected: true,
-  selection_label: "Replace file",
+  selection_label: "Edit file",
   selection_subtext: "Recommended dimensions or file size requirements",
 } %>
 

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -4,63 +4,75 @@
       value: "Upload file",
     }, {
       value: "Select recent file",
-    },
+    }, {
+      style: "danger",
+      modifiers: ["border-before"],
+      value: "Remove image",
+    }
   ]
-
-  dropdown_menu_remove = {
-    icon: "remove-circle",
-    style: "danger",
-    value: "Take A Dangerous Action",
-  }
 %>
 
-<h3 class="t-sage-heading-6">Default State (no file selected)</h3>
+<h3>Default State (no file selected)</h3>
 
 <%= sage_component SageUploadCard, {
   id: "upload-card-default",
   selection_label: "Select file",
-  selection_subtext: "Recommended dimensions or file size requirements",
 } %>
 
+<h3>Selected File State</h3>
 
-<h3 class="t-sage-heading-6">Selected File State</h3>
+<p>Restrict accepted file types using <code>accepted_file_types</code>.</p>
 
 <%= sage_component SageUploadCard, {
   accepted_files: [
     {name: "my-image-file.jpg"},
   ],
   file_selected: true,
-  selection_preview: "https://placekitten.com/520",
+  accepted_file_types: ["image/jpg"],
+  selection_preview: "https://placekitten.com/360",
   id: "upload-card-selected",
-  selection_label: "Edit file",
-  selection_subtext: "Recommended dimensions or file size requirements",
-} %>
+  selection_label: "Edit file"
+} do %>
+  <% content_for :sage_upload_card_instructions do %>
+    <p>Upload a JPEG</p>
+  <% end %>
+<% end %>
 
 
-<h3 class="t-sage-heading-6">Stacked layout</h3>
+<h3>Vertical (stacked) layout</h3>
 <p>The default layout will adjust from a vertical (stacked) orientation to horizontal depending on available space and/or screen size.</p>
 
-<p>Setting <code>stack_layout</code> to <code>true</code> locks the component to its vertical (stacked) orientation.</p>
+<p>Setting <code>stack_layout</code> to <code>true</code> locks the component to the vertical orientation.</p>
 
 <%= sage_component SageUploadCard, {
   accepted_files: [
     {name: "my-image-file.jpg"},
   ],
   file_selected: true,
-  selection_preview: "https://placekitten.com/640/480",
+  selection_preview: "https://placekitten.com/360",
   stack_layout: true,
   id: "upload-card-stack",
   selection_label: "Edit file",
-  selection_subtext: "Recommended dimensions or file size requirements",
-} %>
+} do %>
+  <% content_for :sage_upload_card_instructions do %>
+    <p>Recommended dimensions or file size requirements</p>
+  <% end %>
+<% end %>
 
-<h3 class="t-sage-heading-6">Custom actions</h3>
-<p>Use the <code>sage_upload_card_actions</code> slot to replace the default button and display custom components, like dropdowns.</p>
+<h3>Custom content areas</h3>
+<h4>Instructions area</h4>
+<p>The <code>sage_upload_card_instructions</code> slot provides an area for  extended instructions and custom markup.</p>
+
+<h4>Actions area</h4>
+<p>Use the <code>sage_upload_card_actions</code> slot to replace the default button and display custom components, such as dropdowns.</p>
+<p><strong>NOTE:</strong> a file input field and label are <em>included by default in the base component</em>, as seen in the examples above. When applying a custom file input with `sage_upload_card_actions`, set <code>custom_file_input_field</code> to <code>true</code> to remove these defaults.</p>
 <%= sage_component SageUploadCard, {
   accepted_files: [
-    {name: "my-image-file.jpg"},
+    {name: "fluffy-kitteh.jpg"},
   ],
+  custom_file_input_field: true,
   file_selected: true,
+  selection_preview: "https://placekitten.com/360",
   id: "upload-card-dropdown"
 } do %>
   <% content_for :sage_upload_card_actions do %>
@@ -69,7 +81,7 @@
         <%= sage_component SageButton, {
           style: "secondary",
           icon: { name: "caret-down", style: "right" },
-          value: "Select filezzzz",
+          value: "Edit file",
         } %>
       <% end %>
     <% end %>
@@ -77,13 +89,12 @@
 <% end %>
 
 
-<h3 class="t-sage-heading-6">Error State</h3>
+<h3>Error State</h3>
 
 <%= sage_component SageUploadCard, {
   has_error: true,
   id: "upload-card-error",
   selection_label: "Select a file",
-  selection_subtext: "Recommended dimensions or file size requirements",
   errors: [
     {text: "This is an error message."},
   ]

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -15,7 +15,6 @@
 %>
 
 <h3 class="t-sage-heading-6">Default State (no file selected)</h3>
-<p>This layout will adjust from a vertical (stacked) orientation to horizontal depending on available space and/or screen size.</p>
 
 <%= sage_component SageUploadCard, {
   id: "upload-card-default",
@@ -39,7 +38,9 @@
 
 
 <h3 class="t-sage-heading-6">Stacked layout</h3>
-<p>Locks the layout to vertical (stacked) orientation</p>
+<p>The default layout will adjust from a vertical (stacked) orientation to horizontal depending on available space and/or screen size.</p>
+
+<p>Setting <code>stack_layout</code> to <code>true</code> locks the component to its vertical (stacked) orientation.</p>
 
 <%= sage_component SageUploadCard, {
   accepted_files: [
@@ -48,13 +49,13 @@
   file_selected: true,
   selection_preview: "https://placekitten.com/640/480",
   stack_layout: true,
-  id: "upload-card-selected",
+  id: "upload-card-stack",
   selection_label: "Edit file",
   selection_subtext: "Recommended dimensions or file size requirements",
 } %>
 
 <h3 class="t-sage-heading-6">Custom actions</h3>
-<p>Use the <code>sage_upload_card_actions</code> slot to replace the default button and display custom components like dropdowns.</p>
+<p>Use the <code>sage_upload_card_actions</code> slot to replace the default button and display custom components, like dropdowns.</p>
 <%= sage_component SageUploadCard, {
   accepted_files: [
     {name: "my-image-file.jpg"},

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -15,6 +15,8 @@
 %>
 
 <h3 class="t-sage-heading-6">Default State (no file selected)</h3>
+<p>This layout will adjust from a vertical (stacked) orientation to horizontal depending on available space and/or screen size.</p>
+
 <%= sage_component SageUploadCard, {
   id: "upload-card-default",
   selection_label: "Select file",
@@ -29,14 +31,30 @@
     {name: "my-image-file.jpg"},
   ],
   file_selected: true,
-  selection_preview: "https://placekitten.com/600",
+  selection_preview: "https://placekitten.com/520",
   id: "upload-card-selected",
   selection_label: "Edit file",
   selection_subtext: "Recommended dimensions or file size requirements",
 } %>
 
-<h3 class="t-sage-heading-6">Dropdown actions</h3>
 
+<h3 class="t-sage-heading-6">Stacked layout</h3>
+<p>Locks the layout to vertical (stacked) orientation</p>
+
+<%= sage_component SageUploadCard, {
+  accepted_files: [
+    {name: "my-image-file.jpg"},
+  ],
+  file_selected: true,
+  selection_preview: "https://placekitten.com/640/480",
+  stack_layout: true,
+  id: "upload-card-selected",
+  selection_label: "Edit file",
+  selection_subtext: "Recommended dimensions or file size requirements",
+} %>
+
+<h3 class="t-sage-heading-6">Custom actions</h3>
+<p>Use the <code>sage_upload_card_actions</code> slot to replace the default button and display custom components like dropdowns.</p>
 <%= sage_component SageUploadCard, {
   accepted_files: [
     {name: "my-image-file.jpg"},

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -106,19 +106,3 @@
     <p>Recommended dimensions or file size requirements</p>
   <% end %>
 <% end %>
-
-<h3 class="t-sage-heading-6">Selected Error State</h3>
-
-<%= sage_component SageUploadCard, {
-  accepted_files: [
-    {name: "contacts.csv"},
-  ],
-  file_selected: true,
-  has_error: true,
-  id: "upload-card-selected-error",
-  selection_label: "Replace file",
-  selection_subtext: "Recommended dimensions or file size requirements",
-  errors: [
-    {text: "This is the error message."},
-  ]
-} %>

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -34,6 +34,7 @@
   file_selected: true,
   accepted_file_types: ["image/jpg"],
   selection_preview: "https://placekitten.com/360",
+  selection_label: "Replace file",
   id: "upload-card-selected",
 } do %>
   <% content_for :sage_upload_card_instructions do %>

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -19,7 +19,7 @@
   selection_label: "Select file",
 } do %>
   <% content_for :sage_upload_card_instructions do %>
-    <p>Upload a JPEG sdbfksbfkjb</p>
+    <p>Upload a JPEG</p>
   <% end %>
 <% end %>
 
@@ -101,7 +101,11 @@
   errors: [
     {text: "This is an error message."},
   ]
-} %>
+} do %>
+  <% content_for :sage_upload_card_instructions do %>
+    <p>Recommended dimensions or file size requirements</p>
+  <% end %>
+<% end %>
 
 <h3 class="t-sage-heading-6">Selected Error State</h3>
 

--- a/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
@@ -14,6 +14,7 @@ class SageUploadCard < SageComponent
     selection_preview: [:optional, NilClass, String],
     selection_label: [:optional, NilClass, String],
     selection_subtext: [:optional, NilClass, String],
+    stack_layout:[:optional, NilClass, TrueClass],
   })
   def actions
     %w(upload_card_actions)

--- a/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
@@ -17,13 +17,7 @@ class SageUploadCard < SageComponent
     selection_label: [:optional, NilClass, String],
     stack_layout:[:optional, NilClass, TrueClass],
   })
-  def instructions
-    %w(upload_card_instructions)
-  end
-  def image
-    %w(upload_card_preview)
-  end
-  def actions
-    %w(upload_card_actions)
+  def sections
+    %w(upload_card_instructions upload_card_preview upload_card_actions)
   end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
@@ -4,6 +4,7 @@ class SageUploadCard < SageComponent
       name: [:optional, NilClass, String],
       size: [:optional, NilClass, String],
     ]]],
+    accepted_file_types: [:optional, NilClass, String],
     errors: [:optional, NilClass, [[
       text: [:optional, NilClass, String],
     ]]],

--- a/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
@@ -9,7 +9,13 @@ class SageUploadCard < SageComponent
     ]]],
     file_selected: [:optional, NilClass, TrueClass],
     has_error: [:optional, NilClass, TrueClass],
+    id: String,
+    name: [:optional, NilClass, String],
+    selection_preview: [:optional, NilClass, String],
     selection_label: [:optional, NilClass, String],
     selection_subtext: [:optional, NilClass, String],
   })
+  def actions
+    %w(upload_card_actions)
+  end
 end

--- a/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_upload_card.rb
@@ -4,7 +4,8 @@ class SageUploadCard < SageComponent
       name: [:optional, NilClass, String],
       size: [:optional, NilClass, String],
     ]]],
-    accepted_file_types: [:optional, NilClass, String],
+    accepted_file_types: [:optional, NilClass, Array],
+    custom_file_input_field: [:optional, NilClass, TrueClass],
     errors: [:optional, NilClass, [[
       text: [:optional, NilClass, String],
     ]]],
@@ -14,9 +15,14 @@ class SageUploadCard < SageComponent
     name: [:optional, NilClass, String],
     selection_preview: [:optional, NilClass, String],
     selection_label: [:optional, NilClass, String],
-    selection_subtext: [:optional, NilClass, String],
     stack_layout:[:optional, NilClass, TrueClass],
   })
+  def instructions
+    %w(upload_card_instructions)
+  end
+  def image
+    %w(upload_card_preview)
+  end
   def actions
     %w(upload_card_actions)
   end

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -1,10 +1,10 @@
+<% upload_card_classes = ['sage-upload-card']
+  upload_card_classes << 'sage-upload-card--selected' if component.file_selected.present?
+  upload_card_classes << 'sage-upload-card--error' if component.has_error.present?
+  upload_card_classes << component.generated_css_classes
+%>
 <div
-  class="
-    sage-upload-card
-    <% if component.file_selected.present? %> sage-upload-card--selected<% end %>
-    <% if component.has_error.present? %> sage-upload-card--error<% end %>
-    <%= component.generated_css_classes %>
-  "
+  class="<%= upload_card_classes.join(" ") %>"
   <%= component.generated_html_attributes.html_safe %>
 >
   <div class="sage-upload-card__dropzone">
@@ -20,8 +20,7 @@
       <div class="sage-upload-card__body">
         <p class="sage-upload-card__text"><%= component.accepted_files[0][:name] %></p>
         <%= sage_component SageButton, {
-          style: "primary",
-          subtle: true,
+          style: "secondary",
           value: component.selection_label
         } %>
         <p class="sage-upload-card__subtext"><%= component.selection_subtext %></p>
@@ -30,8 +29,7 @@
       <div class="sage-upload-card__body">
         <i class="sage-upload-card__icon sage-icon-image-2xl" aria-label="Upload graphic"></i>
         <%= sage_component SageButton, {
-          style: "primary",
-          subtle: true,
+          style: "secondary",
           value: component.selection_label
         } %>
         <p class="sage-upload-card__subtext"><%= component.selection_subtext %></p>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -14,7 +14,9 @@
 %>
 <div class="<%= upload_card_classes.join(" ") %>" <%= component.generated_html_attributes.html_safe %>>
   <div class="sage-upload-card__dropzone">
-    <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
+    <% unless component.custom_file_input_field %>
+      <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
+    <% end %>
     <% if component.selection_preview.present? %>
       <%= image_tag(component.selection_preview, upload_card_preview_image_options) %>
     <% else %>
@@ -22,27 +24,28 @@
         color: "draft",
         css_classes: "sage-upload-card__preview",
         icon: "image",
-        label: "Upload graphic",
         size: "2xl",
       } %>
     <% end %>
     <div class="sage-upload-card__body">
       <div class="sage-upload-card__description">
         <% if component.file_selected.present? || component.selection_preview.present? %>
-          <p class="sage-upload-card__text">
+          <p class="sage-upload-card__filename">
             <%= component.accepted_files[0][:name] %>
           </p>
         <% end %>
-        <% if component.selection_subtext.present? %>
-          <p class="sage-upload-card__subtext">
-            <%= component.selection_subtext %>
-          </p>
+        <% if content_for? :sage_upload_card_instructions %>
+          <div class="sage-upload-card__instructions">
+            <%= content_for :sage_upload_card_instructions %>
+          </div>
         <% end %>
       </div>
-      <% if component.selection_label.present? %>
+      <% if component.selection_label.present? && !component.custom_file_input_field %>
         <label for="<%= component.id %>" class="sage-upload-card__input-label sage-btn sage-btn--secondary"><%= upload_card_input_label %></label>
-      <% elsif content_for? :sage_upload_card_actions %>
-        <label for="<%= component.id %>" class="visually-hidden"><%= upload_card_input_label %></label>
+      <% elsif content_for? :sage_upload_card_actions  %>
+        <% if !component.custom_file_input_field %>
+          <label for="<%= component.id %>" class="visually-hidden"><%= upload_card_input_label %></label>
+        <% end %>
         <%= content_for :sage_upload_card_actions %>
       <% end %>
     </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -1,5 +1,6 @@
 <%
   upload_card_classes = ['sage-upload-card']
+  upload_card_classes << 'sage-upload-card--stack-only' if component.stack_layout == true
   upload_card_classes << 'sage-upload-card--selected' if component.file_selected.present?
   upload_card_classes << 'sage-upload-card--error' if component.has_error.present?
   upload_card_classes << component.generated_css_classes
@@ -13,8 +14,7 @@
 %>
 <div class="<%= upload_card_classes.join(" ") %>" <%= component.generated_html_attributes.html_safe %>>
   <div class="sage-upload-card__dropzone">
-    <label for="<%= component.id %>" class="visually-hidden"><%= upload_card_input_label %></label>
-    <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
+    <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" value="<%= upload_card_input_label %>" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
     <% if component.selection_preview.present? %>
       <%= image_tag(component.selection_preview, upload_card_preview_image_options) %>
     <% else %>
@@ -27,7 +27,7 @@
       } %>
     <% end %>
     <div class="sage-upload-card__body">
-      <div class="sage-upload-card__label">
+      <div class="sage-upload-card__description">
         <% if component.file_selected.present? || component.selection_preview.present? %>
           <p class="sage-upload-card__text">
             <%= component.accepted_files[0][:name] %>
@@ -40,10 +40,7 @@
         <% end %>
       </div>
       <% if component.selection_label.present? %>
-        <%= sage_component SageButton, {
-          style: "secondary",
-          value: component.selection_label
-        } %>
+        <label for="<%= component.id %>" class="sage-upload-card__input-label sage-btn sage-btn--secondary"><%= upload_card_input_label %></label>
       <% elsif content_for? :sage_upload_card_actions %>
         <%= content_for :sage_upload_card_actions %>
       <% end %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -5,7 +5,7 @@
   upload_card_classes << 'sage-upload-card--error' if component.has_error.present?
   upload_card_classes << component.generated_css_classes
   upload_card_input_label = component.selection_label.present? ? component.selection_label : "Select a file"
-  upload_card_imagetypes = ['image/*']
+  upload_card_imagetypes = component.accepted_file_types.present? ? component.accepted_file_types.join(",") : "image/*"
 
   upload_card_preview_image_options = {
     class: "sage-upload-card__preview",
@@ -14,7 +14,7 @@
 %>
 <div class="<%= upload_card_classes.join(" ") %>" <%= component.generated_html_attributes.html_safe %>>
   <div class="sage-upload-card__dropzone">
-    <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" value="<%= upload_card_input_label %>" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
+    <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
     <% if component.selection_preview.present? %>
       <%= image_tag(component.selection_preview, upload_card_preview_image_options) %>
     <% else %>
@@ -42,6 +42,7 @@
       <% if component.selection_label.present? %>
         <label for="<%= component.id %>" class="sage-upload-card__input-label sage-btn sage-btn--secondary"><%= upload_card_input_label %></label>
       <% elsif content_for? :sage_upload_card_actions %>
+        <label for="<%= component.id %>" class="visually-hidden"><%= upload_card_input_label %></label>
         <%= content_for :sage_upload_card_actions %>
       <% end %>
     </div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -5,7 +5,7 @@
   upload_card_classes << 'sage-upload-card--error' if component.has_error.present?
   upload_card_classes << component.generated_css_classes
   upload_card_input_label = component.selection_label.present? ? component.selection_label : "Select a file"
-  upload_card_imagetypes = component.accepted_file_types.present? ? component.accepted_file_types.join(",") : "image/*"
+  upload_card_image_types = component.accepted_file_types.present? ? component.accepted_file_types.join(",") : "image/*"
 
   upload_card_preview_image_options = {
     class: "sage-upload-card__preview",
@@ -15,7 +15,7 @@
 <div class="<%= upload_card_classes.join(" ") %>" <%= component.generated_html_attributes.html_safe %>>
   <div class="sage-upload-card__dropzone">
     <% unless component.custom_file_input_field %>
-      <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
+      <input class="sage-upload-card__input" accept="<%= upload_card_image_types %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
     <% end %>
     <% if component.selection_preview.present? %>
       <%= image_tag(component.selection_preview, upload_card_preview_image_options) %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -1,15 +1,23 @@
-<% upload_card_classes = ['sage-upload-card']
+<%
+  upload_card_classes = ['sage-upload-card']
   upload_card_classes << 'sage-upload-card--selected' if component.file_selected.present?
   upload_card_classes << 'sage-upload-card--error' if component.has_error.present?
   upload_card_classes << component.generated_css_classes
+  upload_card_input_label = component.selection_label.present? ? component.selection_label : "Select a file"
+  upload_card_imagetypes = ['image/*']
+
+  upload_card_preview_image_options = {
+    class: "sage-upload-card__preview",
+    alt: ""
+  }
 %>
-<div
-  class="<%= upload_card_classes.join(" ") %>"
-  <%= component.generated_html_attributes.html_safe %>
->
+<div class="<%= upload_card_classes.join(" ") %>" <%= component.generated_html_attributes.html_safe %>>
   <div class="sage-upload-card__dropzone">
-    <input class="sage-upload-card__input" accept=".csv" multiple="multiple" type="file" autocomplete="off" />
-    <% if component.file_selected.present? %>
+    <label for="<%= component.id %>" class="visually-hidden"><%= upload_card_input_label %></label>
+    <input class="sage-upload-card__input" accept="<%= upload_card_imagetypes %>" multiple="multiple" type="file" autocomplete="off" name="<%= component.name.present? ? component.name : component.id %>" id="<%= component.id %>" />
+    <% if component.selection_preview.present? %>
+      <%= image_tag(component.selection_preview, upload_card_preview_image_options) %>
+    <% else %>
       <%= sage_component SageIconCard, {
         color: "draft",
         css_classes: "sage-upload-card__preview",
@@ -17,24 +25,29 @@
         label: "Upload graphic",
         size: "2xl",
       } %>
-      <div class="sage-upload-card__body">
-        <p class="sage-upload-card__text"><%= component.accepted_files[0][:name] %></p>
-        <%= sage_component SageButton, {
-          style: "secondary",
-          value: component.selection_label
-        } %>
-        <p class="sage-upload-card__subtext"><%= component.selection_subtext %></p>
-      </div>
-    <% else %>
-      <div class="sage-upload-card__body">
-        <i class="sage-upload-card__icon sage-icon-image-2xl" aria-label="Upload graphic"></i>
-        <%= sage_component SageButton, {
-          style: "secondary",
-          value: component.selection_label
-        } %>
-        <p class="sage-upload-card__subtext"><%= component.selection_subtext %></p>
-      </div>
     <% end %>
+    <div class="sage-upload-card__body">
+      <div class="sage-upload-card__label">
+        <% if component.file_selected.present? || component.selection_preview.present? %>
+          <p class="sage-upload-card__text">
+            <%= component.accepted_files[0][:name] %>
+          </p>
+        <% end %>
+        <% if component.selection_subtext.present? %>
+          <p class="sage-upload-card__subtext">
+            <%= component.selection_subtext %>
+          </p>
+        <% end %>
+      </div>
+      <% if component.selection_label.present? %>
+        <%= sage_component SageButton, {
+          style: "secondary",
+          value: component.selection_label
+        } %>
+      <% elsif content_for? :sage_upload_card_actions %>
+        <%= content_for :sage_upload_card_actions %>
+      <% end %>
+    </div>
   </div>
   <% if component.errors.present? %>
     <div class="sage-upload-card__errors">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_upload_card.html.erb
@@ -19,6 +19,8 @@
     <% end %>
     <% if component.selection_preview.present? %>
       <%= image_tag(component.selection_preview, upload_card_preview_image_options) %>
+    <% elsif content_for? :sage_upload_card_preview %>
+      <%= content_for :sage_upload_card_preview %>
     <% else %>
       <%= sage_component SageIconCard, {
         color: "draft",

--- a/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
@@ -7,66 +7,68 @@
 
 $-upload-card-border-radius: sage-border(radius-large);
 $-upload-card-border-width: 2;
-$-upload-card-selected-width: rem(200px);
+$-upload-card-error-color: sage-color(red, 300);
+$-upload-card-body-width: rem(200px);
+$-upload-card-body-width-stack: rem(340px);
 $-upload-card-preview-border-radius: sage-border(radius-medium);
 $-upload-card-preview-width: rem(32px);
 $-upload-card-preview-max-width: rem(190px);
-$-upload-card-preview-max-width-mobile: rem(304px);
+$-upload-card-preview-max-width-stack: rem(292px);
 $-upload-card-background: sage-color(white);
+$-upload-card-mobile-breakpoint: 609px;
+
+:root {
+  --sage-upload-card-aspect-ratio: 190 / 107;
+  --sage-upload-card-aspect-ratio-stack: 19 / 12;
+}
 
 .sage-upload-card__body {
   display: flex;
   flex-flow: column;
-  align-items: center;
-  flex: 1;
-  gap: sage-spacing(sm);
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex: 1 1 $-upload-card-body-width;
+  gap: sage-spacing();
   color: sage-color(charcoal, 200);
 
-  :not(.sage-upload-card--selected) & {
-    justify-content: center;
-    align-items: center;
-  }
-
   .sage-upload-card--selected & {
-    justify-content: flex-start;
-    align-items: flex-start;
-  }
-
-  .sage-upload-card--selected & {
-    flex-basis: $-upload-card-selected-width;
     color: sage-color(charcoal, 300);
+  }
+
+  .sage-upload-card--error & {
+    color: $-upload-card-error-color;
   }
 }
 
 .sage-upload-card__dropzone {
   display: flex;
+  flex-flow: row wrap;
   align-items: center;
   justify-content: center;
-  gap: sage-spacing(xs);
+  gap: sage-spacing();
   padding: sage-spacing(md);
   background-color: $-upload-card-background;
   border-radius: $-upload-card-border-radius;
   border: sage-border(default);
 
-  .sage-upload-card:not(.sage-upload-card--selected) & {
-    flex-flow: column;
-  }
-
-  .sage-upload-card--selected & {
-    flex-flow: row wrap;
-    gap: sage-spacing();
-  }
-
   .sage-upload-card.sage-upload-card--error & {
-    border-color: sage-color(red, 300);
+    border-color: $-upload-card-error-color;
   }
 
   .sage-upload-card.sage-upload-card--error & {
     &:hover,
     &:focus,
     &:focus-within {
-      border-color: sage-color(red, 300);
+      border-color: $-upload-card-error-color;
     }
+  }
+
+  .sage-upload-card--stack-only & {
+    flex-flow: column;
+    align-items: flex-start;
+    max-width: $-upload-card-body-width-stack;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 
@@ -76,7 +78,7 @@ $-upload-card-background: sage-color(white);
   > p {
     @extend %t-sage-body-med;
 
-    color: sage-color(red, 300);
+    color: $-upload-card-error-color;
 
     &:not(:last-child) {
       margin-bottom: sage-spacing(2xs);
@@ -89,7 +91,7 @@ $-upload-card-background: sage-color(white);
 
     &:focus,
     &:hover {
-      color: sage-color(red, 300);
+      color: $-upload-card-error-color;
       text-decoration: underline;
       outline: 0;
     }
@@ -109,26 +111,37 @@ $-upload-card-background: sage-color(white);
   @include visually-hidden;
 }
 
+.sage-upload-card__input-label {
+  /* NOTE: label provides keyboard focus but does not allow form interaction */
+  @include sage-focus-ring;
+}
+
 .sage-upload-card__preview {
-  width: $-upload-card-preview-width;
-  max-width: $-upload-card-preview-max-width;
+  width: 100%;
   margin-right: 0;
   text-align: center;
   border-radius: $-upload-card-preview-border-radius;
+  aspect-ratio: var(--sage-upload-card-aspect-ratio-stack);
+  object-fit: cover;
 
-  .sage-upload-card--selected & {
-    width: 100%;
+  @media (min-width: 610px) {
+    max-width: $-upload-card-preview-max-width;
+    aspect-ratio: var(--sage-upload-card-aspect-ratio);
   }
 
-  @media (max-width: 609px) {
-    max-width: $-upload-card-preview-max-width-mobile;
+  .sage-upload-card--stack-only & {
+    max-width: $-upload-card-preview-max-width-stack;
+    aspect-ratio: var(--sage-upload-card-aspect-ratio-stack);
   }
 }
 
-.sage-upload-card__subtext {
+.sage-upload-card__description {
+  display: flex;
+  flex-direction: column;
+  gap: sage-spacing(sm);
+}
+
+.sage-upload-card__instructions {
   @extend %t-sage-body;
-}
-
-.sage-upload-card__text {
-  @extend %t-sage-heading-6;
+  color: sage-color(charcoal, 200);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
@@ -8,22 +8,19 @@
 $-upload-card-border-radius: sage-border(radius-large);
 $-upload-card-border-width: 2;
 $-upload-card-selected-width: rem(200px);
+$-upload-card-preview-border-radius: sage-border(radius-medium);
 $-upload-card-preview-width: rem(32px);
 $-upload-card-preview-max-width: rem(190px);
 $-upload-card-preview-max-width-mobile: rem(304px);
 $-upload-card-background: sage-color(white);
-
-.sage-upload-card {
-  &:focus {
-    outline: none;
-  }
-}
 
 .sage-upload-card__body {
   display: flex;
   flex-flow: column;
   align-items: center;
   flex: 1;
+  gap: sage-spacing(sm);
+  color: sage-color(charcoal, 200);
 
   :not(.sage-upload-card--selected) & {
     justify-content: center;
@@ -37,6 +34,7 @@ $-upload-card-background: sage-color(white);
 
   .sage-upload-card--selected & {
     flex-basis: $-upload-card-selected-width;
+    color: sage-color(charcoal, 300);
   }
 }
 
@@ -116,7 +114,7 @@ $-upload-card-background: sage-color(white);
   max-width: $-upload-card-preview-max-width;
   margin-right: 0;
   text-align: center;
-  border-radius: sage-border(radius-sm);
+  border-radius: $-upload-card-preview-border-radius;
 
   .sage-upload-card--selected & {
     width: 100%;
@@ -128,15 +126,9 @@ $-upload-card-background: sage-color(white);
 }
 
 .sage-upload-card__subtext {
-  @extend %t-sage-body-small;
-
-  margin-top: sage-spacing(2xs);
-  color: sage-color(charcoal, 200);
+  @extend %t-sage-body;
 }
 
 .sage-upload-card__text {
   @extend %t-sage-heading-6;
-
-  margin-bottom: sage-spacing(2xs);
-  color: sage-color(charcoal, 400);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
@@ -114,6 +114,8 @@ $-upload-card-mobile-breakpoint: 609px;
 .sage-upload-card__input-label {
   /* NOTE: label provides keyboard focus but does not allow form interaction */
   @include sage-focus-ring;
+
+  justify-self: flex-start;
 }
 
 .sage-upload-card__preview {

--- a/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
@@ -136,13 +136,10 @@ $-upload-card-mobile-breakpoint: 609px;
 }
 
 .sage-upload-card__description {
+  @extend %t-sage-body-med;
+
   display: flex;
   flex-direction: column;
   gap: sage-spacing(sm);
-}
-
-.sage-upload-card__instructions,
-.sage-upload-card__filename {
-  @extend %t-sage-body-med;
   color: sage-color(charcoal, 200);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
@@ -27,7 +27,7 @@ $-upload-card-mobile-breakpoint: 609px;
   flex-flow: column;
   align-items: flex-start;
   justify-content: flex-start;
-  flex: 1 1 $-upload-card-body-width;
+  flex: 1 1;
   gap: sage-spacing();
   color: sage-color(charcoal, 200);
 
@@ -141,7 +141,8 @@ $-upload-card-mobile-breakpoint: 609px;
   gap: sage-spacing(sm);
 }
 
-.sage-upload-card__instructions {
-  @extend %t-sage-body;
+.sage-upload-card__instructions,
+.sage-upload-card__filename {
+  @extend %t-sage-body-med;
   color: sage-color(charcoal, 200);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_upload_card.scss
@@ -114,8 +114,6 @@ $-upload-card-mobile-breakpoint: 609px;
 .sage-upload-card__input-label {
   /* NOTE: label provides keyboard focus but does not allow form interaction */
   @include sage-focus-ring;
-
-  justify-self: flex-start;
 }
 
 .sage-upload-card__preview {
@@ -142,6 +140,7 @@ $-upload-card-mobile-breakpoint: 609px;
 
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: sage-spacing(sm);
   color: sage-color(charcoal, 200);
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -652,6 +652,7 @@
 /// Adds the basic default panel setup including grid, spacing, and border treatment
 ///
 @mixin sage-panel() {
+  container-type: inline-size;
   padding: sage-spacing(panel);
   background-color: sage-color(white);
   border: sage-border();

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -652,7 +652,6 @@
 /// Adds the basic default panel setup including grid, spacing, and border treatment
 ///
 @mixin sage-panel() {
-  container-type: inline-size;
   padding: sage-spacing(panel);
   background-color: sage-color(white);
   border: sage-border();

--- a/packages/sage-react/lib/UploadCard/UploadCard.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.jsx
@@ -68,17 +68,17 @@ export const UploadCard = ({
           <label htmlFor={id} className="visually-hidden">{selectionLabel || replaceLabel}</label>
         );
       }
-      return actions;
     }
+    return actions;
   };
 
   return (
     <div className={classNames} {...rest}>
       <div className="sage-upload-card__dropzone" {...rootProps}>
         {renderDefaultInputField()}
+        {renderPreviewImage()}
         {filesSelected ? (
           <>
-            {renderPreviewImage()}
             <div className="sage-upload-card__body">
               <div className="sage-upload-card__description">
                 {acceptedFiles.map(({ name }, i) => {
@@ -101,12 +101,6 @@ export const UploadCard = ({
           </>
         ) : (
           <>
-            <IconCard
-              className="sage-upload-card__preview"
-              color={IconCard.COLORS.DRAFT}
-              icon={IconCard.ICONS.FILE}
-              size={IconCard.SIZES.XL}
-            />
             <div className="sage-upload-card__body">
               <div className="sage-upload-card__description">
                 <p className="sage-upload-card__filename">

--- a/packages/sage-react/lib/UploadCard/UploadCard.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.jsx
@@ -54,22 +54,23 @@ export const UploadCard = ({
   );
 
   const renderLabel = () => {
-    if ((selectionLabel || replaceLabel) && !customFileInputField) {
-      return (
-        <>
-          <label htmlFor={id} className="sage-upload-card__input-label sage-btn sage-btn--secondary">{selectionLabel || replaceLabel}</label>
-        </>
-      );
-    }
-
-    if (actions) {
-      if (!customFileInputField) {
-        return (
-          <label htmlFor={id} className="visually-hidden">{selectionLabel || replaceLabel}</label>
-        );
+    let classnames = 'visually-hidden';
+    const CustomLabel = () => (
+      <>
+        <label htmlFor={id} className={classnames}>
+          {selectionLabel || replaceLabel}
+        </label>
+      </>
+    );
+    if ((selectionLabel || replaceLabel) && customFileInputField === false) {
+      classnames = 'sage-upload-card__input-label sage-btn sage-btn--secondary';
+    } else if (actions !== null) {
+      if (customFileInputField === false) {
+        classnames = 'visually-hidden';
       }
+      return actions;
     }
-    return actions;
+    return <CustomLabel />;
   };
 
   return (

--- a/packages/sage-react/lib/UploadCard/UploadCard.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.jsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Button } from '../Button';
 import { IconCard } from '../IconCard';
-import { SageTokens } from '../configs';
-import { render } from 'react-dom';
 
 export const UploadCard = ({
   actions,
@@ -19,6 +16,7 @@ export const UploadCard = ({
   rootProps,
   selectionLabel,
   selectionSubtext,
+  stacked,
   ...rest
 }) => {
   const [filesSelected, updateFilesSelected] = useState(acceptedFiles && acceptedFiles.length > 0);
@@ -32,18 +30,13 @@ export const UploadCard = ({
     {
       'sage-upload-card--selected': filesSelected,
       'sage-upload-card--error': errors,
+      'sage-upload-card--stack-only': stacked,
     }
   );
 
   const renderDefaultInputField = () => (
     !customFileInputField && (
       <input className="sage-upload-card__input" {...inputProps} />
-    )
-  );
-
-  const renderActions = () => (
-    actions && !customFileInputField && (
-      actions
     )
   );
 
@@ -60,20 +53,11 @@ export const UploadCard = ({
     )
   );
 
-  const renderReplaceLabel = () => (
-    replaceLabel && !customFileInputField && (
-      <>
-        <label htmlFor={id} className="sage-upload-card__input-lable sage-btn sage-btn--secondary">{replaceLabel}</label>
-        {renderActions()}
-      </>
-    )
-  );
-
   const renderLabel = () => {
     if ((selectionLabel || replaceLabel) && !customFileInputField) {
       return (
         <>
-          <label htmlFor={id} className="sage-upload-card__input-lable sage-btn sage-btn--secondary">{selectionLabel || replaceLabel}</label>
+          <label htmlFor={id} className="sage-upload-card__input-label sage-btn sage-btn--secondary">{selectionLabel || replaceLabel}</label>
         </>
       );
     }
@@ -84,8 +68,8 @@ export const UploadCard = ({
           <label htmlFor={id} className="visually-hidden">{selectionLabel || replaceLabel}</label>
         );
       }
+      return actions;
     }
-    return actions;
   };
 
   return (
@@ -151,12 +135,14 @@ UploadCard.defaultProps = {
   className: null,
   customFileInputField: false,
   errors: null,
+  id: null,
   inputProps: null,
   previewImage: null,
   replaceLabel: 'Replace file',
   rootProps: null,
   selectionLabel: 'Select a file',
   selectionSubtext: null,
+  stacked: false,
 };
 
 UploadCard.propTypes = {
@@ -168,6 +154,7 @@ UploadCard.propTypes = {
     code: PropTypes.string,
     message: PropTypes.string,
   })),
+  id: PropTypes.string,
   inputProps: PropTypes.shape({}),
   previewImage: PropTypes.shape({
     alt: PropTypes.string,
@@ -177,4 +164,5 @@ UploadCard.propTypes = {
   rootProps: PropTypes.shape({}),
   selectionLabel: PropTypes.string,
   selectionSubtext: PropTypes.string,
+  stacked: PropTypes.bool
 };

--- a/packages/sage-react/lib/UploadCard/UploadCard.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.jsx
@@ -2,15 +2,19 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Button } from '../Button';
-import { Icon } from '../Icon';
 import { IconCard } from '../IconCard';
 import { SageTokens } from '../configs';
+import { render } from 'react-dom';
 
 export const UploadCard = ({
+  actions,
   acceptedFiles,
   className,
+  customFileInputField,
   errors,
+  id,
   inputProps,
+  previewImage,
   replaceLabel,
   rootProps,
   selectionLabel,
@@ -31,11 +35,87 @@ export const UploadCard = ({
     }
   );
 
+  const renderDefaultInputField = () => (
+    !customFileInputField && (
+      <input className="sage-upload-card__input" {...inputProps} />
+    )
+  );
+
+  const renderActions = () => (
+    actions && !customFileInputField && (
+      actions
+    )
+  );
+
+  const renderPreviewImage = () => (
+    previewImage ? (
+      <img className="sage-upload-card__preview" alt={previewImage.alt} src={previewImage.src} />
+    ) : (
+      <IconCard
+        className="sage-upload-card__preview"
+        color={IconCard.COLORS.DRAFT}
+        icon={IconCard.ICONS.FILE}
+        size={IconCard.SIZES.XL}
+      />
+    )
+  );
+
+  const renderReplaceLabel = () => (
+    replaceLabel && !customFileInputField && (
+      <>
+        <label htmlFor={id} className="sage-upload-card__input-lable sage-btn sage-btn--secondary">{replaceLabel}</label>
+        {renderActions()}
+      </>
+    )
+  );
+
+  const renderLabel = () => {
+    if ((selectionLabel || replaceLabel) && !customFileInputField) {
+      return (
+        <>
+          <label htmlFor={id} className="sage-upload-card__input-lable sage-btn sage-btn--secondary">{selectionLabel || replaceLabel}</label>
+        </>
+      );
+    }
+
+    if (actions) {
+      if (!customFileInputField) {
+        return (
+          <label htmlFor={id} className="visually-hidden">{selectionLabel || replaceLabel}</label>
+        );
+      }
+    }
+    return actions;
+  };
+
   return (
     <div className={classNames} {...rest}>
       <div className="sage-upload-card__dropzone" {...rootProps}>
-        <input className="sage-upload-card__input" {...inputProps} />
+        {renderDefaultInputField()}
         {filesSelected ? (
+          <>
+            {renderPreviewImage()}
+            <div className="sage-upload-card__body">
+              <div className="sage-upload-card__description">
+                {acceptedFiles.map(({ name }, i) => {
+                  // Limit to one file for now
+                  if (i > 0) {
+                    return null;
+                  }
+
+                  return (
+                    <React.Fragment key={name}>
+                      <p className="sage-upload-card__filename">
+                        {name}
+                      </p>
+                      {renderLabel()}
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+            </div>
+          </>
+        ) : (
           <>
             <IconCard
               className="sage-upload-card__preview"
@@ -44,47 +124,14 @@ export const UploadCard = ({
               size={IconCard.SIZES.XL}
             />
             <div className="sage-upload-card__body">
-              {acceptedFiles.map(({ name, size }, i) => {
-                // Limit to one file for now
-                if (i > 0) {
-                  return null;
-                }
-
-                return (
-                  <React.Fragment key={name}>
-                    <p className="sage-upload-card__text">{name}</p>
-                    <Button
-                      color={Button.COLORS.PRIMARY}
-                      subtle={true}
-                    >
-                      Replace file
-                    </Button>
-                    <p className="sage-upload-card__subtext">
-                      {`File size: ${size}B`}
-                    </p>
-                  </React.Fragment>
-                );
-              })}
+              <div className="sage-upload-card__description">
+                <p className="sage-upload-card__filename">
+                  {selectionSubtext}
+                </p>
+                {renderLabel()}
+              </div>
             </div>
           </>
-        ) : (
-          <div className="sage-upload-card__body">
-            <Icon
-              className="sage-upload-card__icon"
-              icon={Icon.ICONS.FILE}
-              size={Icon.SIZES.XL}
-              color={SageTokens.COLOR_SLIDERS.CHARCOAL_100}
-            />
-            <Button
-              color={Button.COLORS.PRIMARY}
-              subtle={true}
-            >
-              {selectionLabel}
-            </Button>
-            <p className="sage-upload-card__subtext">
-              {selectionSubtext}
-            </p>
-          </div>
         )}
       </div>
       {errors && (
@@ -100,9 +147,12 @@ export const UploadCard = ({
 
 UploadCard.defaultProps = {
   acceptedFiles: [],
+  actions: null,
   className: null,
+  customFileInputField: false,
   errors: null,
   inputProps: null,
+  previewImage: null,
   replaceLabel: 'Replace file',
   rootProps: null,
   selectionLabel: 'Select a file',
@@ -111,12 +161,18 @@ UploadCard.defaultProps = {
 
 UploadCard.propTypes = {
   acceptedFiles: PropTypes.arrayOf(PropTypes.shape),
+  actions: PropTypes.node,
   className: PropTypes.string,
+  customFileInputField: PropTypes.bool,
   errors: PropTypes.arrayOf(PropTypes.shape({
     code: PropTypes.string,
     message: PropTypes.string,
   })),
   inputProps: PropTypes.shape({}),
+  previewImage: PropTypes.shape({
+    alt: PropTypes.string,
+    src: PropTypes.string
+  }),
   replaceLabel: PropTypes.string,
   rootProps: PropTypes.shape({}),
   selectionLabel: PropTypes.string,

--- a/packages/sage-react/lib/UploadCard/UploadCard.spec.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.spec.jsx
@@ -61,15 +61,16 @@ describe('Sage Upload Card', () => {
         alt: 'cat',
         src: 'https://placekitten.com/360',
       },
+      selectionLabel: 'Select a file',
       selectionSubtext: 'Upload a .csv up to 10KB',
     };
 
     render(<UploadCard {...defaultProps} />);
 
-    const previewImage = document.querySelector('.sage-upload-card__preview');
+    const previewImage = document.querySelector('img');
     expect(previewImage).not.toBeNull();
-    expect(previewImage).toHaveAttribute('src', 'https://placekitten.com/360');
     expect(previewImage).toHaveAttribute('alt', 'cat');
+    expect(previewImage).toHaveAttribute('src', 'https://placekitten.com/360');
   });
 
   it('renders with actions when prop is set', () => {
@@ -97,6 +98,7 @@ describe('Sage Upload Card', () => {
     const defaultProps = {
       errors: [
         {
+          code: '1',
           message: 'This is the error message.',
         },
       ],

--- a/packages/sage-react/lib/UploadCard/UploadCard.spec.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.spec.jsx
@@ -1,0 +1,128 @@
+require('../test/testHelper');
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SageTokens } from '../configs';
+import { Button } from '../Button';
+import { UploadCard } from './UploadCard';
+
+describe('Sage Upload Card', () => {
+  it('renders with correct selection subtext when prop is set', () => {
+    const defaultProps = {
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const selectionSubtext = document.querySelector('.sage-upload-card__filename');
+    expect(selectionSubtext).toHaveTextContent('Upload a .csv up to 10KB');
+  });
+
+  it('renders with correct selection label when prop is set', () => {
+    const defaultProps = {
+      selectionLabel: 'Select a file',
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const selectionLabel = document.querySelector('.sage-upload-card__input-label');
+    expect(selectionLabel).toHaveTextContent('Select a file');
+  });
+
+  it('renders with correct replace label when prop is set', () => {
+    const defaultProps = {
+      replaceLabel: 'Replace file',
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const replaceLabel = document.querySelector('.sage-upload-card__input-label');
+    expect(replaceLabel).toHaveTextContent('Select a file');
+  });
+
+  it('renders with replace label when both label props are set', () => {
+    const defaultProps = {
+      replaceLabel: 'Replace file',
+      selectionLabel: 'Select a file',
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const replaceLabel = document.querySelector('.sage-upload-card__input-label');
+    expect(replaceLabel).toHaveTextContent('Select a file');
+  });
+
+  it('renders with preview image when prop is set', () => {
+    const defaultProps = {
+      previewImage: {
+        alt: 'cat',
+        src: 'https://placekitten.com/360',
+      },
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const previewImage = document.querySelector('.sage-upload-card__preview');
+    expect(previewImage).not.toBeNull();
+    expect(previewImage).toHaveAttribute('src', 'https://placekitten.com/360');
+    expect(previewImage).toHaveAttribute('alt', 'cat');
+  });
+
+  it('renders with actions when prop is set', () => {
+    const defaultProps = {
+      actions: (
+        <Button
+          color={Button.COLORS.SECONDARY}
+          icon={SageTokens.ICONS.CARET_DOWN}
+          iconPosition={Button.ICON_POSITIONS.RIGHT}
+        >
+          Select a file
+        </Button>
+      ),
+      customFileInputField: true,
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const actions = document.querySelector('.sage-btn');
+    expect(actions).not.toBeNull();
+  });
+
+  it('renders with errors when prop is set', () => {
+    const defaultProps = {
+      errors: [
+        {
+          message: 'This is the error message.',
+        },
+      ],
+      previewImage: {
+        alt: 'cat',
+        src: 'https://placekitten.com/360',
+      },
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const errors = document.querySelector('.sage-upload-card__errors');
+    expect(errors).not.toBeNull();
+    expect(errors).toHaveTextContent('This is the error message.');
+  });
+
+  it('renders in stacked layout when prop is set', () => {
+    const defaultProps = {
+      stacked: true,
+      selectionSubtext: 'Upload a .csv up to 10KB',
+    };
+
+    render(<UploadCard {...defaultProps} />);
+
+    const uploadCard = document.querySelector('.sage-upload-card');
+    expect(uploadCard).toHaveClass('sage-upload-card--stack-only');
+  });
+});

--- a/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
@@ -38,19 +38,14 @@ DefaultWithError.args = {
     {
       message: 'This is the error message.'
     },
-  ]
-};
-
-export const SelectedWithError = Template.bind({});
-SelectedWithError.args = {
-  acceptedFiles: [{ name: '.csv', size: '1 M' }],
-  errors: [
-    {
-      message: 'This is the error message.'
-    },
   ],
   previewImage: {
     alt: 'cat',
     src: 'https://placekitten.com/360'
   }
+};
+
+export const Stacked = Template.bind({});
+Stacked.args = {
+  stacked: true,
 };

--- a/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
@@ -34,6 +34,13 @@ Default.decorators = [
 ];
 
 export const DefaultWithError = Template.bind({});
+DefaultWithError.parameters = {
+  docs: {
+    description: {
+      story: 'The Upload Card will display an error message if the `errors` prop is set, with the appropriate styling.'
+    },
+  },
+};
 DefaultWithError.args = {
   errors: [
     {
@@ -47,6 +54,13 @@ DefaultWithError.args = {
 };
 
 export const CustomActions = Template.bind({});
+CustomActions.parameters = {
+  docs: {
+    description: {
+      story: 'The `actions` prop is a slot to allow for custom labels and inputs, buttons, dropdowns, etc. to be used in place of the default input field when the `customFileInputField` prop is set to `true.`'
+    },
+  },
+};
 CustomActions.args = {
   actions: (
     <Button
@@ -61,6 +75,13 @@ CustomActions.args = {
 };
 
 export const Stacked = Template.bind({});
+Stacked.parameters = {
+  docs: {
+    description: {
+      story: 'The default layout will adjust from a vertical (stacked) orientation to horizontal depending on available space and/or screen size. Setting `stack_layout` to `true` locks the component to the vertical orientation.'
+    },
+  },
+};
 Stacked.args = {
   stacked: true,
 };

--- a/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid } from '..';
+import { Button } from '../Button';
+import { Grid, SageTokens } from '..';
 import { UploadCard } from './UploadCard';
 
 export default {
@@ -34,6 +35,15 @@ Default.decorators = [
 
 export const DefaultWithError = Template.bind({});
 DefaultWithError.args = {
+  actions: (
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CARET_DOWN}
+      iconPosition={Button.ICON_POSITIONS.RIGHT}
+    >
+      Select a file
+    </Button>
+  ),
   errors: [
     {
       message: 'This is the error message.'
@@ -44,9 +54,22 @@ DefaultWithError.args = {
 export const SelectedWithError = Template.bind({});
 SelectedWithError.args = {
   acceptedFiles: [{ name: '.csv', size: '1 M' }],
+  actions: (
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CARET_DOWN}
+      iconPosition={Button.ICON_POSITIONS.RIGHT}
+    >
+      Replace a file
+    </Button>
+  ),
   errors: [
     {
       message: 'This is the error message.'
     },
-  ]
+  ],
+  previewImage: {
+    alt: 'cat',
+    src: 'https://placekitten.com/360'
+  }
 };

--- a/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Button } from '../Button';
-import { Grid, SageTokens } from '..';
+import { Grid } from '..';
 import { UploadCard } from './UploadCard';
 
 export default {
@@ -35,15 +34,6 @@ Default.decorators = [
 
 export const DefaultWithError = Template.bind({});
 DefaultWithError.args = {
-  actions: (
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.CARET_DOWN}
-      iconPosition={Button.ICON_POSITIONS.RIGHT}
-    >
-      Select a file
-    </Button>
-  ),
   errors: [
     {
       message: 'This is the error message.'
@@ -54,15 +44,6 @@ DefaultWithError.args = {
 export const SelectedWithError = Template.bind({});
 SelectedWithError.args = {
   acceptedFiles: [{ name: '.csv', size: '1 M' }],
-  actions: (
-    <Button
-      color={Button.COLORS.SECONDARY}
-      icon={SageTokens.ICONS.CARET_DOWN}
-      iconPosition={Button.ICON_POSITIONS.RIGHT}
-    >
-      Replace a file
-    </Button>
-  ),
   errors: [
     {
       message: 'This is the error message.'

--- a/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
+++ b/packages/sage-react/lib/UploadCard/UploadCard.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid } from '..';
+import { Button } from '../Button';
+import { Grid, SageTokens } from '..';
 import { UploadCard } from './UploadCard';
 
 export default {
@@ -43,6 +44,20 @@ DefaultWithError.args = {
     alt: 'cat',
     src: 'https://placekitten.com/360'
   }
+};
+
+export const CustomActions = Template.bind({});
+CustomActions.args = {
+  actions: (
+    <Button
+      color={Button.COLORS.SECONDARY}
+      icon={SageTokens.ICONS.CARET_DOWN}
+      iconPosition={Button.ICON_POSITIONS.RIGHT}
+    >
+      Select a file
+    </Button>
+  ),
+  customFileInputField: true,
 };
 
 export const Stacked = Template.bind({});


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Refactors the Upload Card layout to match with new [Figma](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/branch/Hs9wohE5DRK3luSrVkWzrj/%F0%9F%A7%A9-Sage-components?type=design&node-id=2868%3A22277&mode=design&t=JKPCVczxqsfgzdcs-1) specs. Descriptions have been added to the React stories for more context. New props have been added to the React component to accommodate the refactor and match the Rails version.

**Note**: Because of one usage within `kp`, the `inputProps` prop will remain in React. Additionally, this **should not be merged** in until the `kp` version of the Upload Card has been refactored to accommodate layout changes. There will be a separate PR for this effort.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="1249" alt="Screen Shot 2023-08-15 at 4 09 18 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/f4c87b56-7a8c-4716-8cfb-236a3e7b5310">|<img width="1252" alt="Screen Shot 2023-08-15 at 4 40 46 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/ba5c72d3-9f88-4ff3-88d8-62e274d34bc2">


Stacked Layout
<img width="392" alt="Screen Shot 2023-08-15 at 4 08 30 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/e707aeaa-c5b1-4652-b6f5-0f142ae8a3d5">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
### Rails
- Navigate to [Rails component](http://localhost:4000/pages/component/upload_card?tab=preview)
- Check that layout matches Figma specs
- Check that stacked version matches Figma specs

### React
- Navigate to [React component](http://localhost:4100/?path=/docs/sage-uploadcard--default)
- Check that layout matches Figma specs
- Check that stacked version matches Figma specs


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**BREAKING**) Refactors the Upload Card layout to match with new Figma specs. Will affect existing instances of the Upload Card component in `kp` that utilize Sage classes for styling.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-328](https://kajabi.atlassian.net/browse/DSS-328)

[DSS-328]: https://kajabi.atlassian.net/browse/DSS-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ