### PR TITLE
style(badge): correct interactive icon size

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_badge.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_badge.scss
@@ -126,8 +126,6 @@ $-badge-statuses: (
       align-items: center;
       position: absolute;
       right: rem(8px);
-      width: rem(22px);
-      min-height: rem(22px);
       margin-top: rem(1px);
       border-radius: 0 $-badge-border-radius $-badge-border-radius 0;
 


### PR DESCRIPTION
## Description
The interactive badge has incorrect sizing on the icon.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-06 at 1 49 44 PM](https://github.com/user-attachments/assets/3cfdc2b1-9229-4017-901f-fed48b526c16)|![Screenshot 2024-08-06 at 1 50 11 PM](https://github.com/user-attachments/assets/ea5797a8-70cb-4532-8610-20776c7fc35e)|


## Testing in `sage-lib`
Navigate to [badge](http://localhost:4000/pages/component/badge?tab=preview)
Verify icon is now the correct size in the interactive variant


## Testing in `kajabi-products`

1. (**LOW**) Correct icon size for interactive badge variant.



## Related
https://kajabi.atlassian.net/browse/DSS-772
