### PR TITLE
[STANDARD-714] Ruby 3 Compatibility

### DIFF
--- a/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
+++ b/docs/lib/sage_rails/app/helpers/sage_table_helper.rb
@@ -104,8 +104,7 @@ module SageTableHelper
       @row_proc = block
     end
 
-    def column(attr, opts={})
-      block = Proc.new if block_given?
+    def column(attr, opts={}, &block)
       columns << SageColumn.new(template, attr, block, opts)
     end
 


### PR DESCRIPTION
## Description
Ruby 3 no longer allows the use of `Proc.new` without an accompanying block. Previously, this could be used to forward whatver implicit block had been passed to a method. In this case, whatever content the column was meant to have would have been implicitly passed. For Ruby 3 compatibility, we instead reference the block argument explicitly and pass it along.

## Testing in `sage-lib`
N/A

## Testing in `kajabi-products`
* A green test suite in the monolith on a PR to `main` referencing this branch
* Passing `spec/features/admin/email_sequence_emails_spec.rb` on my Ruby 3 branch (`STANDARD-362-harness-ruby-3`) with this branch referenced.