### PR TITLE
fix(sage-modal): fix scrollable modal height issue on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.23](https://github.com/Kajabi/sage-lib/compare/v6.2.22...v6.2.23) (2025-09-05)
+
+**Note:** Version bump only for package root
+
+
+
+
+
 ## [6.2.22](https://github.com/Kajabi/sage-lib/compare/v6.2.21...v6.2.22) (2025-08-19)
 
 **Note:** Version bump only for package root

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.23](https://github.com/Kajabi/sage-lib/compare/v6.2.22...v6.2.23) (2025-09-05)
+
+**Note:** Version bump only for package @kajabi/sage
+
+
+
+
+
 ## [6.2.22](https://github.com/Kajabi/sage-lib/compare/v6.2.21...v6.2.22) (2025-08-19)
 
 **Note:** Version bump only for package @kajabi/sage

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (6.2.22)
+    sage_rails (6.2.23)
       classy_hash
       rails
 

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "6.2.22"
+  VERSION = "6.2.23"
 end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "6.2.22",
+  "version": "6.2.23",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -38,7 +38,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^6.2.22",
+    "@kajabi/sage-packs": "^6.2.23",
     "@rails/webpacker": "5.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*",
     "docs"
   ],
-  "version": "6.2.22",
+  "version": "6.2.23",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sage-assets/CHANGELOG.md
+++ b/packages/sage-assets/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.23](https://github.com/Kajabi/sage-lib/compare/v6.2.22...v6.2.23) (2025-09-05)
+
+**Note:** Version bump only for package @kajabi/sage-assets
+
+
+
+
+
 ## [6.2.22](https://github.com/Kajabi/sage-lib/compare/v6.2.21...v6.2.22) (2025-08-19)
 
 **Note:** Version bump only for package @kajabi/sage-assets

--- a/packages/sage-assets/lib/stylesheets/components/_modal.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_modal.scss
@@ -90,8 +90,12 @@ $-modal-inner-size: sage-container(md);
   opacity: 0;
 
   .sage-drawer & {
-    height: 100vh;
     border-radius: 0;
+    height: 100vh;
+
+    @supports (height: 100dvh) {
+      height: 100dvh;
+    }
 
     @media (max-width: sage-breakpoint(sm-max)) {
       max-width: var(--sage-drawer-size);
@@ -110,6 +114,10 @@ $-modal-inner-size: sage-container(md);
     margin-block-start: rem(79px);
     margin-inline-end: sage-spacing(sm);
     border-radius: sage-border(radius-large);
+
+    @supports (height: 100dvh) {
+      height: calc(100dvh - 97px);
+    }
   }
 
   .sage-drawer--expanded & {
@@ -182,6 +190,10 @@ $-modal-inner-size: sage-container(md);
     display: grid;
     grid-template-rows: auto 1fr auto;
     max-height: 85vh;
+
+    @supports (height: 100dvh) {
+      max-height: 85dvh;
+    }
   }
 
   .sage-modal--scrollable & > .simple_form {

--- a/packages/sage-assets/lib/stylesheets/components/_tab.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_tab.scss
@@ -42,7 +42,7 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
   &:hover {
     color: $-tab-color-active;
     .sage-tabs--filter & {
-      background: var(--pine-color-border);
+      background-color: var(--pine-color-border-disabled);
     }
   }
 
@@ -71,6 +71,10 @@ $-tab-color-disabled: map-get($sage-tab-colors, disabled);
       background: var(--pine-color-primary);
       &::after {
         display: none;
+      }
+
+      &:hover {
+        background: var(--pine-color-primary-hover);
       }
     }
   }

--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-assets",
-  "version": "6.2.22",
+  "version": "6.2.23",
   "description": "Assets",
   "main": "dist/main.css",
   "repository": {

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.23](https://github.com/Kajabi/sage-lib/compare/v6.2.22...v6.2.23) (2025-09-05)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [6.2.22](https://github.com/Kajabi/sage-lib/compare/v6.2.21...v6.2.22) (2025-08-19)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "6.2.22",
+  "version": "6.2.23",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -31,8 +31,8 @@
     "url": "https://github.com/Kajabi/sage-lib/issues"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^6.2.22",
-    "@kajabi/sage-react": "^6.2.22",
+    "@kajabi/sage-assets": "^6.2.23",
+    "@kajabi/sage-react": "^6.2.23",
     "@kajabi/sage-system": "^6.2.18"
   },
   "devDependencies": {

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.23](https://github.com/Kajabi/sage-lib/compare/v6.2.22...v6.2.23) (2025-09-05)
+
+**Note:** Version bump only for package @kajabi/sage-react
+
+
+
+
+
 ## [6.2.22](https://github.com/Kajabi/sage-lib/compare/v6.2.21...v6.2.22) (2025-08-19)
 
 **Note:** Version bump only for package @kajabi/sage-react

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "6.2.22",
+  "version": "6.2.23",
   "description": "React Components",
   "keywords": [
     "react",
@@ -83,7 +83,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^6.2.22",
+    "@kajabi/sage-assets": "^6.2.23",
     "@popperjs/core": "^2.11.8",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `dvh` units to resolve Safari height issue

## Screenshots
<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="360" height="722" alt="Screenshot 2025-09-19 at 8 32 47 AM" src="https://github.com/user-attachments/assets/e351fd56-3af7-4437-88a2-43a07b98b318" />|<img width="1103" height="764" alt="Screenshot 2025-09-19 at 8 16 28 AM" src="https://github.com/user-attachments/assets/b4e0e62c-5f5b-4633-960a-4bf7550cae2d" />|


## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
In Safari view the Modal view and verify it's using `dvh` units instead of `vh`

## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**MEDIUM**) Resolve Scrollable Modal height issue in Safari
   - [ ] Reactivate account modal

## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-1532](https://kajabi.atlassian.net/browse/DSS-1532)