### PR TITLE
[DSS-457]: fix(modal) - Update modal subheader to match figma spec

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -41,7 +41,10 @@
 
   <%# Standard Modal %>
   <%= sage_component SageModal, { id: "cool-modal", size: "lg" } do %>
-    <%= sage_component SageModalContent, { title: "Modal header" } do %>
+    <%= sage_component SageModalContent, {
+      title: "Modal header",
+      subheader: "This is subheader copy for your viewing pleasure",
+    } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
           style: "secondary",
@@ -78,7 +81,10 @@
 
   <%# Standard Modal with Scrolling %>
   <%= sage_component SageModal, { allow_scroll: true, id: "cool-modal-scrolling" } do %>
-    <%= sage_component SageModalContent, { title: "Modal header" } do %>
+    <%= sage_component SageModalContent, {
+      title: "Modal header",
+      subheader: "This is subheader copy for your viewing pleasure",
+    } do %>
       <% content_for :sage_header_aside do %>
         <%= sage_component SageButton, {
           style: "secondary",

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_modal_content.html.erb
@@ -37,7 +37,7 @@
 
       <% if component.subheader %>
         <%= sage_component SageCardRow, { grid_template: "te" } do %>
-          <h2 class="t-sage-heading-6">
+          <h2 class="<%= "#{SageClassnames::TYPE::BODY} #{SageClassnames::TYPE_COLORS::CHARCOAL_300}" %>">
             <%= component.subheader %>
           </h2>
 

--- a/packages/sage-react/lib/Modal/ModalHeader.jsx
+++ b/packages/sage-react/lib/Modal/ModalHeader.jsx
@@ -55,7 +55,7 @@ export const ModalHeader = ({
         </Card.Row>
         {subheader && (
           <Card.Row>
-            <h2 className={SageClassnames.TYPE.HEADING_6}>{subheader}</h2>
+            <h2 className={`${SageClassnames.TYPE.BODY} ${SageClassnames.TYPE_COLORS.CHARCOAL_300}`}>{subheader}</h2>
             {popover && (
               <Popover
                 title={popover.title}


### PR DESCRIPTION
## Description
Bug was reported that modal subheader text did not match styling as shown in [Figma spec](https://www.figma.com/file/sMbtLUHSt2vfKgKjyQ3052/%F0%9F%A7%A9-Sage-components?type=design&node-id=12613%3A33428&mode=design&t=bKTlAQ8Sg9Bmf0sS-1).
These updates add the appropriate classes to update the styling.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="994" alt="Screenshot 2023-08-29 at 4 09 24 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/bbf004ea-81f3-442d-b79f-3585fb6d1058">|<img width="981" alt="Screenshot 2023-08-29 at 4 10 03 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/74d1ea3d-9686-47c5-9368-97c22403ffa0">|

## Testing in `sage-lib`
Navigate to [Modal](http://localhost:4000/pages/component/modal?tab=preview)
Verify subheader matches the design spec


## Testing in `kajabi-products`
1. (**LOW**) Updates modal subheader text styling to match design spec. Styling only change.

## Related
DSS-457
