### PR TITLE
style(pagination): remove background color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_pagination.scss
@@ -84,7 +84,6 @@ $-pagination-focus-ring-color: sage-color(primary, 200);
   text-decoration: none;
   color: $-pagination-text-color;
   border: 0;
-  background-color: sage-color(white);
   border-radius: $-pagination-radius;
 
   &:hover,


### PR DESCRIPTION
## Description
Since the appframe background color changed the pagination should no longer have a white background color.

This removes the background color.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-21 at 2 54 16 PM](https://github.com/user-attachments/assets/4c0b34a9-27f2-4985-8451-8cc02306b4ed)|![Screenshot 2024-08-21 at 2 52 52 PM](https://github.com/user-attachments/assets/f681b0d2-6e84-4d06-843b-5250a08fcc83)|

> [!NOTE]
> Background color in screenshots was added in dev tools only so the background color change can be seen.


## Testing in `sage-lib`

- Navigate to pagination.
- Verify bg color is no longer applied.


## Testing in `kajabi-products`

1. (**LOW**) Removes background color from pagination.



## Related
https://kajabi.atlassian.net/browse/DSS-823
