### PR TITLE
style(tabs): change active tab underline color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_variables.scss
@@ -15,7 +15,7 @@ $sage-greet-font-path: "#{$sage-font-cdn-root}/greet";
 ///
 $sage-active-underline-configs: (
   height: rem(3px),
-  color: sage-color(charcoal, 400),
+  color: sage-color(mercury, 50),
 );
 
 ///


### PR DESCRIPTION
## Description
We need to update the Tab active color to match the Figma documentation.


## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/3f86d9aa-9913-461d-a551-14dcdef21b55)|![image](https://github.com/user-attachments/assets/99d45464-4f84-406b-941c-e3f18f568980)|


## Testing in `sage-lib`
1. Navigate to Tab Component on the Doc Site -> http://localhost:4000/pages/component/tabs?tab=preview
2. Confirm the color matches `mercury-50` (#FF3E14)


## Testing in `kajabi-products`
1. (**MEDIUM**) Verify that the tab active color matches


## Related
https://kajabi.atlassian.net/browse/DSS-843
