### PR TITLE
style: update body-xs to 12px

### DIFF
--- a/packages/sage-assets/lib/stylesheets/tokens/_font_size.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_font_size.scss
@@ -11,7 +11,7 @@
 /// See core/_typography.scss for where these are primarily implemented.
 ///
 $sage-font-sizes: (
-  xs: rem(11px),
+  xs: rem(12px),
   sm: rem(12px),
   md: rem(14px),
   lg: rem(16px),


### PR DESCRIPTION
## Description
Update `sage-font-size(body-xs)` to match the value of small which is 12px


## Screenshots
|  Before  |  After  |
|--------|--------|
| ![before-xs-change](https://github.com/user-attachments/assets/d0b91bf0-47d9-42f2-9d52-246232f05b6e) | ![after-xs-change](https://github.com/user-attachments/assets/0b7c17ef-6f9d-4ca1-87b9-1ac832d24b6e) |


## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/foundations/icon
2. Scroll to "All Icons"
3. Verify the label size is correct, 12px not 11px


## Related
[DSS-756](https://kajabi.atlassian.net/browse/DSS-756)


[DSS-756]: https://kajabi.atlassian.net/browse/DSS-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ