### PR TITLE
style: removes underline on tabs filter variant

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -31,6 +31,10 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
     background-color: sage-color(grey, 200);
     border-radius: sage-border(radius-x-large);
     @extend %t-sage-body-small-semi;
+
+    &::after {
+      display: none;
+    }
   }
 
   @extend %t-sage-body-semi;


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Removes underline on tabs filter variant.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="251" alt="Screenshot 2024-10-22 at 4 44 00 PM" src="https://github.com/user-attachments/assets/008651c5-c971-4d72-9d2b-5dc1e1ce5cee">|<img width="270" alt="Screenshot 2024-10-22 at 4 42 32 PM" src="https://github.com/user-attachments/assets/b20622b7-02fa-49a0-b21f-082179090917">


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Tabs](http://localhost:4000/pages/component/tabs?tab=preview)
- For the filter variant, click and drag to activate the focus state, or activate focus state in the inspector tools
- Check that there's no mercury outline on the element

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Removes underline on tabs filter variant.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1109](https://kajabi.atlassian.net/browse/DSS-1109)

[DSS-1109]: https://kajabi.atlassian.net/browse/DSS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ