### PR TITLE
fix(dropdownitem): convert before element to pds-icon

### DIFF
--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { Checkbox } from '../Toggle';
 import { Link } from '../Link';
 import { Tooltip } from '../Tooltip';
-import { SageTokens } from '../configs';
+import { SageTokens, SageClassnames } from '../configs';
 import { OptionsDropdown } from './OptionsDropdown';
 import { DROPDOWN_ITEM_COLORS } from './configs';
 
@@ -117,9 +117,12 @@ export const DropdownItem = ({
             value={label}
             {...rest}
           />
-          <span className="sage-dropdown__item-label" title={label}>
-            {label}
-          </span>
+          <>
+            {icon && (<pds-icon class={`sage-dropdown__item-icon ${SageClassnames.SPACERS.XS_RIGHT}`} name={icon} />)}
+            <span className="sage-dropdown__item-label" title={label}>
+              {label}
+            </span>
+          </>
         </label>
       );
     }
@@ -138,9 +141,12 @@ export const DropdownItem = ({
           {...rest}
         >
           {(!customComponent && isLabelVisible) && (
-            <span className="sage-dropdown__item-label" title={label}>
-              {label}
-            </span>
+            <>
+              {icon && (<pds-icon class={`sage-dropdown__item-icon ${SageClassnames.SPACERS.XS_RIGHT}`} name={icon} />)}
+              <span className="sage-dropdown__item-label" title={label}>
+                {label}
+              </span>
+            </>
           )}
           {customComponent && <CustomComponent {...payload} />}
         </Link>
@@ -157,9 +163,12 @@ export const DropdownItem = ({
         {...rest}
       >
         {(!customComponent && isLabelVisible) && (
-          <span className="sage-dropdown__item-label" title={label}>
-            {label}
-          </span>
+          <>
+            {icon && (<pds-icon class={`sage-dropdown__item-icon ${SageClassnames.SPACERS.XS_RIGHT}`} name={icon} />)}
+            <span className="sage-dropdown__item-label" title={label}>
+              {label}
+            </span>
+          </>
         )}
         {customComponent && <CustomComponent {...payload} />}
       </button>


### PR DESCRIPTION
## Description
Icons are not rendering properly in react `dropdownitem` component after `pds-icon` conversion. The pds-icon needed to be added to the component.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-01 at 4 35 49 PM](https://github.com/user-attachments/assets/1db4b648-c630-4b3b-9295-5bc2c7b0f7ea)|![Screenshot 2024-08-01 at 4 34 17 PM](https://github.com/user-attachments/assets/79527634-19a2-4d47-b981-e5f14b92966b)|


## Testing in `sage-lib`
Navigate to [Dropdown Component](http://localhost:4100/?path=/docs/sage-dropdown--default)
Verify the icons are now displaying in the dropdowns


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds pds-icon to dropdownitem component.
   - [ ] URL dropdown in the branded app builder


## Related
[sage-support request](https://kajabi.slack.com/archives/C01A424HY8Y/p1722550098210039)
