### PR TITLE
fix(dropdown): adds missing disabled border styles

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -243,6 +243,9 @@ $-btn-loading-min-height: rem(36px);
     &:hover {
       box-shadow: sage-border-interactive(hover);
     }
+    &:disabled {
+      box-shadow: sage-border-interactive(disabled);
+    }
   }
 
   .sage-expandable-card--align-arrow-right &.sage-expandable-card__trigger {


### PR DESCRIPTION
## Description
The react `SelectDropdown` component border is missing when the component is set to `disabled=true`

This PR updates the styling to show the correct border when disabled.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-02-22 at 3 23 43 PM](https://github.com/Kajabi/sage-lib/assets/1175111/1fb2810a-d8ad-46c4-9bff-5cef91c59231)|![Screenshot 2024-02-22 at 3 23 01 PM](https://github.com/Kajabi/sage-lib/assets/1175111/f4ed7888-d946-440e-87ca-f5e2843a629a)|

## Testing in `sage-lib`

- Navigate to dropdown
- Set the select dropdown to disabled.
- Verify border styling appears as expected.

## Testing in `kajabi-products`
1. (**LOW**) Updates select dropdown to display border when disabled.

## Related
https://kajabi.atlassian.net/browse/DSS-534
