### PR TITLE
[DSS-537] Hero - Missing Classname Prop

### DIFF
--- a/packages/sage-react/lib/Hero/Hero.jsx
+++ b/packages/sage-react/lib/Hero/Hero.jsx
@@ -9,6 +9,7 @@ export const Hero = ({
   borderless,
   children,
   ctaAttributes,
+  className,
   customBackgroundColor,
   description,
   contained,
@@ -20,8 +21,9 @@ export const Hero = ({
   titleTag,
   ...rest
 }) => {
-  const className = classnames(
+  const classNames = classnames(
     'sage-hero',
+    className,
     {
       [`sage-hero--${heroSize}`]: heroSize,
       'sage-hero--borderless': borderless,
@@ -41,7 +43,7 @@ export const Hero = ({
 
   return (
     <article
-      className={className}
+      className={classNames}
       style={{ '--custom-background-color': customBackgroundColor || '' }}
       {...rest}
     >
@@ -85,6 +87,7 @@ Hero.defaultProps = {
   ctaAttributes: null,
   children: null,
   contained: false,
+  className: null,
   customBackgroundColor: null,
   description: null,
   footerActions: null,
@@ -117,6 +120,10 @@ Hero.propTypes = {
    * If true, the image will not fill the space.
    */
   contained: PropTypes.bool,
+  /**
+   * Allows a custom class name to apply to the component.
+   */
+  className: PropTypes.string,
   /**
    * The background color to be applied to the Hero.
    */


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adds missing prop that allows custom classnames.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="1025" alt="Screenshot 2024-03-05 at 3 00 57 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/33763f0c-bb45-4b49-ab09-44c6e6094d1d">|<img width="1040" alt="Screenshot 2024-03-05 at 2 52 03 PM" src="https://github.com/Kajabi/sage-lib/assets/14791307/77189c11-7046-457b-9240-cd318de62fa9">

Adding the class "hero test" breaks the component in the Before image.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to `packages/sage-react/lib/Hero/Hero.story.mdx`
- Add a class to any Hero component story and save.
- Navigate to the [React Hero](http://localhost:4100/?path=/docs/sage-hero--small)
- Check that class is added to the component you changed and that it renders properly

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
(LOW) - Adds missing prop that allows custom classnames. No effect on existing Hero components.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-537](https://kajabi.atlassian.net/browse/DSS-537)

[DSS-537]: https://kajabi.atlassian.net/browse/DSS-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ