### PR TITLE
Remove `require.context` as this is a Webpack function that Vite don't like

### DIFF
--- a/packages/sage-packs/lib/packs/system.js
+++ b/packages/sage-packs/lib/packs/system.js
@@ -4,5 +4,5 @@ import "regenerator-runtime/runtime";
 import "@kajabi/sage-system";
 
 // --- Sage System Assets -------
-require.context("@kajabi/sage-assets/lib/images", true);
+// require.context("@kajabi/sage-assets/lib/images", true);
 import "@kajabi/sage-assets/dist/main.css";

--- a/packages/sage-packs/lib/packs/system.js
+++ b/packages/sage-packs/lib/packs/system.js
@@ -4,5 +4,4 @@ import "regenerator-runtime/runtime";
 import "@kajabi/sage-system";
 
 // --- Sage System Assets -------
-// require.context("@kajabi/sage-assets/lib/images", true);
 import "@kajabi/sage-assets/dist/main.css";


### PR DESCRIPTION
## Description

`require.context` is being used to load images in `packages/sage-packs/lib/packs/system.js`. I'm the one that added this originally, but still can't remember _why_ I did it. Best I can figure, because we were not actively compiling/creating a `dist` that we for some reason needed that call to get the Monolith to find the images 🤷 

Anyhow, Monolith is now on Vite, and has been reporting this line as an error:

```
system.js:6 Uncaught TypeError: __require.context is not a function
    at system.js:6:9
```

Even though this error exists.... nothing seems to be "broken" because of it. We got QE passes, it's been sitting on prod for a day, and so far no barking 🤞 🐶. Vite has a lot of stuff they do under the hood, for instance we automatically get stylesheets with js imports now where we'd have to be explicit before, so my guess is the same magic is happening under the hood for images 🪄 .

I removed the line from my `node_modules`, spun up the monolith, and all looked well to my ignorant eyes. I then asked the Sage team to take a peek at their local dev, and got a sign-off from @ju-Skinner and @pixelflips, so I believe this line is now a null and void thing 🎉 

Going to remove so we can get the error to go away, but please make sure to check it out on your local dev framework to ensure nothing seems crazy. Worst case, we revert, but hopefully this will just run smooth.

Please let me know if you have any questions, thank you!

## Testing in `sage-lib`
Spin it up in your local dev and just make sure the images all look good 👍 


## Testing in `kajabi-products`
1. (**LOW**) Because this is in prod on the Monolith, but Vite errors out on it, we can deduce that this change won't have any impact. If there was a problem with this being missing then the monolith wouldn't be working right at the moment. But, wouldn't hurt to just double check things in case some outlier jumps in


## Related
https://github.com/Kajabi/kajabi-products/pull/32798
