### PR TITLE
fix(dropdown): update dropdown breakpoint

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -15,7 +15,7 @@ $-dropdown-option-menu-size: rem(40px);
 
 $-dropdown-panel-max-height: rem(400px);
 $-dropdown-panel-max-height-small: rem(185px);
-$-dropdown-panel-max-height-breakpoint: 700px;
+$-dropdown-panel-max-height-breakpoint: 775px;
 
 $-dropdown-trigger-label-color-label-background: map-get($sage-field-colors, label-background);
 $-dropdown-trigger-label-color-default: map-get($sage-field-colors, default);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x]  Resolve dropdowns getting cut off on contact ui

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2023-10-16 at 12 23 05 PM](https://github.com/Kajabi/sage-lib/assets/1241836/fef5b9ba-0e60-46a1-9aa0-f3830e16f250)|![Screenshot_2023-10-16_at_12_22_54 PM](https://github.com/Kajabi/sage-lib/assets/1241836/6d098ea5-9450-4727-80f3-11ae75af5618)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the [dropdown Rails page](http://localhost:4000/pages/component/dropdown?tab=preview)
- Set your browser height to less than `775px` tall and verify that the dropdown menu `max-height` is smaller

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Reduce Dropdown menu size on smaller screens.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[AUDS-933](https://kajabi.atlassian.net/browse/AUD-933)