### PR TITLE
style(typography): adds Noto font family for language support

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_button.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_button.scss
@@ -181,7 +181,7 @@ $-btn-loading-min-height: rem(36px);
   align-items: center;
   justify-self: flex-start;
   padding: $-btn-base-padding-block $-btn-base-padding-inline;
-  font-family: $-heading-font;
+  font-family: var(--sage-font-family-heading);
   text-align: left; // Prevents text alignment issue when inner text is truncated
   border-width: 1px;
   border-style: solid;
@@ -246,7 +246,7 @@ $-btn-loading-min-height: rem(36px);
 
   .sage-dropdown__trigger--select & {
     min-height: var(--pine-dimension-xl);
-    font-family: $-body-font-stack;
+    font-family: var(--sage-font-family);
     font-weight: var(--pine-font-weight-medium);
     border-width: var(--pine-dimension-none);
     box-shadow: sage-border-interactive(default);

--- a/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_dropdown.scss
@@ -439,7 +439,7 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 }
 
 .sage-dropdown__trigger--select {
-  font-family: $-body-font-stack;
+  font-family: var(--sage-font-family);
 }
 
 .sage-dropdown__trigger--select,
@@ -496,4 +496,3 @@ $-dropdown-trigger-dropdown-offset: rem(16px) + sage-spacing(xs);
 .sage-dropdown-combo {
   width: 100%;
 }
-

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -25,6 +25,21 @@ $sage-sprig-font-path: "#{$sage-font-cdn-root}/sprig" !default; // pathname of f
 $sprig-file-name: "FAIRE-Sprig";
 $sprig-font-family-name: "FAIRE Sprig";
 
+/* stylelint-disable-next-line annotation-no-unknown */
+$sage-noto-arabic-font-path: "#{$sage-font-cdn-root}/noto" !default; // pathname of font directory
+$noto-arabic-file-name: "Noto-Sans-Arabic";
+$noto-arabic-font-family-name: "Noto Sans Arabic";
+
+/* stylelint-disable-next-line annotation-no-unknown */
+$sage-noto-hebrew-font-path: "#{$sage-font-cdn-root}/noto" !default; // pathname of font directory
+$noto-hebrew-file-name: "Noto-Sans-Hebrew";
+$noto-hebrew-font-family-name: "Noto Sans Hebrew";
+
+/* stylelint-disable-next-line annotation-no-unknown */
+$sage-noto-devanagari-font-path: "#{$sage-font-cdn-root}/noto" !default; // pathname of font directory
+$noto-devanagari-file-name: "Noto-Sans-Devanagari";
+$noto-devanagari-font-family-name: "Noto Sans Devanagari";
+
 // Light
 @font-face {
   font-display: swap;
@@ -591,4 +606,31 @@ $sprig-font-family-name: "FAIRE Sprig";
   font-weight: 900;
   src: local("#{$sprig-file-name}-SuperItalic"),
     url("#{$sage-sprig-font-path}/#{$sprig-file-name}-SuperItalic.woff2?v=#{$body-font-version}") format("woff2");
+}
+
+// Arabic font (Noto Sans Arabic)
+@font-face {
+  font-family: '#{$noto-arabic-font-family-name}';
+  src: local("#{$noto-arabic-file-name}"),
+    url("#{$sage-noto-arabic-font-path}/#{$noto-arabic-file-name}.woff2?v=#{$body-font-version}") format("woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+
+// Hebrew font (Noto Sans Hebrew)
+@font-face {
+  font-family: '#{$noto-hebrew-font-family-name}';
+  src: local("#{$noto-hebrew-file-name}"),
+    url("#{$sage-noto-hebrew-font-path}/#{$noto-hebrew-file-name}.woff2?v=#{$body-font-version}") format("woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+
+// Devanagari font (Noto Sans Devanagari)
+@font-face {
+  font-family: '#{$noto-devanagari-font-family-name}';
+  src: local("#{$noto-devanagari-file-name}"),
+    url("#{$sage-noto-devanagari-font-path}/#{$noto-devanagari-file-name}.woff2?v=#{$body-font-version}") format("woff2");
+  font-weight: normal;
+  font-style: normal;
 }

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -610,6 +610,7 @@ $noto-devanagari-font-family-name: "Noto Sans Devanagari";
 
 // Arabic font (Noto Sans Arabic)
 @font-face {
+  font-display: swap;
   font-family: "#{$noto-arabic-font-family-name}";
   src: local("#{$noto-arabic-file-name}"),
     url("#{$sage-noto-arabic-font-path}/#{$noto-arabic-file-name}.woff2?v=#{$body-font-version}") format("woff2");
@@ -619,6 +620,7 @@ $noto-devanagari-font-family-name: "Noto Sans Devanagari";
 
 // Hebrew font (Noto Sans Hebrew)
 @font-face {
+  font-display: swap;
   font-family: "#{$noto-hebrew-font-family-name}";
   src: local("#{$noto-hebrew-file-name}"),
     url("#{$sage-noto-hebrew-font-path}/#{$noto-hebrew-file-name}.woff2?v=#{$body-font-version}") format("woff2");
@@ -628,6 +630,7 @@ $noto-devanagari-font-family-name: "Noto Sans Devanagari";
 
 // Devanagari font (Noto Sans Devanagari)
 @font-face {
+  font-display: swap;
   font-family: "#{$noto-devanagari-font-family-name}";
   src: local("#{$noto-devanagari-file-name}"),
     url("#{$sage-noto-devanagari-font-path}/#{$noto-devanagari-file-name}.woff2?v=#{$body-font-version}") format("woff2");

--- a/packages/sage-assets/lib/stylesheets/core/_fonts.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_fonts.scss
@@ -610,7 +610,7 @@ $noto-devanagari-font-family-name: "Noto Sans Devanagari";
 
 // Arabic font (Noto Sans Arabic)
 @font-face {
-  font-family: '#{$noto-arabic-font-family-name}';
+  font-family: "#{$noto-arabic-font-family-name}";
   src: local("#{$noto-arabic-file-name}"),
     url("#{$sage-noto-arabic-font-path}/#{$noto-arabic-file-name}.woff2?v=#{$body-font-version}") format("woff2");
   font-weight: normal;
@@ -619,7 +619,7 @@ $noto-devanagari-font-family-name: "Noto Sans Devanagari";
 
 // Hebrew font (Noto Sans Hebrew)
 @font-face {
-  font-family: '#{$noto-hebrew-font-family-name}';
+  font-family: "#{$noto-hebrew-font-family-name}";
   src: local("#{$noto-hebrew-file-name}"),
     url("#{$sage-noto-hebrew-font-path}/#{$noto-hebrew-file-name}.woff2?v=#{$body-font-version}") format("woff2");
   font-weight: normal;
@@ -628,7 +628,7 @@ $noto-devanagari-font-family-name: "Noto Sans Devanagari";
 
 // Devanagari font (Noto Sans Devanagari)
 @font-face {
-  font-family: '#{$noto-devanagari-font-family-name}';
+  font-family: "#{$noto-devanagari-font-family-name}";
   src: local("#{$noto-devanagari-file-name}"),
     url("#{$sage-noto-devanagari-font-path}/#{$noto-devanagari-file-name}.woff2?v=#{$body-font-version}") format("woff2");
   font-weight: normal;

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -306,18 +306,18 @@ h6,
 // Language-specific font-family rules for internationalization
 html[lang="he"],
 [lang="he"] {
-  --sage-font-family: "Noto Sans Hebrew", "Rubik", "Arial Hebrew", "Frank Ruehl", "tahoma", sans-serif;
-  --sage-font-family-heading: "Noto Sans Hebrew", "Rubik", "Arial Hebrew", "Frank Ruehl", "tahoma", sans-serif;
+  --sage-font-family: "Noto Sans Hebrew", "Arial Hebrew", "Rubik", "Frank Ruehl", "tahoma", system-ui, sans-serif;
+  --sage-font-family-heading: "Noto Sans Hebrew", "Arial Hebrew", "Rubik", "Frank Ruehl", "tahoma", system-ui, sans-serif;
 }
 
 html[lang="ar"],
 [lang="ar"] {
-  --sage-font-family: "Noto Sans Arabic", "Cairo", "Amiri", "tahoma", "arial", sans-serif;
-  --sage-font-family-heading: "Noto Sans Arabic", "Cairo", "Amiri", "tahoma", "arial", sans-serif;
+  --sage-font-family: "Noto Sans Arabic", "Cairo", "Amiri", "tahoma", "arial", system-ui, sans-serif;
+  --sage-font-family-heading: "Noto Sans Arabic", "Cairo", "Amiri", "tahoma", "arial", system-ui, sans-serif;
 }
 
 html[lang="hi"],
 [lang="hi"] {
-  --sage-font-family: "Noto Sans Devanagari", "Mangal", "Kokila", "Lohit Devanagari", "Sahadeva", sans-serif;
-  --sage-font-family-heading: "Noto Sans Devanagari", "Mangal", "Kokila", "Lohit Devanagari", "Sahadeva", sans-serif;
+  --sage-font-family: "Noto Sans Devanagari", "Mangal", "Kokila", "Lohit Devanagari", "Sahadeva", "tahoma", system-ui, sans-serif;
+  --sage-font-family-heading: "Noto Sans Devanagari", "Mangal", "Kokila", "Lohit Devanagari", "Sahadeva", "tahoma", system-ui, sans-serif;
 }

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -210,7 +210,12 @@ body:not(.sage-excluded),
   }
 }
 
-h1, h2, h3, h4, h5, h6,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
 [class*="t-sage-heading-"] {
   font-family: var(--sage-font-family-heading);
 }
@@ -299,17 +304,20 @@ h1, h2, h3, h4, h5, h6,
 }
 
 // Language-specific font-family rules for internationalization
-html[lang="he"], [lang="he"] {
-  --sage-font-family: 'Noto Sans Hebrew', 'Rubik', 'Arial Hebrew', 'Frank Ruehl', Tahoma, sans-serif;
-  --sage-font-family-heading: 'Noto Sans Hebrew', 'Rubik', 'Arial Hebrew', 'Frank Ruehl', Tahoma, sans-serif;
+html[lang="he"],
+[lang="he"] {
+  --sage-font-family: "Noto Sans Hebrew", "Rubik", "Arial Hebrew", "Frank Ruehl", "tahoma", sans-serif;
+  --sage-font-family-heading: "Noto Sans Hebrew", "Rubik", "Arial Hebrew", "Frank Ruehl", "tahoma", sans-serif;
 }
 
-html[lang="ar"], [lang="ar"] {
-  --sage-font-family: 'Noto Sans Arabic', 'Cairo', 'Amiri', Tahoma, Arial, sans-serif;
-  --sage-font-family-heading: 'Noto Sans Arabic', 'Cairo', 'Amiri', Tahoma, Arial, sans-serif;
+html[lang="ar"],
+[lang="ar"] {
+  --sage-font-family: "Noto Sans Arabic", "Cairo", "Amiri", "tahoma", "arial", sans-serif;
+  --sage-font-family-heading: "Noto Sans Arabic", "Cairo", "Amiri", "tahoma", "arial", sans-serif;
 }
 
-html[lang="hi"], [lang="hi"] {
-  --sage-font-family: 'Noto Sans Devanagari', 'Mangal', 'Kokila', 'Lohit Devanagari', 'Sahadeva', sans-serif;
-  --sage-font-family-heading: 'Noto Sans Devanagari', 'Mangal', 'Kokila', 'Lohit Devanagari', 'Sahadeva', sans-serif;
+html[lang="hi"],
+[lang="hi"] {
+  --sage-font-family: "Noto Sans Devanagari", "Mangal", "Kokila", "Lohit Devanagari", "Sahadeva", sans-serif;
+  --sage-font-family-heading: "Noto Sans Devanagari", "Mangal", "Kokila", "Lohit Devanagari", "Sahadeva", sans-serif;
 }

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -210,16 +210,6 @@ body:not(.sage-excluded),
   }
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-[class*="t-sage-heading-"] {
-  font-family: var(--sage-font-family-heading);
-}
-
 // Generate text color modifiers
 @each $color-name, $color-slider in $sage-colors {
   $color-value: "";

--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -42,6 +42,10 @@ $-headings-margin-block-end: sage-spacing(sm);
   --sage-line-height-h3: #{map-get($sage-line-heights, 3xl)};
   --sage-line-height-h2: #{map-get($sage-line-heights, 4xl)};
   --sage-line-height-h1: #{map-get($sage-line-heights, 5xl)};
+
+  // Font family
+  --sage-font-family: #{$-body-font-stack};
+  --sage-font-family-heading: #{$-heading-font};
 }
 
 // Responsive adjustments are currently TBD
@@ -206,6 +210,10 @@ body:not(.sage-excluded),
   }
 }
 
+h1, h2, h3, h4, h5, h6,
+[class*="t-sage-heading-"] {
+  font-family: var(--sage-font-family-heading);
+}
 
 // Generate text color modifiers
 @each $color-name, $color-slider in $sage-colors {
@@ -288,4 +296,20 @@ body:not(.sage-excluded),
   text-decoration-thickness: 12%;
   text-underline-offset: 0.3rem;
   text-underline-position: under;
+}
+
+// Language-specific font-family rules for internationalization
+html[lang="he"], [lang="he"] {
+  --sage-font-family: 'Noto Sans Hebrew', 'Rubik', 'Arial Hebrew', 'Frank Ruehl', Tahoma, sans-serif;
+  --sage-font-family-heading: 'Noto Sans Hebrew', 'Rubik', 'Arial Hebrew', 'Frank Ruehl', Tahoma, sans-serif;
+}
+
+html[lang="ar"], [lang="ar"] {
+  --sage-font-family: 'Noto Sans Arabic', 'Cairo', 'Amiri', Tahoma, Arial, sans-serif;
+  --sage-font-family-heading: 'Noto Sans Arabic', 'Cairo', 'Amiri', Tahoma, Arial, sans-serif;
+}
+
+html[lang="hi"], [lang="hi"] {
+  --sage-font-family: 'Noto Sans Devanagari', 'Mangal', 'Kokila', 'Lohit Devanagari', 'Sahadeva', sans-serif;
+  --sage-font-family-heading: 'Noto Sans Devanagari', 'Mangal', 'Kokila', 'Lohit Devanagari', 'Sahadeva', sans-serif;
 }

--- a/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
+++ b/packages/sage-assets/lib/stylesheets/core/mixins/_sage.scss
@@ -707,7 +707,7 @@
 /// Adds the default font family
 ///
 @mixin sage-font-family() {
-  font-family: $-body-font-stack;
+  font-family: var(--sage-font-family);
   font-feature-settings: "liga" 1, "calt" 1; /* fix for Chrome */
 }
 

--- a/packages/sage-assets/lib/stylesheets/global/_reboot.scss
+++ b/packages/sage-assets/lib/stylesheets/global/_reboot.scss
@@ -33,8 +33,7 @@ section {
 
 body {
   margin: 0;
-  font-family: "Inter", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: var(--sage-font-family);
   font-feature-settings: "liga" 1, "calt" 1; /* fix for Chrome */
   font-size: 1rem;
   font-weight: 400;
@@ -62,16 +61,11 @@ h3,
 h4,
 h5,
 h6,
-.t-sage-heading-1,
-.t-sage-heading-2,
-.t-sage-heading-3,
-.t-sage-heading-4,
-.t-sage-heading-5,
-.t-sage-heading-6 {
+[class*="t-sage-heading-"] {
   margin-block-start: 0;
   margin-block-end: 0;
   color: sage-color(grey, 950);
-  font-family: "Greet Standard", "Inter", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Ubuntu", sans-serif ;
+  font-family: var(--sage-font-family-heading);
 }
 
 p {


### PR DESCRIPTION
## Description
Adds Noto fonts to support additional languages

- Noto Sans Arabic
- Noto Sans Hebrew
- Noto Sans Devanagari (used for Hindi)


## Screenshots
No visual changes expected.


## Testing in `sage-lib`
Navigate to the docs site. Verify that when changing the `lang` attribute, the correct font-family is applied.

## Testing in `kajabi-products`
1. (**LOW**) Adds Noto font to system. No KP impact expected.

## Related
https://kajabi.atlassian.net/browse/DSS-1379
