### PR TITLE
fix(button): update XS group gap option to xs instead of null

### DIFF
--- a/packages/sage-react/lib/Button/configs.js
+++ b/packages/sage-react/lib/Button/configs.js
@@ -11,7 +11,7 @@ export const BUTTON_ICON_POSITIONS = {
 };
 
 export const BUTTON_GROUP_GAP_OPTIONS = {
-  XS: null,
+  XS: 'xs',
   SM: 'sm',
   MD: 'md',
   LG: 'lg',


### PR DESCRIPTION
## Description

An issue with the Button Group XS gap not working as expected in the React component, and it appears that the token may be set to `null` in the `packages/sage-react/lib/Button/configs.js` file. 

`XS` token should be set to `xs` in config


## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="1041" height="933" alt="Screenshot 2025-07-16 at 1 00 22 PM" src="https://github.com/user-attachments/assets/5cf3ae6c-0e20-48e4-b51a-ef60d28c8c5a" />|<img width="1068" height="971" alt="Screenshot 2025-07-16 at 1 01 18 PM" src="https://github.com/user-attachments/assets/23d744a4-676d-4f0d-a5d3-c8357959b79e" />|

## Testing in `sage-lib`
Navigate to [button group](http://localhost:4100/?path=/docs/sage-button-group--default)
Verify setting gap to XS works.

## Testing in `kajabi-products`
1. (**LOW**) Sets button group xs gap to correct "xs" value.


## Related
https://kajabi.atlassian.net/browse/DSS-1482
