### PR TITLE
fix(label): convert icon to pds-icon

### DIFF
--- a/packages/sage-react/lib/Label/Label.jsx
+++ b/packages/sage-react/lib/Label/Label.jsx
@@ -67,7 +67,7 @@ export const Label = React.forwardRef(({
       </TagName>
       {interactiveType === LABEL_INTERACTIVE_TYPES.SECONDARY_BUTTON && secondaryButton}
       {(interactiveType === LABEL_INTERACTIVE_TYPES.DROPDOWN) && (
-        <span className="sage-label__decor-icon sage-label__decor-icon--down-small" />
+        <pds-icon className="sage-label__decor-icon" name="down-small" />
       )}
     </span>
   );


### PR DESCRIPTION
## Description
Updates label icon to pds-icon in deprecated label react component. There is usage still in KP.

## Screenshots
No visual changes are expected.

## Testing in `sage-lib`
There is no story available in sage-lib, so will verify on the KP side.

## Testing in `kajabi-products`

1. (**LOW**) Converts dropdown label icon to pds-icon


## Related
N/A
