### PR TITLE
style: dropdown select has incorrect height applied

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -245,7 +245,7 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-dropdown__trigger--select & {
-    height: rem(40px);
+    min-height: rem(40px);
     font-family: $-body-font-stack;
     font-weight: sage-font-weight(medium);
     border-width: 0;


### PR DESCRIPTION
## Description
The dropdown select variant has a `height` applied to help match other inputs, but it should be updated to `min-height` since this variant allows items to have custom content.

Updates fixed `height` to `min-height` to eliminate the issue.

## Screenshots
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-10-28 at 2 42 29 PM](https://github.com/user-attachments/assets/8d9fa138-8b49-4e6c-8d19-417fe532fb38)|![Screenshot 2024-10-28 at 2 44 19 PM](https://github.com/user-attachments/assets/0a714797-ca9f-4cd4-b2f3-9bfa74312ff6)|


## Testing in `sage-lib`
Navigate to Dropdown
Verify select variant updates properly when selecting an option.


## Testing in `kajabi-products`
1. (**MEDIUM**) Adjusted the height of the dropdown select variant.
   - [ ] Coaching >> Group Coaching >> Scheduling (Scheduling preference dropdown.)


## Related
https://kajabi.atlassian.net/browse/DSS-1138
