### PR TITLE
style(alert): add borders

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_alert.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_alert.scss
@@ -34,6 +34,19 @@ $-alert-icon-colors: (
   danger: sage-color(red, 300),
 );
 
+$-alert-border-colors: (
+  default: sage-color(grey, 30),
+  draft: sage-color(grey, 30),
+  info: sage-color(blue, 30),
+  published: sage-color(green, 30),
+  success: sage-color(green, 30),
+  warning: sage-color(yellow, 30),
+  approaching: sage-color(yellow, 30),
+  reached: sage-color(mercury, 30),
+  exceeded: sage-color(red, 30),
+  danger: sage-color(red, 30),
+);
+
 .sage-alert {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -41,6 +54,7 @@ $-alert-icon-colors: (
   gap: sage-spacing(sm);
   padding: sage-spacing();
   margin-bottom: sage-spacing();
+  border: 1px solid sage-color(grey, 30);
   border-radius: sage-border(radius-large);
 
   .sage-frame > &,
@@ -69,6 +83,12 @@ $-alert-icon-colors: (
 @each $name, $value in $-alert-background-colors {
   .sage-alert--#{$name} {
     background-color: $value;
+  }
+}
+
+@each $name, $value in $-alert-border-colors {
+  .sage-alert--#{$name} {
+    border-color: $value;
   }
 }
 


### PR DESCRIPTION
## Description
Adds borders to alert component to match design spec


## Screenshots
|  Before  |
|--------|
|<img width="803" alt="Screenshot 2024-09-04 at 1 49 24 PM" src="https://github.com/user-attachments/assets/51b05348-3c3a-45a2-a004-61d9b3df6cb2">|

## Testing in `sage-lib`
Navigate to Alerts
Verify border is added to alert.


## Testing in `kajabi-products`
1. (**LOW**) Adds borders to alerts


## Related
https://kajabi.atlassian.net/browse/DSS-787