### PR TITLE
fix(dropdown): Add check to resolve sentry typeError exception

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -80,6 +80,10 @@ export const Dropdown = ({
     let directionX = null;
     let directionY = null;
     const el = wrapperRef.current;
+
+    // if el is null, return
+    if (!el) return;
+
     // Elements
     const button = el;
     const panel = el.lastElementChild;


### PR DESCRIPTION
## Description
Sentry is still reporting error: 

```
Cannot read properties of null (reading 'lastElementChild')
``` 

The exception is coming from `positionElement`. An additional check is being added to check to that `el` exists.


## Screenshots
No visual changes.


## Testing in `sage-lib`

- Navigate to [Dropdown](http://localhost:4100/?path=/docs/sage-dropdown--default)
- Verify there are no visual changes
- Verify dropdowns function as expected.


## Testing in `kajabi-products`
1. (**MEDIUM**) Adds check to correct sentry error in dropdown.
   - [ ] Sanity check of react dropdowns in KP recommended.

## Related
https://kajabi.atlassian.net/browse/DSS-609