### PR TITLE
fix: tooltip visibility issue on ios safari back navigation

### DIFF
--- a/packages/sage-react/lib/Tooltip/Tooltip.jsx
+++ b/packages/sage-react/lib/Tooltip/Tooltip.jsx
@@ -1,4 +1,4 @@
-import React, { Children, useState, cloneElement } from 'react';
+import React, { Children, useState, useEffect, cloneElement } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { TooltipElement } from './TooltipElement';
@@ -23,24 +23,40 @@ export const Tooltip = ({
     setActive(false);
   }
 
+  // fix for Safari iOS back button issue
+  useEffect(() => {
+    const handlePageShow = () => {
+      setActive(false);
+    };
+
+    window.addEventListener("pageshow", handlePageShow);
+
+    return () => {
+      window.removeEventListener("pageshow", handlePageShow);
+    };
+  }, []);
+
   return (
     <>
-      {Children.map(children, (child) => cloneElement(child, {
-        onMouseEnter: handleActivate,
-        onFocus: handleActivate,
-        onMouseLeave: handleDeactivate,
-        onBlur: handleDeactivate,
-        ...rest,
-      }))}
-      {active && ReactDOM.createPortal(
-        <TooltipElement
-          content={content}
-          parentDomRect={parentDomRect}
-          position={position}
-          tooltipCustomClass={tooltipCustomClass}
-        />,
-        document.body
+      {Children.map(children, (child) =>
+        cloneElement(child, {
+          onMouseEnter: handleActivate,
+          onFocus: handleActivate,
+          onMouseLeave: handleDeactivate,
+          onBlur: handleDeactivate,
+          ...rest,
+        })
       )}
+      {active &&
+        ReactDOM.createPortal(
+          <TooltipElement
+            content={content}
+            parentDomRect={parentDomRect}
+            position={position}
+            tooltipCustomClass={tooltipCustomClass}
+          />,
+          document.body
+        )}
     </>
   );
 };


### PR DESCRIPTION
## Description
When a tooltip is visible on-page navigation, clicking the back button in Safari on iOS navigates back, but the tooltip remains visible.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![2025-02-18 10 05 17](https://github.com/user-attachments/assets/908d6f32-3d28-48a1-b2f3-f4726fdc8f2c)|![2025-02-18 10 05 56](https://github.com/user-attachments/assets/794d818b-a75c-4237-8de4-904295cc45fb)|

## Testing in `sage-lib`
Navigate to the [tooltip](http://localhost:4100/?path=/docs/sage-tooltip--default)
Verify the tooltip works as expected.


## Testing in `kajabi-products`

1. (**LOW**) Adjust tooltip for visibility issue on ios safari back navigation
   - Dashboard charts cards 


## Related
https://kajabi.atlassian.net/browse/DSS-1283
