### PR TITLE
fix: remove pine core from consumables

### DIFF
--- a/docs/app/views/application/_app_head_content.html.erb
+++ b/docs/app/views/application/_app_head_content.html.erb
@@ -9,6 +9,7 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-T8W9NCJ');</script>
 <% end %>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@pine-ds/core@latest/dist/pine-core/pine-core.css">
 <%= stylesheet_pack_tag "docs" %>
 <link rel="canonical" href="<%= url_for(only_path: false) %>" />
 <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" type="image/png">

--- a/packages/sage-assets/lib/stylesheets/_consumables.scss
+++ b/packages/sage-assets/lib/stylesheets/_consumables.scss
@@ -17,6 +17,3 @@
 // Global Variables
 @import "core/variables";
 
-
-// Pine Styles
-@import "https://cdn.jsdelivr.net/npm/@pine-ds/core@latest/dist/pine-core/pine-core.css";


### PR DESCRIPTION
## Description
This is attempts to remove the many import statements to pine-core in a consuming app. 


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW/MEDIUM/HIGH/BREAKING**) Description of the change and its impact with QA as the audience.
   - [ ] One more examples of the component in use to either test the change or verify the change has not had adverse effects.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
