### PR TITLE
[DSS-464] Resolve Copy Button order and alignment in Expandable Card child

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -240,7 +240,7 @@ $-btn-loading-min-height: rem(36px);
     font-weight: sage-font-weight(regular);
   }
 
-  .sage-expandable-card--align-arrow-right & {
+  .sage-expandable-card--align-arrow-right &.sage-expandable-card__trigger {
     display: flex;
     justify-content: space-between;
     width: 100%;
@@ -799,7 +799,7 @@ a.sage-btn {
     align-items: center;
   }
 
-  .sage-expandable-card--align-arrow-right & {
+  .sage-expandable-card--align-arrow-right .sage-expandable-card__trigger & {
     order: -1;
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] fix order of `CopyButton`s that were children of `ExpandableCard` 
- [x] fix the alignment of `CopyButton`s that were children of `ExpandableCard` 

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screen Shot 2023-09-07 at 8 02 13 PM](https://github.com/Kajabi/sage-lib/assets/1241836/5d68c8f1-8102-4134-8b26-ff70a5f23da5)|![Screen Shot 2023-09-07 at 8 00 59 PM](https://github.com/Kajabi/sage-lib/assets/1241836/8c68acd0-6e19-4366-a5b4-4000bc11cd85)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
To view this fix:
- In the file, `packages/sage-react/lib/ExpandableCard/ExpandableCard.story.jsx`, add the following lines of code on line 51: `<CopyButton>testing</CopyButton>`
- Visit the [ExpandableCard React page](http://localhost:4100/?path=/docs/sage-expandablecard--default)
- Enable the `alignArrowRight` to true to get the full-width trigger
- Verify that the `CopyButton` within the `ExpandableCard` looks as it does in isolation

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) `CopyButton`-  Updates ordering of text when child of `ExpandableCard`


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [DSS-464](https://kajabi.atlassian.net/browse/DSS-464)

[DSS-464]: https://kajabi.atlassian.net/browse/DSS-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ