### PR TITLE
style(input): enhance text input with direction and alignment

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -149,6 +149,13 @@ $-input-text-height: var(--pine-font-size-body);
   }
 }
 
+.sage-input__field[type="tel"],
+.sage-input__field[type="email"],
+.sage-input__field[type="url"] {
+  direction: inherit; /* Inherits from parent context */
+  text-align: start; /* Logical start, so it auto-adjusts */
+}
+
 .sage-input__icon {
   grid-row: 2 / 3;
   grid-column: -1 / -2;

--- a/packages/sage-assets/lib/stylesheets/components/_form_input.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_form_input.scss
@@ -149,13 +149,6 @@ $-input-text-height: var(--pine-font-size-body);
   }
 }
 
-.sage-input__field[type="tel"],
-.sage-input__field[type="email"],
-.sage-input__field[type="url"] {
-  direction: inherit; /* Inherits from parent context */
-  text-align: start; /* Logical start, so it auto-adjusts */
-}
-
 .sage-input__icon {
   grid-row: 2 / 3;
   grid-column: -1 / -2;
@@ -179,4 +172,18 @@ $-input-text-height: var(--pine-font-size-body);
   @include sage-form-field-message;
   display: flex;
   align-items: center;
+}
+
+// Ensures proper text direction for email/tel inputs - LTR for content, inherits direction for placeholder
+.sage-input__field[type="tel"],
+.sage-input__field[type="email"] {
+  text-align: start;
+
+  &:placeholder-shown {
+    direction: inherit;
+  }
+
+  &:not(:placeholder-shown) {
+    direction: ltr;
+  }
 }


### PR DESCRIPTION
## Description
When changing to RTL language, some form inputs do not properly align placeholder text. 
This PR adds additional styling to correct the alignments for better RTL support.

Additionally, tel and email placeholders should align right, but when filled out, they should align left. See [this link](https://rtlstyling.com/posts/rtl-styling/#form-inputs) for more details.

Updates apply to:
- tel
- email

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
||  Before  |  After  |
|--------|--------|--------|
|Placholder|![Screenshot 2025-04-15 at 4 40 51 PM](https://github.com/user-attachments/assets/613da960-5da4-4bdb-b63c-2637d43094e8)|![Screenshot 2025-04-15 at 4 41 01 PM](https://github.com/user-attachments/assets/1534cf2a-8ca5-4545-b3c9-5320a1f430ad)
Filled|![Screenshot 2025-04-15 at 5 24 16 PM](https://github.com/user-attachments/assets/c7ced3d5-f327-41e0-b98e-03426717fb77)|![Screenshot 2025-04-15 at 5 23 30 PM](https://github.com/user-attachments/assets/f7fa2f97-88a8-4e5f-a8a0-9470f8abf36f)|


## Testing in `sage-lib`
Navigate to form input (will need to switch `dir=rtl` in layout file or dev tools).
Verify input types `tel` & `email` show the placeholder aligned to the right for `rtl`.
Verify when input is filled, text aligns to left.


## Testing in `kajabi-products`
1. (**LOW**) Adjusts input alignment styles. No KP impact expected

## Related
https://kajabi.atlassian.net/browse/DSS-1364
