### PR TITLE
[DSS-454]: fix(dropdown) - Prevent MultiSelect triggerLabel update

### DIFF
--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -120,7 +120,7 @@ Sage.dropdown = (function () {
       val = (el.value || el.textContent).trim();
     }
 
-    if (val !== null) {
+    if (val !== null && !isMultiselect) {
       updateTriggerLabel(val, elTrigger);
       updateStateClass(val, elDropdown);
     }


### PR DESCRIPTION
## Description
In the multiSelect dropdown, toggling between multiple checkboxes can sometimes cause the trigger value to get updated.


## Screenshots
|  Before  |  After  |
|--------|--------|
|![2023-08-18 14 27 53](https://github.com/Kajabi/sage-lib/assets/1175111/0a486caa-d826-4f98-b58b-2d0dc45814e6)|![2023-08-18 14 29 14](https://github.com/Kajabi/sage-lib/assets/1175111/dd1fcd2e-0b77-4b50-9966-dfd122065c22)|


## Testing in `sage-lib`

- Navigate to [Dropdown](http://localhost:4000/pages/component/dropdown?tab=preview) 
- Scroll down to `Dropdown Field with full-width Custom Content and Footer`
- Open the dropdown and check/uncheck different checkboxes many times.
- Verify the trigger text doesn't update.

## Testing in `kajabi-products`

1. (**LOW**) Prevents trigger text change on MultiSelect Dropdown. This relies on a new prop/functionality and should not affect KP.
 


## Related
DSS-454

