### PR TITLE
style: add :focus to correct styles on button focus

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -533,6 +533,7 @@ a.sage-btn {
         }
       }
       @else if ($-style-type-name == focus) {
+        &:focus,
         &:focus-visible,
         &:active {
           color: map-get($-style-type-configs, color);


### PR DESCRIPTION
## Description
In KP, button colors are incorrect on focus due to focus-visible change. 
This adds back focus for the color adjustments.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-17 at 1 16 07 PM](https://github.com/user-attachments/assets/191fe7c3-e08d-4b0d-918e-8191132d0f37)|![Screenshot 2024-10-17 at 1 14 28 PM](https://github.com/user-attachments/assets/0d747aa7-825a-4f48-8162-f43c4a86ca70)|


## Testing in `sage-lib`

- Navigate to button
- Verify button focus works as expected


## Testing in `kajabi-products`

- Enable bridge
- Navigate around admin
- Verify focus on the buttons displays the correct colors.

1. (**MEDIUM**) Correct button color styles on focus.
   - [ ] Any buttons

## Related
https://kajabi.atlassian.net/browse/DSS-1132
