### PR TITLE
Form Select: Rails documentation update

### DIFF
--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -380,7 +380,7 @@ module ComponentsHelper
       },
       {
         title: "form_select",
-        description: "The form select presents a selectable menu of options. The options within the menu are represented by <option> elements.",
+        description: "The Select component is a user-friendly form control designed to let users pick an option or multiple options from a set. Upon selection, it presents a dialog showcasing all choices in an easily navigable list, with features like added context messages, error indications, and a disabled mode.",
         scss: "done",
         docs: "todo",
         rails: "done",

--- a/docs/app/helpers/components_helper.rb
+++ b/docs/app/helpers/components_helper.rb
@@ -382,7 +382,7 @@ module ComponentsHelper
         title: "form_select",
         description: "The Select component is a user-friendly form control designed to let users pick an option or multiple options from a set. Upon selection, it presents a dialog showcasing all choices in an easily navigable list, with features like added context messages, error indications, and a disabled mode.",
         scss: "done",
-        docs: "todo",
+        docs: "done",
         rails: "done",
         react: "todo",
         responsive: "todo",

--- a/docs/app/views/examples/components/form_select/_preview.html.erb
+++ b/docs/app/views/examples/components/form_select/_preview.html.erb
@@ -1,178 +1,100 @@
-<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Default</h3>
+<h2>Variants</h2>
+
+<h3>Default</h3>
+<p>The Default variation of the Select component is a simple HTML form element.</p>
 <%= sage_component SageFormSelect, {
-  name: "Characters",
-  id: "characters",
+  name: "Language",
+  id: "language",
   select_options: [
     {
-      text: "-- Please Select a Character --",
-      value: "",
+      text: "de - German",
+      value: "de",
     },
     {
-      text: "(None Specified)",
-      value: "",
+      text: "en - English",
+      value: "en",
     },
     {
-      text: "Mario",
-      value: "mario",
+      text: "es - Spanish",
+      value: "es",
     },
     {
-      text: "Luigi",
-      value: "luigi",
+      text: "fi - Finnish",
+      value: "fi",
     },
     {
-      text: "Princess Peach",
-      value: "princess-peach",
-    },
-    {
-      text: "Daisy",
-      value: "daisy",
-    },
-    {
-      text: "Toad",
-      value: "toad",
+      text: "fr - French",
+      value: "fr",
     },
   ],
-  message: "This is a message"
 } %>
 
-<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Error state with message and disabled option</h3>
+<%= sage_component SageDivider, {} %>
+
+<h3>Select with Message</h3>
+<p>The Select component can be used with a message to provide additional context.</p>
+
 <%= sage_component SageFormSelect, {
-  name: "Pets",
+  name: "Default Currency",
+  select_options: [
+    {
+      text: "USD - United States Dollar",
+      value: "USD",
+    },
+    {
+      text: "AED - United Arab Emirates Dirham",
+      value: "AED",
+    },
+    {
+      text: "AFN - Afghan Afghani",
+      value: "AFN",
+    },
+    {
+      text: "ALL - Albanian Lek",
+      value: "ALL",
+    },
+  ],
+  message: "The default currency will be used for formatting and calculation purposes."
+} %>
+
+<%= sage_component SageDivider, {} %>
+
+<h3>Error State</h3>
+<p>The Select component can indicate an error state.</p>
+
+<%= sage_component SageFormSelect, {
+  name: "Text direction",
   has_error: true,
   select_options: [
     {
-      text: "-- Please Select a Pet --",
-      value: "",
+      text: "Left to right (ltr)",
+      value: "ltr",
     },
     {
-      text: "(None Specified)",
-      value: "",
-      selected: true
-    },
-    {
-      text: "Dog",
-      value: "dog",
-    },
-    {
-      text: "Cat",
-      value: "cat",
-    },
-    {
-      text: "Hamster",
-      value: "hamster",
-    },
-    {
-      text: "Parrot",
-      value: "parrot",
-    },
-    {
-      text: "Spider",
-      value: "spider",
-      disabled: true
-    },
-    {
-      text: "Goldfish",
-      value: "goldfish",
+      text: "Right to left (rtl)",
+      value: "rtl",
     },
   ],
-  message: "This is a message"
+  message: "This field is required."
 } %>
 
-<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Disabled (with pre-selected option)</h3>
+<%= sage_component SageDivider, {} %>
+
+<h3>Disabled</h3>
+<p>The Select component can be marked as disabled. Selects labeled as Disabled will not be submitted in forms.</p>
+
 <%= sage_component SageFormSelect, {
-  name: "Sports",
+  name: "Text direction",
   disabled: true,
   select_options: [
     {
-      text: "Basketball",
-      value: "basketball"
+      text: "Left to right (ltr)",
+      value: "ltr",
     },
     {
-      text: "Football",
-      value: "football"
+      text: "Right to left (rtl)",
+      value: "rtl",
     },
-    {
-      text: "Lacrosse",
-      value: "lacrosse"
-    },
-    {
-      text: "Baseball",
-      value: "baseball",
-      selected: true
-    },
-    {
-      text: "Blitzball",
-      value: "blitzball"
-    },
-  ]
+  ],
+  message: "This field is not available until you select a language."
 } %>
-
-<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Optgroup use</h3>
-<%= sage_component SageFormSelect, {
-  name: "Sports!",
-  select_options: [
-    {
-      text: "Bowling",
-      value: "bowling",
-    },
-    {
-      group_label: "Hand Sports",
-      group_options: [
-        {
-          text: "Football",
-          value: "football",
-        },
-        {
-          text: "Basketball",
-          value: "basketball",
-        },
-      ],
-    },
-    {
-      text: "Nascar",
-      value: "nascar",
-      selected: true,
-    },
-    {
-      group_label: "Foot Sports",
-      group_options: [
-        {
-          text: "Soccer",
-          value: "soccer",
-        },
-      ],
-    },
-  ]
-} %>
-
-<script>
-  const handleOnChange = (consoles) => {
-    var selectedText = consoles.options[consoles.selectedIndex].innerHTML;
-    var selectedVal = consoles.value;
-    alert("Selected Text: " + selectedText + " Value: " + selectedVal);
-  }
-</script>
-<h3 class="<%= SageClassnames::TYPE::HEADING_6 %>">Example on how to pass additional attributes to the component</h3>
-<%= sage_component SageFormSelect, {
-  name: "Consoles",
-  component_attributes: {
-    onChange: "handleOnChange(this)",
-    "my-attribute": "hello"
-  },
-  select_options: [
-    {
-      text: "X-Box",
-      value: "x-box"
-    },
-    {
-      text: "PlayStation",
-      value: "playstation"
-    },
-    {
-      text: "Nintendo Switch",
-      value: "switch"
-    },
-  ]
-} %>
-
-<p><strong>Note:</strong> For a fully styled dropdown selector, see the Dropdown component.</p>

--- a/docs/app/views/examples/components/form_select/_props.html.erb
+++ b/docs/app/views/examples/components/form_select/_props.html.erb
@@ -1,18 +1,18 @@
 <tr>
   <td><%= md('`disabled`') %></td>
-  <td><%= md('Enabling this property adds the `disabled` attribute to the component. <br>⚠️ `disabled` inputs are not submitted in forms.') %></td>
+  <td><%= md('Enabling this property adds the `disabled` attribute to the component. `disabled` inputs are not submitted in forms.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`has_error`') %></td>
-  <td><%= md('Enabling this property adds the `.sage-form-field--error` class to the component.') %></td>
+  <td><%= md('Enabling this property styles the select in the default danger color theme.') %></td>
   <td><%= md('Boolean') %></td>
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
   <td><%= md('`message`') %></td>
-  <td><%= md('Sets the message text for the component.') %></td>
+  <td><%= md('Displays the message text for the component.') %></td>
   <td><%= md('String') %></td>
   <td><%= md('`nil`') %></td>
 </tr>


### PR DESCRIPTION
## Description
Update Form Select documentation to better explain props in Rails.


## Screenshots
|  Before  |  After  |
|--------|--------|
| <img width="1233" alt="Screenshot 2023-10-11 at 3 14 22 PM" src="https://github.com/Kajabi/sage-lib/assets/24237393/ed1b84f7-9d23-4962-bc71-9418a4a8119b"> | <img width="1210" alt="Screenshot 2023-10-11 at 3 13 25 PM" src="https://github.com/Kajabi/sage-lib/assets/24237393/f175e3a7-7e05-4cef-97e8-f00b4325e658"> |

## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/form_select?tab=preview
2. Verify the documentation renders and is valid


## Testing in `kajabi-products`
1. (**LOW**) Documentation only update, nothing tested in kajabi-products
