### PR TITLE
fix: remove title attribute from dropdown item label

### DIFF
--- a/packages/sage-react/lib/Dropdown/DropdownItem.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItem.jsx
@@ -119,7 +119,7 @@ export const DropdownItem = ({
           />
           <>
             {icon && (<pds-icon class={`sage-dropdown__item-icon ${SageClassnames.SPACERS.XS_RIGHT}`} name={icon} />)}
-            <span className="sage-dropdown__item-label" title={label}>
+            <span className="sage-dropdown__item-label">
               {label}
             </span>
           </>
@@ -143,7 +143,7 @@ export const DropdownItem = ({
           {(!customComponent && isLabelVisible) && (
             <>
               {icon && (<pds-icon class={`sage-dropdown__item-icon ${SageClassnames.SPACERS.XS_RIGHT}`} name={icon} />)}
-              <span className="sage-dropdown__item-label" title={label}>
+              <span className="sage-dropdown__item-label">
                 {label}
               </span>
             </>
@@ -165,7 +165,7 @@ export const DropdownItem = ({
         {(!customComponent && isLabelVisible) && (
           <>
             {icon && (<pds-icon class={`sage-dropdown__item-icon ${SageClassnames.SPACERS.XS_RIGHT}`} name={icon} />)}
-            <span className="sage-dropdown__item-label" title={label}>
+            <span className="sage-dropdown__item-label">
               {label}
             </span>
           </>


### PR DESCRIPTION
## Description
Title attribute in React DropdownItem displays [object object] in KP with generated list items.

This PR removes the title from the labels since it's already a duplicate of the actual label text.

## Screenshots
|  Before   |  After  |
|--------|--------|
|![Screenshot 2025-01-16 at 10 58 26 AM](https://github.com/user-attachments/assets/89e12882-bf4e-4eaf-a94c-8b46f5b404a5)|![Screenshot 2025-01-16 at 10 58 49 AM](https://github.com/user-attachments/assets/7237458e-e5e1-46ab-a03a-60105b936c6a)|


## Testing in `sage-lib`

- Navigate to: http://localhost:4100/?path=/docs/sage-dropdown--default
- Open a dropdown and place mouse over one of the links in the menu.
- Verify title no longer appears.


## Testing in `kajabi-products`
1. (**LOW**) Removes title attribute on dropdown item labels.


## Related
https://kajabi.atlassian.net/browse/DSS-1237
