### PR TITLE
Empty state: add text wrap balance to empty state text

### DIFF
--- a/docs/app/views/examples/components/empty_state/_preview.html.erb
+++ b/docs/app/views/examples/components/empty_state/_preview.html.erb
@@ -2,7 +2,7 @@
 <%= sage_component SageEmptyState, {
   icon: "trash",
   title: "Title for state",
-  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor."
+  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor. Lorem ipsum dolor sit amet consectituor.",
 } do %>
   <p>Other stuff such as buttons...</p>
 <% end %>
@@ -12,7 +12,7 @@
 <%= sage_component SageEmptyState, {
   icon: "bold",
   title: "Title for state, compact variety",
-  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor.",
+  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor. Lorem ipsum dolor sit amet consectituor. Lorem ipsum dolor sit amet consectituor.",
   size: "compact",
 } do %>
   <p>Other stuff such as buttons...</p>
@@ -22,7 +22,7 @@
 <%= sage_component SageEmptyState, {
   graphic: image_tag("card-placeholder-lg.png", alt: ""),
   title: "Title for state, with graphic instead of icon",
-  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor.",
+  text: "Text to appear below. Lorem ipsum dolor sit amet consectituor. Lorem ipsum dolor sit amet consectituor. Lorem ipsum dolor sit amet consectituor.",
 } do %>
   <p>Other stuff such as buttons...</p>
 <% end %>

--- a/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_empty_state.scss
@@ -90,6 +90,7 @@ $-empty-state-icon-compact-size: rem(56px);
   @extend %t-sage-body;
 
   word-wrap: break-word;
+  text-wrap: balance;
 }
 
 .sage-empty-state__text,


### PR DESCRIPTION
## Description
[DSS-1195](https://kajabi.atlassian.net/browse/DSS-1195)
Implement `text-wrap: balance` to create a more visually appealing appearance to text in an empty state. Balancing the text wrapping leads to even distribution of text between lines, making the text easier to read and more aesthetically pleasing.

[Browser support](https://caniuse.com/css-text-wrap-balance) is supported across the major browsers: Chrome, Firefox, Edge, and Safari

## Solution
* Add `text-wrap: balance` to `.sage-empty-state__text`
* Add more text in the examples to showcase the use of balanced text wrapping

### Screenshots
|  Before  |  After  |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/1419c5fe-806d-4bb3-a407-6aeb9a462d76) | ![after](https://github.com/user-attachments/assets/38881ea8-9825-4983-995b-14ad24a1c18b) |


## Testing in `sage-lib`
1. navigate to http://localhost:4000/pages/component/empty_state?tab=preview
2. verify that the text wraps appropriately if you add more content in the empty state text slot


## Testing in `kajabi-products`
1. (**LOW**) This CSS style is low impact, no QE needed


[DSS-1195]: https://kajabi.atlassian.net/browse/DSS-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ