### PR TITLE
fix(avatar): use semantic token

### DIFF
--- a/packages/sage-assets/lib/stylesheets/components/_avatar.scss
+++ b/packages/sage-assets/lib/stylesheets/components/_avatar.scss
@@ -10,11 +10,11 @@ $-avatar-max-size: calc(2 * var(--pine-dimension-800));
 $-avatar-ring-colors: (
   charcoal: (
     main: var(--pine-color-primary-hover),
-    bg: var(--pine-color-grey-200)
+    bg: var(--pine-color-background-inset)
   ),
   grey: (
     main: var(--pine-color-primary-hover),
-    bg: var(--pine-color-grey-200)
+    bg: var(--pine-color-background-inset)
   ),
   purple: (
     main: var(--pine-color-accent-hover),
@@ -30,7 +30,7 @@ $-avatar-ring-colors: (
   ),
   orange: (
     main: var(--pine-color-brand),
-    bg: var(--pine-color-grey-150)
+    bg: var(--pine-color-background-muted)
   ),
   red: (
     main: var(--pine-color-danger),
@@ -64,7 +64,7 @@ $-avatar-group-item-sizes: (
   width: $-avatar-min-size;
   height: $-avatar-min-size;
   border-radius: var(--pine-border-radius-full);
-  background-color: var(--pine-color-grey-050);
+  background-color: var(--pine-color-background-container-hover);
 
   // Documentation-specific styles
   .sage-avatar-wrapper > & {


### PR DESCRIPTION
Replace hardcoded grey color tokens with semantic background tokens in the Avatar component for better maintainability and theme support.

**Token changes:**
- `pine-color-grey-200` → `pine-color-background-inset` (charcoal/grey ring backgrounds)
- `pine-color-grey-150` → `pine-color-background-muted` (orange ring background)
- `pine-color-grey-050` → `pine-color-background-container-hover` (base avatar background)

## Screenshots
|  Before  |  After  |
|--------|--------|
| No visual change expected | No visual change expected |

## Testing in `sage-lib`
1. Navigate to the Avatar component page in Storybook
2. Verify avatars with different ring colors (charcoal, grey, orange) display correctly
3. Verify the base avatar background appears as expected

## Testing in `kajabi-products`
1. (**LOW**) Updated Avatar component to use semantic background tokens instead of raw grey color values. No visual changes expected.
   - [ ] Check member avatars in the Community area
   - [ ] Check user avatars in course comments
   - [ ] Verify avatar rings display correctly where applicable

## Related
Part of ongoing effort to migrate from raw color tokens to semantic tokens.