### PR TITLE
chore: add environment to KP when Bridge is enabled

### DIFF
--- a/bin/bridge.sh
+++ b/bin/bridge.sh
@@ -19,6 +19,12 @@ export $(cat $sage_repo_path/.env | xargs)
 if [[ $KAJABI_PRODUCTS_PATH != '' ]]; then
     cd $KAJABI_PRODUCTS_PATH;
     $sage_bin_path/local-link.sh $1
+
+    if [[ $1 == 'true' ]]; then
+      grep -q "^VITE_SAGE_BRIDGE_ENABLED=" "$KAJABI_PRODUCTS_PATH/.env" || echo "VITE_SAGE_BRIDGE_ENABLED=true" >> "$KAJABI_PRODUCTS_PATH/.env"
+    else
+      grep -v "^VITE_SAGE_BRIDGE_ENABLED=" "$KAJABI_PRODUCTS_PATH/.env" > temp.env && mv temp.env "$KAJABI_PRODUCTS_PATH/.env"
+    fi
 else
     echo_custom_error "Please check your .env file for a KAJABI_PRODUCTS_PATH variable."
     exit 1


### PR DESCRIPTION
## Description

The Sage Bridge was not consistently working. After moving in with @pixelflips, I finally found a solution to the problem. The environment variable is used to control which features we need to enable in Vite. 

