### PR TITLE
style(button): change the colors for the accent variant to be purple

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -26,24 +26,24 @@ $-btn-base-styles: (
   accent: (
     default: (
       color: sage-color(white),
-      background-color: sage-color(primary, 300),
-      border-color: sage-color(primary, 300),
+      background-color: sage-color(purple, 50),
+      border-color: sage-color(purple, 50),
       ring-color: sage-color(purple, 30),
     ),
     hover: (
       color: sage-color(white),
-      background-color: sage-color(primary, 400),
-      border-color: sage-color(primary, 400),
+      background-color: sage-color(purple, 60),
+      border-color: sage-color(purple, 60),
     ),
     focus: (
       color: sage-color(white),
-      background-color: sage-color(primary, 300),
-      border-color: sage-color(primary, 300),
+      background-color: sage-color(purple, 50),
+      border-color: sage-color(purple, 50),
     ),
     disabled: (
-      color: sage-color(primary, 200),
-      background-color: sage-color(primary, 100),
-      border-color: sage-color(primary, 100),
+      color: sage-color(purple, 30),
+      background-color: sage-color(purple, 15),
+      border-color: sage-color(purple, 15),
     )
   ),
   primary: (


### PR DESCRIPTION
## Description
The Accent variant button should be updated to match the Rebrand Design. The new color will now be purple.


## Screenshots
### Doc Site
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/2c820e0f-f5c6-4b65-ac12-7316c56875b3)|![image](https://github.com/user-attachments/assets/1061f5cd-0a66-436a-b8a2-9b07b4847847)|

### React Storybook
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/6c9afddc-f75c-42c0-9282-79eb13151dfb)|![image](https://github.com/user-attachments/assets/b627c2a4-4c88-4ff8-8a9d-00135322fb9b)|


## Testing in `sage-lib`
1. Navigate to the
   local doc site -> http://localhost:4000/pages/component/button?tab=preview
   storybook -> http://localhost:4100/?path=/docs/sage-button--primary
2. Confirm `accent` variant matches the Figma Design, repeat for Storybook


## Related
https://kajabi.atlassian.net/browse/DSS-888
