### PR TITLE
feat(typography): update --sage-font-family-heading to Inter [FLEX-2656]

### DIFF
--- a/packages/sage-assets/lib/stylesheets/core/_typography.scss
+++ b/packages/sage-assets/lib/stylesheets/core/_typography.scss
@@ -6,7 +6,7 @@
 
 
 // Font definitions
-$-heading-font: "Greet Standard", "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
+$-heading-font: "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-font-stack: "Inter", -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Ubuntu", sans-serif;
 $-body-margin-block-end: sage-spacing(xs);
 $-headings-margin-block-end: sage-spacing(sm);


### PR DESCRIPTION
# Description

Removes \"Greet Standard\" from the heading font stack in `_typography.scss` so that `--sage-font-family-heading` resolves to Inter instead of Greet.

Also removes all Greet Standard and Greet Condensed `@font-face` declarations from `_fonts.scss` (274 lines), along with the 5 associated Greet SCSS variables. This stops sage-assets from loading Greet font files from the CDN entirely. Inter, FAIRE Sprig, and Noto font declarations are unchanged.

Combined FLEX-2656 + FLEX-2658 — the blocking concern (heading token still referencing Greet) is resolved in the same PR, so there's no reason to ship them separately.

## Files changed

- `packages/sage-assets/lib/stylesheets/core/_typography.scss` — remove \"Greet Standard\" from `\$-heading-font` stack
- `packages/sage-assets/lib/stylesheets/core/_fonts.scss` — remove all Greet @font-face blocks and variables

## Sequencing

Part of the cross-repo Greet font removal chain. ds-tokens `v1.1.0` (merged) updated semantic heading tokens to Inter before this lands.

## Type of change

- [x] Refactor (non-breaking change, no behavior change)

# How Has This Been Tested?

- [x] tested manually

Verify that headings render in Inter (not Greet) and no CDN requests to `sage.kajabi-cdn.com/fonts/greet/` appear in the network tab after this lands.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings