### PR TITLE
fix: correct progress color tokens

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -2,7 +2,7 @@
 animate = component.animate.nil? ? true : component.animate
 content = component.label ? "#{component.label}: " : ""
 content << "#{component.percent}%&nbsp;progress"
-color = component.color || SageTokens::COLOR_PALETTE[:MERCURY_50]
+color = component.color || SageTokens::COLOR_PALETTE[:MERCURY_500]
 %>
 
 <div

--- a/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_progress_bar.scss
@@ -44,7 +44,7 @@ $-progress-bar-height: sage-spacing(xs);
 .sage-progress-bar__value {
   transform-origin: center left;
   height: 100%;
-  background-color: var(--progress-bar-value-color, sage-color(sage, 300));
+  background-color: var(--progress-bar-value-color, sage-color(mercury, 500));
   border-radius: sage-border(radius-small);
 
   .sage-modal__header & {

--- a/packages/sage-react/lib/ProgressBar/ProgressBar.story.jsx
+++ b/packages/sage-react/lib/ProgressBar/ProgressBar.story.jsx
@@ -29,7 +29,7 @@ const Template = (args) => <ProgressBar {...args} />;
 export const Default = Template.bind({});
 export const CustomColor = Template.bind({});
 CustomColor.args = {
-  color: ProgressBar.COLORS.PURPLE_50,
+  color: ProgressBar.COLORS.PURPLE_300,
   backgroundColor: ProgressBar.COLORS.ORANGE_100,
   label: 'Cloning product',
   percent: '44',


### PR DESCRIPTION
## Description
Progress color has incorrect tokens and css colors
Updates tokens and colors for rebrand


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-04 at 5 04 38 PM](https://github.com/user-attachments/assets/2a9deac1-5b20-45c7-8fc1-a3f31dc66651)|![Screenshot 2024-10-04 at 4 59 00 PM](https://github.com/user-attachments/assets/c036d18c-eb28-45af-9c96-61a635813bc6)|


## Testing in `sage-lib`
Navigate to progress
Verify colors are correct.


## Related
N/A
