### PR TITLE
feat(hero): add shadow prop

### DIFF
--- a/docs/app/views/examples/components/hero/_preview.html.erb
+++ b/docs/app/views/examples/components/hero/_preview.html.erb
@@ -142,6 +142,28 @@
   <% end %>
 <% end %>
 
+<%= sage_component SageDivider, {} %>
+
+<h2>Shadow</h2>
+<p>When the Hero has a shadow, a box-shadow will be applied to the Hero container.</p>
+
+<%= sage_component SageHero, {
+  title: "Learn with Kajabi in our live workshops",
+  description: "Did you know we offer free workshops? Kajabi experts host live workshops every week on topics from marketing your products to building out your Kajabi account.",
+  image: "hero-workshop-placeholder.jpg",
+  alt_text: "Multi-layered illustration of UI elements and woman clasping her hands together in excitement",
+  size: "small",
+  borderless: true,
+  shadow: "100",
+} do %>
+  <% content_for :sage_hero_footer_actions do %>
+    <%= sage_component SageButton, {
+      value: "Learn more",
+      style: "primary",
+    } %>
+  <% end %>
+<% end %>
+
 <%# This is the modal triggered from various examples in this documentation %>
 <%= sage_component SageModal, { id: "cool-modal"} do %>
   <%= sage_component SageModalContent, {

--- a/docs/app/views/examples/components/hero/_props.html.erb
+++ b/docs/app/views/examples/components/hero/_props.html.erb
@@ -59,6 +59,12 @@
   <td><%= md('`false`') %></td>
 </tr>
 <tr>
+  <td><%= md('`shadow`') %></td>
+  <td><%= md('Sets the box-shadow on the Hero.') %></td>
+  <td><%= md('String: ["none", "050", "100", "150", "200", "300", "400", "500"]') %></td>
+  <td><%= md('`nil`') %></td>
+</tr>
+<tr>
   <td><%= md('`title`') %></td>
   <td><%= md('Sets the title for the component.') %></td>
   <td><%= md('String') %></td>

--- a/docs/lib/sage_rails/app/sage_components/sage_hero.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_hero.rb
@@ -9,6 +9,7 @@ class SageHero < SageComponent
     description: [:optional, NilClass, String],
     image: [:optional, NilClass, String],
     image_start: [:optional, NilClass, TrueClass],
+    shadow: [:optional, NilClass, SageSchemas::HERO_SHADOW],
     size: [:optional, NilClass, SageSchemas::HERO_SIZE],
     title: [:optional, NilClass, String],
     title_tag: [:optional, NilClass, String],

--- a/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_schemas.rb
@@ -20,6 +20,8 @@ module SageSchemas
 
   HERO_SIZE = Set.new(SageTokens::HERO_SIZES)
 
+  HERO_SHADOW = Set.new(SageTokens::HERO_SHADOWS)
+
   STATUSES = Set.new(SageTokens::STATUSES)
 
   SPACER = {

--- a/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
+++ b/docs/lib/sage_rails/app/sage_tokens/sage_tokens.rb
@@ -97,6 +97,8 @@ module SageTokens
 
   HERO_SIZES = ["small", "large"]
 
+  HERO_SHADOWS = ["none", "050", "100", "150", "200", "300", "400", "500"]
+
   ICONS = [
     "access-key",
     "add",

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_hero.html.erb
@@ -22,6 +22,7 @@
     <%= "sage-hero--contained" if component.contained %>
     <%= "sage-hero--custom-background-color" if component.custom_background_color %>
     <%= "sage-hero--image-start" if component.image_start %>
+    <%= "sage-hero--shadow-#{component.shadow}" if component.shadow.present? %>
     <%= component.generated_css_classes %>
   "
   data-js-hero

--- a/packages/sage-assets/lib/stylesheets/components/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_hero.scss
@@ -66,6 +66,25 @@ $-hero-play-icon-background-color: var(--pine-color-background-container);
   }
 }
 
+// Shadow options — aligned with Pine pds-box shadow values
+// Keep in sync with `packages/sage-react/lib/Hero/configs.js`
+$-sage-hero-shadows: (
+  none: 0,
+  050: sage-shadow(050),
+  100: sage-shadow(100),
+  150: sage-shadow(150),
+  200: sage-shadow(200),
+  300: sage-shadow(300),
+  400: sage-shadow(400),
+  500: sage-shadow(500),
+);
+
+@each $-key, $-val in $-sage-hero-shadows {
+  .sage-hero--shadow-#{$-key} {
+    box-shadow: #{$-val};
+  }
+}
+
 .sage-hero__title {
   @extend %t-sage-heading-3;
   grid-area: title;

--- a/packages/sage-assets/lib/stylesheets/components/_hero.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_hero.scss
@@ -70,7 +70,7 @@ $-hero-play-icon-background-color: var(--pine-color-background-container);
 // Keep in sync with `packages/sage-react/lib/Hero/configs.js`
 $-sage-hero-shadows: (
   none: 0,
-  050: sage-shadow(050),
+  "050": sage-shadow("050"),
   100: sage-shadow(100),
   150: sage-shadow(150),
   200: sage-shadow(200),

--- a/packages/sage-react/lib/Hero/Hero.jsx
+++ b/packages/sage-react/lib/Hero/Hero.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Button } from '../Button';
-import { HERO_SIZES } from './configs';
+import { HERO_SHADOWS, HERO_SIZES } from './configs';
 import { SageClassnames } from '../configs';
 
 export const Hero = ({
@@ -17,6 +17,7 @@ export const Hero = ({
   image,
   imageStart,
   heroSize,
+  shadow,
   title,
   titleTag,
   ...rest
@@ -30,6 +31,7 @@ export const Hero = ({
       'sage-hero--contained': contained,
       'sage-hero--image-start': imageStart,
       'sage-hero--custom-background-color': customBackgroundColor,
+      [`sage-hero--shadow-${shadow}`]: shadow,
     },
   );
 
@@ -80,6 +82,7 @@ export const Hero = ({
   );
 };
 
+Hero.SHADOWS = HERO_SHADOWS;
 Hero.Sizes = HERO_SIZES;
 
 Hero.defaultProps = {
@@ -97,6 +100,7 @@ Hero.defaultProps = {
   },
   imageStart: false,
   heroSize: Hero.Sizes.LARGE,
+  shadow: null,
   title: null,
   titleTag: 'h2',
 };
@@ -151,6 +155,10 @@ Hero.propTypes = {
    * Sets the size of the Hero's width.
    */
   heroSize: PropTypes.oneOf(Hero.Sizes),
+  /**
+   * Sets the box-shadow on the Hero. Aligned with Pine pds-box shadow values.
+   */
+  shadow: PropTypes.oneOf(Object.values(Hero.SHADOWS)),
   /**
    * The title to be rendered within the Hero.
    */

--- a/packages/sage-react/lib/Hero/Hero.story.mdx
+++ b/packages/sage-react/lib/Hero/Hero.story.mdx
@@ -138,6 +138,24 @@ When the image is set to start, the image will be placed at the start of the Her
   </Story>
 </Canvas>
 
+## Shadow
+When the Hero has a shadow, a box-shadow will be applied to the Hero container.
+<Canvas>
+  <Story name="Shadow">
+    <Hero
+      title="Learn with Kajabi in our live workshops"
+      description="Did you know we offer free workshops? Kajabi experts host live workshops every week on topics from marketing your products to building out your Kajabi account."
+      heroSize="small"
+      shadow="100"
+      image={{
+        src: `${heroFull}`,
+        alt: 'Multi layered illustration of UI elements and woman clasping her hands together in excitement'
+      }}
+      footerActions={<><Button color="primary">Learn more</Button></>}
+    />
+  </Story>
+</Canvas>
+
 ## CTA Attribute
 When the Hero has a CTA attribute, the CTA will be applied to the Hero image.
 

--- a/packages/sage-react/lib/Hero/Hero.story.mdx
+++ b/packages/sage-react/lib/Hero/Hero.story.mdx
@@ -149,7 +149,7 @@ When the Hero has a shadow, a box-shadow will be applied to the Hero container.
       shadow="100"
       image={{
         src: `${heroFull}`,
-        alt: 'Multi layered illustration of UI elements and woman clasping her hands together in excitement'
+        alt: 'Multi-layered illustration of UI elements and woman clasping her hands together in excitement'
       }}
       footerActions={<><Button color="primary">Learn more</Button></>}
     />

--- a/packages/sage-react/lib/Hero/configs.js
+++ b/packages/sage-react/lib/Hero/configs.js
@@ -2,3 +2,16 @@ export const HERO_SIZES = {
   SMALL: 'small',
   LARGE: 'large',
 };
+
+// Keep in sync with `packages/sage-assets/lib/stylesheets/components/_hero.scss`
+// Aligned with Pine pds-box shadow values
+export const HERO_SHADOWS = {
+  NONE: 'none',
+  '050': '050',
+  100: '100',
+  150: '150',
+  200: '200',
+  300: '300',
+  400: '400',
+  500: '500',
+};


### PR DESCRIPTION
## Summary

Fixes [DSS-169](https://linear.app/kajabi/issue/DSS-169/sage-hero-component-missing-drop-shadow)

- Adds a `shadow` prop to the Sage Hero component (React and Rails) that applies a `box-shadow` to the Hero container
- Prop values (`none`, `050`, `100`, `150`, `200`, `300`, `400`, `500`) are aligned with Pine's `pds-box` shadow scale for cross-system consistency
- CSS class pattern: `sage-hero--shadow-{value}`
- Default is `nil`/`null` — no shadow class is added when the prop is omitted, preserving current behavior

<img width="788" height="410" alt="Screenshot 2026-02-20 at 10 14 59 AM" src="https://github.com/user-attachments/assets/adf68075-2267-4325-802c-f8090b45fde1" />


## Changes

**Implementation**
- `_hero.scss` — shadow modifier classes via `@each` loop over `$-sage-hero-shadows` map
- `configs.js` — `HERO_SHADOWS` constant
- `Hero.jsx` — `shadow` prop with classnames integration, static ref, default, and propType
- `sage_tokens.rb` — `HERO_SHADOWS` token array
- `sage_schemas.rb` — `HERO_SHADOW` schema set
- `sage_hero.rb` — `shadow` attribute in schema
- `_sage_hero.html.erb` — conditional shadow class output

**Documentation**
- `_props.html.erb` — shadow prop added to Properties tab
- `_preview.html.erb` — shadow example added to Preview tab
- `Hero.story.mdx` — shadow story added to Storybook

## Test plan

- [ ] SCSS compiles and `.sage-hero--shadow-*` classes are generated with correct `box-shadow` values
- [ ] React Storybook — `shadow` prop appears in controls and the Shadow story renders correctly
- [ ] DOM inspection — `sage-hero--shadow-100` class appears on the `<article>` element
- [ ] Rails preview — shadow example renders with visible box-shadow
- [ ] No shadow class is added when prop is omitted (null default)
- [ ] CTA play button overlay retains its own independent shadow