### PR TITLE
style: update mobile typeahead item styles

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
@@ -6,6 +6,7 @@
 
 
 $-typeahead-item-height: rem(68px);
+$-typeahead-item-width: rem(240px);
 
 
 .sage-typeahead {
@@ -25,6 +26,7 @@ $-typeahead-item-height: rem(68px);
   background-color: sage-color(white);
   border-radius: sage-border(radius);
   box-shadow: sage-shadow(md);
+  min-width: $-typeahead-item-width;
 }
 
 .sage-typeahead__null-state {
@@ -73,6 +75,14 @@ $-typeahead-item-height: rem(68px);
   padding: sage-spacing(md) sage-spacing(sm);
   text-align: left;
 
+  @media (hover: none) {
+    gap: 0;
+
+    pds-icon {
+      display: none;
+    }
+  }
+
   &::after {
     border-radius: 0;
   }
@@ -97,9 +107,12 @@ $-typeahead-item-height: rem(68px);
 }
 
 .sage-typeahead__item-actions {
-  visibility: hidden;
   display: flex;
   flex-wrap: nowrap;
+
+  @media (hover: hover) {
+    visibility: hidden;
+  }
 
   :hover > &,
   :focus-within > & {

--- a/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_typeahead.scss
@@ -20,13 +20,13 @@ $-typeahead-item-width: rem(240px);
   inset-inline-end: 0;
   transform: translateY(#{sage-spacing(2xs)});
   overflow-x: hidden;
+  min-width: $-typeahead-item-width;
   padding: 0;
   list-style: none;
   border: sage-border();
   background-color: sage-color(white);
   border-radius: sage-border(radius);
   box-shadow: sage-shadow(md);
-  min-width: $-typeahead-item-width;
 }
 
 .sage-typeahead__null-state {


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
The Typeahead items have little room for text due to the actions on the right. The actions show on hover, but hover is not supported on mobile. We'll show the actions menu all the time.

- [x] adds `min-width` to Typeahead panel
- [x] mobile - remove icon and spacing

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="369" alt="Screen Shot 2023-01-11 at 10 03 09 AM" src="https://github.com/user-attachments/assets/662889a7-9807-4d06-904b-f7bbce3b2159" />|![Screenshot 2025-01-14 at 2 54 32 PM](https://github.com/user-attachments/assets/4d851f5f-998a-40e9-8dac-b93439b51d91)|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change to verify the changes in `sage-lib` -->
- Go to the [Typeahead preview page](http://localhost:4000/pages/component/typeahead?tab=preview)
- Inspect the page and choose a phone to verify that there is more available room for characters

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Stying update for Typeahead dropdown items for mobile viewports.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
Closes [DSS-265](https://kajabi.atlassian.net/browse/DSS-265)

[DSS-265]: https://kajabi.atlassian.net/browse/DSS-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ