### PR TITLE
style(button): correct height of button in input group

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -319,7 +319,7 @@ $-btn-loading-min-height: rem(36px);
     z-index: sage-z-index(default, 1);
     inset-inline-end: rem(1px);
     bottom: rem(1px);
-    height: rem(34px);
+    height: rem(38px);
     background-color: sage-color(white);
     background-color: var(--pine-color-secondary);
     border-color: transparent;


### PR DESCRIPTION
## Description
QE alerted DSS to an alignment issue within the input group. The button was not aligning properly.

This PR adjust the height of the button to correct the issue.


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-04-09 at 3 41 09 PM](https://github.com/user-attachments/assets/4b22d5c4-731e-4c07-ba19-b87c0af2490e)|![Screenshot 2025-04-09 at 3 38 57 PM](https://github.com/user-attachments/assets/0b940b07-fce2-4c78-9c2f-00dccaf0d162)|

## Testing in `sage-lib`
Navigate to [input group](http://localhost:4000/pages/component/input_group?tab=preview)
Verify alignment is corrected.

## Testing in `kajabi-products`

1. (**LOW**) correct height of button in input group.
   - [ ] Affiliate commissions


## Related
N/A
