### PR TITLE
style: adjust focus styles for dropdown field-wrapper

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_search.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_search.scss
@@ -115,10 +115,6 @@ $-search-icon: "::before";
   .sage-dropdown__panel & {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-
-    &:focus-within {
-      box-shadow: inset map-get($sage-toolbar-button-borders, focus);
-    }
   }
 }
 


### PR DESCRIPTION
## Description
Search in a dropdown panel has incorrect focus style


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-16 at 1 06 28 PM](https://github.com/user-attachments/assets/d0589aa2-bbc5-469b-9c10-9b5134333d46)|![Screenshot 2024-10-16 at 1 05 52 PM](https://github.com/user-attachments/assets/952989a3-10dc-4f93-a061-eba4e8ad5def)|

## Testing in `sage-lib`

- Navigate to dropdown
- Verify focus state appears properly


## Testing in `kajabi-products`

1. (**LOW**) Adjust dropdown panel search focus style.


## Related
https://kajabi.atlassian.net/browse/DSS-1125
