### PR TITLE
style(inputs): correct variable name for form field background color

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -414,7 +414,7 @@
   appearance: none;
   border: var(--pine-border);
   border-radius: sage-border(radius-medium);
-  background: var(--pine-color-background);
+  background: var(--pine-color-background-container);
   transition: map-get($sage-transitions, input);
   transition-property: border, box-shadow, color;
 


### PR DESCRIPTION
## Description
Sage form inputs have no background color applied. This seems to be due to incorrect token values in the CSS.

This PR corrects the variable naming so the bg color is applied.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-03-13 at 10 49 23 AM](https://github.com/user-attachments/assets/03bd2bd9-0405-43fa-9e6f-b1f052e7f766)|![Screenshot 2025-03-13 at 10 50 40 AM](https://github.com/user-attachments/assets/ae4f301a-0fd7-447f-8ae6-5438904b3531)|


## Testing in `sage-lib`

- Navigate to input, select, textarea, etc.
- Verify correct variable is now coming through and background color is correct


## Testing in `kajabi-products`

1. (**LOW**) Correct background color for form inputs. Style only change.


## Related
https://kajabi.atlassian.net/browse/DSS-1330
