### PR TITLE
style(button): change button border radius to 9999px

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -13,7 +13,7 @@ $-btn-transition: map-get($sage-transitions, default);
 $-btn-base-padding-block: sage-spacing(xs); // vertical (y) axis
 $-btn-base-padding-inline: sage-spacing(sm); // horizontal (x) axis
 $-btn-base-line-height: var(--sage-line-height-body, #{rem(24px)});
-$-btn-border-radius: sage-border(radius);
+$-btn-border-radius: 9999px;
 $-btn-shadow-base: sage-shadow(sm);
 $-btn-icon-only-standard-size: rem(40px);
 $-btn-icon-only-subtle-size: rem(16px);


### PR DESCRIPTION
## Description
Update the Button component to match the Figma Design, which sets the border-radius to `9999px` for rounded corners.


## Screenshots
### Doc Site
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/8ecc46b1-446e-41bc-84bd-296c3c0e2190)|![image](https://github.com/user-attachments/assets/8485d8ce-7cb6-45f0-a3ee-b3c4b279f2c8)|



### React Storybook
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/1f31bbb3-825f-4dc7-aef8-57855589863e)|![image](https://github.com/user-attachments/assets/09bf39e3-c1f1-49fd-ad7f-d2e431c7c11b)|


## Testing in `sage-lib`
1. Navigate to the Doc Site -> http://localhost:4000/pages/component/button?tab=preview
2. Confirm styles match Figma Design
3. Navigate to the Storybook component -> http://localhost:4100/?path=/docs/sage-button--primary
4. Confirm styles match Figma Design


## Related
https://kajabi.atlassian.net/browse/DSS-845
