### PR TITLE
fix: update headings font weight

### DIFF
--- a/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_type_specs.scss
@@ -83,19 +83,19 @@ $sage-type-specs: (
     kerning: sage-letter-spacing(5xl),
     responsive: true,
     type-pairing: h1,
-    weight: sage-font-weight(bold),
+    weight: sage-font-weight(semibold),
   ),
   "heading-2": (
     kerning: sage-letter-spacing(4xl),
     responsive: true,
     type-pairing: h2,
-    weight: sage-font-weight(bold),
+    weight: sage-font-weight(semibold),
   ),
   "heading-3": (
     kerning: sage-letter-spacing(3xl),
     responsive: true,
     type-pairing: h3,
-    weight: sage-font-weight(bold),
+    weight: sage-font-weight(semibold),
   ),
   "heading-4": (
     kerning: sage-letter-spacing(2xl),


### PR DESCRIPTION
## Description
Typography changes from `700` to `600`

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
![image](https://github.com/user-attachments/assets/3e720475-b7c1-488e-851b-51393ea49fa4)|
![image](https://github.com/user-attachments/assets/19068306-6a68-4b2c-b4f0-116024e3712c)
|


## Testing in `sage-lib`
Navigate to the Foundations - Typography page and inspect the headings. Font-weight should read `600`



## Related
https://kajabi.atlassian.net/browse/DSS-711
