### PR TITLE
[DSS-496]: Tooltip - Remove Size & Theme Props (React)

### DIFF
--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -244,7 +244,5 @@ DropdownItem.propTypes = {
   to: PropTypes.string,
   tooltip: PropTypes.shape({
     position: PropTypes.oneOf(Object.values(Tooltip.POSITIONS)),
-    size: PropTypes.oneOf(Object.values(Tooltip.SIZES)),
-    theme: PropTypes.oneOf(Object.values(Tooltip.THEMES)),
   }),
 };

--- a/packages/sage-react/lib/Link/Link.jsx
+++ b/packages/sage-react/lib/Link/Link.jsx
@@ -101,8 +101,6 @@ Link.propTypes = {
   tag: tagPropTypes,
   tooltip: PropTypes.shape({
     position: PropTypes.oneOf(Object.values(Tooltip.POSITIONS)),
-    size: PropTypes.oneOf(Object.values(Tooltip.SIZES)),
-    theme: PropTypes.oneOf(Object.values(Tooltip.THEMES)),
   }),
   truncate: PropTypes.bool,
 };

--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -3,17 +3,13 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { TooltipElement } from './TooltipElement';
 import {
-  TOOLTIP_SIZES,
-  TOOLTIP_POSITIONS,
-  TOOLTIP_THEMES,
+  TOOLTIP_POSITIONS
 } from './configs';
 
 export const Tooltip = ({
   children,
   content,
   position,
-  size,
-  theme,
   ...rest
 }) => {
   const [active, setActive] = useState(false);
@@ -42,8 +38,6 @@ export const Tooltip = ({
           content={content}
           parentDomRect={parentDomRect}
           position={position}
-          size={size}
-          theme={theme}
         />,
         document.body
       )}
@@ -53,19 +47,13 @@ export const Tooltip = ({
 
 Tooltip.Element = TooltipElement;
 Tooltip.POSITIONS = TOOLTIP_POSITIONS;
-Tooltip.SIZES = TOOLTIP_SIZES;
-Tooltip.THEMES = TOOLTIP_THEMES;
 
 Tooltip.defaultProps = {
   position: TOOLTIP_POSITIONS.DEFAULT,
-  size: TOOLTIP_SIZES.DEFAULT,
-  theme: TOOLTIP_THEMES.DEFAULT,
 };
 
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   content: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
   position: PropTypes.oneOf(Object.values(TOOLTIP_POSITIONS)),
-  size: PropTypes.oneOf(Object.values(TOOLTIP_SIZES)),
-  theme: PropTypes.oneOf(Object.values(TOOLTIP_THEMES)),
 };

--- a/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.story.jsx
@@ -18,8 +18,6 @@ export default {
   argTypes: {
     ...selectArgs({
       position: Tooltip.POSITIONS,
-      size: Tooltip.SIZES,
-      theme: Tooltip.THEMES
     }),
   },
   args: {
@@ -30,8 +28,6 @@ export default {
     ),
     content: 'Hi, I provide more context for this element!',
     position: Tooltip.POSITIONS.DEFAULT,
-    size: Tooltip.SIZES.DEFAULT,
-    theme: Tooltip.THEMES.DEFAULT,
   }
 };
 const Template = (args) => <Tooltip {...args} />;

--- a/packages/sage-react/lib/Tooltip/TooltipElement.jsx
+++ b/packages/sage-react/lib/Tooltip/TooltipElement.jsx
@@ -2,9 +2,7 @@ import React, { useState, useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
-  TOOLTIP_SIZES,
-  TOOLTIP_POSITIONS,
-  TOOLTIP_THEMES,
+  TOOLTIP_POSITIONS
 } from './configs';
 
 const TOOLTIP_DISTANCE = 8;
@@ -13,8 +11,6 @@ export const TooltipElement = ({
   content,
   parentDomRect,
   position,
-  size,
-  theme,
 }) => {
   const tooltipRef = useRef(null);
   const [coordinates, setCoordinates] = useState({ top: null, left: null });
@@ -24,8 +20,6 @@ export const TooltipElement = ({
     {
       'sage-tooltip--static': !parentDomRect,
       [`sage-tooltip--${position}`]: position,
-      [`sage-tooltip--${size}`]: size,
-      [`sage-tooltip--${theme}`]: theme,
     }
   );
 
@@ -86,14 +80,10 @@ export const TooltipElement = ({
 };
 
 TooltipElement.POSITIONS = TOOLTIP_POSITIONS;
-TooltipElement.SIZES = TOOLTIP_SIZES;
-TooltipElement.THEMES = TOOLTIP_THEMES;
 
 TooltipElement.defaultProps = {
   parentDomRect: null,
   position: TOOLTIP_POSITIONS.DEFAULT,
-  size: TOOLTIP_SIZES.DEFAULT,
-  theme: TOOLTIP_THEMES.DEFAULT,
 };
 
 TooltipElement.propTypes = {
@@ -106,6 +96,4 @@ TooltipElement.propTypes = {
     width: PropTypes.number,
   }),
   position: PropTypes.oneOf(Object.values(TOOLTIP_POSITIONS)),
-  size: PropTypes.oneOf(Object.values(TOOLTIP_SIZES)),
-  theme: PropTypes.oneOf(Object.values(TOOLTIP_THEMES)),
 };

--- a/packages/sage-react/lib/Tooltip/configs.js
+++ b/packages/sage-react/lib/Tooltip/configs.js
@@ -1,18 +1,7 @@
-export const TOOLTIP_SIZES = {
-  DEFAULT: null,
-  SMALL: 'small',
-  LARGE: 'large',
-};
-
 export const TOOLTIP_POSITIONS = {
   DEFAULT: 'top',
   TOP: 'top',
   RIGHT: 'right',
   BOTTOM: 'bottom',
   LEFT: 'left',
-};
-
-export const TOOLTIP_THEMES = {
-  DEFAULT: null,
-  LIGHT: 'light',
 };


### PR DESCRIPTION
## Description
Removes `size` and `theme` props from the React Tooltip component. This update is to help discontinue usage and remove any developer confusion with these deprecated props.


## Screenshots
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-01-04 at 3 26 07 PM](https://github.com/Kajabi/sage-lib/assets/1175111/3ab684e8-44dc-4e87-9cc7-abf592e916e2)|![Screenshot 2024-01-04 at 3 26 01 PM](https://github.com/Kajabi/sage-lib/assets/1175111/0264e978-277d-4c2e-95fe-58589b7ef5ed)|

## Testing in `sage-lib`

- Navigate to [Tooltip](http://localhost:4100/?path=/docs/sage-tooltip--default)
- Verify props are removed and no longer exist.
- Verify tooltip still functions in [Link Tooltip](http://localhost:4100/?path=/docs/sage-link--tooltip) and [Dropdown](http://localhost:4100/?path=/docs/sage-dropdown--menu-with-arrow) (tooltip is applied to dropdown item) stories

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Remove theme and sizing from React Tooltips.
   - [ ] I was unable to find any usage of the props in kajabi-products, but a quick sanity check might be useful to make sure.


## Related
https://kajabi.atlassian.net/browse/DSS-496
