### PR TITLE
chore: add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lerna-debug.log
 .DS_Store
 coverage
 package-lock.json
+.idea/


### PR DESCRIPTION
## Description
Added the `.idea` folder to the `.gitignore` file. This is the folder used by RubyMine