### PR TITLE
style: adjust padding on bulk actions

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_checkbox.scss
@@ -125,7 +125,7 @@ $-checkbox-focus-outline-color: sage-color(purple, 300);
 
   .sage-panel-controls__bulk-actions--checked & {
     display: unset;
-    padding-block-end: sage-spacing(sm);
+    padding-inline-end: sage-spacing(sm);
   }
 }
 


### PR DESCRIPTION
## Description
In the panel controls component the bulk actions checkbox has incorrect padding when checked.
The PR corrects the padding.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-11-15 at 4 19 15 PM](https://github.com/user-attachments/assets/4f769458-2075-4a80-98e5-384bae501c97)|![Screenshot 2024-11-15 at 4 03 17 PM](https://github.com/user-attachments/assets/3925f290-a31d-464c-ac69-3dbcfbd8445a)|


## Testing in `sage-lib`

- Navigate to [Panel Controls](http://localhost:4000/pages/component/panel_controls?tab=preview)
- Click the bulk actions checkbox
- Verify the padding is corrected.


## Testing in `kajabi-products`
1. (**LOW**) Updates padding of panel controls checkbox


## Related
https://kajabi.atlassian.net/browse/DSS-1171
