### PR TITLE
feat: add new "customKey" prop to ExpandableCard

### DIFF
--- a/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
+++ b/packages/sage-react/lib/ExpandableCard/ExpandableCard.jsx
@@ -12,6 +12,7 @@ export const ExpandableCard = ({
   expanded,
   children,
   className,
+  customKey,
   headerContent,
   name,
   onClick,
@@ -32,7 +33,7 @@ export const ExpandableCard = ({
     }
   };
 
-  const id = uuid();
+  const id = customKey || uuid();
 
   const containerClassnames = classnames(
     'sage-expandable-card',
@@ -98,6 +99,7 @@ ExpandableCard.defaultProps = {
   expanded: false,
   children: null,
   className: null,
+  customKey: null,
   headerContent: null,
   alignTrigger: 'middle',
   name: null,
@@ -109,6 +111,7 @@ ExpandableCard.defaultProps = {
 ExpandableCard.propTypes = {
   alignArrowRight: PropTypes.bool,
   bodyBordered: PropTypes.bool,
+  customKey: PropTypes.string,
   headerContent: PropTypes.node,
   expanded: PropTypes.bool,
   className: PropTypes.string,


### PR DESCRIPTION
## Description
Adds an optional "key" prop to the ExpandableCard react component. 

When using ExpandableCard as a child component to a parent that's re-rendering on prop changes, the component appears to "flicker" due to re-rendering every time the `id` const changes. Internally, it's set to a new `uuid()` on every render. We would like to provide an optional stable value via a prop so that we don't need to regenerate the id on every render. 


## Screenshots

|  The `id` field utilized by `Button`'s `aria-controls` and the child section  | 
|--------|
| ![2024-10-14 14 26 54](https://github.com/user-attachments/assets/d802efb6-7ca0-480f-b573-0a1879314cea) |

(note: the framerate of the GIF recording doesn't catch the flickering super well, but it is visibly noticeable)

## Testing in `sage-lib`

Rails:

- Navigate to [Expandable Card](http://localhost:4000/pages/component/expandable_card?tab=preview)
- See the `key` prop and verify that a key can be provided, which will set the `id` of the button element. It should be a random uuid otherwise.

React:

- Navigate to [Expandable Card](http://localhost:4100/?path=/docs/sage-expandablecard--default)
- See the `key` prop and verify that a key can be provided, which will set the `id` of the button element. It should be a random uuid otherwise.



## Testing in `kajabi-products`
1. (LOW) Updates ExpandableCard to support custom `key` prop for assigning IDs to child elements.
   - [ ] This is a new prop and should not have any effect on existing components. Should verify consistent behavior of ExpandableCard and Accordion


## Related
https://github.com/Kajabi/kajabi-products/pull/37105