### PR TITLE
fix: dropdown positioning overhaul (react)

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -64,9 +64,11 @@ export const Dropdown = ({
       setShowPanel(false);
       setIsPositioned(false);
     }
+    // eslint-disable-next-line consistent-return
   };
 
   // Show panel after positioning is complete
+  /* eslint-disable consistent-return */
   useEffect(() => {
     if (isPositioned) {
       // Increase delay to ensure popper has fully calculated position
@@ -75,8 +77,8 @@ export const Dropdown = ({
 
         // Force a reflow/repaint to ensure visibility changes apply
         if (panelRef.current) {
-          // This forces a browser repaint
-          void panelRef.current.offsetHeight;
+          // eslint-disable-next-line no-unused-expressions
+          panelRef.current.offsetHeight; // Force reflow
 
           // Also force a popper update after panel is visible
           if (popperInstanceRef.current) {
@@ -86,12 +88,14 @@ export const Dropdown = ({
       }, 50);
 
       return () => clearTimeout(timer);
-    } else {
-      setShowPanel(false);
     }
+
+    setShowPanel(false);
   }, [isPositioned]);
+  /* eslint-enable consistent-return */
 
   // Add a fallback to show the panel after a reasonable timeout
+  /* eslint-disable consistent-return */
   useEffect(() => {
     if (isActive && !showPanel) {
       let isMounted = true; // Helps prevent updates if component unmounts
@@ -116,10 +120,11 @@ export const Dropdown = ({
       };
     }
   }, [isActive, showPanel]);
+  /* eslint-enable consistent-return */
 
   // Setup and manage popper instance
   useEffect(() => {
-    if (!isActive || !triggerRef.current || !panelRef.current) return;
+    if (!isActive || !triggerRef.current || !panelRef.current) return undefined;
 
     // Initially position the panel off-screen to prevent flicker
     if (panelRef.current) {
@@ -159,16 +164,13 @@ export const Dropdown = ({
       } else {
         placement = 'top-start'; // Align to the left edge of the trigger (default)
       }
+    } else if (align === DROPDOWN_POSITIONS.RIGHT) {
+      placement = 'bottom-end'; // Align to the right edge of the trigger
+    } else if (align === DROPDOWN_POSITIONS.CENTER) {
+      placement = 'bottom'; // Center align below the trigger
     } else {
-      // Default placement logic for bottom placement
-      if (align === DROPDOWN_POSITIONS.RIGHT) {
-        placement = 'bottom-end'; // Align to the right edge of the trigger
-      } else if (align === DROPDOWN_POSITIONS.CENTER) {
-        placement = 'bottom'; // Center align below the trigger
-      } else {
-        // Default to left alignment (bottom-start) for both DEFAULT and LEFT values
-        placement = 'bottom-start'; // Align to the left edge of the trigger
-      }
+      // Default to left alignment (bottom-start) for both DEFAULT and LEFT values
+      placement = 'bottom-start'; // Align to the left edge of the trigger
     }
 
     // Create popper instance with proper configuration
@@ -276,12 +278,12 @@ export const Dropdown = ({
       while (parent && parent !== document.body) {
         const style = window.getComputedStyle(parent);
         if (
-          style.overflow === 'auto' ||
-          style.overflow === 'scroll' ||
-          style.overflowY === 'auto' ||
-          style.overflowY === 'scroll' ||
-          style.overflow === 'hidden' ||
-          style.overflowY === 'hidden'
+          style.overflow === 'auto'
+          || style.overflow === 'scroll'
+          || style.overflowY === 'auto'
+          || style.overflowY === 'scroll'
+          || style.overflow === 'hidden'
+          || style.overflowY === 'hidden'
         ) {
           overflowParent = parent;
           break;
@@ -347,10 +349,11 @@ export const Dropdown = ({
     // Only trigger if panelStateToken has changed and isn't null
     if (panelStateToken && panelStateToken !== lastPanelStateToken) {
       setLastPanelStateToken(panelStateToken);
-      setActive(prevActive => !prevActive);
+      setActive((prevActive) => !prevActive);
       setShowPanel(false);
       setIsPositioned(false);
     }
+    // eslint-disable-next-line consistent-return
   }, [panelStateToken, lastPanelStateToken]);
 
   const a11yAttrs = {
@@ -431,18 +434,18 @@ export const Dropdown = ({
             // Only apply these styles when panel should be hidden
             ...(showPanel
               ? {
-                  pointerEvents: 'auto',
-                  opacity: 1,
-                  visibility: 'visible',
-                }
+                pointerEvents: 'auto',
+                opacity: 1,
+                visibility: 'visible',
+              }
               : {
-                  pointerEvents: 'none',
-                  opacity: 0,
-                  position: 'absolute',
-                  left: '-9999px',
-                  top: '-9999px',
-                  visibility: 'hidden',
-                }
+                pointerEvents: 'none',
+                opacity: 0,
+                position: 'absolute',
+                left: '-9999px',
+                top: '-9999px',
+                visibility: 'hidden',
+              }
             ),
             // Force no animation
             transition: 'none',

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { debounce } from 'debounce';
+import { createPopper } from '@popperjs/core';
 import { SageTokens } from '../configs';
 import { DropdownItem } from './DropdownItem';
 import { DropdownItemList } from './DropdownItemList';
@@ -10,6 +10,13 @@ import { DropdownPanel } from './DropdownPanel';
 import { DropdownTrigger } from './DropdownTrigger';
 import { DROPDOWN_ITEM_COLORS, DROPDOWN_PANEL_SIZES, DROPDOWN_PANEL_TYPES, DROPDOWN_POSITIONS } from './configs';
 import { DropdownTriggerSelect } from './DropdownTriggerSelect';
+
+// Create a wrapper for DropdownPanel to forward refs
+const ForwardedDropdownPanel = React.forwardRef((props, ref) => (
+  <DropdownPanel {...props} forwardedRef={ref} />
+));
+
+ForwardedDropdownPanel.displayName = 'ForwardedDropdownPanel';
 
 export const Dropdown = ({
   align,
@@ -39,11 +46,13 @@ export const Dropdown = ({
   triggerWidth,
 }) => {
   const [isActive, setActive] = useState(false);
-  const [coords, updateCoords] = useState(null);
+  const [isPositioned, setIsPositioned] = useState(false);
+  const [showPanel, setShowPanel] = useState(false);
+  const [lastPanelStateToken, setLastPanelStateToken] = useState(panelStateToken);
   const wrapperRef = useRef(null);
-
-  const topBoxOffset = 2;
-  const inlineBoxOffset = -6;
+  const triggerRef = useRef(null);
+  const panelRef = useRef(null);
+  const popperInstanceRef = useRef(null);
 
   const onClickTrigger = () => {
     if (!isActive && clickTriggerHandler) {
@@ -52,133 +61,297 @@ export const Dropdown = ({
 
     if (!disabled) {
       setActive(!isActive);
+      setShowPanel(false);
+      setIsPositioned(false);
     }
   };
 
-  const setPanelCoords = (coords) => {
-    updateCoords(coords);
-  };
+  // Show panel after positioning is complete
+  useEffect(() => {
+    if (isPositioned) {
+      // Increase delay to ensure popper has fully calculated position
+      const timer = setTimeout(() => {
+        setShowPanel(true);
 
-  const onUpdate = useCallback(debounce(() => positionElement(), 0), []); // eslint-disable-line
+        // Force a reflow/repaint to ensure visibility changes apply
+        if (panelRef.current) {
+          // This forces a browser repaint
+          void panelRef.current.offsetHeight;
 
-  // NOTE: getHeight and positionElement must be kept in alignment
-  // with packages/sage-system/lib/dropdown.js since we don't
-  // currently have unified location for Rails and React
+          // Also force a popper update after panel is visible
+          if (popperInstanceRef.current) {
+            popperInstanceRef.current.update();
+          }
+        }
+      }, 50);
 
-  const getHeight = (el) => {
-    const styles = window.getComputedStyle(el);
-    const height = el.offsetHeight;
-    const borderTopWidth = parseFloat(styles.borderTopWidth);
-    const borderBottomWidth = parseFloat(styles.borderBottomWidth);
-    const paddingTop = parseFloat(styles.paddingTop);
-    const paddingBottom = parseFloat(styles.paddingBottom);
-
-    return height - borderBottomWidth - borderTopWidth - paddingTop - paddingBottom;
-  };
-
-  const positionElement = () => {
-    let directionX = null;
-    let directionY = null;
-    const el = wrapperRef.current;
-
-    // if el is null, return
-    if (!el) return;
-
-    // Elements
-    const button = el;
-    const panel = el.lastElementChild;
-
-    // if panel is null, return
-    if (!panel) return;
-
-    // Dimensions
-    const buttonDimensions = button.getBoundingClientRect();
-    const panelDimensions = panel.getBoundingClientRect();
-
-    const panelHeight = getHeight(panel);
-    const enoughSpaceAbove = panelHeight + buttonDimensions.bottom > window.innerHeight;
-    const enoughSpaceBelow = panelHeight + buttonDimensions.bottom < window.innerHeight;
-    const enoughSpaceLeft = panelDimensions.width < buttonDimensions.left;
-    const enoughSpaceRight = panelDimensions.width < window.innerWidth - buttonDimensions.right;
-
-    if (!enoughSpaceBelow && enoughSpaceAbove) {
-      directionY = 'above';
-    } else if (!enoughSpaceAbove && enoughSpaceBelow) {
-      directionY = 'below';
+      return () => clearTimeout(timer);
+    } else {
+      setShowPanel(false);
     }
-    const rect = wrapperRef.current.getBoundingClientRect();
-    const coords = {
-      top: buttonDimensions.bottom + topBoxOffset,
-      left: align === DROPDOWN_POSITIONS.LEFT || null
-        ? rect.left + inlineBoxOffset
-        : null,
-      right: align === DROPDOWN_POSITIONS.RIGHT && isPinned
-        ? window.innerWidth - rect.right + inlineBoxOffset
-        : null,
+  }, [isPositioned]);
+
+  // Add a fallback to show the panel after a reasonable timeout
+  useEffect(() => {
+    if (isActive && !showPanel) {
+      let isMounted = true; // Helps prevent updates if component unmounts
+
+      // If panel hasn't become visible after 300ms, force it to show
+      const fallbackTimer = setTimeout(() => {
+        // Double-check component is still mounted and panel still not shown
+        if (isMounted && !showPanel) {
+          setIsPositioned(true);
+          setShowPanel(true);
+
+          // Force update popper if it exists
+          if (popperInstanceRef.current) {
+            popperInstanceRef.current.update();
+          }
+        }
+      }, 300);
+
+      return () => {
+        isMounted = false;
+        clearTimeout(fallbackTimer);
+      };
+    }
+  }, [isActive, showPanel]);
+
+  // Setup and manage popper instance
+  useEffect(() => {
+    if (!isActive || !triggerRef.current || !panelRef.current) return;
+
+    // Initially position the panel off-screen to prevent flicker
+    if (panelRef.current) {
+      panelRef.current.style.position = 'absolute';
+      panelRef.current.style.left = '-9999px';
+      panelRef.current.style.top = '-9999px';
+      panelRef.current.style.opacity = '0';
+    }
+
+    // Clean up any existing popper instance
+    if (popperInstanceRef.current) {
+      popperInstanceRef.current.destroy();
+      popperInstanceRef.current = null;
+    }
+
+    // Check if we should force a top placement based on viewport position
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const distanceToBottom = viewportHeight - triggerRect.bottom;
+
+    // Use a generous estimate for dropdown height (250px should cover most cases)
+    const estimatedDropdownHeight = 250;
+
+    // If there's not enough space below, force top placement
+    const shouldForceTopPlacement = distanceToBottom < estimatedDropdownHeight;
+
+    // Determine initial placement based on align prop and available space
+    let placement;
+
+    // Force top placement if there's not enough room below
+    if (shouldForceTopPlacement) {
+      // Handle different alignments for top placement
+      if (align === DROPDOWN_POSITIONS.RIGHT) {
+        placement = 'top-end'; // Align to the right edge of the trigger
+      } else if (align === DROPDOWN_POSITIONS.CENTER) {
+        placement = 'top'; // Center align above the trigger
+      } else {
+        placement = 'top-start'; // Align to the left edge of the trigger (default)
+      }
+    } else {
+      // Default placement logic for bottom placement
+      if (align === DROPDOWN_POSITIONS.RIGHT) {
+        placement = 'bottom-end'; // Align to the right edge of the trigger
+      } else if (align === DROPDOWN_POSITIONS.CENTER) {
+        placement = 'bottom'; // Center align below the trigger
+      } else {
+        // Default to left alignment (bottom-start) for both DEFAULT and LEFT values
+        placement = 'bottom-start'; // Align to the left edge of the trigger
+      }
+    }
+
+    // Create popper instance with proper configuration
+    popperInstanceRef.current = createPopper(triggerRef.current, panelRef.current, {
+      placement,
+      strategy: isPinned ? 'fixed' : 'absolute',
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, 8], // Slight offset from the trigger (x, y)
+          },
+        },
+        {
+          name: 'preventOverflow',
+          options: {
+            // Use the closest scrolling ancestor or viewport as boundary
+            // This allows the dropdown to "escape" overflow containers when needed
+            boundary: 'clippingParents',
+            padding: 8, // Keep 8px from boundary edges
+            altAxis: true, // Consider both axes when preventing overflow
+            rootBoundary: 'viewport', // Always respect the viewport boundary
+          },
+        },
+        {
+          name: 'flip',
+          options: {
+            // Set more aggressive flipping with top priority for constrained space
+            fallbackPlacements: placement.startsWith('bottom')
+              ? ['top-start', 'top-end', 'bottom-end', 'bottom-start']
+              : ['bottom-start', 'bottom-end', 'top-end', 'top-start'],
+            padding: 8, // Distance from viewport edges before flipping
+            // Make sure we flip if needed, even in overflow containers
+            flipVariations: true,
+            // Use all available space before deciding to flip
+            fallbackStrategy: 'bestFit',
+            // Lower threshold to make flipping more eager
+            flipVariationsByContent: true,
+            // Always respect viewport constraints
+            rootBoundary: 'viewport',
+          },
+        },
+        // This modifier ensures the dropdown can escape overflow containers
+        {
+          name: 'maxSize',
+          enabled: true,
+          options: {
+            // Allow dropdown to have maximum available size in viewport
+            padding: 8,
+            boundary: 'clippingParents',
+            rootBoundary: 'viewport',
+          },
+        },
+        {
+          name: 'computeStyles',
+          options: {
+            // Minimize inline styles to only the essential ones
+            gpuAcceleration: true,
+            adaptive: false, // Don't add adaptive positioning styles
+            // Only include these specific styles
+            styleProperties: ['transform', 'top', 'left', 'right', 'bottom'],
+          },
+        },
+        // Ensure the dropdown panel stays anchored to the reference element
+        {
+          name: 'arrow',
+          enabled: false,
+        }
+      ],
+      onFirstUpdate: () => {
+        // Mark as positioned after first update
+        setIsPositioned(true);
+
+        // Force an additional update to ensure accurate positioning
+        setTimeout(() => {
+          if (popperInstanceRef.current) {
+            popperInstanceRef.current.update();
+          }
+        }, 10);
+      }
+    });
+
+    // For tables with overflow, we need to ensure the dropdown is visible
+    if (panelRef.current) {
+      // Set a high z-index to escape overflow containers
+      panelRef.current.style.zIndex = '900';
+      // Make sure the dropdown is allowed to escape overflow
+      panelRef.current.style.overflowY = 'auto';
+      panelRef.current.style.overflowX = 'hidden';
+    }
+
+    // Trigger an immediate update
+    if (popperInstanceRef.current) {
+      popperInstanceRef.current.update();
+    }
+
+    // Special handling for table overflow scenarios
+    const checkParentOverflow = () => {
+      if (!triggerRef.current) return;
+
+      // Find the closest scrollable parent (likely the table with overflow)
+      let parent = triggerRef.current.parentElement;
+      let overflowParent = null;
+
+      while (parent && parent !== document.body) {
+        const style = window.getComputedStyle(parent);
+        if (
+          style.overflow === 'auto' ||
+          style.overflow === 'scroll' ||
+          style.overflowY === 'auto' ||
+          style.overflowY === 'scroll' ||
+          style.overflow === 'hidden' ||
+          style.overflowY === 'hidden'
+        ) {
+          overflowParent = parent;
+          break;
+        }
+        parent = parent.parentElement;
+      }
+
+      // If we found an overflow parent and we're near the bottom of it,
+      // force the placement to be 'top-start' to avoid being cut off
+      if (overflowParent && popperInstanceRef.current) {
+        const triggerRect = triggerRef.current.getBoundingClientRect();
+        const parentRect = overflowParent.getBoundingClientRect();
+        const distanceToBottom = parentRect.bottom - triggerRect.bottom;
+
+        // When handling overflow constraints, also update for center alignment
+        if (distanceToBottom < 150 || (viewportHeight - triggerRect.bottom) < 200) {
+          // Get the appropriate top placement based on current alignment
+          let newPlacement;
+          if (placement.endsWith('end')) {
+            newPlacement = 'top-end';
+          } else if (placement === 'bottom') {
+            newPlacement = 'top'; // Handle center alignment
+          } else {
+            newPlacement = 'top-start';
+          }
+
+          popperInstanceRef.current.setOptions({
+            placement: newPlacement
+          });
+          // Update immediately with new placement
+          popperInstanceRef.current.update();
+        }
+      }
     };
 
-    if (!isPinned) {
-      coords.top = null;
-      coords.left = null;
-    }
+    // Check for overflow constraints after a short delay
+    // to ensure all layout calculations are complete
+    setTimeout(checkParentOverflow, 0);
 
-    if (directionY === 'above') {
-      coords.top = ((buttonDimensions.height / 4) + panelDimensions.height) * -1;
-      coords.left = null;
-      if (isPinned) {
-        coords.top = (buttonDimensions.top - panelDimensions.height);
-        coords.right = window.innerWidth - buttonDimensions.right + inlineBoxOffset;
+    // Handle window resize and scroll
+    const updatePopper = () => {
+      if (popperInstanceRef.current) {
+        popperInstanceRef.current.update();
       }
-    }
+    };
 
-    // Check if there is enough space to the left or right
-    // CHECK ISPINNED
-    if (!enoughSpaceRight && enoughSpaceLeft) {
-      directionX = DROPDOWN_POSITIONS.LEFT;
-    } else if (!enoughSpaceLeft && enoughSpaceRight) {
-      directionX = DROPDOWN_POSITIONS.RIGHT;
-    }
-
-    if (directionX === DROPDOWN_POSITIONS.LEFT) {
-      coords.left = null;
-      coords.right = 0;
-      if (isPinned) {
-        coords.right = window.innerWidth - buttonDimensions.right + inlineBoxOffset;
-      }
-    }
-
-    if (directionX === DROPDOWN_POSITIONS.RIGHT) {
-      coords.left = 0;
-      coords.right = null;
-      if (isPinned) {
-        coords.left = buttonDimensions.left + inlineBoxOffset;
-      }
-    }
-
-    setPanelCoords(coords);
-  };
-
-  useEffect(() => {
-    if (!wrapperRef) {
-      return false;
-    }
-
-    positionElement();
-
-    window.addEventListener('scroll', onUpdate);
-    window.addEventListener('resize', onUpdate);
+    window.addEventListener('scroll', updatePopper, { passive: true });
+    window.addEventListener('resize', updatePopper, { passive: true });
 
     return () => {
-      window.removeEventListener('scroll', onUpdate);
-      window.removeEventListener('resize', onUpdate);
-    };
-  }, [wrapperRef, isActive, isPinned, onUpdate]); // eslint-disable-line
+      window.removeEventListener('scroll', updatePopper);
+      window.removeEventListener('resize', updatePopper);
 
+      if (popperInstanceRef.current) {
+        popperInstanceRef.current.destroy();
+        popperInstanceRef.current = null;
+      }
+    };
+  }, [isActive, align, isPinned]);
+
+  // Handle panel state token changes
   useEffect(() => {
-    if (panelStateToken) {
-      setActive(!isActive);
+    // Only trigger if panelStateToken has changed and isn't null
+    if (panelStateToken && panelStateToken !== lastPanelStateToken) {
+      setLastPanelStateToken(panelStateToken);
+      setActive(prevActive => !prevActive);
+      setShowPanel(false);
+      setIsPositioned(false);
     }
-  }, [panelStateToken]); // eslint-disable-line
+  }, [panelStateToken, lastPanelStateToken]);
 
   const a11yAttrs = {
     'aria-expanded': isActive,
@@ -223,30 +396,64 @@ export const Dropdown = ({
       {isActive && (
         <div aria-hidden="true" className="sage-dropdown__screen" onClick={onClickScreen} />
       )}
-      <DropdownTrigger
-        disabled={disabled}
-        disclosure={disclosure}
-        icon={icon}
-        isLabelVisible={isLabelVisible}
-        label={label}
-        modifier={triggerModifier}
-        onClickTrigger={onClickTrigger}
-        subtleButton={triggerButtonSubtle}
-        triggerClassnames={triggerClassnames}
-        width={triggerWidth}
-      >
-        {customTrigger}
-      </DropdownTrigger>
+      <div ref={triggerRef}>
+        <DropdownTrigger
+          disabled={disabled}
+          disclosure={disclosure}
+          icon={icon}
+          isLabelVisible={isLabelVisible}
+          label={label}
+          modifier={triggerModifier}
+          onClickTrigger={onClickTrigger}
+          subtleButton={triggerButtonSubtle}
+          triggerClassnames={triggerClassnames}
+          width={triggerWidth}
+        >
+          {customTrigger}
+        </DropdownTrigger>
+      </div>
+      {/* Render dropdown portal directly to document body to escape overflow containers */}
       {isActive && (
-        <DropdownPanel
+        <ForwardedDropdownPanel
+          ref={panelRef}
           maxWidth={panelMaxWidth}
           modifier={panelModifier}
           onClickScreen={onClickScreen}
           onExit={onExit}
-          coords={coords}
+          style={{
+            zIndex: 10000, // Higher z-index to escape overflow containers
+            minWidth: '200px',
+            // CSS needed to escape overflow containers
+            position: 'absolute',
+            maxHeight: '80vh', // Prevent overly tall dropdowns
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            // Only apply these styles when panel should be hidden
+            ...(showPanel
+              ? {
+                  pointerEvents: 'auto',
+                  opacity: 1,
+                  visibility: 'visible',
+                }
+              : {
+                  pointerEvents: 'none',
+                  opacity: 0,
+                  position: 'absolute',
+                  left: '-9999px',
+                  top: '-9999px',
+                  visibility: 'hidden',
+                }
+            ),
+            // Force no animation
+            transition: 'none',
+            animationDuration: '0s',
+            animationDelay: '0s',
+            transitionDuration: '0s',
+            transitionDelay: '0s'
+          }}
         >
           {children}
-        </DropdownPanel>
+        </ForwardedDropdownPanel>
       )}
     </div>
   );

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -51,7 +51,7 @@ export const DropdownPanel = ({
       style={{
         maxWidth,
         ...style,
-        transitionProperty: style?.transition ? undefined : 'none',
+        transitionProperty: (style && style.transition) ? undefined : 'none',
         willChange: 'transform, opacity'
       }}
     >
@@ -80,5 +80,12 @@ DropdownPanel.propTypes = {
   modifier: PropTypes.string,
   onClickScreen: PropTypes.func,
   onExit: PropTypes.func,
-  style: PropTypes.object,
+  style: PropTypes.objectOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+      PropTypes.object, // For nested style objects like in spread properties
+    ])
+  ),
 };

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -6,11 +6,12 @@ import classnames from 'classnames';
 
 export const DropdownPanel = ({
   children,
-  coords,
+  forwardedRef,
   maxWidth,
   modifier,
   onClickScreen,
   onExit,
+  style,
 }) => {
   const menuEl = useRef(null);
   const classNames = classnames(
@@ -26,17 +27,32 @@ export const DropdownPanel = ({
     }
   };
 
-  const positioningCoords = { ...coords };
+  // Combine provided ref with internal ref if needed
+  const refCallback = (element) => {
+    // Keep our internal ref updated
+    menuEl.current = element;
+
+    // Update the forwarded ref if provided
+    if (forwardedRef) {
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(element);
+      } else {
+        forwardedRef.current = element;
+      }
+    }
+  };
 
   return (
     <div
-      ref={menuEl}
+      ref={refCallback}
       className={classNames}
       onClick={handlePanelClick}
       role="dialog"
       style={{
         maxWidth,
-        ...positioningCoords
+        ...style,
+        transitionProperty: style?.transition ? undefined : 'none',
+        willChange: 'transform, opacity'
       }}
     >
       {children && React.cloneElement(children, { onExit })}
@@ -45,29 +61,24 @@ export const DropdownPanel = ({
 };
 
 DropdownPanel.defaultProps = {
-  coords: null,
   children: null,
+  forwardedRef: null,
   maxWidth: null,
   modifier: null,
   onClickScreen: (evt) => evt,
   onExit: (evt) => evt,
+  style: {},
 };
 
 DropdownPanel.propTypes = {
   children: PropTypes.node,
-  coords: PropTypes.shape({
-    top: PropTypes.number,
-    left: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-    right: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-  }),
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   maxWidth: PropTypes.string,
   modifier: PropTypes.string,
   onClickScreen: PropTypes.func,
   onExit: PropTypes.func,
+  style: PropTypes.object,
 };

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@kajabi/sage-assets": "^6.2.8",
+    "@popperjs/core": "^2.11.8",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "focus-trap": "^6.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,6 +2870,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@rails/webpacker@5.2.2":
   version "5.2.2"
   resolved "https://registry.npmjs.org/@rails/webpacker/-/webpacker-5.2.2.tgz"


### PR DESCRIPTION
## Description

### Issue

- Dropdowns being cut off in overflow containers (responsive tables)
- Inconsistent positioning across different viewport sizes

### Solution

- Integrated `popper.js` for robust positioning
- Added smart overflow detection for tables
- Implemented auto-flip when limited space below
- Optimized z-index to escape overflow containers

This update ensures dropdowns are properly positioned and visible in all contexts, even in complex layouts with overflow constraints.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-03-10 at 8 27 52 AM](https://github.com/user-attachments/assets/6eb841f4-f918-4a8a-b7fa-01192621777f)|![Screenshot 2025-03-12 at 4 37 40 PM](https://github.com/user-attachments/assets/e7d95106-b492-49a4-8872-f9d23a7b0f96)|

## Testing in `sage-lib`

- Navigate to [Dropdown](http://localhost:4100/?path=/docs/sage-dropdown--default)
- Verify the component renders and props still work as expected.


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**HIGH**) Converts dropdown to use popper.js for panel positioning.
   - [ ] Offers index view (with flag `comm_offers_page_revamp`).
   - [ ] General react dropdowns.


## Related
https://kajabi.atlassian.net/browse/DSS-1315
