### PR TITLE
[DSS-455] fix(dropdown): Adds triggerClassnames to select dropdown trigger

### DIFF
--- a/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { SageClassnames, SageTokens } from '../configs';
@@ -11,26 +12,35 @@ export const DropdownTriggerSelect = ({
   icon,
   onClick,
   selectedValue,
-}) => (
-  <>
-    <Button
-      color={Button.COLORS.SECONDARY}
-      className="sage-dropdown__trigger-selected-value"
-      disabled={disabled}
-      icon={SageTokens.ICONS.CARET_DOWN}
-      iconPosition={Button.ICON_POSITIONS.RIGHT}
-      type="button"
-      onClick={onClick}
-    >
-      {icon && (<Icon icon={icon} className={SageClassnames.SPACERS.XS_RIGHT} />)}
-      {selectedValue}
-    </Button>
-    <span className="sage-dropdown__trigger-label">
-      {defaultIcon && (<Icon icon={defaultIcon} className={SageClassnames.SPACERS.XS_RIGHT} />)}
-      {label}
-    </span>
-  </>
-);
+  triggerClassnames
+}) => {
+
+  const classNames = classnames(
+    'sage-dropdown__trigger-selected-value',
+    triggerClassnames,
+  );
+
+  return (
+    <>
+      <Button
+        color={Button.COLORS.SECONDARY}
+        className={classNames}
+        disabled={disabled}
+        icon={SageTokens.ICONS.CARET_DOWN}
+        iconPosition={Button.ICON_POSITIONS.RIGHT}
+        type="button"
+        onClick={onClick}
+      >
+        {icon && (<Icon icon={icon} className={SageClassnames.SPACERS.XS_RIGHT} />)}
+        {selectedValue}
+      </Button>
+      <span className="sage-dropdown__trigger-label">
+        {defaultIcon && (<Icon icon={defaultIcon} className={SageClassnames.SPACERS.XS_RIGHT} />)}
+        {label}
+      </span>
+    </>
+  );
+};
 
 DropdownTriggerSelect.defaultProps = {
   defaultIcon: null,
@@ -38,6 +48,7 @@ DropdownTriggerSelect.defaultProps = {
   icon: null,
   onClick: null,
   selectedValue: ' ',
+  triggerClassnames: null,
 };
 
 DropdownTriggerSelect.propTypes = {
@@ -47,4 +58,5 @@ DropdownTriggerSelect.propTypes = {
   onClick: PropTypes.func,
   label: PropTypes.string.isRequired,
   selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  triggerClassnames: PropTypes.string,
 };

--- a/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
@@ -14,7 +14,6 @@ export const DropdownTriggerSelect = ({
   selectedValue,
   triggerClassnames
 }) => {
-
   const classNames = classnames(
     'sage-dropdown__trigger-selected-value',
     triggerClassnames,

--- a/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/SelectDropdown.jsx
@@ -37,6 +37,7 @@ export const SelectDropdown = ({
   selectionBecomesLabel,
   showSelectionsAsLabels,
   triggerWidth,
+  triggerClassnames,
   ...rest // Used as an option to pass other props to Dropdown (base) component
 }) => {
   const emptySelectedValue = (
@@ -204,6 +205,7 @@ export const SelectDropdown = ({
           label={label}
           icon={configs.icon}
           selectedValue={configs.selectedValue}
+          triggerClassnames={triggerClassnames}
         />
       )}
       disabled={disabled}
@@ -279,6 +281,7 @@ SelectDropdown.defaultProps = {
   searchPlaceholder: 'Find',
   selectionBecomesLabel: true,
   showSelectionsAsLabels: false,
+  triggerClassnames: '',
   triggerWidth: null,
 };
 
@@ -320,5 +323,6 @@ SelectDropdown.propTypes = {
   searchPlaceholder: PropTypes.string,
   selectionBecomesLabel: PropTypes.bool,
   showSelectionsAsLabels: PropTypes.bool,
+  triggerClassnames: PropTypes.string,
   triggerWidth: PropTypes.string,
 };


### PR DESCRIPTION
## Description
When passing `triggerClassnames` to the select dropdown the classes are not being added as expected. These updates allow for the classes to be passed to the trigger as expected.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-01-08 at 12 21 47 PM](https://github.com/Kajabi/sage-lib/assets/1175111/f4734ca6-13bf-4093-9688-0acb275a5647)|![Screenshot 2024-01-08 at 12 20 49 PM](https://github.com/Kajabi/sage-lib/assets/1175111/838299fb-bf9a-4177-9655-f4b6e5eb54f8)|

## Testing in `sage-lib`

- Navigate to [Select Dropdown](http://localhost:4100/?path=/story/sage-dropdown--select)
- Update the `triggerClassnames` controls or update Select story in relevant file: (`packages/sage-react/lib/Dropdown/Dropdown.story.jsx`) 
- Verify class gets added to the select trigger. 


## Testing in `kajabi-products`

1. (**LOW**) Fixes bug where `triggerClassnames` is not adding classes to the select dropdown trigger. No effect on KP is expected.


## Related
https://kajabi.atlassian.net/browse/DSS-455
