### PR TITLE
fix: converts select icon to pds-icon

### DIFF
--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { SageTokens } from '../configs';
 
 export const Select = ({
   className,
@@ -78,7 +79,13 @@ export const Select = ({
           : buildOption(option, i)
         ))}
       </select>
-      <i className="sage-select__arrow" aria-hidden="true" />
+      <pds-icon
+        aria-hidden="true"
+        class="sage-select__arrow"
+        color={SageTokens.COLOR_PALETTE.CHARCOAL_100}
+        name="caret-down"
+        size=""
+      ></pds-icon>
       {label && (
         <label htmlFor={id} className="sage-select__label">{label}</label>
       )}

--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -85,7 +85,7 @@ export const Select = ({
         color={SageTokens.COLOR_PALETTE.CHARCOAL_100}
         name="caret-down"
         size=""
-      ></pds-icon>
+      />
       {label && (
         <label htmlFor={id} className="sage-select__label">{label}</label>
       )}


### PR DESCRIPTION
## Description
The dropdown icon/arrow is not showing in the Select React component.
This icon was missed during the `pds-icon` conversion.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-07-31 at 9 54 56 AM](https://github.com/user-attachments/assets/85b61b4a-6c06-4507-ac1d-0a06cb404163)|![Screenshot 2024-07-31 at 9 50 51 AM](https://github.com/user-attachments/assets/40b5fb36-1bc1-4998-ba50-6a7d240d3a40)|

## Testing in `sage-lib`
Navigate to [Select](http://localhost:4100/?path=/docs/sage-select--default)
Verify icon/arrow is rendering


## Testing in `kajabi-products`
1. (**LOW**) Corrects missing arrow icon in the Select React component.
