### PR TITLE
fix(react-input): allow ref to be forwarded to component

### DIFF
--- a/packages/sage-react/lib/Input/Input.jsx
+++ b/packages/sage-react/lib/Input/Input.jsx
@@ -8,7 +8,7 @@ import {
   INPUT_TYPE
 } from './configs';
 
-export const Input = ({
+export const Input = React.forwardRef(({
   autocomplete,
   className,
   disabled,
@@ -38,7 +38,7 @@ export const Input = ({
   suffix,
   value,
   ...rest
-}) => {
+}, ref) => {
   const inputPaddingOffset = 16;
   const [fieldValue, updateFieldValue] = useState(null);
   const [inputStyles, updateStyles] = useState(rest.style || {});
@@ -123,6 +123,7 @@ export const Input = ({
         pattern={pattern}
         placeholder={setPlaceholder()}
         readOnly={readonly}
+        ref={ref}
         required={required}
         step={step}
         style={inputStyles}
@@ -165,7 +166,7 @@ export const Input = ({
       {popover}
     </div>
   );
-};
+});
 Input.Mode = INPUT_MODE;
 Input.Type = INPUT_TYPE;
 

--- a/packages/sage-react/lib/Input/Input.story.jsx
+++ b/packages/sage-react/lib/Input/Input.story.jsx
@@ -144,6 +144,36 @@ export const InputWithPopover = (args) => {
   );
 };
 
+const FocusTemplate = (args) => {
+  const [value, updateValue] = useState(args.value);
+  const onChange = (e) => {
+    updateValue(e.target.value);
+  };
+
+  const onFocus = () => {
+    console.log('Has Focus!!!!');
+  };
+
+  const inputRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  return (
+    <Input {...args} onChange={onChange} value={value} onFocus={onFocus} ref={inputRef} />
+  );
+};
+
+export const InputFocusTest = FocusTemplate.bind({});
+InputFocusTest.args = {
+  inputType: Input.Type.EMAIL,
+  label: 'Email address',
+  id: 'field-focus',
+};
+
 Default.args = {
   id: 'field-1',
   message: 'this is a test message',


### PR DESCRIPTION
## Description
In a support request, it was discovered the `ref` was not working as expected. This solves the issue now. 

# Implemenation example.
```
import { Input } from '@kajabi/sage-react'

const inputRef = React.useRef(null);

React.useEffect(() => {
  if (inputRef.current) {
    inputRef.current.focus();
  }
}, []);

return (
  <Input onFocus={onFocus} ref={inputRef} />
);
```

Video Reference:  Hopefully the audio was recorded. 
https://www.loom.com/share/6ceb6bb9b0284072b147a5c442e09191

## Testing in `sage-lib`
1. You can load storybook locally and navigate to `http://localhost:4100/?path=/story/sage-input--input-focus-test`
2. Result...input should be focused. Clicking off it will show the placeholder text. 

