### PR TITLE
fix(popover): Add "active" prop 

### DIFF
--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -7,6 +7,7 @@ import { SageTokens } from '../configs';
 import { POPOVER_POSITIONS } from './configs';
 
 export const Popover = ({
+  active,
   className,
   children,
   customContentClassName,
@@ -20,7 +21,7 @@ export const Popover = ({
   title,
   ...rest
 }) => {
-  const [selfActive, setSelfActive] = useState(false);
+  const [selfActive, setSelfActive] = useState(active);
 
   const handleExpandClick = () => {
     setSelfActive(true);
@@ -84,6 +85,7 @@ export const Popover = ({
         role="button"
         onKeyDown={handleKeydown}
         tabIndex={-1}
+        aria-expanded={selfActive}
       />
       <div className="sage-popover__panel">
         {media && (
@@ -118,6 +120,7 @@ export const Popover = ({
 Popover.POSITIONS = POPOVER_POSITIONS;
 
 Popover.defaultProps = {
+  active: false,
   className: null,
   children: null,
   customContentClassName: null,
@@ -132,6 +135,7 @@ Popover.defaultProps = {
 };
 
 Popover.propTypes = {
+  active: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
   customContentClassName: PropTypes.string,

--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -21,19 +21,19 @@ export const Popover = ({
   title,
   ...rest
 }) => {
-  const [selfActive, setSelfActive] = useState(active);
+  const [isActive, setisActive] = useState(active);
 
   const handleExpandClick = () => {
-    setSelfActive(true);
+    setisActive(true);
   };
 
   const handleCloseClick = () => {
-    setSelfActive(false);
+    setisActive(false);
   };
 
   const handleKeydown = (ev) => {
-    if (selfActive && ev.keyCode === 27) {
-      setSelfActive(false);
+    if (isActive && ev.keyCode === 27) {
+      setisActive(false);
     }
   };
 
@@ -41,7 +41,7 @@ export const Popover = ({
     'sage-popover',
     className,
     {
-      'sage-popover--is-expanded': selfActive,
+      'sage-popover--is-expanded': isActive,
       [`sage-popover--${position}`]: position,
     }
   );
@@ -67,7 +67,7 @@ export const Popover = ({
     >
       <Button
         aria-controls={id}
-        aria-expanded={selfActive}
+        aria-expanded={isActive}
         aria-haspopup={true}
         className="sage-popover__button"
         color={Button.COLORS.SECONDARY}
@@ -85,7 +85,7 @@ export const Popover = ({
         role="button"
         onKeyDown={handleKeydown}
         tabIndex={-1}
-        aria-expanded={selfActive}
+        aria-expanded={isActive}
       />
       <div className="sage-popover__panel">
         {media && (

--- a/packages/sage-react/lib/Popover/Popover.jsx
+++ b/packages/sage-react/lib/Popover/Popover.jsx
@@ -21,19 +21,19 @@ export const Popover = ({
   title,
   ...rest
 }) => {
-  const [isActive, setisActive] = useState(active);
+  const [isActive, setIsActive] = useState(active);
 
   const handleExpandClick = () => {
-    setisActive(true);
+    setIsActive(true);
   };
 
   const handleCloseClick = () => {
-    setisActive(false);
+    setIsActive(false);
   };
 
   const handleKeydown = (ev) => {
     if (isActive && ev.keyCode === 27) {
-      setisActive(false);
+      setIsActive(false);
     }
   };
 

--- a/packages/sage-react/lib/Popover/Popover.story.jsx
+++ b/packages/sage-react/lib/Popover/Popover.story.jsx
@@ -21,6 +21,7 @@ export default {
     }),
   },
   args: {
+    active: false,
     label: 'Learn more',
     icon: SageTokens.ICONS.QUESTION_CIRCLE,
     iconOnly: true,


### PR DESCRIPTION
## Description

Adds `active` prop to component to allow to show and hide.


## Screenshots
No visual changes are expected with these updates.


## Testing in `sage-lib`

- Navigate to [popover](http://localhost:4100/?path=/docs/sage-popover--default)
- Verify `active` prop exists and functions as expected.
- Verify popover still functions as expected when interacted with.



## Testing in `kajabi-products`
1. (**LOW**) Adds new active prop to Popover (React).


## Related
https://kajabi.atlassian.net/browse/DSS-501
