### PR TITLE
style: update dropdown item hover color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -188,7 +188,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
 
   &:hover {
-    background-color: sage-color(grey, 200);
+    background-color: sage-color(grey, 150);
   }
 
   &:focus-within {


### PR DESCRIPTION
## Description
Dropdown items have incorrect hover color.
Updates hover color to match sidebar. grey-150


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-02 at 4 20 10 PM](https://github.com/user-attachments/assets/956e92de-7925-44cb-8652-93aa98b3c9bc)|![Screenshot 2024-10-02 at 4 20 36 PM](https://github.com/user-attachments/assets/89f91a90-1c2d-4891-9585-4b0488e232b3)|


## Testing in `sage-lib`
Navigate to Dropdown.
Verify hover color is updated.


## Testing in `kajabi-products`

1. (**LOW**) Update hover color of dropdown items.


## Related
https://kajabi.atlassian.net/browse/DSS-1042
