### PR TITLE
[DSS-483] React Dropdown right & center positioning fix

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -102,22 +102,22 @@ export const Dropdown = ({
     const rect = wrapperRef.current.getBoundingClientRect();
     const coords = {
       top: buttonDimensions.bottom + topBoxOffset,
-      left: align !== 'right'
+      left: align === DROPDOWN_POSITIONS.LEFT || null
         ? rect.left + inlineBoxOffset
-        : 'initial',
-      right: align === 'right' && isPinned
+        : null,
+      right: align === DROPDOWN_POSITIONS.RIGHT && isPinned
         ? window.innerWidth - rect.right + inlineBoxOffset
-        : 'initial',
+        : null,
     };
 
     if (!isPinned) {
       coords.top = null;
-      coords.left = 'initial';
+      coords.left = null;
     }
 
     if (directionY === 'above') {
       coords.top = ((buttonDimensions.height / 4) + panelDimensions.height) * -1;
-      coords.left = 'initial';
+      coords.left = null;
       if (isPinned) {
         coords.top = (buttonDimensions.top - panelDimensions.height);
         coords.right = window.innerWidth - buttonDimensions.right + inlineBoxOffset;
@@ -127,22 +127,22 @@ export const Dropdown = ({
     // Check if there is enough space to the left or right
     // CHECK ISPINNED
     if (!enoughSpaceRight && enoughSpaceLeft) {
-      directionX = 'left';
+      directionX = DROPDOWN_POSITIONS.LEFT;
     } else if (!enoughSpaceLeft && enoughSpaceRight) {
-      directionX = 'right';
+      directionX = DROPDOWN_POSITIONS.RIGHT;
     }
 
-    if (directionX === 'left') {
-      coords.left = 'initial';
+    if (directionX === DROPDOWN_POSITIONS.LEFT) {
+      coords.left = null;
       coords.right = 0;
       if (isPinned) {
         coords.right = window.innerWidth - buttonDimensions.right + inlineBoxOffset;
       }
     }
 
-    if (directionX === 'right') {
+    if (directionX === DROPDOWN_POSITIONS.RIGHT) {
       coords.left = 0;
-      coords.right = 'initial';
+      coords.right = null;
       if (isPinned) {
         coords.left = buttonDimensions.left + inlineBoxOffset;
       }


### PR DESCRIPTION
## Description
The React version of the Dropdown component restricts alignment to the right of the dropdown button/trigger unless the `isPinned` prop is also enabled

Center alignment isn't applied whether or not `isPinned` is active


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
| | Before  |  After  |
|----|----|--------|
|Right align|![before-right](https://github.com/Kajabi/sage-lib/assets/816579/4d913f3e-7907-4caa-a086-5cc6fb80de9d)|![after-right](https://github.com/Kajabi/sage-lib/assets/816579/d5cf474c-7c2a-4fb4-923a-acc5044fe71a)|
|Center align|![before-center](https://github.com/Kajabi/sage-lib/assets/816579/2d798733-da21-4814-992b-e50c9ebdf0ab)|![after-center](https://github.com/Kajabi/sage-lib/assets/816579/b9812ed8-ad50-430c-a85c-6b5f0d5e6c96)|


## Testing in `sage-lib`
1. Navigate to the Dropdown story
2. Select “RIGHT” from the “align” menu
3. Toggle the dropdown button in the preview window. Verify that the dropdown menu position is right-aligned
4. Select “CENTER” from the “align” menu
5. Verify that the dropdown menu is centered
6. Toggle the `isPinned` property, verify that the dropdown menu remains centered
7. With `isPinned` still active, select “RIGHT” from the “align” menu and confirm that the dropdown menu position stays right-aligned


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Dropdown: corrects right- and center-aligned menu positioning
   - [ ] Sales -> Payments -> Transactions row overflow menu
   - [ ] Contacts -> Contact row overflow menu
   - [ ] Products -> Courses -> Course -> Quiz -> overflow menu


## Related
- DSS-483
- [COMM-4706](https://kajabi.atlassian.net/browse/COMM-4706)

[COMM-4706]: https://kajabi.atlassian.net/browse/COMM-4706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ