### PR TITLE
fix: remove rtl logical wrapper

### DIFF
--- a/packages/sage-assets/lib/stylesheets/utilities/_spacer.scss
+++ b/packages/sage-assets/lib/stylesheets/utilities/_spacer.scss
@@ -37,9 +37,5 @@ $css-property-map-rtl: (
     .sage-spacer-#{$-box-side}#{$suffix} {
       margin-#{$css-logical-property}: $-value;
     }
-
-    [dir="rtl"] .sage-spacer-#{$-box-side}#{$suffix} {
-      margin-#{$css-logical-property-rtl}: $-value;
-    }
   }
 }


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] remove rtl conditional from spacer function. The nature of the logical property makes this unneeded

## Gif
![margin-rtl](https://github.com/user-attachments/assets/222f9153-959a-4559-8d03-652a97c2bbd8)



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Remove conditional rtl styles


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
