### PR TITLE
fix: empty state tokens

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_empty_state.html.erb
@@ -23,7 +23,7 @@ end
   <% if component.icon.present? %>
     <div
       class="sage-empty-state__icon-container"
-      style="--color-background-icon: <%= component.icon_background || SageTokens::COLOR_PALETTE[:MERCURY_30] %>"
+      style="--color-background-icon: <%= component.icon_background || SageTokens::COLOR_PALETTE[:MERCURY_300] %>"
     >
       <%= sage_component SageIcon, {
         color: "white",


### PR DESCRIPTION
## Description
The empty state has an incorrect default token color


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-04 at 5 22 49 PM](https://github.com/user-attachments/assets/39f85603-f3c6-4135-82c0-03f2fa71f039)|![Screenshot 2024-10-04 at 5 23 56 PM](https://github.com/user-attachments/assets/966b8cea-000d-4719-9b94-379e63b47c97)|

## Testing in `sage-lib`
Navigate to empty state
Verify bg color on icon shows

