### PR TITLE
revert(select): removes size prop from pds-icon

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_form_select.html.erb
@@ -53,7 +53,6 @@
     class="sage-select__arrow"
     color="<%= SageTokens::COLOR_PALETTE[:CHARCOAL_100] %>"
     name="caret-down"
-    size=""
   ></pds-icon>
   <% if component.message.present? %>
     <div class="sage-select__info">

--- a/packages/sage-react/lib/Select/Select.jsx
+++ b/packages/sage-react/lib/Select/Select.jsx
@@ -84,7 +84,6 @@ export const Select = ({
         class="sage-select__arrow"
         color={SageTokens.COLOR_PALETTE.CHARCOAL_100}
         name="caret-down"
-        size=""
       />
       {label && (
         <label htmlFor={id} className="sage-select__label">{label}</label>


### PR DESCRIPTION
## Description
Removes using the size attribute to resolve the pds-icon overwritten using the internal style attribute.


## Screenshots
No Visual Changes

## Testing in `sage-lib`
1. Go to Components -> Form Select in Rails Doc. 
2. Navigate to storybook -> Select 
3. In both steps, verify the icon is aligned.

