### PR TITLE
fix(checkbox): add component attributes support

### DIFF
--- a/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_checkbox.html.erb
@@ -42,6 +42,7 @@
       <%= "checked" if component.checked %>
       <%= "disabled" if component.disabled %>
       <%= "required" if component.required %>
+      <%= component.generated_component_attributes.html_safe %>
     >
     <label for="<%= component.id %>" class="sage-checkbox__label">
       <%= component.label_text %>


### PR DESCRIPTION
## Description
On the rails checkbox component you cannot pass data attributes to the input for the non-standalone version of the checkbox.

This PR adds support for passing attributes to the input using the `component_attributes` as expected.


## Screenshots
No visual changes expected

## Testing in `sage-lib`
Verify when adding `component_attributes` to the non-standalone checkbox component the attributes are added to the internal `input` element.


## Testing in `kajabi-products`
1. (**LOW**) Adds component_attributes support to checkbox. No KP impact expected.


## Related
https://kajabi.atlassian.net/browse/DSS-1312
