### PR TITLE
style: add selector for icon-only buttons to not rely on icon name

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -113,7 +113,8 @@
 
   // --- Standalone Icon Buttons
   @else if $direction == only {
-    .sage-btn--icon-only-#{$icon-name} {
+    .sage-btn--icon-only-#{$icon-name},
+    [class*="sage-btn--icon-only-"]  {
       justify-content: center;
       text-align: center;
       border-radius: sage-border(radius-round);


### PR DESCRIPTION
## Description
Since we no longer update the icon list in Sage, this has caused a padding issue on the icon-only buttons when new icons are added to the system.

Currently, the generated class names include the icon name. We should adjust the style selector so the icon name is unnecessary since we no longer update the list of icons in Sage.

This PR adjusts the CSS selector so the icon name is not required.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-01-30 at 12 06 54 PM](https://github.com/user-attachments/assets/52e63183-d7ba-411c-9f19-984955d766a6)|![Screenshot 2025-01-30 at 12 06 38 PM](https://github.com/user-attachments/assets/d3476fe2-58fe-4e45-bd3b-99daf13b3485)|


## Testing in `sage-lib`

- Navigate to docs site
- On one of the icon-only buttons change the class name to an icon that does not exist (`sage-btn--icon-only-file-search`)
- Verify that the padding is correct on the button and it remains round.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) style fix for icon-only buttons that have new icons.


## Related
https://kajabi.atlassian.net/browse/DSS-1249
