### PR TITLE
Fix sentry errors for null related to Sage Dropdown

### DIFF
--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -190,8 +190,12 @@ Sage.dropdown = (function () {
   }
 
   function positionElement(el) {
+    // Guard clause to check if wrapperRef.current is null
+    if (!wrapperRef.current) return;
+
     let directionX = null;
     let directionY = null;
+    const el = wrapperRef.current;
   
     // Elements
     const button = el;

--- a/packages/sage-system/lib/dropdown.js
+++ b/packages/sage-system/lib/dropdown.js
@@ -189,24 +189,23 @@ Sage.dropdown = (function () {
     return height - borderBottomWidth - borderTopWidth - paddingTop - paddingBottom;
   }
 
-  function positionElement(el) {
+  function positionElement(dropdownElement) {
     // Guard clause to check if wrapperRef.current is null
-    if (!wrapperRef.current) return;
+    if (!dropdownElement) return;
 
     let directionX = null;
     let directionY = null;
-    const el = wrapperRef.current;
   
     // Elements
-    const button = el;
-    const panel = el.lastElementChild;
+    const button = dropdownElement;
+    const panel = dropdownElement.lastElementChild;
     const win = panel.ownerDocument.defaultView;
     const docEl = window.document.documentElement;
 
     panel.style.top = ''; // resets the style
     panel.style.left = ''; // resets the style
     panel.style.right = ''; // resets the style
-  
+
     // Dimensions
     const buttonDimensions = button.getBoundingClientRect();
     const panelDimensions = panel.getBoundingClientRect();
@@ -215,14 +214,14 @@ Sage.dropdown = (function () {
       top: (buttonDimensions.height / 2) + panelDimensions.height,
       left: (buttonDimensions.width / 2) + panelDimensions.width,
     };
-  
+
     const viewport = {
       top: docEl.scrollTop,
       bottom: window.pageYOffset + docEl.clientHeight,
       left: docEl.scrollLeft,
       right: window.pageXOffset + docEl.clientWidth,
     };
-  
+
     const offset = {
       top: panelDimensions.top + win.pageYOffset,
       left: panelDimensions.left + win.pageXOffset,
@@ -257,7 +256,7 @@ Sage.dropdown = (function () {
     } else if (!enoughSpaceLeft && enoughSpaceRight) {
       directionX = 'right';
     }
-    
+
     if (directionX === 'left') {
       panel.style.left = 'inherit';
       panel.style.right = 0;
@@ -266,7 +265,7 @@ Sage.dropdown = (function () {
       panel.style.right = 'inherit';
     }
   }
-  
+
   function open(el) {
     el.setAttribute("aria-expanded", "true");
     positionElement(el);


### PR DESCRIPTION
## Description
Add a guard clause in the `positionElement` function to check for null before accessing `wrapperRef.current` properties. This prevents runtime errors related to attempting to access properties on null when the dropdown component mounts or updates under certain conditions. Solves Sentry errors "Cannot read properties of null (reading lastElementChild)" and "null is not an object (evaluating r.lastElementChild)".


## Screenshots
N/A


## Testing in `sage-lib`
1. Navigate to dropdown component
3. Verify it works in both Rail and React


## Testing in `kajabi-products`
1. (**LOW**) - Core code of the dropdown has not changed 


## Related
[Error 1](https://kajabi-qc.sentry.io/issues/4305843420/?project=5541287&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=0#exception) and [Error 2](https://kajabi-qc.sentry.io/issues/4305844335/?project=5541287&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=3)