### PR TITLE
feat(select-react): add the placeholder attribute

### DIFF
--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -12,6 +12,7 @@ export const Select = ({
   message,
   onChange,
   options,
+  placeholder,
   required,
   value,
   ...rest
@@ -70,6 +71,7 @@ export const Select = ({
         required={required}
         {...rest}
       >
+        {(placeholder && <option value="" disabled hidden>{placeholder}</option>)}
         {(label && includeLabelInOptions) && <option label={label} />}
         {options && options.map((option, i) => (option.groupLabel
           ? buildOptgroup(option, i)
@@ -98,6 +100,7 @@ Select.defaultProps = {
   message: null,
   onChange: (evt) => evt,
   options: [],
+  placeholder: null,
   required: false,
   value: '',
 };
@@ -137,6 +140,7 @@ Select.propTypes = {
       }),
     ]),
   ),
+  placeholder: PropTypes.string,
   required: PropTypes.bool,
   value: PropTypes.string,
 };

--- a/packages/sage-react/lib/Select/Select.story.jsx
+++ b/packages/sage-react/lib/Select/Select.story.jsx
@@ -23,6 +23,7 @@ export default {
       'Option 3',
       'Option 4',
     ],
+    placeholder: 'Select an option',
   },
 };
 
@@ -67,7 +68,6 @@ DisabledSelectFieldWithOptionPreselected.args = {
   ],
   disabled: true,
   value: 'Option 3',
-  placeholder: 'Choose wisely…'
 };
 
 export const SelectWithOptionDisabled = (args) => {
@@ -85,17 +85,17 @@ SelectWithOptionDisabled.args = {
   id: 'field-4',
   label: 'Select from the following:',
   options: [
-    'First option',
     {
-      label: 'Second option',
-      value: 'second-option',
+      label: 'Country',
+      value: '',
       disabled: true,
     },
+    'First option',
     'Third option',
     'Fourth option',
     'Fifth option',
   ],
-  placeholder: 'Select from the following:'
+  placeholder: 'Pick an option:'
 };
 
 export const SelectWithOptgroups = (args) => {


### PR DESCRIPTION

fix: DSS-400

## Description
There was a Sage Support request where a customer requested to have the React Select component to allow a placeholder to be used. This allows for that functionality to be used.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<img width="361" alt="image" src="https://github.com/Kajabi/sage-lib/assets/1633290/673352ec-e067-419c-b6e0-779b4fe38094">|


## Testing in `sage-lib`
1. Navigate to your local instance of Storybook by clicking [here](http://localhost:4100/?path=/docs/sage-select--disabled-select-field-with-option-preselected)
2. You should see the placeholder being used. 


## Testing in `kajabi-products`
No Impact since this is a new feature.

## Related
n/a
