### PR TITLE
style(tab): adjust tab underline variable value

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -670,7 +670,7 @@
   $item-underline: "after";
 
   &::#{$item-underline} {
-    $spacing-off: 50%;
+    $spacing-off: calc(50% + #{sage-letter-spacing(lg)});
 
     content: "";
     position: absolute;


### PR DESCRIPTION
## Description
The tab underline is sometimes showing a 1px bottom border on non-active tabs. This appears to be related to the letter-spacing token updates. 

Adjusting the positioning of the underline to include the letter spacing seems to address the problem. 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-22 at 1 31 15 PM](https://github.com/user-attachments/assets/1bf184f2-fc48-4780-92ef-3871ed27d1fb)|![Screenshot 2024-08-22 at 1 32 24 PM](https://github.com/user-attachments/assets/3d3cf4f8-3fb2-415f-bd8c-785db13af24a)|


## Testing in `sage-lib`

- Navigate to a component
- Switch between the tabs on the page
- Verify border does not appear when tab is not active.
- Specifically test in Safari


## Testing in `kajabi-products`
1. (**LOW**) Adjusts border styles on inactive tab.


## Related
https://kajabi.atlassian.net/browse/DSS-812