### PR TITLE
style: adjust page heading image background color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_page_heading.scss
@@ -84,7 +84,7 @@ $-page-heading-image-height-mobile: rem(120px);
   grid-area: image;
   overflow: hidden;
   min-height: $-page-heading-image-height-min;
-  background: sage-color(grey, 300);
+  background: sage-color(grey, 100);
   border-radius: sage-border(radius);
   border: sage-border();
 


### PR DESCRIPTION
## Description
The page heading image has an incorrect background color which causes some instances in KP to look incorrect.

This change updates the background color to match the new site background.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-22 at 4 02 06 PM](https://github.com/user-attachments/assets/660d1242-577b-45ee-bc2c-07c42a6fac9f)|![Screenshot 2024-10-22 at 3 52 20 PM](https://github.com/user-attachments/assets/7ede0821-a418-4da7-b2a3-4e9569fe2f95)|


## Testing in `sage-lib`
Navigate to Page Heading
Verify image background color is updated.


## Testing in `kajabi-products`
1. (**LOW**) Adjust the page heading background color.


## Related
https://kajabi.atlassian.net/browse/DSS-1077