### PR TITLE
fix: adjust token color for spinner

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
@@ -1,6 +1,6 @@
 <%
   component_description = component.type === "success" ? "Success" : "Loading..."
-  stroke_color = SageTokens::COLOR_PALETTE[:MERCURY_40]
+  stroke_color = SageTokens::COLOR_PALETTE[:MERCURY_400]
 %>
 
 <div class="


### PR DESCRIPTION
## Description
Color token needs update for spinner


## Screenshots
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-04 at 11 14 42 AM](https://github.com/user-attachments/assets/b3936ae6-544e-42fd-bab9-e2221eda883a)|![Screenshot 2024-10-04 at 11 13 13 AM](https://github.com/user-attachments/assets/58b9dfff-6862-4850-8376-a12c5cea3917)|


## Testing in `sage-lib`
Navigate to loader
Confirm the spinner is orange


## Testing in `kajabi-products`
1. (**LOW**) Adjust spinner color

## Related
N/A
