### PR TITLE
docs: convert icons to pine in grid template demos

### DIFF
--- a/docs/app/views/pages/grid_templates.html.erb
+++ b/docs/app/views/pages/grid_templates.html.erb
@@ -101,12 +101,12 @@ dashes = [
 ]
 
 dots = [
-  %(<i class="sage-icon-check-circle t-sage--color-sage"></i>).html_safe,
+  %(<pds-icon name="check-circle" class="sage-icon-check-circle t-sage--color-sage"></pds-icon>).html_safe,
   sage_component(SageBadge, { value: "In progress", color: "warning" }).html_safe,
-  %(<i class="sage-icon-star t-sage--color-orange"></i>).html_safe,
+  %(<pds-icon name="star" class="sage-icon-star t-sage--color-orange"></pds-icon>).html_safe,
   sage_component(SageBadge, { value: "Verified", color: "published" }).html_safe,
   %(<span class="t-sage-body-small-semi">$5.99</span>).html_safe,
-  %(<i class="sage-icon-dot-menu-horizontal t-sage--color-grey"></i>).html_safe
+  %(<pds-icon name="dot-menu-horizontal" class="sage-icon-dot-menu-horizontal t-sage--color-charcoal"></pds-icon>).html_safe
 ]
 %>
 


### PR DESCRIPTION
## Description
Grid template docs were missing icons.
This update converts the icons to updated pds-icon implementation.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-07 at 12 44 14 PM](https://github.com/user-attachments/assets/22d96348-10e6-471a-bc6f-f7dedf51d810)|![Screenshot 2024-08-07 at 12 44 55 PM](https://github.com/user-attachments/assets/c2487c83-d79a-411c-9a72-37d5abe2dc6d)|


## Testing in `sage-lib`
Navigate to [Grid Template Docs](http://localhost:4000/pages/patterns/grid_templates)
Verify icons display as expected.


## Testing in `kajabi-products`
N/A - No effect on KP.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
