### PR TITLE
feat: adds "...rest" to components

### DIFF
--- a/packages/sage-react/lib/Card/CardHighlight.jsx
+++ b/packages/sage-react/lib/Card/CardHighlight.jsx
@@ -9,7 +9,8 @@ export const CardHighlight = ({
   color,
   customColor,
   position,
-  value
+  value,
+  ...rest
 }) => {
   const hasContent = value || children;
   const classNames = classnames(
@@ -29,6 +30,7 @@ export const CardHighlight = ({
       style={(customColor && customColor !== '') && ({
         '--color': customColor,
       })}
+      {...rest}
     >
       {children && (
         <span className="visually-hidden">{children}</span>

--- a/packages/sage-react/lib/Carousel/Carousel.jsx
+++ b/packages/sage-react/lib/Carousel/Carousel.jsx
@@ -8,6 +8,7 @@ import { Indicator } from '../Indicator';
 export const Carousel = ({
   children,
   options,
+  ...rest
 }) => {
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [slidesLength, setSlidesLength] = useState(0);
@@ -78,7 +79,7 @@ export const Carousel = ({
   }, [mySlider]);
 
   return (
-    <div className="sage-carousel" aria-roledescription="carousel">
+    <div className="sage-carousel" aria-roledescription="carousel" {...rest}>
       <div className="sage-carousel__container">
         <CarouselArrow
           disabled={arrowPrevDisabled}

--- a/packages/sage-react/lib/Carousel/CarouselArrow.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselArrow.jsx
@@ -8,6 +8,7 @@ export const CarouselArrow = ({
   icon,
   id,
   onClickCallback,
+  ...rest
 }) => {
   const baseClass = 'sage-carousel__arrow';
   const classNames = classnames(
@@ -24,6 +25,7 @@ export const CarouselArrow = ({
       onClick={onClickCallback}
       role="button"
       tabIndex={-1}
+      {...rest}
     >
       <Icon icon={icon} size="lg" />
     </div>

--- a/packages/sage-react/lib/Carousel/CarouselSlide.jsx
+++ b/packages/sage-react/lib/Carousel/CarouselSlide.jsx
@@ -5,12 +5,14 @@ export const CarouselSlide = ({
   content,
   index,
   length,
+  ...rest
 }) => (
   <div
     aria-label={`${index + 1} of ${length}`}
     aria-roledescription="slide"
     className="sage-carousel__slide"
     role="group"
+    {...rest}
   >
     {content}
   </div>

--- a/packages/sage-react/lib/Chart/Chart.jsx
+++ b/packages/sage-react/lib/Chart/Chart.jsx
@@ -14,6 +14,7 @@ export const Chart = ({
   loading,
   containerStyles,
   type,
+  ...rest
 }) => {
   const renderChart = () => {
     if (!data) {
@@ -42,7 +43,7 @@ export const Chart = ({
   };
 
   return (
-    <div className="sage-chart-container" style={containerStyles}>
+    <div className="sage-chart-container" style={containerStyles} {...rest}>
       {loading ? (
         <Loader loading={true} type={Loader.TYPES.SPINNER} />
       ) : renderChart()}

--- a/packages/sage-react/lib/Chart/parts/Legend.jsx
+++ b/packages/sage-react/lib/Chart/parts/Legend.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const Legend = ({ payload }) => (
-  <ul className="sage-chart-legend">
+export const Legend = ({ payload, ...rest }) => (
+  <ul className="sage-chart-legend" {...rest}>
     {
       payload.map(({ value, color }) => (
         <li

--- a/packages/sage-react/lib/Chart/parts/Tooltip.jsx
+++ b/packages/sage-react/lib/Chart/parts/Tooltip.jsx
@@ -8,6 +8,7 @@ export const Tooltip = ({
   active,
   payload,
   contentFormatterFn,
+  ...rest
 }) => ((active && payload && payload.length > 0) ? (
   <TooltipElement
     content={(
@@ -21,6 +22,7 @@ export const Tooltip = ({
     )}
     position={null}
     theme={TooltipElement.THEMES.LIGHT}
+    {...rest}
   />
 ) : null);
 

--- a/packages/sage-react/lib/CopyButton/CopyButton.jsx
+++ b/packages/sage-react/lib/CopyButton/CopyButton.jsx
@@ -10,7 +10,8 @@ export const CopyButton = ({
   children,
   className,
   fillContainer,
-  semibold
+  semibold,
+  ...rest
 }) => {
   const classNames = classnames(
     'sage-copy-btn',
@@ -38,6 +39,7 @@ export const CopyButton = ({
         subtle={true}
         type="button"
         onClick={onClick}
+        {...rest}
       >
         {borderless ? (
           children

--- a/packages/sage-react/lib/CopyText/CopyText.jsx
+++ b/packages/sage-react/lib/CopyText/CopyText.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SageClassnames } from '../configs';
 
-export const CopyText = ({ children, className, semibold }) => {
+export const CopyText = ({ children, className, semibold, ...rest }) => {
   const classNames = classnames(
     'sage-copy-text',
     className,
@@ -14,7 +14,7 @@ export const CopyText = ({ children, className, semibold }) => {
 
   return (
     <>
-      <span className={classNames}>
+      <span className={classNames} {...rest}>
         {children}
       </span>
       <pds-icon name="copy" class={SageClassnames.SPACERS.SM_LEFT} />

--- a/packages/sage-react/lib/CopyText/CopyTextCard.jsx
+++ b/packages/sage-react/lib/CopyText/CopyTextCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-export const CopyTextCard = ({ children, className, semibold }) => {
+export const CopyTextCard = ({ children, className, semibold, ...rest }) => {
   const classNames = classnames(
     'sage-copy-text-card',
     className,
@@ -12,7 +12,7 @@ export const CopyTextCard = ({ children, className, semibold }) => {
   );
 
   return (
-    <div className={classNames}>
+    <div className={classNames} {...rest}>
       {children}
     </div>
   );

--- a/packages/sage-react/lib/Drawer/Drawer.jsx
+++ b/packages/sage-react/lib/Drawer/Drawer.jsx
@@ -31,6 +31,7 @@ export const Drawer = ({
   showClose,
   size,
   title,
+  ...rest
 }) => {
   useEffect(() => {
     if (onExpandChange) {
@@ -76,6 +77,7 @@ export const Drawer = ({
       style={{
         '--sage-drawer-compact-width': `${customWidth}px`
       }}
+      {...rest}
     >
       {(customHeader || title || showClose) && (
         <Modal.Header

--- a/packages/sage-react/lib/Dropdown/Dropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/Dropdown.jsx
@@ -44,6 +44,7 @@ export const Dropdown = ({
   triggerClassnames,
   triggerModifier,
   triggerWidth,
+  ...rest
 }) => {
   const [isActive, setActive] = useState(false);
   const [isPositioned, setIsPositioned] = useState(false);
@@ -290,7 +291,7 @@ export const Dropdown = ({
   );
 
   return (
-    <div ref={wrapperRef} className={classNames} {...a11yAttrs}>
+    <div ref={wrapperRef} className={classNames} {...a11yAttrs} {...rest}>
       {isActive && (
         <div aria-hidden="true" className="sage-dropdown__screen" onClick={onClickScreen} />
       )}

--- a/packages/sage-react/lib/Dropdown/DropdownItemList.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItemList.jsx
@@ -15,6 +15,7 @@ export const DropdownItemList = ({
   onSearch,
   searchable,
   searchPlaceholder,
+  ...rest
 }) => {
   const [searchTerms, updateSearchTerms] = useState('');
   const [filteredItems, updateFilteredItem] = useState(items);
@@ -54,7 +55,7 @@ export const DropdownItemList = ({
           onChangeSearchTerms={onChangeSearchTerms}
         />
       )}
-      <ul className="sage-dropdown__menu" role="menu">
+      <ul className="sage-dropdown__menu" role="menu" {...rest}>
         {localSelectedItems.length > 0 && localSelectedItems.map((item, i) => (
           <DropdownItem
             borderAfter={i === localSelectedItems.length - 1}

--- a/packages/sage-react/lib/Dropdown/DropdownItemSearch.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownItemSearch.jsx
@@ -7,6 +7,7 @@ export const DropdownItemSearch = ({
   onEnter,
   placeholder,
   selectedValue,
+  ...rest
 }) => {
   const [value, updateValue] = useState('');
 
@@ -34,6 +35,7 @@ export const DropdownItemSearch = ({
       onKeyUp={onKeyUp}
       placeholder={placeholder}
       role="none"
+      {...rest}
     />
   );
 };

--- a/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownPanel.jsx
@@ -12,6 +12,7 @@ export const DropdownPanel = ({
   onClickScreen,
   onExit,
   style,
+  ...rest
 }) => {
   const menuEl = useRef(null);
   const classNames = classnames(
@@ -54,6 +55,7 @@ export const DropdownPanel = ({
         transitionProperty: (style && style.transition) ? undefined : 'none',
         willChange: 'transform, opacity'
       }}
+      {...rest}
     >
       {children && React.cloneElement(children, { onExit })}
     </div>

--- a/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTrigger.jsx
@@ -15,6 +15,7 @@ export const DropdownTrigger = ({
   subtleButton,
   triggerClassnames,
   width,
+  ...rest
 }) => {
   const onClick = () => {
     onClickTrigger();
@@ -47,6 +48,7 @@ export const DropdownTrigger = ({
             label={label}
             onClick={onClickTrigger}
             subtle={subtleButton}
+            {...rest}
           />
         )}
     </div>

--- a/packages/sage-react/lib/Dropdown/DropdownTriggerDefault.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerDefault.jsx
@@ -12,6 +12,7 @@ export const DropdownTriggerDefault = ({
   label,
   onClick,
   subtle,
+  ...rest
 }) => (
   <Button
     className={className}
@@ -23,6 +24,7 @@ export const DropdownTriggerDefault = ({
     onClick={onClick}
     type="button"
     subtle={subtle}
+    {...rest}
   >
     {label}
   </Button>

--- a/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
+++ b/packages/sage-react/lib/Dropdown/DropdownTriggerSelect.jsx
@@ -12,7 +12,8 @@ export const DropdownTriggerSelect = ({
   icon,
   onClick,
   selectedValue,
-  triggerClassnames
+  triggerClassnames,
+  ...rest
 }) => {
   const classNames = classnames(
     'sage-dropdown__trigger-selected-value',
@@ -29,6 +30,7 @@ export const DropdownTriggerSelect = ({
         iconPosition={Button.ICON_POSITIONS.RIGHT}
         type="button"
         onClick={onClick}
+        {...rest}
       >
         {icon && (<Icon icon={icon} className={SageClassnames.SPACERS.XS_RIGHT} />)}
         {selectedValue}

--- a/packages/sage-react/lib/Dropdown/ToolbarEditorDropdown.jsx
+++ b/packages/sage-react/lib/Dropdown/ToolbarEditorDropdown.jsx
@@ -17,6 +17,7 @@ export const ToolbarEditorDropdown = ({
   options,
   triggerClassnames,
   triggerButtonSubtle,
+  ...rest
 }) => (
   <Dropdown
     align={align}
@@ -33,6 +34,7 @@ export const ToolbarEditorDropdown = ({
     triggerModifier="options"
     triggerButtonSubtle={triggerButtonSubtle}
     triggerClassnames={triggerClassnames}
+    {...rest}
   >
     <ul className="sage-dropdown__menu">
       {options.map((item) => (

--- a/packages/sage-react/lib/Indicator/Indicator.jsx
+++ b/packages/sage-react/lib/Indicator/Indicator.jsx
@@ -9,6 +9,7 @@ export const Indicator = ({
   numItems,
   preposition,
   showText,
+  ...rest
 }) => {
   let classNames;
   const baseClass = 'sage-indicator';
@@ -42,6 +43,7 @@ export const Indicator = ({
         <ul
           className={`sage-indicator-list ${className}`}
           aria-label={`Showing ${label} ${currentItem} ${preposition} ${numItems}`}
+          {...rest}
         >
           {items}
         </ul>

--- a/packages/sage-react/lib/List/ListItem.jsx
+++ b/packages/sage-react/lib/List/ListItem.jsx
@@ -10,6 +10,7 @@ export const ListItem = ({
   id,
   moreActions,
   sortable,
+  ...rest
 }) => {
   const classNames = classnames(
     'sage-list__item',
@@ -20,7 +21,7 @@ export const ListItem = ({
   );
 
   return (
-    <li className={classNames} id={id}>
+    <li className={classNames} id={id} {...rest}>
       {sortable && (
         <div className="sage-list__item-sortable-handle">
           <Icon icon={Icon.ICONS.HANDLE_2_VERTICAL} label="Drag to sort" />

--- a/packages/sage-react/lib/NextBestAction/NextBestAction.jsx
+++ b/packages/sage-react/lib/NextBestAction/NextBestAction.jsx
@@ -13,6 +13,7 @@ export const NextBestAction = ({
   graphic,
   onClickDismiss,
   title,
+  ...rest
 }) => {
   const baseClass = 'sage-next-best-action';
 
@@ -26,7 +27,7 @@ export const NextBestAction = ({
   );
 
   return (
-    <div className={classNames}>
+    <div className={classNames} {...rest}>
       {graphic.element && (
         <div className="sage-next-best-action__graphic">
           {graphic.element}

--- a/packages/sage-react/lib/Pagination/Pagination.jsx
+++ b/packages/sage-react/lib/Pagination/Pagination.jsx
@@ -28,6 +28,7 @@ export const Pagination = ({
   pageCountSuffix,
   pageSize,
   pageURLFn,
+  ...rest
 }) => {
   // Get a safe page count:
   let localPageCount;
@@ -194,7 +195,7 @@ export const Pagination = ({
   };
 
   return (
-    <Tagname className={classNames}>
+    <Tagname className={classNames} {...rest}>
       {renderPageCount()}
       <ul className="sage-pagination__pages">
         <PaginationItem

--- a/packages/sage-react/lib/Pagination/PaginationItem.jsx
+++ b/packages/sage-react/lib/Pagination/PaginationItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-export const PaginationItem = ({ children, current, disabled, onClick, url, }) => {
+export const PaginationItem = ({ children, current, disabled, onClick, url, ...rest }) => {
   const classNames = classnames(
     'sage-pagination__page',
     {
@@ -18,7 +18,7 @@ export const PaginationItem = ({ children, current, disabled, onClick, url, }) =
     }
   };
 
-  const attrs = {};
+  const attrs = { ...rest };
   if (!url) {
     attrs.role = 'button';
   }

--- a/packages/sage-react/lib/PanelControls/PanelControls.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControls.jsx
@@ -17,6 +17,7 @@ export const PanelControls = ({
   className,
   controlSettings,
   onRequestChange,
+  ...rest
 }) => {
   const [selfConfigs, setSelfConfigs] = useState({
     // Set locally
@@ -150,7 +151,7 @@ export const PanelControls = ({
   );
 
   return (
-    <div className={classNames}>
+    <div className={classNames} {...rest}>
       {children}
       {selfConfigs.showDefaultToolbar && (
         <div className="sage-panel-controls__default-controls">

--- a/packages/sage-react/lib/PanelControls/PanelControlsBulkActions.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControlsBulkActions.jsx
@@ -18,6 +18,7 @@ export const PanelControlsBulkActions = ({
   rowNoun,
   selectionType,
   totalItems,
+  ...rest
 }) => {
   const selectionCount = selectionType === SELECTION_TYPES.ALL
     ? totalItems
@@ -46,7 +47,7 @@ export const PanelControlsBulkActions = ({
   );
 
   return (
-    <div className={classNames}>
+    <div className={classNames} {...rest}>
       <Checkbox
         className={checkboxClassNames}
         id={uuid()}

--- a/packages/sage-react/lib/PanelControls/PanelControlsPagination.jsx
+++ b/packages/sage-react/lib/PanelControls/PanelControlsPagination.jsx
@@ -7,8 +7,9 @@ export const PanelControlsPagination = ({
   currentPage,
   onClickPagination,
   totalPages,
+  ...rest
 }) => (
-  <div className="sage-panel-controls__pagination">
+  <div className="sage-panel-controls__pagination" {...rest}>
     <Button
       className="sage-panel-controls__pagination-prev"
       color={Button.COLORS.SECONDARY}

--- a/packages/sage-react/lib/StatBox/StatBox.jsx
+++ b/packages/sage-react/lib/StatBox/StatBox.jsx
@@ -22,6 +22,7 @@ export const StatBox = ({
   raised,
   timeframe,
   title,
+  ...rest
 }) => {
   const statBoxContainer = classnames(
     'sage-stat-box',
@@ -67,6 +68,7 @@ export const StatBox = ({
   return (
     <article
       className={statBoxContainer}
+      {...rest}
     >
       {icon && (
         <div className="sage-stat-box__icon">

--- a/packages/sage-react/lib/Table/Table.jsx
+++ b/packages/sage-react/lib/Table/Table.jsx
@@ -52,6 +52,7 @@ export const Table = ({
   selectedRows,
   showSelectAll,
   tableAttributes,
+  ...rest
 }) => {
   const [selfSelectedRows, setSelfSelectedRows] = useState([]);
   const [selfHeaders, setSelfHeaders] = useState([]);
@@ -288,7 +289,7 @@ export const Table = ({
 
   // Renders the table itself
   const renderTable = () => (
-    <table className={tableClassNames} {...tableAttributes}>
+    <table className={tableClassNames} {...tableAttributes} {...rest}>
       {caption && (
         <caption className={`sage-table__caption--${captionSide || CAPTION_SIDE.BOTTOM}`}>
           {caption}

--- a/packages/sage-react/lib/Table/TableRow.jsx
+++ b/packages/sage-react/lib/Table/TableRow.jsx
@@ -19,6 +19,7 @@ export const TableRow = ({
   selectable,
   selected,
   typeRenderers,
+  ...rest
 }) => {
   const [selfSelected, setSelfSelected] = useState(false);
   const [selfCells, setSelfCells] = useState([]);
@@ -86,7 +87,7 @@ export const TableRow = ({
   };
 
   return (
-    <tr className={classNames} data-table-row-id={id}>
+    <tr className={classNames} data-table-row-id={id} {...rest}>
       {selectable && (
         <td className={selectableClassNames}>
           <Checkbox

--- a/packages/sage-react/lib/Tag/Tag.jsx
+++ b/packages/sage-react/lib/Tag/Tag.jsx
@@ -9,7 +9,8 @@ export const Tag = ({
   dismissAttributes,
   image,
   showDismiss,
-  value
+  value,
+  ...rest
 }) => {
   const classNames = classnames(
     'sage-tag',
@@ -22,6 +23,7 @@ export const Tag = ({
   return (
     <span
       className={classNames}
+      {...rest}
     >
       {image && (
         <img className="sage-tag__image" src={image} alt="" role="presentation" />

--- a/packages/sage-react/lib/Toast/Toast.jsx
+++ b/packages/sage-react/lib/Toast/Toast.jsx
@@ -18,6 +18,7 @@ export const Toast = ({
   link,
   type,
   title,
+  ...rest
 }) => {
   const [isDismissed, setDismissed] = useState(!isActive);
 
@@ -79,7 +80,7 @@ export const Toast = ({
 
   return !isDismissed && (
     <div className="sage-toast-container">
-      <dialog open className={classNames} aria-labelledby={`sage-toast-label-${id}`}>
+      <dialog open className={classNames} aria-labelledby={`sage-toast-label-${id}`} {...rest}>
         {renderAsset()}
 
         <output

--- a/packages/sage-react/lib/Tooltip/TooltipElement.jsx
+++ b/packages/sage-react/lib/Tooltip/TooltipElement.jsx
@@ -76,6 +76,7 @@ export const TooltipElement = ({
       ref={tooltipRef}
       className={classNames}
       style={parentDomRect ? coordinates : {}}
+      {...rest}
     >
       {content}
     </div>

--- a/packages/sage-react/lib/Tooltip/TooltipElement.jsx
+++ b/packages/sage-react/lib/Tooltip/TooltipElement.jsx
@@ -12,6 +12,7 @@ export const TooltipElement = ({
   parentDomRect,
   position,
   tooltipCustomClass,
+  ...rest
 }) => {
   const tooltipRef = useRef(null);
   const [coordinates, setCoordinates] = useState({ top: null, left: null });

--- a/packages/sage-react/lib/Topbar/Topbar.jsx
+++ b/packages/sage-react/lib/Topbar/Topbar.jsx
@@ -7,11 +7,12 @@ export const Topbar = ({
   contentLeftDesktop,
   contentLeftMobile,
   contentRight,
+  ...rest
 }) => {
   const classNames = classnames('sage-topbar', className);
 
   return (
-    <div className={classNames}>
+    <div className={classNames} {...rest}>
       <div className="sage-topbar__left">
         <div className="sage-topbar__left-mobile">
           {contentLeftMobile}

--- a/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
+++ b/packages/sage-react/lib/TransactionCard/TransactionCard.jsx
@@ -21,6 +21,7 @@ export const TransactionCard = ({
   transactionState,
   transactionStateColor,
   transactionTime,
+  ...rest
 }) => {
   const NameTag = nameTag;
   const amountClassNames = classnames(
@@ -36,7 +37,7 @@ export const TransactionCard = ({
     }
   );
   return (
-    <article className="sage-transaction-card">
+    <article className="sage-transaction-card" {...rest}>
       <div className="sage-transaction-card__header">
         <Badge className="sage-transaction-card__label" value={labelText} color={labelColor} />
         <div className={stateClassNames}>


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Per prior discussions and collaboration with QE, this PR adds `...rest` to React components where missing. The goal of this work is to provide engineers access to adding test ids to Sage React components going forward while Pine patterns are built out. This aims to help QE provide communication around setting standards for testing Sage components in the monolith.


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
- Check that components can accept data attributes when set


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Adds `...rest` to components to aid in QE testing.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1430](https://kajabi.atlassian.net/browse/DSS-1430)

[DSS-1430]: https://kajabi.atlassian.net/browse/DSS-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ