### PR TITLE
fix: increases Dropdown flip padding

### DIFF
--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -203,7 +203,7 @@ export const Dropdown = ({
               'top-start', 'top', 'top-end',
               'bottom-start', 'bottom', 'bottom-end'
             ],
-            padding: 15, // Larger padding to flip sooner when approaching edges
+            padding: 20, // Larger padding to flip sooner when approaching edges
             flipVariations: true, // Consider alignment variations when flipping
             allowedAutoPlacements: ['top', 'bottom'], // Restrict to vertical placements
           },


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Increases Dropdown flip padding in Popper.js to fix issue with dropdown rendering under fixed header.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<!-- Before img here -->|<!-- After img here -->|
<img width="552" alt="Screenshot 2025-04-10 at 5 18 07 PM" src="https://github.com/user-attachments/assets/61029a50-73e2-49d5-b5a3-65ff4d568d66" />|<img width="659" alt="Screenshot 2025-04-10 at 5 13 34 PM" src="https://github.com/user-attachments/assets/30a7c28a-c420-4667-a987-21b1e16e1bcf" />

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
**Requires Kajabi Payments set up locally

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Increases Dropdown flip padding in Popper.js to fix issue with dropdown rendering under fixed header.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
N/A