### PR TITLE
[DSS-479] Sortable - Content Width Issue

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_sortable.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_sortable.scss
@@ -15,7 +15,7 @@ $-sortable-image-height: rem(48px);
 
 .sage-sortable__item {
   display: grid;
-  grid-template-columns: min-content minmax(0, min-content) auto auto;
+  grid-template-columns: min-content minmax(0, 1fr) auto auto;
   gap: sage-spacing(card);
   align-items: center;
   padding: sage-spacing(xs) sage-spacing(panel);
@@ -114,6 +114,7 @@ $-sortable-image-height: rem(48px);
 
 .sage-sortable__item-subtitle {
   @extend %t-sage-body-xsmall;
+  @include truncate();
   color: sage-color(charcoal, 100);
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Fixes an issue with the truncation of the title dictating the width of the content. Both the title and subtitle should be able to truncate independently of the other and the content area should take up 100% of the available space.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="1292" alt="Screenshot 2023-10-17 at 5 00 06 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/58afe7e8-6841-47a7-9d08-ff8512a9b502">|<img width="1287" alt="Screenshot 2023-10-17 at 4 48 24 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/a70db917-8f3a-4ee0-93a0-ce0edb16deb2">
<img width="500" alt="Screenshot 2023-10-17 at 4 59 56 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/dbbd5665-6612-4ca9-b8b1-be97509f244a">|<img width="492" alt="Screenshot 2023-10-17 at 4 48 43 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/dc6f5ade-ca7e-4d8a-96d1-81e90e331ed1">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
1. Navigate to [Sortable](http://localhost:4000/pages/component/sortable?tab=preview)
2. In browser dev tools, add extra text to the subtitle 
3. Check that the content area expands the full length of the grid track
4. Check that subtitle can expand independently from the title


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(**MEDIUM**) Fixes an issue with the truncation of the title dictating the width of the content. Both the title and subtitle should be able to truncate independently of the other and the content area should take up 100% of the available space. Minor UI update but touches multiple parts of the app.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-479](https://kajabi.atlassian.net/browse/DSS-479)

[DSS-479]: https://kajabi.atlassian.net/browse/DSS-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ