### PR TITLE
style: adjust copy button hover background color 

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_copy_text.scss
@@ -76,7 +76,7 @@ $-copy-text-color-hover: var(--pine-color-text-secondary-hover);
   }
 
   &:hover {
-    background-color: var(--pine-color-grey-200);
+    background-color: inherit;
   }
 
   &:hover::before {


### PR DESCRIPTION
## Description
The bordered copy button has an incorrect hover style applied. This updates corrects the styling.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-02-20 at 2 38 17 PM](https://github.com/user-attachments/assets/17210895-c571-4976-a6e5-0dd0f6fdf51e)|![Screenshot 2025-02-20 at 2 38 34 PM](https://github.com/user-attachments/assets/7f0db870-aaac-4018-9d50-b18975a1be50)|



## Testing in `sage-lib`
Navigate to Copy Button
Verify hover state is corrected


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Corrected hover state styling on copy button
   - [ ] Affiliates


## Related
N/A
