### PR TITLE
[DSS-471] - docs(): Update color palette syntax in documentation

### DIFF
--- a/docs/app/views/pages/_color_values.html.erb
+++ b/docs/app/views/pages/_color_values.html.erb
@@ -24,7 +24,7 @@
           <%= sage_component SageCopyButton, {
             borderless: true,
             css_classes: "colors__copy-btn",
-            value: "SageTokens::COLOR_PALETTE::#{color.upcase}_100"
+            value: "SageTokens::COLOR_PALETTE[:#{color.upcase}_100]"
           } %>
         </div>
         <div>
@@ -62,7 +62,7 @@
           <%= sage_component SageCopyButton, {
             borderless: true,
             css_classes: "colors__copy-btn",
-            value: "SageTokens::COLOR_PALETTE::#{color.upcase}_200"
+            value: "SageTokens::COLOR_PALETTE[:#{color.upcase}_200]"
           } %>
         </div>
         <div>
@@ -100,7 +100,7 @@
           <%= sage_component SageCopyButton, {
             borderless: true,
             css_classes: "colors__copy-btn",
-            value: "SageTokens::COLOR_PALETTE::#{color.upcase}_300"
+            value: "SageTokens::COLOR_PALETTE[:#{color.upcase}_300]"
           } %>
         </div>
         <div>
@@ -138,7 +138,7 @@
           <%= sage_component SageCopyButton, {
             borderless: true,
             css_classes: "colors__copy-btn",
-            value: "SageTokens::COLOR_PALETTE::#{color.upcase}_400"
+            value: "SageTokens::COLOR_PALETTE[:#{color.upcase}_400]"
           } %>
         </div>
         <div>
@@ -176,7 +176,7 @@
           <%= sage_component SageCopyButton, {
             borderless: true,
             css_classes: "colors__copy-btn",
-            value: "SageTokens::COLOR_PALETTE::#{color.upcase}_500"
+            value: "SageTokens::COLOR_PALETTE[:#{color.upcase}_500]"
           } %>
         </div>
         <div>

--- a/docs/app/views/pages/_color_values_base.html.erb
+++ b/docs/app/views/pages/_color_values_base.html.erb
@@ -24,7 +24,7 @@
           <%= sage_component SageCopyButton, {
             borderless: true,
             css_classes: "colors__copy-btn",
-            value: "SageTokens::COLOR_PALETTE::#{color.upcase}"
+            value: "SageTokens::COLOR_PALETTE[:#{color.upcase}]"
           } %>
         </div>
         <div>

--- a/docs/app/views/pages/_color_values_neutral.html.erb
+++ b/docs/app/views/pages/_color_values_neutral.html.erb
@@ -25,7 +25,7 @@
             <%= sage_component SageCopyButton, {
               borderless: true,
               css_classes: "colors__copy-btn",
-              value: "SageTokens::COLOR_PALETTE::#{color.upcase}_#{i}00"
+              value: "SageTokens::COLOR_PALETTE[:#{color.upcase}_#{i}00]"
             } %>
           </div>
           <div>


### PR DESCRIPTION
## Description
Updates color syntax for color palette-related documentation in the docs site.

`SageTokens::COLOR_PALETTE::<color>` to `SageTokens::COLOR_PALETTE[:<color]`


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="321" alt="Screenshot 2023-09-18 at 3 42 13 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/24373893-98af-4872-b4d2-bbb3f7f4a907">|<img width="329" alt="Screenshot 2023-09-18 at 3 41 55 PM" src="https://github.com/Kajabi/sage-lib/assets/1175111/a36c8327-0988-47cd-a16b-eef4db7b7500">|

## Testing in `sage-lib`

- Navigate to [colors](http://localhost:4000/pages/foundations/color)
- Verify color syntax has been updated.

## Testing in `kajabi-products`
1. (**LOW**) Update color syntax in the documentation. No effect on KP.

## Related
DSS-471
