### PR TITLE
style: updates avatar styles and tokens

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -46,13 +46,13 @@ end
       <%= sage_component SageIcon, {
         icon: component.badge_icon ? component.badge_icon : "check-circle-filled",
         size: badge_icon_size,
-        color: component.badge_foregroundColor ? component.badge_foregroundColor : "primary-300",
+        color: component.badge_foregroundColor ? component.badge_foregroundColor : "purple-600",
       } %>
     </div>
   <% end %>
 
   <% if !component.initials && !component.image %>
-    <svg class="sage-avatar__graphic" viewBox="0 0 28 28"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.038 14.594a8.167 8.167 0 1 0-10.077 0C3.767 16.236 0 21.094 0 26.834a1.167 1.167 0 1 0 2.333 0c0-5.8 4.701-10.5 10.5-10.5h2.334c5.799 0 10.5 4.7 10.5 10.5a1.167 1.167 0 1 0 2.333 0c0-5.74-3.766-10.598-8.962-12.24ZM8.167 8.167a5.833 5.833 0 1 1 11.666 0 5.833 5.833 0 0 1-11.666 0Z" fill="#054FB8"/></svg>
+    <pds-icon name="user-filled" color="var(--pine-color-mercury-500)" class="sage-avatar__graphic"></pds-icon>
   <% end %>
 
   <% if component.image %>

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -5,8 +5,8 @@
 ////
 
 
-$-avatar-min-size: rem(32px);
-$-avatar-max-size: rem(128px);
+$-avatar-min-size: var(--pine-dimension-lg);
+$-avatar-max-size: calc(2 * var(--pine-dimension-800));
 $-avatar-ring-colors: (
   charcoal: (
     main: var(--pine-color-primary-hover),
@@ -38,7 +38,7 @@ $-avatar-ring-colors: (
   )
 );
 $-avatar-tile-size: rem(216px);
-$-avatar-group-size: rem(80px);
+$-avatar-group-size: calc(2 * var(--pine-dimension-xl));
 $-avatar-group-item-sizes: (
   1: var(--pine-dimension-2xl),
   2: var(--pine-dimension-lg),
@@ -95,8 +95,8 @@ $-avatar-group-item-sizes: (
 
     // Positioning is same for first item is same in all configs
     &:nth-child(1) {
-      inset-block-start: 0;
-      inset-inline-start: 0;
+      inset-block-start: var(--pine-dimension-none);
+      inset-inline-start: var(--pine-dimension-none);
     }
   }
 
@@ -109,11 +109,11 @@ $-avatar-group-item-sizes: (
   .sage-avatar-group--4-up & {
     &:nth-child(2) {
       inset-block-end: var(--pine-dimension-sm);
-      inset-inline-end: 0;
+      inset-inline-end: var(--pine-dimension-none);
     }
 
     &:nth-child(3) {
-      inset-block-end: 0;
+      inset-block-end: var(--pine-dimension-none);
       inset-inline-start: var(--pine-dimension-sm);
     }
 
@@ -154,8 +154,8 @@ $-avatar-group-item-sizes: (
 .sage-avatar__badge {
   position: absolute;
   z-index: sage-z-index(default, 3);
-  inset-block-end: calc(var(--pine-dimension-2xs) * -1);
-  inset-inline-end: calc(var(--pine-dimension-2xs) * -1);
+  inset-block-end: calc(-1 * var(--pine-dimension-2xs));
+  inset-inline-end: calc(-1 * var(--pine-dimension-2xs));
   background-color: var(--pine-color-secondary);
   border-radius: var(--pine-border-radius-full);
   border: var(--pine-dimension-025) solid var(--pine-color-secondary);
@@ -170,7 +170,7 @@ $-avatar-group-item-sizes: (
   }
 
   .sage-avatar--custom-badge & {
-    border: 0;
+    border: var(--pine-dimension-none);
   }
 }
 

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -9,19 +9,19 @@ $-avatar-min-size: rem(32px);
 $-avatar-max-size: rem(128px);
 $-avatar-ring-colors: (
   charcoal: (
-    main: var(--pine-color-grey-950),
+    main: var(--pine-color-primary-hover),
     bg: var(--pine-color-grey-200)
   ),
   grey: (
-    main: var(--pine-color-grey-950),
+    main: var(--pine-color-primary-hover),
     bg: var(--pine-color-grey-200)
   ),
   purple: (
-    main: var(--pine-color-purple-600),
+    main: var(--pine-color-accent-hover),
     bg: var(--pine-color-purple-150)
   ),
   sage: (
-    main: var(--pine-color-green-600),
+    main: var(--pine-color-success-hover),
     bg: var(--pine-color-green-150)
   ),
   yellow: (
@@ -29,21 +29,21 @@ $-avatar-ring-colors: (
     bg: var(--pine-color-yellow-150)
   ),
   orange: (
-    main: var(--pine-color-mercury-500),
+    main: var(--pine-color-brand),
     bg: var(--pine-color-mercury-150)
   ),
   red: (
-    main: var(--pine-color-red-500),
+    main: var(--pine-color-danger),
     bg: var(--pine-color-red-150)
   )
 );
 $-avatar-tile-size: rem(216px);
 $-avatar-group-size: rem(80px);
 $-avatar-group-item-sizes: (
-  1: rem(48px),
-  2: rem(32px),
-  3: rem(24px),
-  4: rem(16px),
+  1: var(--pine-dimension-2xl),
+  2: var(--pine-dimension-lg),
+  3: var(--pine-dimension-md),
+  4: var(--pine-dimension-sm),
 );
 
 
@@ -68,7 +68,7 @@ $-avatar-group-item-sizes: (
 
   // Documentation-specific styles
   .sage-avatar-wrapper > & {
-    margin-inline-end: var(--pine-dimension-300);
+    margin-inline-end: var(--pine-dimension-md);
   }
 
   .sage-table td > & {
@@ -108,18 +108,18 @@ $-avatar-group-item-sizes: (
   .sage-avatar-group--3-up &,
   .sage-avatar-group--4-up & {
     &:nth-child(2) {
-      inset-block-end: rem(16px);
+      inset-block-end: var(--pine-dimension-sm);
       inset-inline-end: 0;
     }
 
     &:nth-child(3) {
       inset-block-end: 0;
-      inset-inline-start: rem(16px);
+      inset-inline-start: var(--pine-dimension-sm);
     }
 
     &:nth-child(4) {
-      inset-block-start: rem(8px);
-      inset-inline-end: rem(8px);
+      inset-block-start: var(--pine-dimension-xs);
+      inset-inline-end: var(--pine-dimension-xs);
     }
   }
 }
@@ -133,11 +133,11 @@ $-avatar-group-item-sizes: (
 .sage-avatar-wrapper {
   display: flex;
   flex-wrap: wrap;
-  margin-block-end: var(--pine-dimension-300);
+  margin-block-end: var(--pine-dimension-md);
 }
 
 .sage-avatar--tile {
-  padding: var(--pine-dimension-300);
+  padding: var(--pine-dimension-md);
   border-radius: initial;
 
   @include avatar-scaling;
@@ -154,11 +154,11 @@ $-avatar-group-item-sizes: (
 .sage-avatar__badge {
   position: absolute;
   z-index: sage-z-index(default, 3);
-  inset-block-end: rem(-4px);
-  inset-inline-end: rem(-4px);
-  background-color: var(--pine-color-white);
+  inset-block-end: calc(var(--pine-dimension-2xs) * -1);
+  inset-inline-end: calc(var(--pine-dimension-2xs) * -1);
+  background-color: var(--pine-color-secondary);
   border-radius: var(--pine-border-radius-full);
-  border: rem(2px) solid var(--pine-color-white);
+  border: var(--pine-dimension-025) solid var(--pine-color-secondary);
 
   &.sage-avatar__badge--custom-bg {
     background-color: var(--badge-custom-bg-color);
@@ -178,8 +178,8 @@ $-avatar-group-item-sizes: (
   grid-area: full;
   width: 100%;
   text-align: center;
-  color: var(--pine-color-mercury-500);
-  fill: var(--pine-color-mercury-500);
+  color: var(--pine-color-brand);
+  fill: var(--pine-color-brand);
 
   @extend %t-sage-body-xsmall-bold;
 
@@ -228,6 +228,6 @@ $-avatar-group-item-sizes: (
 
   // Documentation-specific styles
   .sage-avatar-wrapper & {
-    margin-inline-end: var(--pine-dimension-300);
+    margin-inline-end: var(--pine-dimension-md);
   }
 }

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -9,32 +9,32 @@ $-avatar-min-size: rem(32px);
 $-avatar-max-size: rem(128px);
 $-avatar-ring-colors: (
   charcoal: (
-    main: sage-color(grey, 950),
-    bg: sage-color(grey, 200)
+    main: var(--pine-color-grey-950),
+    bg: var(--pine-color-grey-200)
   ),
   grey: (
-    main: sage-color(grey, 950),
-    bg: sage-color(grey, 200)
+    main: var(--pine-color-grey-950),
+    bg: var(--pine-color-grey-200)
   ),
   purple: (
-    main: sage-color(purple, 600),
-    bg: sage-color(purple, 150)
+    main: var(--pine-color-purple-600),
+    bg: var(--pine-color-purple-150)
   ),
   sage: (
-    main: sage-color(sage, 300),
-    bg: sage-color(sage, 100)
+    main: var(--pine-color-green-600),
+    bg: var(--pine-color-green-150)
   ),
   yellow: (
-    main: sage-color(yellow, 400),
-    bg: sage-color(yellow, 150)
+    main: var(--pine-color-yellow-400),
+    bg: var(--pine-color-yellow-150)
   ),
   orange: (
-    main: sage-color(orange, 300),
-    bg: sage-color(orange, 100)
+    main: var(--pine-color-mercury-500),
+    bg: var(--pine-color-mercury-150)
   ),
   red: (
-    main: sage-color(red, 500),
-    bg: sage-color(red, 150)
+    main: var(--pine-color-red-500),
+    bg: var(--pine-color-red-150)
   )
 );
 $-avatar-tile-size: rem(216px);
@@ -63,17 +63,17 @@ $-avatar-group-item-sizes: (
   position: relative;
   width: $-avatar-min-size;
   height: $-avatar-min-size;
-  border-radius: sage-border(radius-round);
-  background-color: sage-color(primary, 100);
+  border-radius: var(--pine-border-radius-full);
+  background-color: var(--pine-color-mercury-050);
 
   // Documentation-specific styles
   .sage-avatar-wrapper > & {
-    margin-inline-end: sage-spacing();
+    margin-inline-end: var(--pine-dimension-300);
   }
 
   .sage-table td > & {
-    margin-block-start: -1 * sage-spacing(2xs);
-    margin-block-end: -1 * sage-spacing(2xs);
+    margin-block-start: calc(-1 * var(--pine-dimension-050));
+    margin-block-end: calc(-1 * var(--pine-dimension-050));
   }
 
   // Items inside avatar group should be 100% to start
@@ -133,11 +133,11 @@ $-avatar-group-item-sizes: (
 .sage-avatar-wrapper {
   display: flex;
   flex-wrap: wrap;
-  margin-block-end: sage-spacing();
+  margin-block-end: var(--pine-dimension-300);
 }
 
 .sage-avatar--tile {
-  padding: sage-spacing(md);
+  padding: var(--pine-dimension-300);
   border-radius: initial;
 
   @include avatar-scaling;
@@ -156,9 +156,9 @@ $-avatar-group-item-sizes: (
   z-index: sage-z-index(default, 3);
   inset-block-end: rem(-4px);
   inset-inline-end: rem(-4px);
-  background-color: sage-color(white);
-  border-radius: sage-border(radius-round);
-  border: rem(2px) solid sage-color(white);
+  background-color: var(--pine-color-white);
+  border-radius: var(--pine-border-radius-full);
+  border: rem(2px) solid var(--pine-color-white);
 
   &.sage-avatar__badge--custom-bg {
     background-color: var(--badge-custom-bg-color);
@@ -178,8 +178,8 @@ $-avatar-group-item-sizes: (
   grid-area: full;
   width: 100%;
   text-align: center;
-  color: sage-color(primary, 400);
-  fill: sage-color(primary, 400);
+  color: var(--pine-color-mercury-500);
+  fill: var(--pine-color-mercury-500);
 
   @extend %t-sage-body-xsmall-bold;
 
@@ -205,7 +205,7 @@ $-avatar-group-item-sizes: (
   grid-area: full;
   height: 100%;
   width: 100%;
-  border-radius: sage-border(radius-round);
+  border-radius: var(--pine-border-radius-full);
   object-fit: cover;
 
   .sage-avatar--tile & {
@@ -228,6 +228,6 @@ $-avatar-group-item-sizes: (
 
   // Documentation-specific styles
   .sage-avatar-wrapper & {
-    margin-inline-end: sage-spacing();
+    margin-inline-end: var(--pine-dimension-300);
   }
 }

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { PdsIcon } from '@pine-ds/react';
 import { SageTokens } from '../configs';
 import { Icon } from '../Icon';
 import { AVATAR_COLORS } from './configs';
@@ -82,7 +83,7 @@ export const Avatar = ({
         <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
       )}
       {(!image.src || useFallbackGraphic) && (
-        <svg className="sage-avatar__graphic" viewBox="0 0 28 28"><path fillRule="evenodd" clipRule="evenodd" d="M19.038 14.594a8.167 8.167 0 1 0-10.077 0C3.767 16.236 0 21.094 0 26.834a1.167 1.167 0 1 0 2.333 0c0-5.8 4.701-10.5 10.5-10.5h2.334c5.799 0 10.5 4.7 10.5 10.5a1.167 1.167 0 1 0 2.333 0c0-5.74-3.766-10.598-8.962-12.24ZM8.167 8.167a5.833 5.833 0 1 1 11.666 0 5.833 5.833 0 0 1-11.666 0Z" fill="#054FB8" /></svg>
+        <PdsIcon name="user-filled" color="var(--pine-color-mercury-500)" className="sage-avatar__graphic" />
       )}
     </div>
   );

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { PdsIcon } from '@pine-ds/react';
 import { SageTokens } from '../configs';
 import { Icon } from '../Icon';
 import { AVATAR_COLORS } from './configs';
@@ -83,7 +82,7 @@ export const Avatar = ({
         <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
       )}
       {(!image.src || useFallbackGraphic) && (
-        <PdsIcon name="user-filled" color="var(--pine-color-mercury-500)" className="sage-avatar__graphic" />
+        <pds-icon name="user-filled" color="var(--pine-color-mercury-500)" className="sage-avatar__graphic" />
       )}
     </div>
   );


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates Avatar styles and tokens to match Pine.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="603" alt="Screenshot 2025-02-04 at 10 47 40 AM" src="https://github.com/user-attachments/assets/38c2eea7-b49e-4653-98b4-c57379be77bb" />|<img width="817" alt="Screenshot 2025-02-03 at 5 37 07 PM" src="https://github.com/user-attachments/assets/53b6c311-6c22-4283-9d32-10d00fe65fe9" />


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Rails](http://localhost:4000/pages/component/avatar?tab=preview] and [React](http://localhost:4100/?path=/docs/sage-avatar--default)
- Check that styles match Pine branch `style/new-tokensets`

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Updates Avatar styles and tokens to match Pine.



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1255](https://kajabi.atlassian.net/browse/DSS-1255)

[DSS-1255]: https://kajabi.atlassian.net/browse/DSS-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ