### PR TITLE
style: update font from sf pro to inter

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -5,7 +5,7 @@
 ////
 $-body-font-version: 1;
 
-$-greet-font-path: "#{$sage-font-cdn-root}/greet" !default; // pathname of font directory
+$sage-greet-font-path: "#{$sage-font-cdn-root}/greet" !default; // pathname of font directory
 $-greet-font-name: "greetstandard";
 
 $sage-inter-font-path: "#{$sage-font-cdn-root}/inter" !default; // pathname of font directory
@@ -22,6 +22,7 @@ $-inter-font-name: "Inter";
   font-family: "GreetStandard";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: local("#{$-greet-font-name}-light"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-light.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-light.woff?v=#{$-body-font-version}") format("woff");
@@ -32,6 +33,7 @@ $-inter-font-name: "Inter";
   font-family: "GreetStandard";
   font-style: italic;
   font-weight: 300;
+  font-display: swap;
   src: local("#{$-greet-font-name}-lightitalic"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-lightitalic.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-lightitalic.woff?v=#{$-body-font-version}") format("woff");
@@ -42,6 +44,7 @@ $-inter-font-name: "Inter";
   font-family: "GreetStandard";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local("#{$-greet-font-name}-regular"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-regular.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-regular.woff?v=#{$-body-font-version}") format("woff");
@@ -52,6 +55,7 @@ $-inter-font-name: "Inter";
   font-family: "GreetStandard";
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: local("#{$-greet-font-name}-regularitalic"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-regularitalic.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-regularitalic.woff?v=#{$-body-font-version}") format("woff");
@@ -62,6 +66,7 @@ $-inter-font-name: "Inter";
   font-family: "GreetStandard";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: local("#{$-greet-font-name}-medium"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-medium.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-medium.woff?v=#{$-body-font-version}") format("woff");
@@ -72,6 +77,7 @@ $-inter-font-name: "Inter";
   font-family: "GreetStandard";
   font-style: italic;
   font-weight: 500;
+  font-display: swap;
   src: local("#{$-greet-font-name}-mediumitalic"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-mediumitalic.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-mediumitalic.woff?v=#{$-body-font-version}") format("woff");

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -8,6 +8,9 @@ $-body-font-version: 1;
 $-greet-font-path: "#{$sage-font-cdn-root}/greet" !default; // pathname of font directory
 $-greet-font-name: "greetstandard";
 
+$sage-inter-font-path: "#{$sage-font-cdn-root}/inter" !default; // pathname of font directory
+$-inter-font-name: "Inter";
+
 // Sample Url
 // https://sage.kajabi-cdn.com/font/greet/greetstandard-bold.woff2?v=1
 // https://sage.kajabi-cdn.com/font/greet/greetstandard-bold.woff?v=1
@@ -138,4 +141,185 @@ $-greet-font-name: "greetstandard";
   src: local("#{$-greet-font-name}-heavyitalic"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-heavyitalic.woff2?v=#{$-body-font-version}") format("woff2"),
     url("#{$sage-greet-font-path}/#{$-greet-font-name}-heavyitalic.woff?v=#{$-body-font-version}") format("woff");
+}
+
+
+// Inter
+
+// Thin
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Thin"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Thin.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Thin Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 100;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-ThinItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-ThinItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Extra Light
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 200;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-ExtraLight"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-ExtraLight.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Extra Light Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 200;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-ExtraLightItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-ExtraLightItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Light
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Light"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Light.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Light Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 300;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-LightItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-LightItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Regular
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Regular"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Regular.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Italic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Italic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Medium
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Medium"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Medium.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Medium Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 500;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-MediumItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-MediumItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Thin"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-SemiBold.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 600;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Thin"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-SemiBoldItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Semi-Bold
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-SemiBold"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Bold.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Bold Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-BoldItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-BoldItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Extra Bold
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 800;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-ExtraBold"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-ExtraBold.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Extra Bold Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 800;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-ExtraBoldItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-ExtraBoldItalic.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Black
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-Black"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-Black.woff2?v=#{$-body-font-version}") format("woff2");
+}
+
+// Black Italic
+@font-face {
+  font-family: "Inter";
+  font-style: italic;
+  font-weight: 900;
+  font-display: swap;
+  src: local("#{$-inter-font-name}-BlackItalic"),
+    url("#{$sage-inter-font-path}/#{$-inter-font-name}-BlackItalic.woff2?v=#{$-body-font-version}") format("woff2");
 }

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -6,7 +6,7 @@
 
 
 // Font definitions
-$-body-font-stack: -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu";
+$-body-font-stack: "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-margin-bottom: sage-spacing(xs);
 $-headings-margin-bottom: sage-spacing(sm);
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -701,6 +701,7 @@
 ///
 @mixin sage-font-family() {
   font-family: $-body-font-stack;
+  font-feature-settings: "liga" 1, "calt" 1; /* fix for Chrome */
 }
 
 ///

--- a/packages/sage-assets/lib/stylesheets/global/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/global/_reboot.scss
@@ -33,7 +33,7 @@ section {
 
 body {
   margin: 0;
-  font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu",
+  font-family: "Inter", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-size: 1rem;
   font-weight: 425;
@@ -66,7 +66,7 @@ h6,
   margin-top: 0;
   margin-bottom: 0;
   color: sage-color(charcoal, 500);
-  font-family: "GreetStandard", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu" ;
+  font-family: "GreetStandard", "Inter", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif ;
 }
 
 p {

--- a/packages/sage-assets/lib/stylesheets/global/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/global/_reboot.scss
@@ -35,6 +35,7 @@ body {
   margin: 0;
   font-family: "Inter", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-feature-settings: "liga" 1, "calt" 1; /* fix for Chrome */
   font-size: 1rem;
   font-weight: 425;
   line-height: 1.5; /* NOTE: line-height must be '1.5' to avoid conflicts with Ladera */


### PR DESCRIPTION
## Description
This changes the font family from SFPro to Inter font face

## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/foundations/typography
2. Poke around and confirm fonts used are Inter. Exclude headings from your validations.

## Related
https://kajabi.atlassian.net/browse/DSS-734
