### PR TITLE
[DSS-473] React Form Section title

### DIFF
--- a/packages/sage-react/lib/FormSection/FormSection.jsx
+++ b/packages/sage-react/lib/FormSection/FormSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from '../Grid';
 import { Panel } from '../Panel';
+import { SageClassnames } from '../configs';
 
 export const FormSection = ({
   children,
@@ -17,7 +18,7 @@ export const FormSection = ({
       <Grid.Row>
         <Grid.Col size={4} small={12} large={4}>
           <div className="sage-form-section__info">
-            <TagName className="sage-form-section__title">{title}</TagName>
+            <TagName className={`sage-form-section__title ${SageClassnames.TYPE.HEADING_5}`}>{title}</TagName>
             {subtitle && (
               <div className="sage-form-section__subtitle">{subtitle}</div>
             )}

--- a/packages/sage-react/lib/FormSection/FormSection.jsx
+++ b/packages/sage-react/lib/FormSection/FormSection.jsx
@@ -7,36 +7,43 @@ export const FormSection = ({
   children,
   subtitle,
   title,
+  titleTag,
   ...rest
-}) => (
-  <Grid className="sage-form-section" {...rest}>
-    <Grid.Row>
-      <Grid.Col size={4} small={12} large={4}>
-        <div className="sage-form-section__info">
-          <h3 className="sage-form-section__title">{title}</h3>
-          {subtitle && (
-            <div className="sage-form-section__subtitle">{subtitle}</div>
-          )}
-        </div>
-      </Grid.Col>
-      <Grid.Col size={8} small={12} large={8}>
-        <Panel>
-          <div className="sage-form-section__content">
-            {children}
+}) => {
+  const TagName = titleTag || 'h5';
+
+  return (
+    <Grid className="sage-form-section" {...rest}>
+      <Grid.Row>
+        <Grid.Col size={4} small={12} large={4}>
+          <div className="sage-form-section__info">
+            <TagName className="sage-form-section__title">{title}</TagName>
+            {subtitle && (
+              <div className="sage-form-section__subtitle">{subtitle}</div>
+            )}
           </div>
-        </Panel>
-      </Grid.Col>
-    </Grid.Row>
-  </Grid>
-);
+        </Grid.Col>
+        <Grid.Col size={8} small={12} large={8}>
+          <Panel>
+            <div className="sage-form-section__content">
+              {children}
+            </div>
+          </Panel>
+        </Grid.Col>
+      </Grid.Row>
+    </Grid>
+  );
+};
 
 FormSection.defaultProps = {
   children: null,
   subtitle: null,
+  titleTag: null,
 };
 
 FormSection.propTypes = {
   children: PropTypes.node,
   subtitle: PropTypes.node,
   title: PropTypes.string.isRequired,
+  titleTag: PropTypes.string,
 };


### PR DESCRIPTION
## Description
The React Form Section title style and heading element are mismatched from the Rails component

- Changed to default to an H5 instead of an H3
- Makes `title_tag` prop available to override heading
- Applies `t-sage-heading-5` style


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![form-section-before](https://github.com/Kajabi/sage-lib/assets/816579/4161d264-181f-428e-a1f1-9d218fbb30c3)|![formsection-after](https://github.com/Kajabi/sage-lib/assets/816579/c4c400b8-235a-4808-b7bf-e1a0a6992860)|



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Form Section title: applies H5 element and styles as default
   - [ ] Products -> Courses -> Quiz -> Quiz settings
   - [ ] Settings -> Payment Integrations -> Other connected providers


## Related
- DSS-473