### PR TITLE
style(progress): update the default fill color to mercury-50

### DIFF
--- a/docs/app/views/examples/components/progress_bar/_preview.html.erb
+++ b/docs/app/views/examples/components/progress_bar/_preview.html.erb
@@ -1,13 +1,11 @@
 <h2 class="t-sage-heading-6">Default</h2>
 <%= sage_component SageProgressBar, {
-  color: SageTokens::COLOR_PALETTE[:PRIMARY_300],
   percent: 70,
   label: "Cloning product"
 } %>
 
 <h2 class="t-sage-heading-6">Default with Percentage</h2>
 <%= sage_component SageProgressBar, {
-  color: SageTokens::COLOR_PALETTE[:SAGE_300],
   display_percent: true,
   percent: 70,
   label: "Cloning product"

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -2,7 +2,7 @@
 animate = component.animate.nil? ? true : component.animate
 content = component.label ? "#{component.label}: " : ""
 content << "#{component.percent}%&nbsp;progress"
-color = component.color || SageTokens::COLOR_PALETTE[:SAGE_300]
+color = component.color || SageTokens::COLOR_PALETTE[:MERCURY_50]
 %>
 
 <div

--- a/packages/sage-react/lib/ProgressBar/ProgressBar.jsx
+++ b/packages/sage-react/lib/ProgressBar/ProgressBar.jsx
@@ -81,7 +81,7 @@ ProgressBar.defaultProps = {
   animate: true,
   backgroundColor: null,
   className: null,
-  color: ProgressBar.COLORS.PRIMARY_300,
+  color: ProgressBar.COLORS.MERCURY_50,
   disableTooltip: false,
   displayPercent: false,
   label: null,

--- a/packages/sage-react/lib/ProgressBar/ProgressBar.story.jsx
+++ b/packages/sage-react/lib/ProgressBar/ProgressBar.story.jsx
@@ -14,7 +14,6 @@ export default {
     },
   },
   args: {
-    color: ProgressBar.COLORS.PRIMARY_300,
     label: 'Cloning product',
     percent: '44',
   },
@@ -30,7 +29,7 @@ const Template = (args) => <ProgressBar {...args} />;
 export const Default = Template.bind({});
 export const CustomColor = Template.bind({});
 CustomColor.args = {
-  color: ProgressBar.COLORS.ORANGE_300,
+  color: ProgressBar.COLORS.PURPLE_50,
   backgroundColor: ProgressBar.COLORS.ORANGE_100,
   label: 'Cloning product',
   percent: '44',


### PR DESCRIPTION
## Description
With the rebrand, the design requires changing the active tab indicator to be mercury-50.


## Screenshots
### Doc Site
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/7075a97f-7846-4f58-98d4-af71808548cf)|![image](https://github.com/user-attachments/assets/13b2ad2f-d17b-41a0-8ebe-bb1576e8c035)|

### Storybook
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/4ec5f4d7-f4f9-453f-89b3-e1b641eeb5f2)|![image](https://github.com/user-attachments/assets/5743a35d-5fcf-48ab-8ba4-73b427b72772)
|

## Testing in `sage-lib`
1. Navigate to the doc site -> http://localhost:4000/pages/component/progress_bar?tab=preview and http://localhost:4100/?path=/docs/sage-progressbar--default
2. Confirm values are matching the figma designs



## Related
https://kajabi.atlassian.net/browse/DSS-842
