### PR TITLE
Add shadow-20 and white background to box-like elements

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -11,6 +11,8 @@ $-sage-card-background: transparent;
 .sage-card {
   @include sage-card();
 
+  background-color: sage-color(white);
+  box-shadow: sage-shadow(md);
   position: relative;
   width: 100%;
 }

--- a/packages/sage-assets/lib/stylesheets/components/_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_card.scss
@@ -11,10 +11,10 @@ $-sage-card-background: transparent;
 .sage-card {
   @include sage-card();
 
-  background-color: sage-color(white);
-  box-shadow: sage-shadow(md);
   position: relative;
   width: 100%;
+  background-color: sage-color(white);
+  box-shadow: sage-shadow(md);
 }
 
 .sage-card--border-dashed {

--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -41,8 +41,10 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   padding: sage-spacing();
   text-decoration: none;
   color: $-choice-color-default;
+  background-color: sage-color(white);
   border: sage-border();
   border-radius: sage-border(radius-large);
+  box-shadow: sage-shadow(md);
   transition: map-get($sage-transitions, default);
   transition-property: color, background-color, border-color, box-shadow;
 

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -9,8 +9,10 @@ $-stat-box-image-max-width: rem(48px);
 .sage-stat-box {
   // Styles here
   @include sage-card($grid: false);
+  background-color: sage-color(white);
   padding: rem(18px) sage-spacing(sm);
   border-radius: sage-border(radius-large);
+  box-shadow: sage-shadow(md);
 
   &.sage-stat-box--raised {
     box-shadow: sage-shadow(sm);

--- a/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_stat_box.scss
@@ -9,10 +9,10 @@ $-stat-box-image-max-width: rem(48px);
 .sage-stat-box {
   // Styles here
   @include sage-card($grid: false);
-  background-color: sage-color(white);
   padding: rem(18px) sage-spacing(sm);
   border-radius: sage-border(radius-large);
   box-shadow: sage-shadow(md);
+  background-color: sage-color(white);
 
   &.sage-stat-box--raised {
     box-shadow: sage-shadow(sm);

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -39,9 +39,11 @@ $-switch-toggle-size: rem(16px);
 
   &.sage-switch--has-border {
     align-items: center;
+    background-color: sage-color(white);
     padding: sage-spacing(card);
     border: sage-border();
     border-radius: sage-border(radius);
+    box-shadow: sage-shadow(md);
   }
 
   &.sage-switch--toggle-right {

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -39,11 +39,11 @@ $-switch-toggle-size: rem(16px);
 
   &.sage-switch--has-border {
     align-items: center;
-    background-color: sage-color(white);
     padding: sage-spacing(card);
     border: sage-border();
     border-radius: sage-border(radius);
     box-shadow: sage-shadow(md);
+    background-color: sage-color(white);
   }
 
   &.sage-switch--toggle-right {

--- a/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
@@ -11,10 +11,10 @@ $-transaction-card-price-max-width: rem(100px);
 .sage-transaction-card {
   @include sage-card;
 
-  background-color: sage-color(white);
-  box-shadow: sage-shadow(md);
   position: relative;
   width: 100%;
+  background-color: sage-color(white);
+  box-shadow: sage-shadow(md);
 
   > * {
     min-width: 0;

--- a/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_transaction_card.scss
@@ -11,6 +11,8 @@ $-transaction-card-price-max-width: rem(100px);
 .sage-transaction-card {
   @include sage-card;
 
+  background-color: sage-color(white);
+  box-shadow: sage-shadow(md);
   position: relative;
   width: 100%;
 

--- a/packages/sage-assets/lib/stylesheets/layout/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_container.scss
@@ -6,8 +6,6 @@
 
 
 .sage-container {
-  background-color: sage-color(white);
-  box-shadow: sage-shadow(md);
   width: 100%;
   margin: 0 auto;
 

--- a/packages/sage-assets/lib/stylesheets/layout/_container.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_container.scss
@@ -6,6 +6,8 @@
 
 
 .sage-container {
+  background-color: sage-color(white);
+  box-shadow: sage-shadow(md);
   width: 100%;
   margin: 0 auto;
 

--- a/packages/sage-assets/lib/stylesheets/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_frame.scss
@@ -145,7 +145,7 @@ $-sage-frame-wraps: (
 // 2. Variables for default settings
 //
 $-sage-frame-alignment: top-left;
-$-sage-frame-background: sage-color(white);
+$-sage-frame-background: transparent;
 $-sage-frame-border: none;
 $-sage-frame-border-radius: none;
 $-sage-frame-direction: vertical;
@@ -164,11 +164,6 @@ $-sage-frame-wrap: none;
 // Root element
 .sage-frame {
   display: flex;
-  background-color: $-sage-frame-background;
-
-  .sage-frame {
-    background-color: inherit; // ensures nested frames inherit the main parent frame background color
-  }
 
   // Add default settings
   &:not([class*="sage-frame--align-"]) {
@@ -221,6 +216,7 @@ $-sage-frame-wrap: none;
 
 @each $-key, $-val in $-sage-frame-borders {
   .sage-frame--border-#{$-key} {
+    background-color: sage-color(white);
     border: #{$-val};
   }
 }

--- a/packages/sage-assets/lib/stylesheets/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_frame.scss
@@ -166,6 +166,10 @@ $-sage-frame-wrap: none;
   display: flex;
   background-color: $-sage-frame-background;
 
+  .sage-frame {
+    background-color: inherit; // ensures nested frames inherit the main parent frame background color
+  }
+
   // Add default settings
   &:not([class*="sage-frame--align-"]) {
     align-items: map-get(map-get($-sage-frame-alignments, $-sage-frame-alignment), v);

--- a/packages/sage-assets/lib/stylesheets/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_frame.scss
@@ -163,8 +163,8 @@ $-sage-frame-wrap: none;
 
 // Root element
 .sage-frame {
-  background-color: $-sage-frame-background;
   display: flex;
+  background-color: $-sage-frame-background;
 
   // Add default settings
   &:not([class*="sage-frame--align-"]) {

--- a/packages/sage-assets/lib/stylesheets/layout/_frame.scss
+++ b/packages/sage-assets/lib/stylesheets/layout/_frame.scss
@@ -145,7 +145,7 @@ $-sage-frame-wraps: (
 // 2. Variables for default settings
 //
 $-sage-frame-alignment: top-left;
-$-sage-frame-background: transparent;
+$-sage-frame-background: sage-color(white);
 $-sage-frame-border: none;
 $-sage-frame-border-radius: none;
 $-sage-frame-direction: vertical;
@@ -163,6 +163,7 @@ $-sage-frame-wrap: none;
 
 // Root element
 .sage-frame {
+  background-color: $-sage-frame-background;
   display: flex;
 
   // Add default settings
@@ -242,7 +243,7 @@ $-sage-frame-wrap: none;
   .sage-frame--gap-#{$-key} {
     gap: #{$-val};
   }
-  
+
   .sage-frame--padding-#{$-key} {
     padding: #{$_val};
   }

--- a/packages/sage-assets/lib/stylesheets/tokens/_shadow.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_shadow.scss
@@ -9,7 +9,7 @@
 /// Sage shadows token
 ///
 $sage-shadows: (
-  sm: (0 1px 2px rgba(sage-color(grey, 95), 0.06), 0 1px 3px rgba(sage-color(grey, 95), 0.10)),
+  sm: (0 1px 2px rgba(sage-color(grey, 95), 0.06), 0 1px 3px rgba(sage-color(grey, 95), 0.1)),
   md: (0 4px 6px -2px rgba(sage-color(grey, 95), 0.03), 0 12px 16px -4px rgba(sage-color(grey, 95), 0.08)),
   lg: (0 24px 48px -12px rgba(sage-color(grey, 95), 0.18)),
   modal: (0 32px 64px -12px rgba(sage-color(grey, 95), 0.24)),

--- a/packages/sage-assets/lib/stylesheets/tokens/_shadow.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_shadow.scss
@@ -9,10 +9,10 @@
 /// Sage shadows token
 ///
 $sage-shadows: (
-  sm: (0 2px 4px rgba(sage-color(black), 0.12), 0 0 2px rgba(sage-color(black), 0.08)),
-  md: (0 8px 14px rgba(sage-color(black), 0.16), 0 0 4px rgba(sage-color(black), 0.08)),
-  lg: (0 8px 40px rgba(sage-color(black), 0.24)),
-  modal: (0 8px 40px rgba(sage-color(black), 0.24), 0 0 4px rgba(sage-color(black), 0.1)),
+  sm: (0 1px 2px rgba(sage-color(grey, 95), 0.06), 0 1px 3px rgba(sage-color(grey, 95), 0.10)),
+  md: (0 4px 6px -2px rgba(sage-color(grey, 95), 0.03), 0 12px 16px -4px rgba(sage-color(grey, 95), 0.08)),
+  lg: (0 24px 48px -12px rgba(sage-color(grey, 95), 0.18)),
+  modal: (0 32px 64px -12px rgba(sage-color(grey, 95), 0.24)),
 );
 
 ///


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add white background-color to the box-like elements
- [x] add a box shadow to those same elements

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-07 at 4 01 21 PM](https://github.com/user-attachments/assets/6be3d720-d081-4cf1-9650-b363a623c09d)|![Screenshot 2024-08-07 at 4 01 05 PM](https://github.com/user-attachments/assets/975567e0-0249-4d02-9d98-b81a047a7a7c)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
