### PR TITLE
style(line-height): update line-height to have rem units

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -32,15 +32,15 @@ $-headings-margin-bottom: sage-spacing(sm);
   --sage-font-size-h1: #{map-get($sage-font-sizes, 5xl)};
 
   // Line heights
-  --sage-line-height-body-xs: 1.425;
-  --sage-line-height-body-sm: 1.425;
-  --sage-line-height-body: 1.425;
-  --sage-line-height-h6: 1.25;
-  --sage-line-height-h5: 1.25;
-  --sage-line-height-h4: 1.25;
-  --sage-line-height-h3: 1.25;
-  --sage-line-height-h2: 1.25;
-  --sage-line-height-h1: 1.25;
+  --sage-line-height-body-xs: #{map-get($sage-line-heights, xs)};
+  --sage-line-height-body-sm: #{map-get($sage-line-heights, sm)};
+  --sage-line-height-body: #{map-get($sage-line-heights, md)};
+  --sage-line-height-h6: #{map-get($sage-line-heights, lg)};
+  --sage-line-height-h5: #{map-get($sage-line-heights, lg)};
+  --sage-line-height-h4: #{map-get($sage-line-heights, xl)};
+  --sage-line-height-h3: #{map-get($sage-line-heights, xl)};
+  --sage-line-height-h2: #{map-get($sage-line-heights, 2xl)};
+  --sage-line-height-h1: #{map-get($sage-line-heights, 3xl)};
 }
 
 // Responsive adjustments are currently TBD

--- a/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
+++ b/packages/sage-assets/lib/stylesheets/tokens/_line_height.scss
@@ -10,15 +10,15 @@
 /// See core/_typography.scss for where these are primarily implemented.
 ///
 $sage-line-heights: (
-  xs: sage-baseline(3.5),   // 14
-  sm: sage-baseline(4),     // 16
-  md: sage-baseline(4.5),   // 18
-  lg: sage-baseline(5),     // 20
-  xl: sage-baseline(5.5),   // 22
-  2xl: sage-baseline(6.5),  // 26
-  3xl: sage-baseline(7),    // 28
-  4xl: sage-baseline(8),    // 32
-  5xl: sage-baseline(9),    // 36
+  xs: rem(18px),
+  sm: rem(18px),
+  md: rem(20px),
+  lg: rem(20px),
+  xl: rem(22px),
+  2xl: rem(26px),
+  3xl: rem(28px),
+  4xl: rem(32px),
+  5xl: rem(36px),
 );
 
 ///


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Adding back units to the `line-height` token to ensure existing functions work as expected

- [x] resolve icons not showing when adjacent body type is present

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-06 at 2 30 36 PM](https://github.com/user-attachments/assets/cfc5ec16-f456-43e4-bc93-d30749c2208d)|![Screenshot 2024-08-06 at 2 30 15 PM](https://github.com/user-attachments/assets/3b2c7b0f-69ab-4225-b2ae-783001dc223e)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Resolves icons not showing when adjacent body type was present.
   - [ ] Products -> Coaching -> Click Programs tab


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-777](https://kajabi.atlassian.net/browse/DSS-777)

[DSS-777]: https://kajabi.atlassian.net/browse/DSS-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ