### PR TITLE
style(button): change font weight to med 500

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -169,7 +169,7 @@ $-btn-loading-min-height: rem(36px);
 
 // stylelint-disable max-nesting-depth
 .sage-btn {
-  @extend %t-sage-body-semi;
+  @extend %t-sage-body-med;
   @include sage-button-style-reset();
   @include sage-focus-ring;
 


### PR DESCRIPTION
## Description
Change the the font-weight for buttons from 600 to 500.


## Screenshots
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/71590f7b-b310-4ae9-9524-58a7987da8f8)![image](https://github.com/user-attachments/assets/5eda57fe-bb0c-4f78-9ce2-121d90902ebc)|


## Testing in `sage-lib`
1. Navigate to http://localhost:4000/pages/component/button?tab=preview
2. Confirm font-weight is 500 as expected.

## Related
https://kajabi.atlassian.net/browse/DSS-944
