### PR TITLE
fix(link): add missing icon for help link variant

### DIFF
--- a/docs/app/views/examples/components/link/_preview.html.erb
+++ b/docs/app/views/examples/components/link/_preview.html.erb
@@ -115,3 +115,22 @@ Neutral links live in items with non-white backgrounds, such as Banner and Toast
     }
   }
 } %>
+
+<h3 class="t-sage-heading-6">Help Link</h3>
+
+<div>
+  <%= sage_component SageLink, {
+    url: "https://example.com",
+    label: "External link",
+    help_link: true,
+    show_label: false
+  } %>
+</div>
+<div>
+  <%= sage_component SageLink, {
+    url: "https://example.com",
+    label: "Help link label",
+    help_link: true,
+    show_label: true,
+  } %>
+</div>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_link.html.erb
@@ -52,8 +52,11 @@ html_attributes[:class] = css_classes
   .squish
 %>
 <%= link_to component.url, html_attributes do %>
-  <% if component.icon %>
+  <% if component.icon && !component.help_link %>
     <pds-icon name="<%= component.icon[:name] %>" class="sage-link__icon"></pds-icon>
+  <% end %>
+  <% if component.help_link && !component.icon %>
+    <pds-icon name="question-circle" class="sage-link__icon"></pds-icon>
   <% end %>
   <%= label %>
 <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -167,6 +167,7 @@ $-link-base-styles: (
 .sage-link--help-icon-only {
   position: relative;
   text-decoration: none;
+  color: inherit;
 
   &::before,
   pds-icon {
@@ -179,6 +180,7 @@ $-link-base-styles: (
   &:active,
   &:focus {
     outline: 0;
+    color: inherit;
 
     pds-icon {
       color: sage-color(charcoal, 300);

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -179,8 +179,8 @@ $-link-base-styles: (
   &:hover,
   &:active,
   &:focus {
-    outline: 0;
     color: inherit;
+    outline: 0;
 
     pds-icon {
       color: sage-color(charcoal, 300);


### PR DESCRIPTION
## Description
The rails link component was missing the icon for the help link variation.
This update adds back the missing `question-circle` icon.
Page headings were not affected by this bug.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |
|--------|
|![Screenshot 2024-08-09 at 9 47 56 AM](https://github.com/user-attachments/assets/07762c04-385c-4d3b-98a0-b77ed9f94556)|


## Testing in `sage-lib`
Navigate to [link docs](http://localhost:4000/pages/component/link?tab=preview)
Verify icon displays in help link section demos


## Testing in `kajabi-products`
1. (**MEDIUM**) Add missings icon for help link variant.
   - [ ] Spot-check any panels or single usage of help links. Automation panel in course edit view or assessments edit view.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
