### PR TITLE
fix(dropdown): remove unnecessary wrapper div

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -399,22 +399,21 @@ export const Dropdown = ({
       {isActive && (
         <div aria-hidden="true" className="sage-dropdown__screen" onClick={onClickScreen} />
       )}
-      <div ref={triggerRef}>
-        <DropdownTrigger
-          disabled={disabled}
-          disclosure={disclosure}
-          icon={icon}
-          isLabelVisible={isLabelVisible}
-          label={label}
-          modifier={triggerModifier}
-          onClickTrigger={onClickTrigger}
-          subtleButton={triggerButtonSubtle}
-          triggerClassnames={triggerClassnames}
-          width={triggerWidth}
-        >
-          {customTrigger}
-        </DropdownTrigger>
-      </div>
+      <DropdownTrigger
+        disabled={disabled}
+        disclosure={disclosure}
+        icon={icon}
+        isLabelVisible={isLabelVisible}
+        label={label}
+        modifier={triggerModifier}
+        onClickTrigger={onClickTrigger}
+        ref={triggerRef}
+        subtleButton={triggerButtonSubtle}
+        triggerClassnames={triggerClassnames}
+        width={triggerWidth}
+      >
+        {customTrigger}
+      </DropdownTrigger>
       {/* Render dropdown portal directly to document body to escape overflow containers */}
       {isActive && (
         <ForwardedDropdownPanel


### PR DESCRIPTION
## Description
Removes erroneous trigger wrapper div that broke styles during positioning refactor. 


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1360" alt="d99e062c-460d-483c-bf73-9be770708f4f" src="https://github.com/user-attachments/assets/5f257154-d78a-48f8-8d3e-15893b1a11eb" />|![Screenshot 2025-03-26 at 4 16 04 PM](https://github.com/user-attachments/assets/a1401403-1ac7-44f8-90c0-5ccc7c685c54)|


## Testing in `sage-lib`
Navigate to Storybook dropdown
Verify that it still functions as expected.


## Testing in `kajabi-products`
I've verified against the [pages reported by QE](https://kajabi.atlassian.net/browse/QEINBOX-4341?focusedCommentId=187717), and this does seem to address them all.


## Related
https://github.com/Kajabi/kajabi-products/pull/40784
