### PR TITLE
style(progress): make width transition when value changes after page …

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -54,6 +54,7 @@ $-progress-bar-height: sage-spacing(xs);
 
 .sage-progress-bar__animate {
   animation: 3s sage-progress-bar--slide ease;
+  transition: 1s width ease;
 }
 
 .sage-progress-bar__element {

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -53,8 +53,8 @@ $-progress-bar-height: sage-spacing(xs);
 }
 
 .sage-progress-bar__animate {
-  animation: 3s sage-progress-bar--slide ease;
   transition: 1s width ease;
+  animation: 3s sage-progress-bar--slide ease;
 }
 
 .sage-progress-bar__element {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] transition width if value is update

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![progressAnimateWidth](https://github.com/Kajabi/sage-lib/assets/1241836/3a1525be-57ae-4094-9b9b-dd8caa6669ea)|![progressAnimateWidthAfter](https://github.com/Kajabi/sage-lib/assets/1241836/3480660c-acbd-44ee-8f4a-91d1c82475b7)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->

Visit the following views to inspect the element, `.sage-progress-bar__value sage-progress-bar__animate` and verify that the width animates after load when the value changes:
- [Progress - Rails](http://localhost:4000/pages/component/progress_bar?tab=preview)
- [Progress - React](http://localhost:4100/?path=/docs/sage-progressbar--default)

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**)  Progress - add transition to width after page load

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-532](https://kajabi.atlassian.net/browse/DSS-532)

[DSS-532]: https://kajabi.atlassian.net/browse/DSS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ