### PR TITLE
fix(Icon): adds back rest to icon component

### DIFF
--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -15,6 +15,7 @@ export const Icon = ({
   icon,
   label,
   size,
+  ...rest
 }) => {
   const classNames = classnames(
     className,

--- a/packages/sage-react/lib/Icon/Icon.jsx
+++ b/packages/sage-react/lib/Icon/Icon.jsx
@@ -58,7 +58,7 @@ export const Icon = ({
   };
 
   const renderIcon = () => (
-    <pds-icon name={icon} class={`t-sage--color-${color} ${classNames}`} size={sizeMapping[size]} />
+    <pds-icon name={icon} class={`t-sage--color-${color} ${classNames}`} size={sizeMapping[size]} {...rest} />
   );
 
   const setBackgroundDimensions = () => {


### PR DESCRIPTION
## Description
When converting icons to pds-icon, `...rest` got removed unintentionally. Bringing back to resolve some issues this causes in KP.

## Screenshots
No visual changes


## Testing in `sage-lib`
Verify `...rest ` is available in code.


## Testing in `kajabi-products`
1. (**LOW**) Adds rest back to the icon component.


## Related
N/A
