### PR TITLE
Remove global adjacent p tag spacing

### DIFF
--- a/docs/lib/sage-frontend/stylesheets/docs/_panel.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_panel.scss
@@ -1,7 +1,11 @@
 .docs-panel {
   @include sage-panel;
-  
+
   @media screen and (min-width: sage-breakpoint(lg-min)) {
     padding: 5rem;
+  }
+
+  p + p {
+    margin-top: 1.5rem;
   }
 }

--- a/packages/sage-assets/lib/stylesheets/global/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/global/_reboot.scss
@@ -73,10 +73,6 @@ h6,
 p {
   margin-top: 0;
   margin-bottom: 0;
-
-  + p {
-    margin-top: 1.5rem;
-  }
 }
 
 li {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove global `p` tag `margin-top`
- [x] reposition to only affect docs site

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-07 at 8 26 30 AM](https://github.com/user-attachments/assets/d936eb3f-1fb4-4597-847d-cb649f2debe2)|![Screenshot 2024-08-07 at 8 26 53 AM](https://github.com/user-attachments/assets/8e1e7e9a-adc2-47de-8788-4c3a6349ac1c)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit Foundations -> Typography

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Remove global `p` tag adjacent top spacing.
   - [ ] [qa8 Dashboard](https://app.newkajabi-qa8.com/) -> click User Profile dropdown in the top right


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
