### PR TITLE
fix(dropdown): add visual indicator when dropdown is scrollable

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -267,12 +267,12 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__menu {
-  border-radius: sage-border(radius-medium);
   overflow: auto;
   min-width: $-dropdown-width;
   width: auto;
   max-height: $-dropdown-panel-max-height;
   padding: sage-spacing(xs) 0;
+  border-radius: sage-border(radius-medium);
   
   // adds a box shadow to the menu when it is scrollable
   overflow-scrolling: touch;

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -267,11 +267,45 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__menu {
+  border-radius: sage-border(radius-medium);
   overflow: auto;
   min-width: $-dropdown-width;
   width: auto;
   max-height: $-dropdown-panel-max-height;
   padding: sage-spacing(xs) 0;
+  
+  // adds a box shadow to the menu when it is scrollable
+  overflow-scrolling: touch;
+  background:
+    /* Shadow Cover TOP */
+    linear-gradient(
+      white 30%,
+      rgba(255, 255, 255, 0)
+    ) center top,
+    
+    /* Shadow Cover BOTTOM */
+    linear-gradient(
+      rgba(255, 255, 255, 0), 
+      white 70%
+    ) center bottom,
+    
+    /* Shadow TOP */
+    radial-gradient(
+      farthest-side at 50% 0,
+      rgba(0, 0, 0, 0.2),
+      rgba(0, 0, 0, 0)
+    ) center top,
+    
+    /* Shadow BOTTOM */
+    radial-gradient(
+      farthest-side at 50% 100%,
+      rgba(0, 0, 0, 0.2),
+      rgba(0, 0, 0, 0)
+    ) center bottom;
+  
+  background-repeat: no-repeat;
+  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+  background-attachment: local, local, scroll, scroll;
 
   :not(.sage-dropdown--anchor-right) > .sage-dropdown__panel & {
     left: 0;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add visual indicator when scrolling is available in the dropdown menu

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
![Screenshot_2023-10-26_at_2_29_38 PM](https://github.com/Kajabi/sage-lib/assets/1241836/1c6f1d69-5cfc-4dbe-ba42-c00e7879dcbf)


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Set screen height to < `775px`
- Visit the following views and verify that the menu shadow is present to denote scrolling in that direction 
    - [Rails Dropdown view](http://localhost:4000/pages/component/dropdown?tab=preview)
    - [React Dropdown view](http://localhost:4100/?path=/docs/sage-dropdown--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Adds visual aid when dropdown is scrollable. Affects all `Dropdown`s when screen height is < `775px`.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [DSS-485](https://kajabi.atlassian.net/browse/DSS-485)

[DSS-485]: https://kajabi.atlassian.net/browse/DSS-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ