### PR TITLE
style(sortable): text alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_sortable.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_sortable.scss
@@ -15,7 +15,7 @@ $-sortable-image-height: rem(48px);
 
 .sage-sortable__item {
   display: grid;
-  grid-template-columns: min-content minmax(0, 1fr) auto auto;
+  grid-template-columns: min-content min-content minmax(0, 1fr) auto auto;
   gap: sage-spacing(card);
   align-items: center;
   padding: sage-spacing(xs) sage-spacing(panel);


### PR DESCRIPTION
## Description
Sortable items have incorrect text alignment in some cases. This is due to new elements appearing in items as SVG icons.

This updates the grid template to account and corrects text alignment.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-08-22 at 2 44 06 PM](https://github.com/user-attachments/assets/fb646540-a33a-4bf7-8391-cc6ea0069a3b)|![Screenshot 2024-08-22 at 2 45 52 PM](https://github.com/user-attachments/assets/7afcfbd5-75f7-4e03-a333-8005536f4c2e)|



## Testing in `sage-lib`
Navigate to Sortable
Verify text alignment is corrected.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Fixes text alignment issue in sortable.
   - [ ] Products library sorting

## Related
https://kajabi.atlassian.net/browse/DSS-837
