### PR TITLE
[DSS-654]feat: add Card.Header component with updates to storybook

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -6,7 +6,7 @@
 
 
 // Default background option
-$-sage-frame-background: transparent;
+$-sage-card-background: transparent;
 
 .sage-card {
   @include sage-card();
@@ -165,7 +165,7 @@ $-sage-frame-background: transparent;
 
 @each $-color, $-sliders in $sage-colors {
   @each $-number, $-configs in $-sliders {
-    .sage-frame--background-#{"" + $-color}-#{$-number} {
+    .sage-card--background-#{"" + $-color}-#{$-number} {
       background: #{sage-color($-color, $-number)};
     }
   }

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -5,6 +5,9 @@
 ////
 
 
+// Default background option
+$-sage-frame-background: transparent;
+
 .sage-card {
   @include sage-card();
 
@@ -153,6 +156,26 @@
 
 .sage-card__header {
   @include sage-grid-card-row();
+}
+
+
+.sage-card--background-custom {
+  background: var(--sage-card-background, transparent);
+}
+
+@each $-color, $-sliders in $sage-colors {
+  @each $-number, $-configs in $-sliders {
+    .sage-frame--background-#{"" + $-color}-#{$-number} {
+      background: #{sage-color($-color, $-number)};
+    }
+  }
+}
+
+.sage-card__header-layout {
+  width: calc(100% + #{2 * sage-spacing(card)});
+  margin: (-1 * sage-spacing(card)) (-1 * sage-spacing(card)) (-1 * sage-spacing(card));
+  border-top-left-radius: sage-border(radius-large);
+  border-top-right-radius: sage-border(radius-large);
 }
 
 .sage-card__list {

--- a/packages/sage-react/.storybook/preview-head.html
+++ b/packages/sage-react/.storybook/preview-head.html
@@ -2,7 +2,31 @@
   Need local instance of Pine CORE running. not PINE ICONS
   Make sure that the port here matches what is running in your local instance.
 -->
-<script type="module" src="https://localhost:7300/build/pine-core.esm.js"></script>
-<script nomodule src="https://localhost:7300/build/index.esm.js"></script>
+<script>
+  const LOCAL_PORT = 7301;
+  const host = window.location.host;
+  const timestamp = new Date().getTime(); // Generate a unique timestamp
 
-<link rel="stylesheet" href="https://localhost:7300/build/pine-core.css" />
+  if ( host.includes('localhost') ) {
+    window.PINE_CORE_URL = `https://localhost:${LOCAL_PORT}/build`;
+  } else {
+    window.PINE_CORE_URL = 'https://cdn.jsdelivr.net/npm/@pine-ds/core/dist/pine-core';
+  }
+
+  function setScriptLinks() {
+    const scriptModule = document.getElementById("scriptModule");
+    const scriptNoModule = document.getElementById("scriptNoModule");
+    const linkStyleSheet = document.getElementById("linkStyleSheet");
+
+    scriptModule.src = `${window.PINE_CORE_URL}/pine-core.esm.js?v=${timestamp}`;
+    scriptNoModule.src = `${window.PINE_CORE_URL}/index.esm.js?v=${timestamp}`;
+    linkStyleSheet.href = `${window.PINE_CORE_URL}/pine-core.css?v=${timestamp}`;
+  }
+
+  document.addEventListener('DOMContentLoaded', setScriptLinks);
+</script>
+
+<script id="scriptNoModule" nomodule></script>
+<script id="scriptModule" type="module"></script>
+<link id="linkStyleSheet" rel="stylesheet" />
+

--- a/packages/sage-react/lib/Card/Card.jsx
+++ b/packages/sage-react/lib/Card/Card.jsx
@@ -5,6 +5,7 @@ import { Loader } from '../Loader';
 import { CardBlock } from './CardBlock';
 import { CardDivider } from './CardDivider';
 import { CardFigure } from './CardFigure';
+import { CardHeader } from './CardHeader';
 import { CardFooter } from './CardFooter';
 import { CardHighlight } from './CardHighlight';
 import { CardImage } from './CardImage';
@@ -52,6 +53,7 @@ export const Card = ({
 Card.Block = CardBlock;
 Card.Divider = CardDivider;
 Card.Figure = CardFigure;
+Card.Header = CardHeader;
 Card.Footer = CardFooter;
 Card.Highlight = CardHighlight;
 Card.Image = CardImage;

--- a/packages/sage-react/lib/Card/Card.story.jsx
+++ b/packages/sage-react/lib/Card/Card.story.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { selectArgs } from '../story-support/helpers';
-import { SageTokens } from '../configs';
+import { SageTokens, SageClassnames } from '../configs';
 import { Button } from '../Button';
 import { Grid } from '../Grid';
 import { Icon } from '../Icon';
 import { Link } from '../Link';
 import { Card } from './Card';
+import { Frame } from '../Frame';
 
 export default {
   title: 'Sage/Card',
@@ -19,6 +20,7 @@ export default {
     },
   },
   subcomponents: {
+    'Card.Header': Card.Header,
     'Card.Title': Card.Title,
     'Card.Block': Card.Block,
     'Card.Stack': Card.Stack,
@@ -47,7 +49,6 @@ Default.decorators = [
 Default.args = {
   children: (
     <>
-      <Card.Title>Card Title</Card.Title>
       <Card.Title>Block (with Sage Type)</Card.Title>
       <Card.Block sageType={true}>
         <p>
@@ -132,6 +133,41 @@ Default.args = {
     </>
   ),
 };
+
+export const CardWithHeader = (args) => (
+  <Card>
+    <Card.Header background={args.background}>
+      <Frame padding={Frame.PADDINGS.SM} direction={Frame.DIRECTIONS.HORIZONTAL}>
+        <Frame direction={Frame.DIRECTIONS.VERTICAL} gap={Frame.GAPS.NONE}>
+          <p className={SageClassnames.TYPE.BODY_SMALL}>November 7, 2018</p>
+          <p className={SageClassnames.TYPE.BODY_SMALL_BOLD}>Order #12931820</p>
+        </Frame>
+        <Frame direction={Frame.DIRECTIONS.VERTICAL} gap={Frame.GAPS.NONE}>
+          <p className={SageClassnames.TYPE.BODY_SMALL}>Total</p>
+          <p className={SageClassnames.TYPE.BODY_SMALL_BOLD}>$623.98</p>
+        </Frame>
+      </Frame>
+    </Card.Header>
+    <Card.Row gridTemplate={SageTokens.GRID_TEMPLATES.ETE}>
+      <p>Main content goes here.</p>
+    </Card.Row>
+    <Card.Footer>
+      <Button color="secondary">Lorem ipsum</Button>
+      <Button>Dolor sit</Button>
+    </Card.Footer>
+  </Card>
+);
+
+CardWithHeader.args = {
+  background: SageTokens.COLOR_SLIDERS.GREY_200,
+};
+
+CardWithHeader.argTypes = {
+  ...selectArgs({
+    background: SageTokens.COLOR_SLIDERS
+  }),
+};
+
 
 export const InteractiveCard = () => (
   <Card interactive={true}>

--- a/packages/sage-react/lib/Card/Card.story.jsx
+++ b/packages/sage-react/lib/Card/Card.story.jsx
@@ -168,7 +168,6 @@ CardWithHeader.argTypes = {
   }),
 };
 
-
 export const InteractiveCard = () => (
   <Card interactive={true}>
     <Link className="sage-card__link--primary" href="//example.com">

--- a/packages/sage-react/lib/Card/CardHeader.jsx
+++ b/packages/sage-react/lib/Card/CardHeader.jsx
@@ -10,7 +10,7 @@ export const CardHeader = ({ background, children, ...rest }) => {
     && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
 
   if (hasCustomBackground) {
-    styles['--sage-frame-background'] = background;
+    styles['--sage-card-background'] = background;
   }
 
   return (
@@ -18,8 +18,8 @@ export const CardHeader = ({ background, children, ...rest }) => {
       className={
         [
           'sage-card__header-layout',
-          hasCustomBackground ? 'sage-frame--background-custom' : '',
-          background && !hasCustomBackground ? `sage-frame--background-${background}` : ''
+          hasCustomBackground ? 'sage-card--background-custom' : '',
+          background && !hasCustomBackground ? `sage-card--background-${background}` : ''
         ].filter((x) => x).join(' ')
       }
       {...rest}

--- a/packages/sage-react/lib/Card/CardHeader.jsx
+++ b/packages/sage-react/lib/Card/CardHeader.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes, { oneOfType } from 'prop-types';
+import { SageClassnames, SageTokens } from '../configs';
+
+export const CardHeader = ({ background, children, ...rest }) => {
+    const { style } = rest;
+    const styles = style || {};
+    
+    const hasCustomBackground = background
+    && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
+
+    if (hasCustomBackground) {
+        styles['--sage-frame-background'] = background;
+    }
+
+    return (
+        <div
+            className={
+                [
+                    'sage-card__header-layout',
+                    hasCustomBackground ? 'sage-frame--background-custom': '',
+                    background && !hasCustomBackground ? `sage-frame--background-${background}` : ''
+                ].filter(x => x).join(' ')
+            }
+            {...rest}
+            style={styles}
+        >
+            {children}
+        </div>
+    );
+};
+
+CardHeader.defaultProps = {
+  background: SageTokens.COLOR_SLIDERS.GREY_200,
+  children: null,
+};
+
+CardHeader.propTypes = {
+  background: oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(Object.values(SageTokens.COLOR_SLIDERS)),
+  ]),
+  children: PropTypes.node,
+};

--- a/packages/sage-react/lib/Card/CardHeader.jsx
+++ b/packages/sage-react/lib/Card/CardHeader.jsx
@@ -1,33 +1,33 @@
 import React from 'react';
 import PropTypes, { oneOfType } from 'prop-types';
-import { SageClassnames, SageTokens } from '../configs';
+import { SageTokens } from '../configs';
 
 export const CardHeader = ({ background, children, ...rest }) => {
-    const { style } = rest;
-    const styles = style || {};
-    
-    const hasCustomBackground = background
+  const { style } = rest;
+  const styles = style || {};
+
+  const hasCustomBackground = background
     && !Object.values(SageTokens.COLOR_SLIDERS).includes(background);
 
-    if (hasCustomBackground) {
-        styles['--sage-frame-background'] = background;
-    }
+  if (hasCustomBackground) {
+    styles['--sage-frame-background'] = background;
+  }
 
-    return (
-        <div
-            className={
-                [
-                    'sage-card__header-layout',
-                    hasCustomBackground ? 'sage-frame--background-custom': '',
-                    background && !hasCustomBackground ? `sage-frame--background-${background}` : ''
-                ].filter(x => x).join(' ')
-            }
-            {...rest}
-            style={styles}
-        >
-            {children}
-        </div>
-    );
+  return (
+    <div
+      className={
+        [
+          'sage-card__header-layout',
+          hasCustomBackground ? 'sage-frame--background-custom' : '',
+          background && !hasCustomBackground ? `sage-frame--background-${background}` : ''
+        ].filter((x) => x).join(' ')
+      }
+      {...rest}
+      style={styles}
+    >
+      {children}
+    </div>
+  );
 };
 
 CardHeader.defaultProps = {


### PR DESCRIPTION
## Description
Implement a Card.Header sub component for a non-opinionated header with a configurable background.
It should allow for a configurable background prop that will either
- match an existing CODE from SageTokens.COLOR_SLIDERS
- allow a custom HEX value if the provided background prop does not match to a COLOR_SLIDERS key
This will function exactly as the background prop in the <Frame /> component.

## Implementation example:
```javascript
<Card.Header background={SageTokens.COLOR_SLIDERS.GREY_200}>
    {...}
</Card.Header>
```

## Screenshots

|  Before  |  After  |
|--------|--------|
|<img width="806" alt="image" src="https://github.com/Kajabi/sage-lib/assets/122644735/55f6456f-1aec-408f-b226-ce20f55e8253">|<img width="817" alt="image" src="https://github.com/Kajabi/sage-lib/assets/122644735/90b44617-9fd3-4624-91bf-9c52b42edc17">|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
