### PR TITLE
fix(sage-icon): add html_attributes to render on pds-icon

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_icon.html.erb
@@ -32,6 +32,7 @@ end
       <%= component.generated_css_classes %>
     "
     size="<%= "#{component.size}" if component.size.present? %>"
+    <%= component.generated_html_attributes.html_safe %>
     ></pds-icon>
 <% if component.card_color.present? %>
   </div>


### PR DESCRIPTION
## Description
HTML Attributes were not being passed along to pds-icon




## Related
https://kajabi.atlassian.net/browse/DSS-749
