### PR TITLE
Docs/intro page

### DIFF
--- a/packages/sage-react/lib/Introduction.jsx
+++ b/packages/sage-react/lib/Introduction.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PackageInfo from '../../../docs/package.json';
+
+export const Introduction = () => (
+  <div>
+    <h1>Welcome to React Storybook Design System! 🎉</h1>
+    <p>Hello and welcome! We're delighted to have you explore our design system. Our components are crafted with consistency, reusability, and clarity. With Sage, your development process will be smoother and more efficient.
+    </p>
+    <br />
+    <h2>Recommended Components to Start With</h2>
+    <ul>
+      <li><strong>Button</strong> - A versatile component, offering various sizes and styles.</li>
+      <li><strong>Input</strong> - Ensures user inputs are captured seamlessly, with built-invalidation features.</li>
+      <li><strong>Card</strong> - Ideal for displaying content in a neat, organized manner.</li>
+      <li><strong>Modal</strong> - Capture user's attention with our highly customizable modal dialogs.</li>
+      <li><strong>Tooltip</strong> - Provide additional information on hover or click, enhancing user understanding.</li>
+    </ul>
+    <br />
+    <p>Dive right into these components to get a feel of our system. And remember, we're always here to help should you have any questions or feedback!</p>
+    <br />
+    <p>Happy coding! 🚀</p>
+    <br />
+    <h2>Version Information</h2>
+    <h3>{`v${PackageInfo.version}`}</h3>
+    <p>View the <a href={`https://github.com/Kajabi/sage-lib/releases/tag/v${PackageInfo.version}`}>change log.</a></p>
+  </div>
+);

--- a/packages/sage-react/lib/Introduction.jsx
+++ b/packages/sage-react/lib/Introduction.jsx
@@ -16,7 +16,7 @@ export const Introduction = () => (
     </ul>
     <br />
     <p>Dive into these components to get a feel for our system.
-      And remember, we are always here to help should you have any questions or feedback!
+      And remember, we are always here to help should you have any questions or feedback at our internal channel for <a href="https://app.slack.com/client/T026K7YCY/C01A424HY8Y">Sage Support</a>.
     </p>
     <br />
     <p>Happy coding! 🚀</p>

--- a/packages/sage-react/lib/Introduction.jsx
+++ b/packages/sage-react/lib/Introduction.jsx
@@ -3,25 +3,26 @@ import PackageInfo from '../../../docs/package.json';
 
 export const Introduction = () => (
   <div>
-    <h1>Welcome to React Storybook Design System! 🎉</h1>
-    <p>Hello and welcome! We're delighted to have you explore our design system. Our components are crafted with consistency, reusability, and clarity. With Sage, your development process will be smoother and more efficient.
+    <h1>Welcome to the React Storybook for Sage!</h1>
+    <p>Sage is our source of truth, providing everything
+      you need to build the best experiences for all Kajabi entrepreneurs.
     </p>
     <br />
     <h2>Recommended Components to Start With</h2>
     <ul>
-      <li><strong>Button</strong> - A versatile component, offering various sizes and styles.</li>
-      <li><strong>Input</strong> - Ensures user inputs are captured seamlessly, with built-invalidation features.</li>
-      <li><strong>Card</strong> - Ideal for displaying content in a neat, organized manner.</li>
-      <li><strong>Modal</strong> - Capture user's attention with our highly customizable modal dialogs.</li>
-      <li><strong>Tooltip</strong> - Provide additional information on hover or click, enhancing user understanding.</li>
+      <li><strong><a href="/?path=/docs/sage-button--primary">Button</a></strong> - A versatile component, offering various styles.</li>
+      <li><strong><a href="/?path=/docs/sage-card--default">Card</a></strong> - Ideal for displaying content in a neat, organized manner.</li>
+      <li><strong><a href="/?path=/docs/sage-modal--default">Modal</a></strong> - Capture users attention with our highly customizable modal dialogs.</li>
     </ul>
     <br />
-    <p>Dive right into these components to get a feel of our system. And remember, we're always here to help should you have any questions or feedback!</p>
+    <p>Dive into these components to get a feel for our system.
+      And remember, we are always here to help should you have any questions or feedback!
+    </p>
     <br />
     <p>Happy coding! 🚀</p>
     <br />
     <h2>Version Information</h2>
     <h3>{`v${PackageInfo.version}`}</h3>
-    <p>View the <a href={`https://github.com/Kajabi/sage-lib/releases/tag/v${PackageInfo.version}`}>change log.</a></p>
+    <p><a href={`https://github.com/Kajabi/sage-lib/releases/tag/v${PackageInfo.version}`}>Change log</a> for {`v${PackageInfo.version}`}.</p>
   </div>
 );

--- a/packages/sage-react/lib/Introduction.story.mdx
+++ b/packages/sage-react/lib/Introduction.story.mdx
@@ -1,7 +1,6 @@
 import { Meta } from "@storybook/addon-docs";
+import { Introduction } from './Introduction';
 
 <Meta title="Introduction" />
 
-# Sage React Storybook
-
-Content coming soon!
+<Introduction />

--- a/packages/sage-react/lib/Introduction.story.mdx
+++ b/packages/sage-react/lib/Introduction.story.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs";
 import { Introduction } from './Introduction';
 
-<Meta title="Introduction" />
+<Meta title="Welcome to Sage" />
 
 <Introduction />

--- a/packages/sage-react/lib/index.js
+++ b/packages/sage-react/lib/index.js
@@ -37,6 +37,7 @@ export { Icon } from './Icon';
 export { IconCard } from './IconCard';
 export { IconList } from './IconList';
 export { Indicator } from './Indicator';
+export { Introduction } from './Introduction';
 export { Input } from './Input';
 export { Label } from './Label';
 export { Link } from './Link';


### PR DESCRIPTION
## Description
Add an intro page with content that welcomes folks to the storybook. Previously, there was simply a "coming soon" intro page. This ticket is a quick update and open to suggestions to improve! 


## Screenshots

|  Before  |  After  |
|--------|--------|
|![before](https://github.com/Kajabi/sage-lib/assets/24237393/602ddfd0-f4a8-4df4-870b-4c8d09ff902b) | ![after](https://github.com/Kajabi/sage-lib/assets/24237393/53830fc8-5564-4902-aa02-b199c67b6343) |



## Testing in `sage-lib`
1. Navigate to http://localhost:4100/?path=/docs/welcome-to-sage--page
2. Verify spelling, grammar, and tone works for welcoming folks to the site

## Testing in `kajabi-products`
1. (**LOW**) Doc change only. No admin app testing
