### PR TITLE
style: correct dropdown select size and fonts

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -244,6 +244,9 @@ $-btn-loading-min-height: rem(36px);
     font-weight: sage-font-weight(regular);
     border-width: 0;
     box-shadow: sage-border-interactive(default);
+    height: rem(40px);
+    font-family: $-body-font-stack;
+    font-weight: sage-font-weight(medium);;
     &:hover {
       box-shadow: sage-border-interactive(hover);
     }

--- a/packages/sage-assets/lib/stylesheets/components/_form_select.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_select.scss
@@ -96,7 +96,7 @@ $-select-arrow-position-inverse-with-message: calc(100% - #{$-select-height + $-
   }
 
   .sage-select--value-selected & {
-    color: sage-color(grey, 900);
+    color: map-get($sage-field-colors, default);
   }
 
   .sage-select--value-selected &:not(:disabled) + .sage-select__arrow::before {


### PR DESCRIPTION
## Description
Dropdown select variant height and fonts are incorrect due to button changes
This PR updates the dropdown select size and fonts to match other inputs.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|


## Testing in `sage-lib`
Navigate to Dropdown
Check font is now Inter and height is now 40px.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
