### PR TITLE
Breadcrumbs - Rails resolve has_back_icon bug

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
@@ -1,5 +1,5 @@
 <%
-has_back_icon = component.has_back_icon.present? ? component.has_back_icon : component.items.length() == 1
+has_back_icon = component.has_back_icon.nil? ? component.items.length() == 1 : component.has_back_icon
 is_progressbar = component.is_progressbar.present? && component.is_progressbar
 %>
 <nav
@@ -38,7 +38,7 @@ is_progressbar = component.is_progressbar.present? && component.is_progressbar
         <i class="sage-breadcrumbs__icon sage-icon-arrow-left" aria-hidden="true"></i>
       <% end %>
       <%= component.items[0][:text] %>
-    </a>  
+    </a>
   </p>
   <% end %>
 </nav>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_breadcrumbs.html.erb
@@ -1,4 +1,5 @@
 <%
+# The intent is to set this prop to false unless the has_back_icon prop is explicitly set
 has_back_icon = component.has_back_icon.nil? ? component.items.length() == 1 : component.has_back_icon
 is_progressbar = component.is_progressbar.present? && component.is_progressbar
 %>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] Resolve bug where setting `has_back_icon: false` was not working

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![28 05 2024_10 55 03_REC](https://github.com/Kajabi/sage-lib/assets/1241836/fcc910b6-8ff9-4ab8-b3a1-e0fe04533b16)|![28 05 2024_10 55 54_REC](https://github.com/Kajabi/sage-lib/assets/1241836/9b34f863-b056-44eb-8530-a2b640ca7883)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the breadcrumbs page and verify the back icon shows for that example. This shows that change is not breaking.
- In VS Code, go tho this file, docs/app/views/examples/components/breadcrumbs/_preview.html.erb
- In the `SageBreadcrumbs` on link 33 add `has_back_icon: false,`
- Refresh your page and see that back icon is not there

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Breadcrumbs - fix bug in the` has_back_icon` prop
   - [ ] Super admin -> Users

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-624](https://kajabi.atlassian.net/browse/DSS-624)

[DSS-624]: https://kajabi.atlassian.net/browse/DSS-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ