### PR TITLE
[DSS-479] Sortable - Content Width Issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.18.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@5.17.5...@kajabi/sage@5.18.0) (2023-10-16)
+
+
+### Bug Fixes
+
+* **upload card:** align specs, refactor template logic ([c04f9c2](https://github.com/Kajabi/sage-lib/commit/c04f9c23447b804b2f46927982a65e3c0cd93ed5))
+* **upload card:** examples, file types and a11y fixes ([28078c4](https://github.com/Kajabi/sage-lib/commit/28078c44ccd449cee81ae3bf8f2fdc253402fdb6))
+* **upload card:** fixes issue with content for content is replicated in multiple upload cards ([8dbdb8b](https://github.com/Kajabi/sage-lib/commit/8dbdb8b4977994dee8c6fe1f5e0350878afec47e))
+* **upload card:** remove input and label with custom actions ([23efd64](https://github.com/Kajabi/sage-lib/commit/23efd646cf818ad4898d788329fd93f3a26339c3))
+
+
+### Features
+
+* **upload card:** adjust content areas ([91c7fa8](https://github.com/Kajabi/sage-lib/commit/91c7fa80a3acd8db129aef16215154b297f7969e))
+* **upload card:** force stack layout option ([f2536ca](https://github.com/Kajabi/sage-lib/commit/f2536ca7cac07c3f7fc541e3efbca3155271dd0a))
+
+
+
+
+
 ## [5.17.5](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage@5.17.4...@kajabi/sage@5.17.5) (2023-10-02)
 
 **Note:** Version bump only for package @kajabi/sage

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (5.17.5)
+    sage_rails (5.18.0)
       classy_hash
       rails
 

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "5.17.5"
+  VERSION = "5.18.0"
 end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "5.17.5",
+  "version": "5.18.0",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^1.0.45",
+    "@kajabi/sage-packs": "^1.0.46",
     "@rails/webpacker": "5.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/packages/sage-assets/CHANGELOG.md
+++ b/packages/sage-assets/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.12.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-assets@1.11.7...@kajabi/sage-assets@1.12.0) (2023-10-16)
+
+
+### Bug Fixes
+
+* **upload card:** align specs, refactor template logic ([c04f9c2](https://github.com/Kajabi/sage-lib/commit/c04f9c23447b804b2f46927982a65e3c0cd93ed5))
+* **upload card:** style adjustments ([fde0ba7](https://github.com/Kajabi/sage-lib/commit/fde0ba7b4a9a3941c34b1743bd8821501ec62403))
+
+
+### Features
+
+* **upload card:** adds stacked layout and id props ([4ccb1ca](https://github.com/Kajabi/sage-lib/commit/4ccb1cab5ac21bae8f07079f23da2cf0068b8166))
+
+
+
+
+
 ## [1.11.7](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-assets@1.11.6...@kajabi/sage-assets@1.11.7) (2023-09-11)
 
 

--- a/packages/sage-assets/lib/stylesheets/components/_sortable.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_sortable.scss
@@ -15,7 +15,7 @@ $-sortable-image-height: rem(48px);
 
 .sage-sortable__item {
   display: grid;
-  grid-template-columns: min-content minmax(0, min-content) auto auto;
+  grid-template-columns: min-content minmax(0, 1fr) auto auto;
   gap: sage-spacing(card);
   align-items: center;
   padding: sage-spacing(xs) sage-spacing(panel);
@@ -114,6 +114,7 @@ $-sortable-image-height: rem(48px);
 
 .sage-sortable__item-subtitle {
   @extend %t-sage-body-xsmall;
+  @include truncate();
   color: sage-color(charcoal, 100);
 }
 

--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-assets",
-  "version": "1.11.7",
+  "version": "1.12.0",
   "description": "Assets",
   "main": "dist/main.css",
   "repository": {

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.46](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@1.0.45...@kajabi/sage-packs@1.0.46) (2023-10-16)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [1.0.45](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-packs@1.0.44...@kajabi/sage-packs@1.0.45) (2023-10-02)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -31,8 +31,8 @@
     "url": "https://github.com/Kajabi/sage-lib/issues"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^1.11.7",
-    "@kajabi/sage-react": "^1.16.4",
+    "@kajabi/sage-assets": "^1.12.0",
+    "@kajabi/sage-react": "^1.17.0",
     "@kajabi/sage-system": "^1.2.12"
   },
   "devDependencies": {

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.17.0](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@1.16.4...@kajabi/sage-react@1.17.0) (2023-10-16)
+
+
+### Features
+
+* **upload card:** adds stacked layout and id props ([4ccb1ca](https://github.com/Kajabi/sage-lib/commit/4ccb1cab5ac21bae8f07079f23da2cf0068b8166))
+
+
+
+
+
 ## [1.16.4](https://github.com/Kajabi/sage-lib/compare/@kajabi/sage-react@1.16.3...@kajabi/sage-react@1.16.4) (2023-10-02)
 
 

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "1.16.4",
+  "version": "1.17.0",
   "description": "React Components",
   "keywords": [
     "react",
@@ -84,7 +84,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^1.11.7",
+    "@kajabi/sage-assets": "^1.12.0",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "focus-trap": "^6.2.2",


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes an issue with the truncation of the title dictating the width of the content. Both the title and subtitle should be able to truncate independently of the other and the content area should take up 100% of the available space.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1292" alt="Screenshot 2023-10-17 at 5 00 06 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/58afe7e8-6841-47a7-9d08-ff8512a9b502">|<img width="1287" alt="Screenshot 2023-10-17 at 4 48 24 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/a70db917-8f3a-4ee0-93a0-ce0edb16deb2">
<img width="500" alt="Screenshot 2023-10-17 at 4 59 56 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/dbbd5665-6612-4ca9-b8b1-be97509f244a">|<img width="492" alt="Screenshot 2023-10-17 at 4 48 43 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/dc6f5ade-ca7e-4d8a-96d1-81e90e331ed1">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
1. Navigate to [Sortable](http://localhost:4000/pages/component/sortable?tab=preview)
2. In browser dev tools, add extra text to the subtitle 
3. Check that the content area expands the full length of the grid track
4. Check that subtitle can expand independently from the title


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**MEDIUM**) Fixes an issue with the truncation of the title dictating the width of the content. Both the title and subtitle should be able to truncate independently of the other and the content area should take up 100% of the available space. Minor UI update but touches multiple parts of the app.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-479](https://kajabi.atlassian.net/browse/DSS-479)

[DSS-479]: https://kajabi.atlassian.net/browse/DSS-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ