### PR TITLE
fix: correct className typo in avatar (react)

### DIFF
--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -79,7 +79,7 @@ export const Avatar = ({
         </div>
       )}
       {image.src && (
-        <img alt={image.alt || ''} class="sage-avatar__image" src={image.src} id={image.id} />
+        <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
       )}
       {(!image.src || useFallbackGraphic) && (
         <pds-icon name="user-filled" color="var(--pine-color-mercury-500)" class="sage-avatar__graphic" />


### PR DESCRIPTION
## Description
The icon placement in the avatar is displayed in the wrong position. The issues are due to the usage of `className=` instead of `class=` on the icon component so the styles are not applied.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-02-20 at 2 21 02 PM](https://github.com/user-attachments/assets/501e1986-fc9f-4e18-b46c-e9e2888e79be)|![Screenshot 2025-02-20 at 2 21 48 PM](https://github.com/user-attachments/assets/3007fb23-bf93-47b0-9935-68f06bac2d83)|


## Testing in `sage-lib`

- Navigate to storybook
- Verify icon displays in correct location


## Testing in `kajabi-products`

1. (**LOW) Corrects avatar icon class to correct positioning
   - [ ] All Contacts


## Related
N/A
