### PR TITLE
style(choice): correct icon alignment

### DIFF
--- a/docs/app/views/examples/components/choice/_preview.html.erb
+++ b/docs/app/views/examples/components/choice/_preview.html.erb
@@ -50,6 +50,15 @@ long_description = "Description with longer text to cause wrapping and make the 
     text: "Option 1",
     type: "icon",
     icon: "video-on",
+  }
+%>
+
+<p>With additional subtext.</p>
+<%= sage_component SageChoice, {
+    target: "example",
+    text: "Option 1",
+    type: "icon",
+    icon: "video-on",
     subtext: "Description of Option 1",
   }
 %>

--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -141,10 +141,6 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     transition: color map-get($sage-transitions, default);
   }
 
-  pds-icon {
-    margin-top: var(--icon-top-offset);
-  }
-
   &.sage-choice--vertical-align-icon-start::#{$-choice-el-icon} {
     align-self: start;
     margin-top: var(--icon-top-offset);


### PR DESCRIPTION
## Description
The choice icon variant is misaligned.
This updates the alignment and adds additional documentation example.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-21 at 4 08 18 PM](https://github.com/user-attachments/assets/4663c089-0401-49e7-a5e4-0d028994909a)|![Screenshot 2024-08-21 at 4 08 40 PM](https://github.com/user-attachments/assets/5fca7df8-0ca1-47e2-b74d-ea95fdd5f8a6)|


## Testing in `sage-lib`
Navigate to Choice
Verify icons align in Icon Variation examples


## Testing in `kajabi-products`
1. (**LOW**) Adjust choice icon alignment



## Related
https://kajabi.atlassian.net/browse/DSS-832
