### PR TITLE
[DSS-535] Modal - move scrollbars to the edge of the container when scrollable

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -182,6 +182,7 @@ $-modal-inner-size: sage-container(md);
     display: grid;
     grid-template-rows: auto 1fr auto;
     max-height: 85vh;
+    overflow: hidden; /* needed to apply border-radius to scrollbar */
   }
 
   .sage-modal--scrollable & > .simple_form {
@@ -268,8 +269,8 @@ $-modal-inner-size: sage-container(md);
   .sage-modal--scrollable & {
     @include overflow-scroll(y);
 
-    margin-top: 0;
-    padding: sage-spacing(xs) sage-spacing(3xs);
+    padding: sage-spacing(xs) sage-spacing(md) sage-spacing(md);
+    margin: 0;
 
     > :first-child {
       margin-top: sage-spacing(xs);

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -181,7 +181,6 @@ $-modal-inner-size: sage-container(md);
   .sage-modal--scrollable & > .simple_form {
     display: grid;
     grid-template-rows: auto 1fr auto;
-    overflow: hidden; /* needed to apply border-radius to scrollbar */
     max-height: 85vh;
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -181,8 +181,8 @@ $-modal-inner-size: sage-container(md);
   .sage-modal--scrollable & > .simple_form {
     display: grid;
     grid-template-rows: auto 1fr auto;
-    max-height: 85vh;
     overflow: hidden; /* needed to apply border-radius to scrollbar */
+    max-height: 85vh;
   }
 
   .sage-modal--scrollable & > .simple_form {

--- a/packages/sage-react/lib/Modal/Modal.story.jsx
+++ b/packages/sage-react/lib/Modal/Modal.story.jsx
@@ -148,6 +148,7 @@ export default {
     'Modal.FooterAside': Modal.FooterAside,
   },
   args: {
+    allowScroll: false,
     animation: Modal.ANIMATION_PRESETS,
   },
   argTypes: {
@@ -264,6 +265,7 @@ export const ModalWithCustomSize = (args) => {
       </Button>
       <Modal
         active={active}
+        allowScroll={true}
         animation={{ direction: Modal.ANIMATION_DIRECTIONS.BOTTOM }}
         onExit={onExit}
         size={Modal.SIZES.LG}


### PR DESCRIPTION
## Description
- [x] Modal - position the scrollbars to the edge of the container instead of being next to the content

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="595" alt="Screenshot_2024-03-05_at_5_51_04 PM" src="https://github.com/Kajabi/sage-lib/assets/1241836/794d93a4-55dd-426d-8f56-0751138c4fad">|<img width="605" alt="Screenshot_2024-03-05_at_5_50_50 PM" src="https://github.com/Kajabi/sage-lib/assets/1241836/1b33d8b9-ea04-4dd9-b41d-7f42dd4c05a8">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the [Modal View](http://localhost:4000/pages/component/modal?tab=preview) and click on the `Scrollable content` example
- Verify that the scrollbars are positioned at the edge of the container instead of next to the content

**Note: You may need to adjust you scrollbar configuration to test**
  - System settings -> Appearance -> Show scrollbars

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Modal - Reposition scrollbars in scrollable modals.

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-535](https://kajabi.atlassian.net/browse/DSS-535)

[DSS-535]: https://kajabi.atlassian.net/browse/DSS-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ