### PR TITLE
style: adds fallback stack for heading-font

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -6,7 +6,7 @@
 
 
 // Font definitions
-$-heading-font: "GreetStandard", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif;
+$-heading-font: "GreetStandard", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-font-stack: "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-margin-bottom: sage-spacing(xs);
 $-headings-margin-bottom: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -6,7 +6,7 @@
 
 
 // Font definitions
-$-heading-font: "GreetStandard";
+$-heading-font: "GreetStandard", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-font-stack: "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-margin-bottom: sage-spacing(xs);
 $-headings-margin-bottom: sage-spacing(sm);

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -6,7 +6,7 @@
 
 
 // Font definitions
-$-heading-font: "GreetStandard", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
+$-heading-font: "GreetStandard", "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-font-stack: "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-margin-bottom: sage-spacing(xs);
 $-headings-margin-bottom: sage-spacing(sm);


### PR DESCRIPTION
## Description
On the first (empty cache) or slow page load, the buttons appear with an awful font.
This update adds fallback to the font stack to stop the drastic font shift.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-16 at 2 52 37 PM](https://github.com/user-attachments/assets/5c782e2e-a5d8-4379-b0c6-0f5fde960350)|![Screenshot 2024-10-16 at 2 53 10 PM](https://github.com/user-attachments/assets/3a942ca2-e4d1-4806-847a-9bd760a0b0a8)|


## Testing in `sage-lib`

- Navigate to [Docs Site](http://localhost:4000/pages/index)
- Throttle page load in dev tools network panel
- Reload the page, verify buttons no longer show with default serif 👎🏼 
- Verify buttons show new backups




## Testing in `kajabi-products`
1. (**LOW**) Adjust font-stack for heading font variable.



## Related
N/A
