### PR TITLE
style: updates button styles to match Pine

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -10,105 +10,105 @@
 // Base style variables
 //
 $-btn-transition: map-get($sage-transitions, default);
-$-btn-base-padding-block: sage-spacing(xs); // vertical (y) axis
-$-btn-base-padding-inline: sage-spacing(sm); // horizontal (x) axis
-$-btn-base-line-height: var(--sage-line-height-body, #{rem(24px)});
-$-btn-border-radius: 9999px;
-$-btn-shadow-base: sage-shadow(050);
-$-btn-icon-only-standard-size: rem(40px);
-$-btn-icon-only-subtle-size: rem(16px);
-$-btn-icon-only-hover-size: rem(24px);
-$-btn-icon-only-focus-size: rem(32px);
-$-btn-toolbar-group-height: rem(40px);
+$-btn-base-padding-block: var(--pine-dimension-xs); // vertical (y) axis
+$-btn-base-padding-inline: var(--pine-dimension-sm); // horizontal (x) axis
+$-btn-base-line-height: var(--pine-line-height-body);
+$-btn-border-radius: var(--pine-border-radius-full);
+$-btn-shadow-base: var(--pine-box-shadow-050);
+$-btn-icon-only-standard-size: var(--pine-dimension-xl);
+$-btn-icon-only-subtle-size: var(--pine-dimension-sm);
+$-btn-icon-only-hover-size: var(--pine-dimension-md);
+$-btn-icon-only-focus-size: var(--pine-dimension-lg);
+$-btn-toolbar-group-height: var(--pine-dimension-xl);
 $-btn-disclosure-left-padding: rem(26px);
 
 $-btn-base-styles: (
   accent: (
     default: (
-      color: sage-color(white),
-      background-color: sage-color(purple, 500),
-      border-color: sage-color(purple, 500),
-      ring-color: sage-color(purple, 300),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-accent),
+      border-color: var(--pine-color-accent),
+      ring-color: var(--pine-color-focus-ring),
     ),
     hover: (
-      color: sage-color(white),
-      background-color: sage-color(purple, 600),
-      border-color: sage-color(purple, 600),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-accent-hover),
+      border-color: var(--pine-color-accent-hover),
     ),
     focus: (
-      color: sage-color(white),
-      background-color: sage-color(purple, 500),
-      border-color: sage-color(purple, 500),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-accent),
+      border-color: var(--pine-color-accent),
     ),
     disabled: (
-      color: sage-color(purple, 300),
-      background-color: sage-color(purple, 150),
-      border-color: sage-color(purple, 150),
+      color: var(--pine-color-text-accent-disabled),
+      background-color: var(--pine-color-accent-disabled),
+      border-color: var(--pine-color-accent-disabled),
     )
   ),
   primary: (
     default: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 900),
-      border-color: sage-color(grey, 900),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-primary),
+      border-color: var(--pine-color-primary),
       ring-color: sage-color(purple, 300),
     ),
     hover: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 950),
-      border-color: sage-color(grey, 950),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-primary-hover),
+      border-color: var(--pine-color-primary-hover),
     ),
     focus: (
-      color: sage-color(white),
-      background-color: sage-color(grey, 900),
-      border-color: sage-color(grey, 900),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-primary),
+      border-color: var(--pine-color-primary),
     ),
     disabled: (
-      color: sage-color(grey, 400),
-      background-color: sage-color(grey, 150),
-      border-color: sage-color(grey, 150),
+      color: var(--pine-color-text-primary-disabled),
+      background-color: var(--pine-color-primary-disabled),
+      border-color: var(--pine-color-primary-disabled),
     )
   ),
   secondary: (
     default: (
-      color: sage-color(grey, 800),
-      background-color: sage-color(white),
-      ring-color: sage-color(purple, 300),
+      color: var(--pine-color-text-secondary),
+      background-color: var(--pine-color-secondary),
+      ring-color: var(--pine-color-focus-ring),
     ),
     hover: (
-      color: sage-color(grey, 950),
-      background-color: sage-color(grey, 100),
+      color: var(--pine-color-text-secondary-hover),
+      background-color: var(--pine-color-secondary-hover),
     ),
     focus: (
-      color: sage-color(grey, 900),
-      background-color: sage-color(white),
+      color: var(--pine-color-text-secondary),
+      background-color: var(--pine-color-secondary),
     ),
     disabled: (
-      color: sage-color(grey, 600),
-      background-color: sage-color(grey, 100),
+      color: var(--pine-color-text-secondary-disabled),
+      background-color: var(--pine-color-secondary-disabled),
     )
   ),
   danger: (
     default: (
-      color: sage-color(white),
-      background-color: sage-color(red, 500),
-      border-color: sage-color(red, 500),
-      ring-color: sage-color(red, 300),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-danger),
+      border-color: var(--pine-color-danger),
+      ring-color: var(--pine-color-focus-ring-danger),
     ),
     hover: (
-      color: sage-color(white),
-      background-color: sage-color(red, 600),
-      border-color: sage-color(red, 600),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-danger-hover),
+      border-color: var(--pine-color-danger-hover),
     ),
     focus: (
-      color: sage-color(white),
-      background-color: sage-color(red, 500),
-      border-color: sage-color(red, 500),
+      color: var(--pine-color-text-primary),
+      background-color: var(--pine-color-danger),
+      border-color: var(--pine-color-danger),
     ),
     disabled: (
-      color: sage-color(red, 300),
-      background-color: sage-color(red, 150),
-      border-color: sage-color(red, 150),
+      color: var(--pine-color-text-danger-disabled),
+      background-color: var(--pine-color-danger-disabled),
+      border-color: var(--pine-color-danger-disabled),
     )
   ),
 );
@@ -166,7 +166,7 @@ $-alert-close-btn-background-colors: (
 //
 // Custom variables
 //
-$-btn-interactive-badge-icon-size: rem(24px);
+$-btn-interactive-badge-icon-size: var(--pine-dimension-md);
 $-btn-loading-min-height: rem(36px);
 
 // stylelint-disable max-nesting-depth
@@ -217,7 +217,7 @@ $-btn-loading-min-height: rem(36px);
     border-radius: inherit;
 
     &:hover {
-      background-color: sage-color(white);
+      background-color: var(--pine-color-secondary);
     }
   }
 
@@ -233,11 +233,11 @@ $-btn-loading-min-height: rem(36px);
     width: 100%;
     padding-block-start: rem(9px);
     padding-block-end: rem(9px);
-    border-radius: 0;
+    border-radius: var(--pine-dimension-none);
   }
 
   .sage-dropdown__trigger > & {
-    line-height: sage-line-height(body);
+    line-height: var(--pine-line-height-body);
   }
 
   .sage-dropdown__trigger--custom-width > & {
@@ -245,10 +245,10 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-dropdown__trigger--select & {
-    min-height: rem(40px);
+    min-height: var(--pine-dimension-xl);
     font-family: $-body-font-stack;
-    font-weight: sage-font-weight(medium);
-    border-width: 0;
+    font-weight: var(--pine-font-weight-medium);
+    border-width: var(--pine-dimension-none);
     box-shadow: sage-border-interactive(default);
     &:hover {
       box-shadow: sage-border-interactive(hover);
@@ -264,7 +264,7 @@ $-btn-loading-min-height: rem(36px);
     width: 100%;
 
     &::before {
-      margin-inline-end: 0;
+      margin-inline-end: var(--pine-dimension-none);
     }
 
     &::after {
@@ -273,40 +273,40 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-input-group & {
-    border-start-start-radius: 0;
-    border-end-start-radius: 0;
+    border-start-start-radius: var(--pine-dimension-none);
+    border-end-start-radius: var(--pine-dimension-none);
   }
 
   .sage-badge & {
     display: flex;
     justify-content: center;
     position: absolute;
-    inset-inline-end: 0;
+    inset-inline-end: var(--pine-dimension-none);
     width: $-btn-interactive-badge-icon-size;
-    margin: auto 0;
-    border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
+    margin: auto var(--pine-dimension-none);
+    border-radius: var(--pine-dimension-none) sage-border(radius-x-large) sage-border(radius-x-large) var(--pine-dimension-none);
 
     &::before {
       transform: translateY(1px); /* needed as sage-font-size(sm) equates to 13px, not 14px. This 1px is accounting for that 1px */
-      font-size: sage-font-size(sm);
+      font-size: var(--pine-font-size-body-sm);
     }
 
     &::after {
       width: $-btn-interactive-badge-icon-size;
       height: $-btn-interactive-badge-icon-size;
-      border-radius: 0 sage-border(radius-x-large) sage-border(radius-x-large) 0;
+      border-radius: var(--pine-dimension-none) sage-border(radius-x-large) sage-border(radius-x-large) var(--pine-dimension-none);
     }
 
     &:first-child:not(:last-child) {
-      margin-inline-end: sage-spacing(xs);
+      margin-inline-end: var(--pine-dimension-xs);
     }
 
     + & {
-      margin-inline-start: 0;
+      margin-inline-start: var(--pine-dimension-none);
     }
 
     &.sage-btn--tag::before {
-      font-size: sage-font-size(md, false);
+      font-size: var(--pine-font-size-body-md);
     }
   }
 
@@ -315,7 +315,7 @@ $-btn-loading-min-height: rem(36px);
   }
   .sage-sortable__item-actions & {
     &:not(:last-child) {
-      margin-inline-end: sage-spacing(sm);
+      margin-inline-end: var(--pine-dimension-sm);
     }
   }
 
@@ -325,14 +325,14 @@ $-btn-loading-min-height: rem(36px);
     inset-inline-end: rem(1px);
     bottom: rem(1px);
     height: rem(38px);
-    background-color: sage-color(white);
-    box-shadow: rem(-1px) 0 0 0 sage-color(grey, 300);
+    background-color: var(--pine-color-secondary);
+    box-shadow: rem(-1px) 0 0 0 var(--pine-color-grey-300);
     border-color: transparent;
 
     @include sage-focus-outline--update-color(transparent);
 
     &::before {
-      margin-inline-end: 0;
+      margin-inline-end: var(--pine-dimension-none);
     }
 
     &:focus {
@@ -343,24 +343,24 @@ $-btn-loading-min-height: rem(36px);
   .sage-panel-controls__toolbar-btn-group > &,
   .sage-toolbar__group > &,
   .sage-toolbar__group > .sage-dropdown .sage-dropdown__trigger > & {
-    border-radius: 0;
+    border-radius: var(--pine-dimension-none);
   }
 
   .sage-panel-controls__toolbar-btn-group > &:not(.sage-btn--secondary) {
     position: absolute;
-    inset-inline-end: 0;
-    inset-block-end: 0;
-    min-height: calc(#{$-btn-toolbar-group-height} + #{rem(2px)}); /* expand to toolbar group height + border offset */
+    inset-inline-end: var(--pine-dimension-none);
+    inset-block-end: var(--pine-dimension-none);
+    min-height: calc(#{$-btn-toolbar-group-height} + var(--pine-dimension-025)); /* expand to toolbar group height + border offset */
   }
 
   .sage-toolbar__group > .sage-input ~ &.sage-btn--primary,
   .sage-toolbar__group > .sage-search ~ &.sage-btn--primary {
-    box-shadow: 0 0 0 1px sage-color(grey, 900);
+    box-shadow: 0 0 0 1px var(--pine-color-primary);
     border-color: transparent;
   }
 
   .sage-toolbar__group .sage-dropdown__trigger > & {
-    border-color: sage-color(grey, 500);
+    border-color: var(--pine-color-border);
   }
 
   .sage-panel-controls__toolbar-btn-group &:not(:only-child) {
@@ -368,13 +368,13 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group > &:first-child {
-    border-start-start-radius: sage-border(radius);
-    border-end-start-radius: sage-border(radius);
+    border-start-start-radius: var(--pine-dimension-xs);
+    border-end-start-radius: var(--pine-dimension-xs);
   }
 
   .sage-panel-controls__toolbar-btn-group > &:last-child {
-    border-start-end-radius: sage-border(radius);
-    border-end-end-radius: sage-border(radius);
+    border-start-end-radius: var(--pine-dimension-xs);
+    border-end-end-radius: var(--pine-dimension-xs);
   }
 
   .sage-toolbar__group > &:first-child,
@@ -400,30 +400,30 @@ $-btn-loading-min-height: rem(36px);
   }
 
   .sage-panel-controls__toolbar-btn-group--expand-collapse > & {
-    border-radius: sage-border(radius);
+    border-radius: var(--pine-dimension-xs);
   }
 
   .sage-panel-controls__toolbar > &,
   .sage-toolbar > &,
   .sage-panel-controls__pagination > & {
-    border-radius: sage-border(radius);
+    border-radius: var(--pine-dimension-xs);
   }
 
   .sage-panel-controls__toolbar > &,
   .sage-panel-controls__pagination > & {
     &:not(:last-child) {
-      margin-inline-end: sage-spacing(card);
+      margin-inline-end: var(--pine-dimension-md);
     }
   }
 
   .sage-panel-controls__toolbar &,
   .sage-toolbar & {
-    border-color: sage-color(grey, 500);
+    border-color: var(--pine-color-border);
   }
 
   .sage-upload-card & {
     &.sage-btn--subtle:focus {
-      @include sage-focus-outline--update-color(sage-color(purple, 300));
+      @include sage-focus-outline--update-color(var(--pine-color-focus-ring));
     }
   }
 
@@ -445,11 +445,11 @@ $-btn-loading-min-height: rem(36px);
       @include sage-icon-base(caret-down, xs, pine);
 
       inset-inline-end: $-btn-disclosure-left-padding;
-      font-weight: sage-font-weight(bold);
+      font-weight: var(--pine-font-weight-bold);
     }
 
     &[class*="icon-only"].sage-btn--small::after {
-      inset-inline-end: rem(12px);
+      inset-inline-end: var(--pine-dimension-150);
     }
 
     &:has(pds-icon) {
@@ -462,7 +462,7 @@ $-btn-loading-min-height: rem(36px);
   .toolbar-editor & {
     $-btn-rte-padding: rem(6px);
 
-    padding: $-btn-base-padding-block sage-spacing(lg) $-btn-base-padding-block sage-spacing(xs);
+    padding: $-btn-base-padding-block var(--pine-dimension-lg) $-btn-base-padding-block var(--pine-dimension-xs);
     border-radius: 6px;
     border-width: 0;
 
@@ -471,30 +471,30 @@ $-btn-loading-min-height: rem(36px);
     }
 
     &::before {
-      font-size: sage-font-size(body-xs);
+      font-size: var(--pine-font-size-body-sm);
     }
 
     &::after {
       right: 7px;
       font-size: 11px;
-      font-weight: sage-font-weight(bold);
+      font-weight: var(--pine-font-weight-bold);
     }
 
     &:hover {
-      background-color: sage-color(grey, 200);
+      background-color: var(--pine-color-grey-200);
     }
 
     &.sage-btn--selected {
-      color: sage-color(white);
-      background-color: sage-color(grey, 900);
+      color: var(--pine-color-text-primary);
+      background-color: var(--pine-color-primary);
 
       &::after {
-        color: sage-color(white);
+        color: var(--pine-color-secondary);
       }
     }
 
     &:not(.sage-btn--subtle):not(.sage-btn--disclosure) {
-      padding: sage-spacing(xs);
+      padding: var(--pine-dimension-xs);
 
       @media (max-width: sage-breakpoint(sm-max)) {
         padding: $-btn-rte-padding;
@@ -598,27 +598,27 @@ a.sage-btn {
 
 // Secondary styles, no shadow variation
 .sage-btn--secondary {
-  color: sage-color(grey, 800);
-  background-color: sage-color(white);
-  border: 1px solid sage-color(grey, 200);
+  color: var(--pine-color-text-secondary);
+  background-color: var(--pine-color-secondary);
+  border: var(--pine-border);
 
   &:hover {
-    color: sage-color(grey, 950);
-    background-color: sage-color(grey, 100);
-    border-color: sage-color(grey, 300);
+    color: var(--pine-color-text-secondary-hover);
+    background-color: var(--pine-color-secondary-hover);
+    border-color: var(--pine-color-border-hover);
   }
 
   &:focus-visible,
   &:active {
-    background-color: sage-color(white);
-    border-color: sage-color(grey);
+    background-color: var(--pine-color-secondary);
+    border-color: var(--pine-color-border);
   }
 
   &:disabled,
   &[aria-disabled="true"] {
-    color: sage-color(grey, 400);
-    background-color: sage-color(white);
-    border-color: sage-color(grey, 150);
+    color: var(--pine-color-text-secondary-disabled);
+    background-color: var(--pine-color-secondary-disabled);
+    border-color: var(--pine-color-border-disabled);
   }
 }
 
@@ -865,6 +865,6 @@ a.sage-btn {
 }
 
 .sage-btn-group--border-top {
-  padding-block-start: sage-spacing(lg);
-  border-block-start: 1px solid sage-color(grey, 300);
+  padding-block-start: var(--pine-dimension-lg);
+  border-block-start: var(--pine-border);
 }

--- a/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
@@ -5,11 +5,11 @@
 ////
 
 
-$-copy-text-border: 1px solid sage-color(grey, 300);
-$-copy-text-border-focus-color: sage-color(purple, 300);
-$-copy-text-border-hover-color: sage-color(grey, 500);
-$-copy-text-color: sage-color(grey, 900);
-$-copy-text-color-hover: sage-color(grey, 950);
+$-copy-text-border: var(--pine-border);
+$-copy-text-border-focus-color: var(--pine-color-focus-ring);
+$-copy-text-border-hover-color: var(--pine-color-border-hover);
+$-copy-text-color: var(--pine-color-text-secondary);
+$-copy-text-color-hover: var(--pine-color-text-secondary-hover);
 
 
 .sage-copy-text {
@@ -38,7 +38,8 @@ $-copy-text-color-hover: sage-color(grey, 950);
   @include sage-copy-text;
 
   width: 100%;
-  padding: sage-spacing(card);
+  padding: var(--pine-dimension-md);
+  border-radius: 10px;
 }
 
 .sage-copy-text-card--truncate-contents {
@@ -60,17 +61,22 @@ $-copy-text-color-hover: sage-color(grey, 950);
   flex-flow: row-reverse;
   align-items: center;
   max-width: 100%;
-  padding-inline-end: sage-spacing(2xs);
+  padding-inline-end: var(--pine-dimension-2xs);
+  border-radius: var(--pine-border-radius-full);
 
   &::before {
     @include sage-icon-base(copy, md, pine);
 
-    margin-inline-start: sage-spacing(sm);
+    margin-inline-start: var(--pine-dimension-sm);
     color: $-copy-text-color;
   }
 
   &::after {
     transform: translate3d(-50%, -50%, 0);
+  }
+
+  &:hover {
+    background-color: var(--pine-color-grey-200);
   }
 
   &:hover::before {
@@ -93,5 +99,6 @@ $-copy-text-color-hover: sage-color(grey, 950);
 
 .sage-copy-text--semibold,
 .sage-copy-text-card--semibold {
-  @extend %t-sage-body-semi;
+  font: var(--pine-typography-body-semi-bold);
+  letter-spacing: var(--pine-letter-spacing);
 }

--- a/packages/sage-assets/lib/stylesheets/core/_variables.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_variables.scss
@@ -102,11 +102,11 @@ $sage-text-colors: (
 /// Toolbar border styles
 ///
 $sage-toolbar-button-borders: (
-  default: 0 0 0 1px sage-color(grey, 500),
-  focus: 0 0 0 2px sage-color(purple, 300),
-  hover: 0 0 0 1px sage-color(charcoal, 100),
-  hover-large: 0 0 0 2px sage-color(charcoal, 100),
-  active-hover: 0 0 0 4px sage-color(primary, 200),
+  default: 0 0 0 1px var(--pine-color-border),
+  focus: 0 0 0 2px var(--pine-color-focus-ring),
+  hover: 0 0 0 1px var(--pine-color-border-hover),
+  hover-large: 0 0 0 2px var(--pine-color-border-hover),
+  active-hover: 0 0 0 4px var(--pine-color-focus-ring),
 );
 
 ///

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -53,15 +53,15 @@
 /// Sets up styles for sage "copy" (system) text.
 ///
 @mixin sage-copy-text() {
-  @extend %t-sage-body;
-
   @include truncate();
 
-  padding: rem(6px) sage-spacing(sm);
-  color: sage-color(grey, 900);
+  font: var(--pine-typography-body-medium);
+  letter-spacing: var(--pine-letter-spacing);
+  padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
+  color: var(--pine-color-text-secondary);
   background-color: transparent;
   border: $-copy-text-border;
-  border-radius: sage-border(radius-medium);
+  border-radius: var(--pine-border-radius-full);
 }
 
 ///

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -55,10 +55,10 @@
 @mixin sage-copy-text() {
   @include truncate();
 
-  font: var(--pine-typography-body-medium);
-  letter-spacing: var(--pine-letter-spacing);
   padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
+  font: var(--pine-typography-body-medium);
   color: var(--pine-color-text-secondary);
+  letter-spacing: var(--pine-letter-spacing);
   background-color: transparent;
   border: $-copy-text-border;
   border-radius: var(--pine-border-radius-full);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Updates button styles to match Pine.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="917" alt="Screenshot 2025-02-05 at 4 48 32 PM" src="https://github.com/user-attachments/assets/80564cd5-d658-4f33-aeb0-d1bf5e545ff4" />|<img width="932" alt="Screenshot 2025-02-05 at 4 47 41 PM" src="https://github.com/user-attachments/assets/5e4bd0b0-f3f4-4cfc-95a6-6e66812eaa66" />
<img width="1270" alt="Screenshot 2025-02-05 at 4 50 39 PM" src="https://github.com/user-attachments/assets/ccd75b56-78a3-428c-aa0d-1490c74db42f" />|<img width="1264" alt="Screenshot 2025-02-05 at 4 50 50 PM" src="https://github.com/user-attachments/assets/d7b5bce1-46a7-466a-a8af-a2453d3e6a7a" />
<img width="1080" alt="Screenshot 2025-02-05 at 4 53 56 PM" src="https://github.com/user-attachments/assets/0436afe6-f46d-475d-9549-fa765879aafc" />|<img width="1027" alt="Screenshot 2025-02-05 at 4 54 02 PM" src="https://github.com/user-attachments/assets/b5d325aa-bfe9-4100-aed0-ffe69ff6bba5" />
<img width="1285" alt="Screenshot 2025-02-06 at 1 57 46 PM" src="https://github.com/user-attachments/assets/5a75284d-8956-4784-99c0-3b7d77970396" />|<img width="1275" alt="Screenshot 2025-02-06 at 1 58 00 PM" src="https://github.com/user-attachments/assets/91339de1-4833-4a5f-862e-ad94c77401a6" />



## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Navigate to [Button](http://localhost:4000/pages/component/button?tab=preview), [Copy Text](http://localhost:4000/pages/component/copy_text?tab=preview), [Panel Controls](http://localhost:4000/pages/component/panel_controls?tab=preview), [Toolbar](http://localhost:4000/pages/component/toolbar?tab=preview)
- Check that components that use Buttons have uniform design comparable to Pine.

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Updates button styles to match Pine.



## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1256](https://kajabi.atlassian.net/browse/DSS-1256)

[DSS-1256]: https://kajabi.atlassian.net/browse/DSS-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ