### PR TITLE
fix(modal): add stacked modal attribute and restore original close all

### DIFF
--- a/docs/app/views/examples/components/modal/_preview.html.erb
+++ b/docs/app/views/examples/components/modal/_preview.html.erb
@@ -43,7 +43,7 @@ Basic modals contain a title, a body of content, and a footer with buttons.
 <%= sage_component SageDivider, {} %>
 
 <h3>Destructive</h3>
-<p>Contain a title, a body of content, and a footer with buttons. The call to action button 
+<p>Contain a title, a body of content, and a footer with buttons. The call to action button
 in the footer contain error styling to indicate that the action is destructive.</p>
 <%= sage_component SageButton, {
   style: "primary",
@@ -1004,4 +1004,94 @@ in the footer contain error styling to indicate that the action is destructive.<
       console.info("sage.modal.closeAll global event fired", e);
     });
   })();
+</script>
+
+<%= sage_component SageDivider, {} %>
+
+<h3>Stacked Modals</h3>
+<p>By default, clicking a close button or the backdrop will close all modals. To enable stacked modals where only the topmost modal closes:</p>
+
+<ul>
+  <li>Add <code>data-js-modal-close</code> to your close button to enable modal closing</li>
+  <li>Add <code>data-js-modal-stacked</code> to make the button close only its parent modal</li>
+</ul>
+
+<%= sage_component SageButtonGroup, { gap: :sm } do %>
+  <%= sage_component SageButton, {
+    style: "primary",
+    icon: { name: "launch", style: "right" },
+    value: "Open Stacked Modal Example",
+    attributes: {
+      "data-js-modaltrigger": "stacked-modal-example",
+    }
+  } %>
+<% end %>
+
+<%= sage_component SageModal, { id: "stacked-modal-example" } do %>
+  <%= sage_component SageModalContent, { title: "First Modal" } do %>
+    <% content_for :sage_header_aside do %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        value: "Close Modal",
+        icon: { name: "remove", style: "only" },
+        attributes: {
+          "data-js-modal-close": true,
+          "data-js-modal-stacked": true
+        }
+      } %>
+    <% end %>
+
+    <p>This modal's close button will only close this modal.</p>
+
+    <%= sage_component SageButton, {
+      style: "primary",
+      icon: { name: "launch", style: "right" },
+      value: "Open Second Modal",
+      attributes: {
+        "data-js-modaltrigger": "stacked-modal-example-2",
+      }
+    } %>
+  <% end %>
+<% end %>
+
+<%= sage_component SageModal, { id: "stacked-modal-example-2", fullscreen: true } do %>
+  <%= sage_component SageModalContent, { title: "Second Modal" } do %>
+    <% content_for :sage_header_aside do %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        subtle: true,
+        value: "Close Modal",
+        icon: { name: "remove", style: "only" },
+        attributes: {
+          "data-js-modal-close": true,
+          "data-js-modal-stacked": true
+        }
+      } %>
+    <% end %>
+
+    <p>This modal will stack on top of the first modal. Clicking its close button will only close this modal, leaving the first modal visible.</p>
+
+    <% content_for :sage_footer do %>
+      <%= sage_component SageButton, {
+        style: "secondary",
+        value: "Close All Modals",
+        attributes: {
+          "data-js-modal-close": true
+        }
+      } %>
+      <%= sage_component SageButton, {
+        style: "primary",
+        value: "Close This Modal Only",
+        attributes: {
+          "data-js-modal-close": true,
+          "data-js-modal-stacked": true
+        }
+      } %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<script>
+  // ... existing script ...
 </script>

--- a/packages/sage-system/lib/modal.js
+++ b/packages/sage-system/lib/modal.js
@@ -10,6 +10,7 @@ Sage.modal = (function() {
   const SELECTOR_MODAL_REMOTE_URL = "data-js-remote-url";
   const SELECTOR_MODAL_REMOVE_CONTENTS_ON_CLOSE = "data-js-modal-remove-content-on-close";
   const SELECTOR_MODAL_CLOSE = "data-js-modal-close";
+  const SELECTOR_MODAL_STACKED = "data-js-modal-stacked";
   const SELECTOR_MODALTRIGGER = "data-js-modaltrigger";
   const SELECTOR_PAGE_HAS_OPEN_MODAL = "sage-page--has-open-modal";
   const SELECTOR_FOCUSABLE_ELEMENTS = "a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type='text']:not([disabled]), input[type='radio']:not([disabled]), input[type='checkbox']:not([disabled]), select:not([disabled])";
@@ -58,8 +59,12 @@ Sage.modal = (function() {
       let closeButton = findElementWithAttribute(target, SELECTOR_MODAL_CLOSE);
 
       if (closeButton) {
-        // Find the parent modal of the close button
-        dispatchClose(el);
+        // If stacked attribute exists, close only current modal, otherwise close all
+        if (closeButton.hasAttribute(SELECTOR_MODAL_STACKED)) {
+          dispatchClose(el);
+        } else {
+          dispatchCloseAll();
+        }
         evt.stopPropagation(); // Prevent event bubbling
       }
     });
@@ -172,12 +177,18 @@ Sage.modal = (function() {
     document.removeEventListener("keyup", onModalKeypress);
   }
 
-  // Function to dispatch a close event for a specific modal
   function dispatchClose(modalEl) {
     if (!modalEl) return;
 
-    modalEl.dispatchEvent(new Event(EVENT_CLOSE));
-    closeModal(modalEl);
+    // Check if the close button has the stacked attribute
+    const closeButton = findElementWithAttribute(modalEl, SELECTOR_MODAL_CLOSE);
+    const isStacked = closeButton && closeButton.hasAttribute(SELECTOR_MODAL_STACKED);
+
+    if (isStacked) {
+      dispatchCloseAll();
+    } else {
+      closeModal(modalEl);
+    }
 
     // Only remove the keyup listener if there are no more active modals
     const activeModals = document.querySelectorAll(`.${MODAL_ACTIVE_CLASS}`);


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add stacked modal variant

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  CloseAll  | Stacked  |
|--------|--------|
|![modalCloseAll](https://github.com/user-attachments/assets/6e36f96a-643f-402b-9278-2e5463987f1c)|![modalStacked](https://github.com/user-attachments/assets/8a10607a-694c-4609-92f8-d627635eb846)|

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Visit the Rails Modal view and view the Stacked Modal section at the bottom 


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Modal - Add stacked modal variant.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
