### PR TITLE
[DSS-490]: Form Input & SelectDropdown Styling Mismatch

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -238,6 +238,11 @@ $-btn-loading-min-height: rem(36px);
 
   .sage-dropdown__trigger--select & {
     font-weight: sage-font-weight(regular);
+    border-width: 0;
+    box-shadow: sage-border-interactive(default);
+    &:hover {
+      box-shadow: sage-border-interactive(hover);
+    }
   }
 
   .sage-expandable-card--align-arrow-right &.sage-expandable-card__trigger {


### PR DESCRIPTION
## Description
Corrects trigger styling mismatch for select variants of the dropdown. The dropdown select variant does not match other form inputs. The difference is the border color and overall height due to the use of a border instead of a box shadow like other form inputs. 

This causes a minor styling mismatch when a form element and a dropdown are placed side-by-side.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-01-04 at 4 48 35 PM](https://github.com/Kajabi/sage-lib/assets/1175111/ca6120c1-dbe1-4bf0-a0d0-743fe3a18dd6)|![Screenshot 2024-01-04 at 4 49 04 PM](https://github.com/Kajabi/sage-lib/assets/1175111/1c404f27-cb01-4470-b9f1-500899a158f8)|


## Testing in `sage-lib`

- Navigate to [dropdown](http://localhost:4000/pages/component/dropdown?tab=preview)
- Verify styling matches the select component (border color and heights should now match.)


## Testing in `kajabi-products`
1. (**LOW**) Corrects trigger styling mismatch for select variants of the dropdown.



## Related
https://kajabi.atlassian.net/browse/DSS-490
