### PR TITLE
fix: removes dasherize from variable used for attributes

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
@@ -1,8 +1,7 @@
 <%
   # Temporary variables here until refactor for 'name' is complete; see https://kajabi.atlassian.net/browse/SAGE-214
   label = component.label || component.name;
-  select_id = component.id.downcase.dasherize if component.id;
-  select_name = label.downcase.dasherize;
+  select_id = component.id.downcase if component.id;
 %>
 
 <div class="
@@ -48,7 +47,7 @@
       <% end %>
     <% end %>
   </select>
-  <label class="sage-select__label" for="<%= select_name %>"><%= label %></label>
+  <label class="sage-select__label" for="<%= select_id %>"><%= label %></label>
   <i class="sage-select__arrow" aria-hidden="true"></i>
   <% if component.message.present? %>
     <div class="sage-select__info">

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
@@ -1,7 +1,7 @@
 <%
   # Temporary variables here until refactor for 'name' is complete; see https://kajabi.atlassian.net/browse/SAGE-214
   label = component.label || component.name;
-  select_id = component.id.downcase if component.id;
+  select_id = component.id ? component.id.downcase : label.downcase.dasherize;
 %>
 
 <div class="

--- a/package.json
+++ b/package.json
@@ -71,5 +71,6 @@
     "watch:assets": "cd packages/sage-assets && yarn build:watch",
     "watch:react": "cd packages/sage-react && yarn build:watch",
     "watch:system": "cd packages/sage-system && yarn build:watch"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,5 @@
     "watch:assets": "cd packages/sage-assets && yarn build:watch",
     "watch:react": "cd packages/sage-react && yarn build:watch",
     "watch:system": "cd packages/sage-system && yarn build:watch"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
## Description
Name and ID attributes are being converted into dash-case. This is causing issues when devs expect these values to use underscores.

This is an attempt to address the issue, but I am not fully aware of the ramifications. We will need testing and QE help.

## Screenshots
No visual changes are expected.

## Testing in `sage-lib`
Verify when passing an ID with underscores that the underscores remain.

## Testing in `kajabi-products`
1. (**HIGH**) Removes automatic conversion of name and id attributes in selects.

## Related
https://kajabi.atlassian.net/browse/DSS-628
