### PR TITLE
docs: update broken image paths

### DIFF
--- a/docs/app/views/examples/components/media_tile/_preview.html.erb
+++ b/docs/app/views/examples/components/media_tile/_preview.html.erb
@@ -32,7 +32,7 @@ panels = [
     caption: %(
       <p>Vivamus dictum rutrum dui, nec placerat ante</p>
     ),
-    media: %(<img src="/assets/card-placeholder-lg.png" alt="Image of Product Abra" />),
+    media: %(#{image_tag("card-placeholder-lg.png", alt: "media tile image placeholder")}),
     title: "Product Abra",
   },
   {
@@ -44,7 +44,7 @@ panels = [
     caption: %(
       <p>Suspendisse eu tellus quis arcu sagittis semper</p>
     ),
-    media: %(<img src="/assets/card-placeholder-lg.png" alt="Image of Product Cadabra" />),
+    media: %(#{image_tag("card-placeholder-lg.png", alt: "media tile image placeholder")}),
     title: "Product Cadabra",
   },
   {
@@ -56,7 +56,7 @@ panels = [
     caption: %(
       <p>Maecenas vitae leo eu tellus efficitur viverra sit amet ut tortor vestibulum</p>
     ),
-    media: %(<img src="/assets/card-placeholder-lg.png" alt="Image of Product Jimminycricket" />),
+    media: %(#{image_tag("card-placeholder-lg.png", alt: "media tile image placeholder")}),
     title: "Product Jimminycricket",
   },
 ]

--- a/docs/app/views/examples/components/upload_card/_preview.html.erb
+++ b/docs/app/views/examples/components/upload_card/_preview.html.erb
@@ -33,7 +33,7 @@
   ],
   file_selected: true,
   accepted_file_types: ["image/jpg"],
-  selection_preview: "https://placekitten.com/360",
+  selection_preview: "hero-workshop-placeholder.jpg",
   selection_label: "Replace file",
   id: "upload-card-selected",
 } do %>
@@ -53,7 +53,7 @@
     {name: "my-image-file.jpg"},
   ],
   file_selected: true,
-  selection_preview: "https://placekitten.com/360",
+  selection_preview: "hero-workshop-placeholder.jpg",
   stack_layout: true,
   id: "upload-card-stack",
   selection_label: "Edit file",
@@ -72,11 +72,11 @@
 <p><strong>NOTE:</strong> a file input field and label are <em>included by default in the base component</em>, as seen in the examples above. When applying a custom file input with `sage_upload_card_actions`, set <code>custom_file_input_field</code> to <code>true</code> to remove these defaults.</p>
 <%= sage_component SageUploadCard, {
   accepted_files: [
-    {name: "fluffy-kitteh.jpg"},
+    {name: "my-image-file.jpg"},
   ],
   custom_file_input_field: true,
   file_selected: true,
-  selection_preview: "https://placekitten.com/360",
+  selection_preview: "hero-workshop-placeholder.jpg",
   id: "upload-card-dropdown"
 } do %>
   <% content_for :sage_upload_card_actions do %>


### PR DESCRIPTION
## Description
Noticed that on the upload card and media tile docs pages, the images are broken.
Adjusts the image paths so that images load properly.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-11-27 at 3 43 32 PM](https://github.com/user-attachments/assets/410a0999-77e5-49da-9eb3-c5f4ede97aef)|![Screenshot 2024-11-27 at 3 43 45 PM](https://github.com/user-attachments/assets/03a2c921-a920-486a-946a-104fc0429a9b)|
|![Screenshot 2024-11-27 at 3 45 34 PM](https://github.com/user-attachments/assets/35fce72e-00cb-48e7-93e3-54f247578599)|![Screenshot 2024-11-27 at 3 44 45 PM](https://github.com/user-attachments/assets/b82a4f8d-5ac4-401f-95d5-67fe088f2df0)|

## Testing in `sage-lib`
Navigate to [upload card](http://localhost:4000/pages/component/upload_card?tab=preview)
Verify images loading

Navigate to [media tile](http://localhost:4000/pages/component/media_tile?tab=preview)
Verify images are loading


## Testing in `kajabi-products`
1. (**LOW**) Documentation update. No effect on KP.

