### PR TITLE
fix(nav): Adjust sizing and color of text and icon

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_nav_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_nav_link.html.erb
@@ -22,7 +22,7 @@ attributes = component.attributes.present? ? component.attributes : {}
 %>
 <%= link_to component.link, method: component.method, class: "sage-nav__link #{active_class} #{component_class} #{nav_link_icon_class}", **attributes do %>
   <% if component.icon %>
-    <i class="sage-icon-<%= component.icon %>-lg sage-nav__icon"></i>
+    <i class="sage-icon-<%= component.icon %> sage-nav__icon"></i>
   <% end %>
   <span class="sage-nav__label">
     <%= component.text %>

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -4,11 +4,11 @@
 /// @group sage
 ////
 
-$-nav-color-text: sage-color(charcoal, 500);
+$-nav-color-text: sage-color(charcoal, 300);
 $-nav-color-focus: sage-color(grey, 500);
 $-nav-color-background: sage-color(grey, 300);
 $-nav-color-background-hover: sage-color(grey, 300);
-$-nav-icon-size: rem(20px);
+$-nav-icon-size: rem(16px);
 $-nav-icon-spacing: rem(8px);
 $-nav-subitem-border-width: rem(2px);
 
@@ -49,6 +49,7 @@ $-nav-subitem-border-width: rem(2px);
   transition-property: background, box-shadow;
 
   &:hover {
+    color: $-nav-color-text;
     background-color: $-nav-color-background-hover;
   }
 }


### PR DESCRIPTION
## Description
As a follow-up to previous nav adjustments, these updates will adjust the link color and icon size in the nav.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-01-23 at 12 03 00 PM](https://github.com/Kajabi/sage-lib/assets/1175111/276c1d0d-7da6-4b62-b99b-b0930475b830)|![Screenshot 2024-01-23 at 12 02 35 PM](https://github.com/Kajabi/sage-lib/assets/1175111/80e7e034-e4cd-4310-bd1f-c9d3f590d2d0)|



## Testing in `sage-lib`

- Navigate to [Nav component](http://localhost:4000/pages/component/nav_link?tab=preview)
- Verify nav link color updates and icon size changes.


## Testing in `kajabi-products`
1. (**LOW**) Updates the color of the nav link and icon related to the sidebar.
    - [ ] Quick sanity that color updated in admin sidebar 


## Related
https://kajabi.atlassian.net/browse/DSS-505
