### PR TITLE
add a GITHUB_TOKEN so that we don't get rate limited

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -14,6 +14,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           excludes: prerelease, draft
 
       - name: Notify Standard Model Bot


### PR DESCRIPTION
## Description
From discussion with @pixelflips 

We went through the same process this morning, but we seem to be getting a rate limit failure. when you have a few minutes could you take a quick peek and let me know if anything jumps out. it's not a huge issue, but just odd, it never seems to have happened before.  maybe it's just a github hiccup?
Failure: https://github.com/Kajabi/sage-lib/actions/runs/17921216303
All prev runs: https://github.com/Kajabi/sage-lib/actions/workflows/release-notification.yml


See https://github.com/pozetroninc/github-action-get-latest-release and discussion in readme around rate limiting. Fix: pass default GITHUB_TOKEN.
