### PR TITLE
refactor(inputaffixes): streamline affix handling and correct padding

### DIFF
--- a/packages/sage-system/lib/inputaffixes.js
+++ b/packages/sage-system/lib/inputaffixes.js
@@ -11,47 +11,12 @@ Sage.inputaffixes = (() => {
   const valueClass = "sage-input__affix-value";
   const valueElement = "span";
   const inputPaddingOffset = 16;
+  const observers = []; // To store IntersectionObserver instances for cleanup
 
 
   // ==================================================
   // Functions
   // ==================================================
-
-  // Adds affix content to an element
-  const addAffixes = (el) => {
-    const elRoot = el;
-    const elInput = el.querySelector(`.${fieldClass}`);
-
-    // Toggle off the affixed class
-    elRoot.classList.remove(affixRootClass);
-
-    if (elRoot.dataset.jsInputPrefix) {
-      const elLabel = makeLabel(elRoot.dataset.jsInputPrefix, 'prefix');
-      elRoot.appendChild(elLabel);
-      elRoot.classList.add(prefixRootClass);
-      const parentDir = elRoot.closest("html").getAttribute('dir');
-      console.log("parentDir", parentDir);
-
-      if (parentDir === 'rtl') {
-        elInput.style.paddingRight = `${elLabel.offsetWidth + inputPaddingOffset}px`;
-      } else {
-        elInput.style.paddingLeft = `${elLabel.offsetWidth + inputPaddingOffset}px`;
-      }
-    }
-
-    if (elRoot.dataset.jsInputSuffix) {
-      const elLabel = makeLabel(elRoot.dataset.jsInputSuffix, 'suffix');
-      elRoot.appendChild(elLabel);
-      elRoot.classList.add(suffixRootClass);
-      const parentDir = elRoot.closest("html").getAttribute('dir');
-
-      if (parentDir === 'rtl') {
-        elInput.style.paddingLeft = `${elLabel.offsetWidth + inputPaddingOffset}px`;
-      } else {
-        elInput.style.paddingRight = `${elLabel.offsetWidth + inputPaddingOffset}px`;
-      }
-    }
-  };
 
   // Make the sage-label that will display the affix content
   const makeLabel = (content, type) => {
@@ -71,22 +36,130 @@ Sage.inputaffixes = (() => {
     return elLabel;
   };
 
+  // Updates the padding on the input field based on visible affix widths
+  const updateInputPadding = (elRoot, elInput) => {
+    if (!elInput) return;
+
+    // Reset padding for recalculation using logical properties
+    elInput.style.paddingInlineStart = '';
+    elInput.style.paddingInlineEnd = '';
+
+    const prefixEl = elRoot.querySelector(`.${affixClass}--prefix`);
+    if (prefixEl && prefixEl.offsetWidth > 0) { // Check offsetWidth to ensure visibility
+      elInput.style.paddingInlineStart = `${prefixEl.offsetWidth + inputPaddingOffset}px`;
+    }
+
+    const suffixEl = elRoot.querySelector(`.${affixClass}--suffix`);
+    if (suffixEl && suffixEl.offsetWidth > 0) { // Check offsetWidth to ensure visibility
+      elInput.style.paddingInlineEnd = `${suffixEl.offsetWidth + inputPaddingOffset}px`;
+    }
+  };
+
+  // Sets up the DOM structure for affixes (labels) and manages root classes.
+  // This function is designed to be idempotent for DOM creation.
+  const setupAffixesDOMAndClasses = (elRoot) => {
+    const elInput = elRoot.querySelector(`.${fieldClass}`);
+    if (!elInput) return; // Should not happen if elRoot is a valid affix container
+
+    let hasActiveAffixes = false;
+
+    // Handle Prefix
+    if (elRoot.dataset.jsInputPrefix) {
+      // Add prefix label only if it doesn't exist
+      if (!elRoot.querySelector(`.${affixClass}--prefix`)) {
+        const elLabel = makeLabel(elRoot.dataset.jsInputPrefix, 'prefix');
+        elRoot.appendChild(elLabel);
+      }
+      elRoot.classList.add(prefixRootClass);
+      hasActiveAffixes = true;
+    } else {
+      // If no data-prefix attribute, remove any existing prefix DOM and class
+      const existingPrefix = elRoot.querySelector(`.${affixClass}--prefix`);
+      if (existingPrefix) existingPrefix.remove();
+      elRoot.classList.remove(prefixRootClass);
+    }
+
+    // Handle Suffix
+    if (elRoot.dataset.jsInputSuffix) {
+      // Add suffix label only if it doesn't exist
+      if (!elRoot.querySelector(`.${affixClass}--suffix`)) {
+        const elLabel = makeLabel(elRoot.dataset.jsInputSuffix, 'suffix');
+        elRoot.appendChild(elLabel);
+      }
+      elRoot.classList.add(suffixRootClass);
+      hasActiveAffixes = true;
+    } else {
+      // If no data-suffix attribute, remove any existing suffix DOM and class
+      const existingSuffix = elRoot.querySelector(`.${affixClass}--suffix`);
+      if (existingSuffix) existingSuffix.remove();
+      elRoot.classList.remove(suffixRootClass);
+    }
+
+    // Manage the main affixRootClass based on whether any affixes are active
+    if (hasActiveAffixes) {
+      elRoot.classList.add(affixRootClass); // Ensure it's present
+    } else {
+      // If no affixes are active (e.g. data attributes removed), remove the root class
+      elRoot.classList.remove(affixRootClass);
+    }
+  };
+
+
   const handleAffixClick = (ev) => {
     if (ev.target.classList.contains(valueClass)) {
       // Find neighboring input and focus on it
-      ev.target.parentNode.parentNode.querySelector(`.${fieldClass}`).focus();
+      const affixContainer = ev.target.closest(`.${affixRootClass}`);
+      const inputField = affixContainer ? affixContainer.querySelector(`.${fieldClass}`) : null;
+      if (inputField) {
+        inputField.focus();
+      }
     }
   };
 
   const unbind = () => {
     document.removeEventListener("click", handleAffixClick);
+    observers.forEach(observer => observer.disconnect());
+    observers.length = 0; // Clear the array of observers
   };
 
   const init = () => {
-    if (document.querySelector(`.${affixRootClass}`) !== null) {
-      const affixElements = Sage.util.nodelistToArray(document.querySelectorAll(`.${affixRootClass}`));
-      affixElements.forEach((el) => {
-        addAffixes(el);
+    unbind(); // Clear any previous observers and listeners
+
+    // Select elements that are designated affix roots or have data attributes for affixes
+    const elementsToProcess = Sage.util.nodelistToArray(
+      document.querySelectorAll(`.${affixRootClass}, [data-js-input-prefix], [data-js-input-suffix]`)
+    );
+
+    if (elementsToProcess.length > 0) {
+      elementsToProcess.forEach((elRoot) => {
+        const elInput = elRoot.querySelector(`.${fieldClass}`);
+        if (!elInput) {
+          // Only warn if it was explicitly an affixRootClass but structure is wrong
+          if (elRoot.classList.contains(affixRootClass)) {
+            console.warn('Sage.inputaffixes: Affix root is missing its field element.', elRoot);
+          }
+          return; // Skip elements without an input field
+        }
+
+        setupAffixesDOMAndClasses(elRoot); // Ensure DOM and classes are correctly set up
+
+        // If after setup, the element no longer qualifies for affixes, skip observer
+        if (!elRoot.classList.contains(affixRootClass) && !elRoot.dataset.jsInputPrefix && !elRoot.dataset.jsInputSuffix) {
+            return;
+        }
+
+        // Create an IntersectionObserver for this element
+        const observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              // Element is now visible, update its padding
+              updateInputPadding(entry.target, entry.target.querySelector(`.${fieldClass}`));
+            }
+          });
+        }, { threshold: 0.01 }); // Trigger when at least 1% of the element is visible
+
+        observer.observe(elRoot);
+        observers.push(observer); // Store for cleanup in unbind
       });
 
       document.addEventListener("click", handleAffixClick);


### PR DESCRIPTION
## Description

Form inputs with prefixes/suffixes that are hidden on page load (e.g., a hidden expandable div) receive incorrect padding when they become visible. This happens because their dimensions can't be measured when hidden, causing text overlap or misalignment once they become visible.

The `inputaffixes.js` script will now use an `IntersectionObserver` to calculate padding when an input becomes visible, ensuring correct dimensions. Padding will also now utilize CSS logical properties (paddingInlineStart/paddingInlineEnd) for automatic LTR/RTL support.

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|![2025-05-06 16 04 23](https://github.com/user-attachments/assets/0f0af164-2238-49f4-b381-d33b3d2c86e4)|![2025-05-06 16 05 12](https://github.com/user-attachments/assets/a65ff078-84b9-4f27-9853-4cab6398ee36)|

## Testing in `sage-lib`
Navigate to the form input
Verify the prefix and suffix functions as expected


## Testing in `kajabi-products`

1. (**LOW**) Refactor input prefix/suffix padding JS. 
   - [ ] Sanity check any inputs with prefix/suffix


## Related
https://kajabi.atlassian.net/browse/DSS-1274
