### PR TITLE
fix(badge): down icon needed to remove the width

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_badge.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_badge.scss
@@ -126,7 +126,6 @@ $-badge-statuses: (
       align-items: center;
       position: absolute;
       right: rem(8px);
-      width: rem(22px);
       min-height: rem(22px);
       margin-top: rem(1px);
       border-radius: 0 $-badge-border-radius $-badge-border-radius 0;


### PR DESCRIPTION
## Description
In Sage Support channel, we had an issue with the icon being to wide.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/2e56cb72-7549-4e50-ab73-ce1fabcaf653)|![image](https://github.com/user-attachments/assets/2487fe85-b026-493a-9ca1-99ea7adcc432)|


## Testing in `sage-lib`
1. Navigate to the Badge component in the Doc Site -> http://localhost:4000/pages/component/badge?tab=preview
2. Confirm that the down chevron appears as it does in the screenshot.



## Testing in `kajabi-products`
1. (**LOW**) Confirm that the dropdown icons look small


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
