### PR TITLE
style(dropdown): add display flex to dropdown trigger

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -413,9 +413,9 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__trigger {
+  display: flex;
   width: 100%;
   border-radius: inherit;
-  display: flex;
 
   &.sage-dropdown__trigger--options {
     min-width: auto;

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -273,7 +273,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   max-height: $-dropdown-panel-max-height;
   padding: sage-spacing(xs) 0;
   border-radius: sage-border(radius-medium);
-  
+
   // adds a box shadow to the menu when it is scrollable
   overflow-scrolling: touch;
   background:
@@ -282,27 +282,27 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
       white 30%,
       rgba(255, 255, 255, 0)
     ) center top,
-    
+
     /* Shadow Cover BOTTOM */
     linear-gradient(
-      rgba(255, 255, 255, 0), 
+      rgba(255, 255, 255, 0),
       white 70%
     ) center bottom,
-    
+
     /* Shadow TOP */
     radial-gradient(
       farthest-side at 50% 0,
       rgba(0, 0, 0, 0.2),
       rgba(0, 0, 0, 0)
     ) center top,
-    
+
     /* Shadow BOTTOM */
     radial-gradient(
       farthest-side at 50% 100%,
       rgba(0, 0, 0, 0.2),
       rgba(0, 0, 0, 0)
     ) center bottom;
-  
+
   background-repeat: no-repeat;
   background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
   background-attachment: local, local, scroll, scroll;
@@ -322,7 +322,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   .sage-dropdown--page-size & {
     min-width: 100%;
   }
-  
+
   @media (max-height: $-dropdown-panel-max-height-breakpoint) {
     max-height: $-dropdown-panel-max-height-small;
   }
@@ -415,6 +415,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown__trigger {
   width: 100%;
   border-radius: inherit;
+  display: flex;
 
   &.sage-dropdown__trigger--options {
     min-width: auto;


### PR DESCRIPTION
## Description
Adds display flex to ensure proper alignment.


## Testing in `sage-lib`
Navigate to [dropdown](http://localhost:4000/pages/component/dropdown?tab=preview)
Verify buttons are aligned properly


## Testing in `kajabi-products`

1. (**LOW**) Add display flex to dropdown trigger to ensure alignment



## Related
https://kajabi.atlassian.net/browse/DSS-776
