### PR TITLE
fix: remove button role from react modal

### DIFF
--- a/packages/sage-react/lib/Modal/Modal.jsx
+++ b/packages/sage-react/lib/Modal/Modal.jsx
@@ -80,7 +80,6 @@ export const Modal = ({
     attrs.onMouseDown = handleMouseDown;
     attrs.onMouseUp = handleMouseUp;
     attrs.onKeyPress = handleBackgroundKeypress;
-    attrs.role = 'button';
     attrs.tabIndex = '0';
   }
 


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] The react version of the Sage Modal contains role="button" . This treats the entire accessibility tree as a button

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
View the React Modal page and verify that doesn't contain `role="button"`

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Removes `role` attribute from Modal wrapper.
   - [ ] Products -> Courses -> Add Course -> Creation Wizard Full Screen Modal


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1238](https://kajabi.atlassian.net/browse/DSS-1238)

[DSS-1238]: https://kajabi.atlassian.net/browse/DSS-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ