### PR TITLE
fix: add focus outline override to components with focus-visible

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -187,6 +187,10 @@ $-btn-loading-min-height: rem(36px);
   transition: $-btn-transition;
   transition-property: border, background-color, box-shadow;
 
+  &:focus {
+    outline: none;
+  }
+
   &:disabled,
   &[aria-disabled="true"] {
     @include sage-button-style-disabled;
@@ -595,10 +599,6 @@ a.sage-btn {
   &:hover {
     background-color: sage-color(white);
     border-color: sage-color(grey, 600);
-  }
-
-  &:focus {
-    outline: none;
   }
 
   &:focus-visible,

--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -213,6 +213,10 @@ $-checkbox-focus-outline-color: sage-color(purple, 300);
     background-color: sage-color(grey, 100);
   }
 
+  &:focus:not(:disabled) {
+    outline: none;
+  }
+
   &:focus-visible:not(:disabled),
   &:active:not(:disabled) {
     outline: none;

--- a/packages/sage-assets/lib/stylesheets/components/_choice.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_choice.scss
@@ -65,6 +65,10 @@ $-choice-radio-color-checked-inner: map-get($sage-radio-colors, checked-inner);
     color: $-choice-color-active;
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     border-color: sage-color(purple, 300);
     outline: none;

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -122,6 +122,10 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 
   @extend %t-sage-body;
 
+  &:focus {
+    outline: none;
+  }
+
   &:active,
   &:focus-visible,
   &:focus-within {

--- a/packages/sage-assets/lib/stylesheets/components/_link.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_link.scss
@@ -176,6 +176,10 @@ $-link-base-styles: (
     color: sage-color(grey, 600);
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:hover,
   &:active,
   &:focus-visible {

--- a/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_media_tile.scss
@@ -77,6 +77,10 @@ $-media-tile-breakpoints: (
     color: inherit;
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     outline: 0;
 

--- a/packages/sage-assets/lib/stylesheets/components/_radio.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_radio.scss
@@ -176,6 +176,10 @@ $-radio-focus-outline-color: currentColor;
     }
   }
 
+  &:focus:not(:disabled) {
+    outline: none;
+  }
+
   &:focus-visible:not(:disabled),
   &:active:not(:disabled) {
     outline: none;

--- a/packages/sage-assets/lib/stylesheets/components/_switch.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_switch.scss
@@ -95,6 +95,10 @@ $-switch-toggle-size: rem(16px);
   border-radius: $-switch-border-radius;
   transition: background 0.3s ease-out;
 
+  &:focus {
+    outline: none !important; /* stylelint-disable-line declaration-no-important */
+  }
+
   .sage-switch--has-border & {
     position: absolute;
   }


### PR DESCRIPTION
## Description
Changing some components to `focus-visible` removed the `outline:none` for `focus`.
These updates bring back the `focus` to remove the outline caused by some default styles in KP.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-16 at 12 30 07 PM](https://github.com/user-attachments/assets/cced0db4-490a-4ded-a382-04bc2ef5fa8e)|![Screenshot 2024-10-16 at 12 30 18 PM](https://github.com/user-attachments/assets/547e1c0e-45ee-4263-b6a7-a5b0b96ba0d9)|


## Testing in `sage-lib`
N/A


## Testing in `kajabi-products`

- Enable bridge with KP
- Navigate around and confirm no outlines on buttons, radios, switches, etc on focus.


1. (**LOW**) Adds focus outline override for various components.
   - [ ] Any buttons, switches, radios, etc...


## Related
https://kajabi.atlassian.net/browse/DSS-1116
