### PR TITLE
ci: adding workflows to report deployment/pr info to GetDX

### DIFF
--- a/.github/workflows/getdx-service-identification.yml
+++ b/.github/workflows/getdx-service-identification.yml
@@ -1,0 +1,18 @@
+name: "GetDX Service Identification"
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'main'
+
+jobs:
+  identify-services:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify Services
+        uses: Kajabi/getdx-monorepo-service-identifier-action@main
+        with:
+          getdx-instance-name: 'kajabi'
+          getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}

--- a/.github/workflows/getdx-service-identification.yml
+++ b/.github/workflows/getdx-service-identification.yml
@@ -6,6 +6,7 @@ on:
       - closed
     branches:
       - 'main'
+      - 'develop'
 
 jobs:
   identify-services:

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -138,7 +138,7 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_SHA_TAG }}-release-${{ env.POSTFIX }}
   
       - name: Report sage-docs-site production deployment to GetDX
-        if: ${{ env.POSTFIX == 'production' && always() }}
+        if: ${{ env.POSTFIX == 'production' }}
         uses: Kajabi/getdx-deployment-identifier-action@main
         env:
           POSTFIX: ${{ needs.setup.outputs.postfix }}
@@ -198,7 +198,7 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_SHA_TAG }}-release-${{ env.POSTFIX }}
 
       - name: Report sage-storybook-site production deployment to GetDX
-        if: ${{ env.POSTFIX == 'production' && always() }}
+        if: ${{ env.POSTFIX == 'production' }}
         uses: Kajabi/getdx-deployment-identifier-action@main
         env:
           POSTFIX: ${{ needs.setup.outputs.postfix }}
@@ -251,7 +251,7 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_SHA_TAG }}-release-${{ env.POSTFIX }}
 
       - name: Report sage-storybook-site production deployment to GetDX
-        if: ${{ env.POSTFIX == 'production' && always() }}
+        if: ${{ env.POSTFIX == 'production' }}
         uses: Kajabi/getdx-deployment-identifier-action@main
         env:
           POSTFIX: ${{ needs.setup.outputs.postfix }}

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -136,6 +136,16 @@ jobs:
           push: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_SHA_TAG }}-release-${{ env.POSTFIX }}
+  
+      - name: Report sage-docs-site production deployment to GetDX
+        if: ${{ env.POSTFIX == 'production' && always() }}
+        uses: Kajabi/getdx-deployment-identifier-action@main
+        env:
+          POSTFIX: ${{ needs.setup.outputs.postfix }}
+        with:
+          getdx-instance-name: 'kajabi'
+          getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}
+          service-name: 'sage-docs-site'
 
   # This is kind of "hacky", but we were having problems with the Dockerfile doing a
   # correct build for Storybook. This will build it on the runner and then just copy
@@ -187,6 +197,16 @@ jobs:
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_SHA_TAG }}-release-${{ env.POSTFIX }}
 
+      - name: Report sage-storybook-site production deployment to GetDX
+        if: ${{ env.POSTFIX == 'production' && always() }}
+        uses: Kajabi/getdx-deployment-identifier-action@main
+        env:
+          POSTFIX: ${{ needs.setup.outputs.postfix }}
+        with:
+          getdx-instance-name: 'kajabi'
+          getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}
+          service-name: 'sage-storybook-site'
+
   deploy-sassdocs-site:
     needs: [setup, login]
     runs-on: ubuntu-latest
@@ -213,7 +233,6 @@ jobs:
         with:
           mask-password: true
 
-
       # Sassdocs Site
       - name: Build and push sassdocs
         uses: docker/build-push-action@v2
@@ -230,3 +249,13 @@ jobs:
           push: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_SHA_TAG }}-release-${{ env.POSTFIX }}
+
+      - name: Report sage-storybook-site production deployment to GetDX
+        if: ${{ env.POSTFIX == 'production' && always() }}
+        uses: Kajabi/getdx-deployment-identifier-action@main
+        env:
+          POSTFIX: ${{ needs.setup.outputs.postfix }}
+        with:
+          getdx-instance-name: 'kajabi'
+          getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}
+          service-name: 'sage-sassdocs-site'

--- a/docs/catalog-info.yaml
+++ b/docs/catalog-info.yaml
@@ -10,7 +10,10 @@ metadata:
     - documentation
   links:
     - url: https://sage-lib-documentation.production.kajabi.farm/pages/index
-      title: Public Documentation Site
+      title: Storybook Production Site
+      icon: dashboard
+    - url: https://sage-lib-documentation.staging.kajabi.farm/pages/index
+      title: Storybook Production Site
       icon: dashboard
 spec:
   type: website
@@ -18,3 +21,5 @@ spec:
   owner: user-experience
   system: sage
   subcomponentOf: sage-lib
+  dependsOn:
+    - sage-packs

--- a/packages/sage-assets/catalog-info.yaml
+++ b/packages/sage-assets/catalog-info.yaml
@@ -9,8 +9,11 @@ metadata:
     - scss
     - icons
   links:
-    - url: https://sage-lib-sassdocs.herokuapp.com/
-      title: SassDocs Site
+    - url: https://sage-lib-sassdocs.production.kajabi.farm/
+      title: SassDocs Production Site
+      icon: dashboard
+    - url: https://sage-lib-sassdocs.staging.kajabi.farm/
+      title: SassDocs Staging Site
       icon: dashboard
   annotations:
     github.com/project-slug: Kajabi/sage-lib
@@ -32,8 +35,11 @@ metadata:
     - scss
     - sass
   links:
-    - url: https://sage-lib-sassdocs.herokuapp.com/
-      title: SassDocs Site
+    - url: https://sage-lib-sassdocs.production.kajabi.farm/
+      title: SassDocs Production Site
+      icon: dashboard
+    - url: https://sage-lib-sassdocs.staging.kajabi.farm/
+      title: SassDocs Staging Site
       icon: dashboard
   annotations:
     github.com/project-slug: Kajabi/sage-lib

--- a/packages/sage-packs/catalog-info.yaml
+++ b/packages/sage-packs/catalog-info.yaml
@@ -15,3 +15,7 @@ spec:
   owner: user-experience
   system: sage
   subcomponentOf: sage-lib
+  dependsOn:
+    - sage-assets
+    - sage-react
+    - sage-system

--- a/packages/sage-react/catalog-info.yaml
+++ b/packages/sage-react/catalog-info.yaml
@@ -7,8 +7,11 @@ metadata:
     - react
     - javascript
   links:
-    - url: https://sage-lib-storybook.herokuapp.com/
-      title: Storybook Site
+    - url: https://sage-lib-storybook.production.kajabi.farm/
+      title: Storybook Production Site
+      icon: dashboard
+    - url: https://sage-lib-storybook.staging.kajabi.farm/
+      title: Storybook Staging Site
       icon: dashboard
   annotations:
     github.com/project-slug: Kajabi/sage-lib
@@ -30,8 +33,11 @@ metadata:
     - javascript
     - storybook
   links:
-    - url: https://sage-lib-storybook.herokuapp.com/
-      title: Storybook Site
+    - url: https://sage-lib-storybook.production.kajabi.farm/
+      title: Storybook Production Site
+      icon: dashboard
+    - url: https://sage-lib-storybook.staging.kajabi.farm/
+      title: Storybook Staging Site
       icon: dashboard
   annotations:
     github.com/project-slug: Kajabi/sage-lib


### PR DESCRIPTION
This introduces a few new workflows and workflow steps for GetDX reporting. The new `getdx-service-identification` workflow will run on merge to `develop` && `main` (~ensuring this is correct with the GetDX team~ EDIT: This is correct), and will inform them of what services are affected by a PR merge.

Calls about deployments are being made for `production` level deploys in the `deploy-release` workflows and are tied to the sites they create.

These are new actions, so there may be some bugs to work out. If you run into issues please let us know on IPA.