### PR TITLE
Sentry error - ensure valid node before removal to prevent errors

### DIFF
--- a/packages/sage-system/lib/tooltip.js
+++ b/packages/sage-system/lib/tooltip.js
@@ -53,16 +53,17 @@ Sage.tooltip = (function() {
     positionTooltip(evt.target, tooltip, pos);
   }
 
-
   // Removes tooltip from DOM
   function removeTooltip(evt) {
-    if (!evt.target.hasAttribute(DATA_ATTR) || !document.querySelector(SELECTOR) || !document.querySelector(`.${TOOLTIP_CLASS}`) || !evt.target.dataset.jsTooltip)  return;
+    if (!evt.target.hasAttribute(DATA_ATTR) || !document.querySelector(SELECTOR) || !document.querySelector(`.${TOOLTIP_CLASS}`) || !evt.target.dataset.jsTooltip) return;
 
     window.requestAnimationFrame(function() {
-      document.body.removeChild(document.querySelector(`.${TOOLTIP_CLASS}`));
+        var tooltip = document.querySelector(`.${TOOLTIP_CLASS}`);
+        if (tooltip && tooltip.parentNode === document.body) { // Ensure tooltip exists and its parent is document.body before removing
+            document.body.removeChild(tooltip);
+        }
     });
   }
-
 
   // Builds list of modifier classes from array of data-attributes
   function generateClasses(ele, evt) {


### PR DESCRIPTION
## Description
This commit fixes an issue where the `removeTooltip` function attempted to remove a tooltip element from the DOM without verifying if it was a valid child of `document.body`. The updated implementation adds a check to ensure the tooltip exists and its parent node is `document.body` before proceeding with the removal. This change prevents the "Failed to execute removeChild on Node: parameter 1 is not of type Node." error from being thrown, enhancing the robustness and reliability of tooltip removal.


## Screenshots
N/A

## Testing in `sage-lib`
1. Navigate to tooltip
2. Verify the functionality still works properly with Rails and React

## Testing in `kajabi-products`
1. (**LOW**) This fix should not impact `kajabi-products`

## Related
[Error in sentry](https://kajabi-qc.sentry.io/issues/3233768622/?project=5541287&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=1)
