### PR TITLE
style: updates Button styles to match Figma

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -14,7 +14,7 @@ $-btn-base-padding-block: sage-spacing(xs); // vertical (y) axis
 $-btn-base-padding-inline: sage-spacing(sm); // horizontal (x) axis
 $-btn-base-line-height: var(--sage-line-height-body, #{rem(24px)});
 $-btn-border-radius: 9999px;
-$-btn-shadow-base: sage-shadow(sm);
+$-btn-shadow-base: sage-shadow(050);
 $-btn-icon-only-standard-size: rem(40px);
 $-btn-icon-only-subtle-size: rem(16px);
 $-btn-icon-only-hover-size: rem(24px);
@@ -49,13 +49,14 @@ $-btn-base-styles: (
   primary: (
     default: (
       color: sage-color(white),
-      background-color: sage-color(charcoal, 400),
-      border-color: sage-color(charcoal, 400),
+      background-color: sage-color(grey, 900),
+      border-color: sage-color(grey, 900),
       ring-color: sage-color(purple, 300),
     ),
     hover: (
       color: sage-color(white),
       background-color: sage-color(grey, 950),
+      border-color: sage-color(grey, 950),
     ),
     focus: (
       color: sage-color(white),
@@ -63,19 +64,19 @@ $-btn-base-styles: (
       border-color: sage-color(grey, 900),
     ),
     disabled: (
-      color: sage-color(grey, 600),
-      background-color: sage-color(grey, 200),
-      border-color: sage-color(grey, 200),
+      color: sage-color(grey, 400),
+      background-color: sage-color(grey, 150),
+      border-color: sage-color(grey, 150),
     )
   ),
   secondary: (
     default: (
-      color: sage-color(grey, 900),
+      color: sage-color(grey, 800),
       background-color: sage-color(white),
       ring-color: sage-color(purple, 300),
     ),
     hover: (
-      color: sage-color(grey, 900),
+      color: sage-color(grey, 950),
       background-color: sage-color(grey, 100),
     ),
     focus: (
@@ -96,7 +97,8 @@ $-btn-base-styles: (
     ),
     hover: (
       color: sage-color(white),
-      background-color: sage-color(red, 800),
+      background-color: sage-color(red, 600),
+      border-color: sage-color(red, 600),
     ),
     focus: (
       color: sage-color(white),
@@ -184,6 +186,7 @@ $-btn-loading-min-height: rem(36px);
   border-width: 1px;
   border-style: solid;
   border-radius: $-btn-border-radius;
+  box-shadow: $-btn-shadow-base;
   transition: $-btn-transition;
   transition-property: border, background-color, box-shadow;
 
@@ -588,13 +591,14 @@ a.sage-btn {
 
 // Secondary styles, no shadow variation
 .sage-btn--secondary {
-  color: sage-color(grey, 900);
+  color: sage-color(grey, 800);
   background-color: sage-color(white);
-  border: 1px solid sage-color(grey, 500);
+  border: 1px solid sage-color(grey, 200);
 
   &:hover {
-    background-color: sage-color(white);
-    border-color: sage-color(grey, 600);
+    color: sage-color(grey, 950);
+    background-color: sage-color(grey, 100);
+    border-color: sage-color(grey, 300);
   }
 
   &:focus {
@@ -603,16 +607,15 @@ a.sage-btn {
 
   &:focus-visible,
   &:active {
-    color: sage-color(grey, 800);
     background-color: sage-color(white);
     border-color: sage-color(grey);
   }
 
   &:disabled,
   &[aria-disabled="true"] {
-    color: sage-color(grey, 600);
+    color: sage-color(grey, 400);
     background-color: sage-color(white);
-    border-color: sage-color(grey, 200);
+    border-color: sage-color(grey, 100);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -615,7 +615,7 @@ a.sage-btn {
   &[aria-disabled="true"] {
     color: sage-color(grey, 400);
     background-color: sage-color(white);
-    border-color: sage-color(grey, 100);
+    border-color: sage-color(grey, 150);
   }
 }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates Button styles to match Figma. This PR fixes incorrect color tokens for all buttons, including the Secondary button for the Jira ticket.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
<img width="556" alt="Screenshot 2024-10-16 at 12 31 02 PM" src="https://github.com/user-attachments/assets/5884e3c8-9a05-4926-a644-98df5675808b">|<img width="554" alt="Screenshot 2024-10-16 at 12 36 53 PM" src="https://github.com/user-attachments/assets/23627cc9-011c-405b-b6a0-6e0401c368a7">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Button](http://localhost:4000/pages/component/button?tab=preview)
- Check that styles match [Figma](https://www.figma.com/design/CC1YmaGKHnsvB28yLY9mEH/%F0%9F%A7%A9-Mercury-components?m=auto&node-id=34239-33855&t=u3QPXyUGh5cMbdQf-1)


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Updates Button styles to match Figma


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1081](https://kajabi.atlassian.net/browse/DSS-1081)

[DSS-1081]: https://kajabi.atlassian.net/browse/DSS-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ