### PR TITLE
style(radio): correct alignment of input and label

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -229,7 +229,7 @@ $-radio-focus-outline-color: currentColor;
   }
 
   .sage-radio & {
-    margin-top: rem(4px);
+    margin-top: rem(2px);
   }
 
   .sage-sortable & {


### PR DESCRIPTION
## Description
The label and input for the radio are out of alignment.
This updates the margin on the input to correct the alignment.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-06 at 12 03 13 PM](https://github.com/user-attachments/assets/ff583e05-01df-4d98-9ec0-906bbec820c2)|![Screenshot 2024-08-06 at 12 02 51 PM](https://github.com/user-attachments/assets/7320bceb-e8e3-4e20-8468-70bdd3bb34b7)|



## Testing in `sage-lib`
Navigate to [Radio](http://localhost:4000/pages/component/radio?tab=preview)
Verify label and input are properly aligned.


## Testing in `kajabi-products`

1. (**LOW) Correct alignment of radio input and label



## Related
https://kajabi.atlassian.net/browse/DSS-775
