### PR TITLE
fix: remove instance of mercury color

### DIFF
--- a/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
+++ b/docs/lib/sage-frontend/stylesheets/docs/_colors.scss
@@ -53,7 +53,7 @@
     // Determine class name for $value == 50
     $classname: ".color-#{"" + $name}-#{$value}";
 
-    /* stylelint-disable max-nesting-depth, block-closing-brace-newline-after */
+    /* stylelint-disable block-closing-brace-newline-after */
     // This should be numeric, not string
     @if ($value == 50) {
       $classname: ".color-#{"" + $name}-0#{$value}";
@@ -79,7 +79,7 @@
         text-transform: uppercase;
       }
     }
-    /* stylelint-enable max-nesting-depth, block-closing-brace-newline-after */
+    /* stylelint-enable block-closing-brace-newline-after */
   }
 }
 /* stylelint-enable max-nesting-depth */

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_avatar.html.erb
@@ -52,7 +52,7 @@ end
   <% end %>
 
   <% if !component.initials && !component.image %>
-    <pds-icon name="user-filled" color="var(--pine-color-mercury-500)" class="sage-avatar__graphic"></pds-icon>
+    <pds-icon name="user-filled" color="var(--pine-color-brand)" class="sage-avatar__graphic"></pds-icon>
   <% end %>
 
   <% if component.image %>

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_loader.html.erb
@@ -1,6 +1,6 @@
 <%
   component_description = component.type === "success" ? "Success" : "Loading..."
-  stroke_color = SageTokens::COLOR_PALETTE[:MERCURY_400]
+  stroke_color = "var(--pine-color-brand)"
 %>
 
 <div class="

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_progress_bar.html.erb
@@ -2,7 +2,7 @@
 animate = component.animate.nil? ? true : component.animate
 content = component.label ? "#{component.label}: " : ""
 content << "#{component.percent}%&nbsp;progress"
-color = component.color || SageTokens::COLOR_PALETTE[:MERCURY_500]
+color = component.color || "var(--pine-color-brand)"
 %>
 
 <div

--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -30,7 +30,7 @@ $-avatar-ring-colors: (
   ),
   orange: (
     main: var(--pine-color-brand),
-    bg: var(--pine-color-mercury-150)
+    bg: var(--pine-color-grey-150)
   ),
   red: (
     main: var(--pine-color-danger),
@@ -64,7 +64,7 @@ $-avatar-group-item-sizes: (
   width: $-avatar-min-size;
   height: $-avatar-min-size;
   border-radius: var(--pine-border-radius-full);
-  background-color: var(--pine-color-mercury-050);
+  background-color: var(--pine-color-grey-050);
 
   // Documentation-specific styles
   .sage-avatar-wrapper > & {

--- a/packages/sage-react/lib/Avatar/Avatar.jsx
+++ b/packages/sage-react/lib/Avatar/Avatar.jsx
@@ -82,7 +82,7 @@ export const Avatar = ({
         <img alt={image.alt || ''} className="sage-avatar__image" src={image.src} id={image.id} />
       )}
       {(!image.src || useFallbackGraphic) && (
-        <pds-icon name="user-filled" color="var(--pine-color-mercury-500)" class="sage-avatar__graphic" />
+        <pds-icon name="user-filled" color="var(--pine-color-brand)" class="sage-avatar__graphic" />
       )}
     </div>
   );

--- a/packages/sage-react/lib/ProgressBar/ProgressBar.jsx
+++ b/packages/sage-react/lib/ProgressBar/ProgressBar.jsx
@@ -81,7 +81,7 @@ ProgressBar.defaultProps = {
   animate: true,
   backgroundColor: null,
   className: null,
-  color: ProgressBar.COLORS.MERCURY_500,
+  color: ProgressBar.COLORS.GREY_500,
   disableTooltip: false,
   displayPercent: false,
   label: null,


### PR DESCRIPTION
## Description
<!-- REQUIRED: add a short description of this update -->
Removes deprecated mercury color token usage across multiple components, replacing them with the appropriate design tokens (pine-color-brand and pine-color-grey).

Fixes DSS-54

## Testing in `sage-lib`
<!-- REQUIRED: Provide general notes describing this change in order to verify the changes in `sage-lib` -->
Verify updated colors for the Progress, Avatar, and Loader components


## Testing in `kajabi-products`
<!-- REQUIRED: Provide general notes describing this change in order for QA to verify the changes within `kajabi-products`. Follow this format: Describe this PR, its impact level (LOW/MEDIUM/HIGH/BREAKING), and where it can be tested. If this a new feature on existing component, indicate places you can demonstrate it has not had adverse effects.
  Read more here: https://github.com/Kajabi/sage-lib/wiki/Version-Bump-Process
  IMPORTANT: Once merged, the list below should be transferred to the anticipated version bump PR -->
1. (**LOW**) Update mercury to brand.


## Related
<!-- OPTIONAL: link to related issues or PRs for context -->
[DSS-54](https://linear.app/kajabi/issue/DSS-54/bump-token-version-and-adjust-components-to-align-with-brand-updates)