### PR TITLE
fix: spinner color react

### DIFF
--- a/packages/sage-react/lib/Loader/Loader.jsx
+++ b/packages/sage-react/lib/Loader/Loader.jsx
@@ -36,7 +36,7 @@ export const Loader = ({
           className="sage-loader__spinner sage-loader__spinner--loading-button"
           viewBox="0 0 200 200"
           fill="none"
-          color={SageTokens.COLOR_PALETTE.MERCURY_40}
+          color={SageTokens.COLOR_PALETTE.MERCURY_400}
           aria-hidden="true"
         >
           <defs>
@@ -61,7 +61,7 @@ export const Loader = ({
           className="sage-loader__spinner"
           viewBox="0 0 200 200"
           fill="none"
-          color={SageTokens.COLOR_PALETTE.MERCURY_40}
+          color={SageTokens.COLOR_PALETTE.MERCURY_400}
           aria-hidden="true"
         >
           <defs>


### PR DESCRIPTION
## Description
Color token needs update for spinner


## Screenshots

![Screenshot 2024-10-04 at 1 22 34 PM](https://github.com/user-attachments/assets/f350627c-0373-458b-beec-7beac3ec7052)


## Testing in `sage-lib`
Navigate to loader
Confirm the spinner is orange


## Testing in `kajabi-products`
1. (**LOW**) Adjust spinner color

## Related
N/A
