### PR TITLE
style: focus state updates

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -153,7 +153,7 @@ $-alert-icon-colors: (
     }
 
     &:focus {
-      @include sage-focus-outline--update-color(sage-color(primary, 200));
+      @include sage-focus-outline--update-color(sage-color(purple, 30));
     }
   }
 
@@ -180,7 +180,7 @@ $-alert-icon-colors: (
     }
 
     &:focus {
-      @include sage-focus-outline--update-color(sage-color(primary, 200));
+      @include sage-focus-outline--update-color(sage-color(purple, 30));
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_badge.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_badge.scss
@@ -102,7 +102,7 @@ $-badge-statuses: (
 
     .sage-badge__value {
       @include sage-focus-outline($outline-offset-block: -1, $outline-offset-inline: -1);
-      @include sage-focus-outline--update-color(sage-color(primary, 200));
+      @include sage-focus-outline--update-color(sage-color(purple, 30));
 
       position: static;
       padding-right: rem(24px);

--- a/packages/sage-assets/lib/stylesheets/components/_breadcrumbs.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_breadcrumbs.scss
@@ -6,7 +6,7 @@
 
 $-breadcrumb-current-color: sage-color(charcoal, 400);
 $-breadcrumb-interactive-color: sage-color(charcoal, 400);
-$-breadcrumb-outline-color: sage-color(primary, 200);
+$-breadcrumb-outline-color: sage-color(purple, 30);
 
 .sage-breadcrumbs {
   display: flex;
@@ -89,10 +89,10 @@ $-breadcrumb-outline-color: sage-color(primary, 200);
     background: transparent;
     border-radius: rem(6px);
     @include sage-focus-outline(
-      $outline-width: 4px,
-      $outline-offset-block: -4,
-      $outline-offset-inline: -6,
-      $outline-border-radius: rem(6px)
+      $outline-width: 2px,
+      $outline-offset-block: -2,
+      $outline-offset-inline: -3,
+      $outline-border-radius: rem(3px)
     );
     @include sage-focus-outline--update-color($-breadcrumb-outline-color);
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -262,15 +262,6 @@ $-btn-loading-min-height: rem(36px);
     }
   }
 
-  .sage-accordion &.sage-expandable-card__trigger {
-    &:focus {
-      box-shadow: inherit;
-    }
-    &:focus-visible {
-      @include sage-focus-ring;
-    }
-  }
-
   .sage-input-group & {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -28,7 +28,7 @@ $-btn-base-styles: (
       color: sage-color(white),
       background-color: sage-color(primary, 300),
       border-color: sage-color(primary, 300),
-      ring-color: sage-color(primary, 200),
+      ring-color: sage-color(purple, 30),
     ),
     hover: (
       color: sage-color(white),
@@ -51,7 +51,7 @@ $-btn-base-styles: (
       color: sage-color(white),
       background-color: sage-color(charcoal, 400),
       border-color: sage-color(charcoal, 400),
-      ring-color: sage-color(primary, 200),
+      ring-color: sage-color(purple, 30),
     ),
     hover: (
       color: sage-color(white),
@@ -72,7 +72,7 @@ $-btn-base-styles: (
     default: (
       color: sage-color(charcoal, 400),
       background-color: sage-color(white),
-      ring-color: sage-color(primary, 200),
+      ring-color: sage-color(purple, 30),
     ),
     hover: (
       color: sage-color(charcoal, 400),
@@ -117,7 +117,7 @@ $-btn-subtle-styles: (
     hover: sage-color(primary, 300),
     hover-background: sage-color(primary, 100),
     focus: sage-color(primary, 300),
-    focus-outline: sage-color(primary, 200),
+    focus-outline: sage-color(purple, 30),
     disabled: sage-color(primary, 200),
   ),
   primary: (
@@ -125,7 +125,7 @@ $-btn-subtle-styles: (
     hover: sage-color(charcoal, 400),
     hover-background: sage-color(grey, 200),
     focus: sage-color(charcoal, 400),
-    focus-outline: sage-color(primary, 200),
+    focus-outline: sage-color(purple, 30),
     disabled: sage-color(charcoal, 100),
   ),
   secondary: (
@@ -133,7 +133,7 @@ $-btn-subtle-styles: (
     hover: sage-color(charcoal, 400),
     hover-background: sage-color(grey, 200),
     focus: sage-color(charcoal, 400),
-    focus-outline: sage-color(primary, 200),
+    focus-outline: sage-color(purple, 30),
     disabled: sage-color(charcoal, 100),
   ),
   danger: (
@@ -422,7 +422,7 @@ $-btn-loading-min-height: rem(36px);
 
   .sage-upload-card & {
     &.sage-btn--subtle:focus {
-      @include sage-focus-outline--update-color(sage-color(primary, 300));
+      @include sage-focus-outline--update-color(sage-color(purple, 30));
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -32,8 +32,8 @@ $-checkbox-marker-offset: $-checkbox-marker-border * 2;
 // Focus state
 //
 $-checkbox-focus-outline-size: rem(3px);
-$-checkbox-focus-outline-width: 4;
-$-checkbox-focus-outline-color: sage-color(primary, 200);
+$-checkbox-focus-outline-width: 2;
+$-checkbox-focus-outline-color: sage-color(purple, 30);
 
 
 .sage-checkbox {

--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -66,7 +66,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
   }
 
   &:focus {
-    border-color: sage-color(primary, 200);
+    border-color: sage-color(purple, 30);
     outline: none;
   }
 
@@ -77,6 +77,7 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
       border-color: sage-color(charcoal, 400);
       border-width: rem(4px);
     }
+
   }
 
   &[aria-disabled="true"],

--- a/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
@@ -6,7 +6,7 @@
 
 
 $-copy-text-border: 1px solid sage-color(grey, 400);
-$-copy-text-border-focus-color: sage-color(primary, 200);
+$-copy-text-border-focus-color: sage-color(purple, 30);
 $-copy-text-border-hover-color: sage-color(grey, 500);
 $-copy-text-color: sage-color(charcoal, 400);
 $-copy-text-color-hover: sage-color(charcoal, 500);

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -126,7 +126,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
   &:focus-within {
     outline: none;
 
-    @include sage-focus-outline--update-color(sage-color(primary, 200));
+    @include sage-focus-outline--update-color(sage-color(purple, 30));
   }
 }
 
@@ -144,7 +144,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 .sage-dropdown__item--disabled {
   &:active {
-    @include sage-focus-outline--update-color(sage-color(primary, 200));
+    @include sage-focus-outline--update-color(sage-color(purple, 30));
   }
 }
 
@@ -161,7 +161,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown__item-control {
   @include sage-button-style-reset();
   @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: -2px);
-  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  @include sage-focus-outline--update-color(sage-color(purple, 30));
 
   @extend %t-sage-body-med;
 
@@ -192,7 +192,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
   &:focus-within {
     @include sage-focus-outline($outline-offset-inline: 4px, $outline-offset-block: -2px);
-    @include sage-focus-outline--update-color(sage-color(primary, 200));
+    @include sage-focus-outline--update-color(sage-color(purple, 30));
 
     &::after {
       opacity: 1;

--- a/packages/sage-assets/lib/stylesheets/components/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_hero.scss
@@ -134,7 +134,7 @@ $-hero-play-icon-background-color: sage-color(white);
   @include sage-focus-ring;
 
   &:focus {
-    @include sage-focus-outline--update-color(sage-color(primary, 200));
+    @include sage-focus-outline--update-color(sage-color(purple, 30));
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -77,7 +77,7 @@ $-link-base-styles: (
   &:focus {
     color: sage-color(primary, 300);
 
-    @include sage-focus-outline--update-color(sage-color(primary, 200));
+    @include sage-focus-outline--update-color(sage-color(purple, 30));
   }
 
   .sage-card--interactive & {
@@ -214,7 +214,7 @@ $-link-base-styles: (
     $outline-offset-block: 4px,
     $outline-border-radius: sage-border(radius-round),
   );
-  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  @include sage-focus-outline--update-color(sage-color(purple, 30));
 }
 
 .sage-link--remove-underline {

--- a/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
@@ -81,8 +81,8 @@ $-media-tile-breakpoints: (
     outline: 0;
 
     &::after {
-      border-width: sage-spacing(2xs);
-      border-color: sage-color(primary, 200);
+      border-width: rem(2px);
+      border-color: sage-color(purple, 30);
     }
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -36,7 +36,7 @@ $-nav-subitem-border-width: rem(2px);
     $outline-offset-block: -4,
     $outline-border-radius: sage-border(radius-medium),
   );
-  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  @include sage-focus-outline--update-color(sage-color(purple, 30));
 
   display: flex;
   align-items: center;
@@ -63,7 +63,7 @@ $-nav-subitem-border-width: rem(2px);
   @extend %t-sage-body-small-med;
 
   &.sage-nav__link--active {
-    @include sage-focus-outline--update-color(sage-color(primary, 200));
+    @include sage-focus-outline--update-color(sage-color(purple, 30));
 
     background: $-nav-color-background;
   }
@@ -88,7 +88,7 @@ $-nav-subitem-border-width: rem(2px);
 
   &:not(.sage-nav__list--sub) {
     .sage-nav__link--active {
-      @include sage-focus-outline--update-color(sage-color(primary, 200));
+      @include sage-focus-outline--update-color(sage-color(purple, 30));
     }
 
     .sage-nav__link--active::after {

--- a/packages/sage-assets/lib/stylesheets/components/_nav.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_nav.scss
@@ -31,9 +31,9 @@ $-nav-subitem-border-width: rem(2px);
 .sage-nav__link,
 .sage-nav__link--active {
   @include sage-focus-outline(
-    $outline-width: 4px,
-    $outline-offset-inline: -2,
-    $outline-offset-block: -4,
+    $outline-width: 2px,
+    $outline-offset-inline: 0,
+    $outline-offset-block: -1,
     $outline-border-radius: sage-border(radius-medium),
   );
   @include sage-focus-outline--update-color(sage-color(purple, 30));

--- a/packages/sage-assets/lib/stylesheets/components/_pagination.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_pagination.scss
@@ -12,7 +12,7 @@ $-pagination-text-color: sage-color(charcoal, 400);
 $-pagination-text-color-disabled: sage-color(charcoal, 100);
 $-pagination-bg-color-current: sage-color(grey, 200);
 $-pagination-bg-color-hover: sage-color(grey, 300);
-$-pagination-focus-ring-color: sage-color(primary, 200);
+$-pagination-focus-ring-color: sage-color(purple, 30);
 
 
 .sage-pagination {

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -15,7 +15,7 @@ $-radio-color-disabled: map-get($sage-radio-colors, disabled);
 $-radio-color-error: map-get($sage-radio-colors, error);
 $-radio-color-hover: map-get($sage-radio-colors, hover);
 $-radio-color-text-disabled: sage-color(grey, 500);
-$-radio-color-focus-outline: sage-color(primary, 200);
+$-radio-color-focus-outline: sage-color(purple, 30);
 $-radio-color-focus-outline-error: sage-color(red, 200);
 
 // Additional configurations
@@ -26,7 +26,7 @@ $-radio-selected-indicator-size: rem(6px);
 
 // Focus state
 $-radio-focus-outline-size: rem(3px);
-$-radio-focus-outline-width: 4;
+$-radio-focus-outline-width: 2;
 $-radio-focus-outline-color: currentColor;
 
 // stylelint-disable max-nesting-depth

--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -197,9 +197,12 @@ $-search-icon: "::before";
       box-shadow: map-get($sage-toolbar-button-borders, hover);
     }
 
-    &:focus,
     &:active {
       box-shadow: map-get($sage-toolbar-button-borders, active-hover);
+    }
+
+    &:focus {
+      box-shadow: map-get($sage-toolbar-button-borders, focus);
     }
   }
 

--- a/packages/sage-assets/lib/stylesheets/components/_status_icon.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_status_icon.scss
@@ -20,7 +20,7 @@
     $outline-offset-block: 4px,
     $outline-border-radius: sage-border(radius-round),
   );
-  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  @include sage-focus-outline--update-color(sage-color(purple, 30));
 
   &:hover:not(:focus):not(:active) {
     color: sage-color(charcoal, 400);

--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -45,7 +45,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
   &:focus {
     z-index: sage-z-index(default, 1);
     outline: none;
-    box-shadow: 0 0 0 4px sage-color(primary, 200);
+    box-shadow: 0 0 0 1px white, 0 0 0 4px sage-color(purple, 30);
     border-radius: sage-border(radius-small);
 
     .sage-tabs--filter & {

--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -43,9 +43,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
   }
 
   &:focus {
-    z-index: sage-z-index(default, 1);
-    outline: none;
-    box-shadow: 0 0 0 1px white, 0 0 0 4px sage-color(purple, 30);
+    @include sage-focus-ring();
     border-radius: sage-border(radius-small);
 
     .sage-tabs--filter & {

--- a/packages/sage-assets/lib/stylesheets/components/_toast.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_toast.scss
@@ -161,7 +161,7 @@ $-toast-bottom-spacing: sage-spacing(xs);
   text-decoration: underline;
 
   @include sage-focus-outline($outline-offset-inline: 4px);
-  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  @include sage-focus-outline--update-color(sage-color(purple, 30));
 }
 
 @keyframes rotate {

--- a/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
@@ -58,7 +58,7 @@ $-typeahead-item-height: rem(68px);
     $outline-offset-inline: -4px,
     $outline-animation-speed: 0.05s
   );
-  @include sage-focus-outline--update-color(sage-color(primary, 200));
+  @include sage-focus-outline--update-color(sage-color(purple, 30));
 
   display: grid;
   position: unset; // Undo position defined in sage-focus-outline()

--- a/packages/sage-assets/lib/stylesheets/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_variables.scss
@@ -103,7 +103,7 @@ $sage-text-colors: (
 ///
 $sage-toolbar-button-borders: (
   default: 0 0 0 1px sage-color(grey, 500),
-  focus: 0 0 0 4px sage-color(primary, 200),
+  focus: 0 0 0 2px sage-color(purple, 30),
   hover: 0 0 0 1px sage-color(charcoal, 100),
   hover-large: 0 0 0 2px sage-color(charcoal, 100),
   active-hover: 0 0 0 4px sage-color(primary, 200),

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -185,7 +185,7 @@
   &:focus {
     z-index: sage-z-index(default, 1);
     outline: none;
-    box-shadow: 0 0 0 $focus-width-inner white, 0 0 0 $focus-width-outter $focus-shadow;
+    box-shadow: 0 0 0 $focus-width-inner #fff, 0 0 0 $focus-width-outter $focus-shadow;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -178,13 +178,14 @@
 /// @param {time} $focus-animation-speed [0.2s] How quickly the focus ring animates on activation
 ///
 @mixin sage-focus-ring(
-  $focus-shadow: sage-color(primary, 200),
-  $focus-width: 4px
+  $focus-shadow: sage-color(purple, 30),
+  $focus-width-inner: 1px,
+  $focus-width-outter: 4px
 ) {
   &:focus {
     z-index: sage-z-index(default, 1);
     outline: none;
-    box-shadow: 0 0 0 $focus-width $focus-shadow;
+    box-shadow: 0 0 0 $focus-width-inner white, 0 0 0 $focus-width-outter $focus-shadow;
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -180,7 +180,7 @@
 @mixin sage-focus-ring(
   $focus-shadow: sage-color(purple, 30),
   $focus-width-inner: 1px,
-  $focus-width-outter: 4px
+  $focus-width-outter: 3px
 ) {
   &:focus {
     z-index: sage-z-index(default, 1);
@@ -199,7 +199,7 @@
 /// @param {time} $outline-animation-speed [0.2s] How quickly the focus ring animates on activation
 ///
 @mixin sage-focus-outline(
-  $outline-width: 4px,
+  $outline-width: 2px,
   $outline-offset-block: 0,
   $outline-offset-inline: 0,
   $outline-animation-speed: 0.2s,


### PR DESCRIPTION
## Description
Updates focus states to match new width and color

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="585" alt="Screenshot 2024-09-04 at 9 50 41 AM" src="https://github.com/user-attachments/assets/b194be25-00b9-4e73-b8f3-64d0c6df707e">|<img width="550" alt="Screenshot 2024-09-04 at 9 49 21 AM" src="https://github.com/user-attachments/assets/2dc27ba2-505f-4aaf-a18e-80e96d0245f3">|


## Testing in `sage-lib`
Navigate to Docs & Storybook
Tab through or focus on interactive elements
Verify new focus width and color are displayed


## Testing in `kajabi-products`
1. (**LOW**) Updates focus states to match new width and color


## Related
https://kajabi.atlassian.net/browse/DSS-854