### PR TITLE
Radio: align radio with text, adjust indicator size to match spec

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -22,7 +22,7 @@ $-radio-color-focus-outline-error: sage-color(red, 200);
 $-radio-button-size: $sage-radio-size;
 $-radio-gap-spacing: rem(12px);
 $-radio-transition: 0.15s ease-in-out;
-$-radio-selected-indicator-size: rem(7px);
+$-radio-selected-indicator-size: rem(6px);
 
 // Focus state
 $-radio-focus-outline-size: rem(3px);
@@ -226,10 +226,6 @@ $-radio-focus-outline-color: currentColor;
         border-radius: sage-border(radius);
       }
     }
-  }
-
-  .sage-radio & {
-    margin-top: rem(4px);
   }
 
   .sage-sortable & {


### PR DESCRIPTION
## Description
Radio alignment with text is off center for the current implementation. This is for our current implementation, **not the Rebrand.**

### Changes made
* Changed size of indicator from 7px to 6px to align with the [component specs](https://www.figma.com/design/sMbtLUHSt2vfKgKjyQ3052/%F0%9F%A7%A9-Sage-components?node-id=557-27894&t=TEdlIs7SDANn4JIQ-0)
* Removed margin-top for the radio


## Screenshots for all three main browsers
|  Before  |  After  |
|--------|--------|
| ![before-browsers-radio](https://github.com/user-attachments/assets/ee8eb75a-25a6-4aa7-81dd-cc3802653e6c) | ![after-browsers-radio](https://github.com/user-attachments/assets/5a6fc23a-eb0d-4f45-bfb8-7ab6dbba53a4) |


## Testing in `sage-lib`
1. Pull down PR
2. Navigate to http://localhost:4000/pages/component/radio?tab=preview
3. Verify the radio is aligned properly
4. Review this [PR](https://github.com/Kajabi/sage-lib/pull/1932) to inform if my approach here is acceptable

## Testing in `kajabi-products`
N/A - minor alignment update


## Related
[DSS-780](https://kajabi.atlassian.net/browse/DSS-780)

[DSS-780]: https://kajabi.atlassian.net/browse/DSS-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ