### PR TITLE
fix(rails-icon): sage icon schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+mercury-rising:
+  - base-branch: ['mercury-rising']

--- a/docs/lib/sage_rails/app/sage_components/sage_icon.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_icon.rb
@@ -6,7 +6,7 @@ class SageIcon < SageComponent
     card_color: [:optional, NilClass, Set.new(SageSchemas::STATUSES), String],
     circular: [:optional, NilClass, TrueClass],
     color: [:optional, NilClass, SageSchemas::COLOR_SLIDER],
-    icon: SageSchemas::ICON,
+    icon: String,
     label: [:optional, NilClass, String],
     size: [:optional, NilClass, SageSchemas::ICON_SIZE],
   })


### PR DESCRIPTION
## Description
With icons now being contained in Pine design system, the list of icons will not match the schema in Rails. 

Jira Ticket: 
https://kajabi.atlassian.net/browse/DSS-895

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![image](https://github.com/user-attachments/assets/2dde9cf0-3b89-407b-87e0-1c1eed8301c1)|
![image](https://github.com/user-attachments/assets/8c670136-bc50-43e8-adf5-857df2574224)
|


## Testing in `sage-lib`
1. Go to the `docs/app/views/examples/components/icon/_preview.html.erb` and change an icon to a random string.
2. Then navigate to `http://localhost:4000/pages/component/icon?tab=preview`
3. The page should render, but no icon will be visible. If you put a non-existent icon name.

