### PR TITLE
style(alert): adjust small variant icon alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -117,7 +117,7 @@ $-alert-icon-colors: (
   }
 
   .sage-alert--small & {
-    transform: translateY(-2px);
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
## Description
The icon is misaligned in the small variate of the alert.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-06 at 11 37 16 AM](https://github.com/user-attachments/assets/dd7c8288-71e2-434e-9ad2-ae20e6c949a9)|![Screenshot 2024-08-06 at 11 36 54 AM](https://github.com/user-attachments/assets/913f2d41-0720-4d09-8c5a-4ac4992ce3e5)|


## Testing in `sage-lib`
Navigate to [Alert](http://localhost:4000/pages/component/alert?tab=preview)
Verify icon aligns in small variant.


## Testing in `kajabi-products`
1. (**LOW**) Adjusts icon alignment in small alert



## Related
https://kajabi.atlassian.net/browse/DSS-773
