### PR TITLE
[COMMOPX-908] fix(sage-system): null-guard popover + audit-driven cleanup

### DIFF
--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -48,17 +48,22 @@ Sage.accordion = (function () {
     // Toggle target
     const toggle = el.getAttribute('aria-expanded') === 'true';
     el.setAttribute('aria-expanded', !toggle);
-    el.closest('.sage-expandable-card').classList.toggle('sage-expandable-card--expanded')
+    const expandableCard = el.closest('.sage-expandable-card');
+    if (expandableCard) {
+      expandableCard.classList.toggle('sage-expandable-card--expanded');
+    }
   }
 
   // In a single panel accordion, this closes all panels that are not the current target
   function resetAccordion(el){
-    let accordion = el.closest(SELECTOR_ACCORDION);
-    let accordionItems = accordion.querySelectorAll(SELECTOR_ACCORDION_EXPANDABLE_CARD);
+    const accordion = el.closest(SELECTOR_ACCORDION);
+    if (!accordion) return;
+    const accordionItems = accordion.querySelectorAll(SELECTOR_ACCORDION_EXPANDABLE_CARD);
 
     accordionItems.forEach((item) => {
       if (item !== el.parentElement) {
-        item.querySelector(SELECTOR_ACCORDION_HEADER).setAttribute('aria-expanded', false);
+        const header = item.querySelector(SELECTOR_ACCORDION_HEADER);
+        if (header) header.setAttribute('aria-expanded', false);
         item.classList.remove('sage-expandable-card--expanded');
       }
     });
@@ -66,7 +71,8 @@ Sage.accordion = (function () {
 
   function init(el) {
     const header = el;
-    const body = el.closest('.sage-expandable-card').querySelector(`[${JS_ACCORDION_ROOT}="${JS_ACCORDION_BODY}"]`);
+    const expandableCard = el.closest('.sage-expandable-card');
+    const body = expandableCard && expandableCard.querySelector(`[${JS_ACCORDION_ROOT}="${JS_ACCORDION_BODY}"]`);
 
     // Ensure there's a corresponding body
     if (!body) {

--- a/packages/sage-system/lib/inputgroup.js
+++ b/packages/sage-system/lib/inputgroup.js
@@ -7,9 +7,11 @@ Sage.inputgroup = (function() {
   const inputBoxShadowWidth = 1;
 
   function togglePasswordDisplay(evt) {
-    const parentEle = evt.target.parentElement,
-          field = parentEle.querySelector(".sage-input__field"),
-          activeClassName = "sage-input-group--visible";
+    const parentEle = evt.target.parentElement;
+    if (!parentEle) return;
+    const field = parentEle.querySelector(".sage-input__field");
+    if (!field) return;
+    const activeClassName = "sage-input-group--visible";
 
     if (field.type === "password") {
       field.type = "text";
@@ -27,7 +29,9 @@ Sage.inputgroup = (function() {
 
     inputGroupBtns.forEach(function(btn) {
       const parentGroup = btn.closest(".sage-input-group");
+      if (!parentGroup) return;
       const field = parentGroup.querySelector(".sage-input__field");
+      if (!field) return;
       const parentDir = btn.closest('html[dir="rtl"]');
 
       if (parentDir) {
@@ -47,8 +51,10 @@ Sage.inputgroup = (function() {
 
       inputGroupsWithErrors.forEach(function (group) {
         const parentGroup = group.closest(".sage-input-group");
+        if (!parentGroup) return;
         const label = parentGroup.querySelector(".sage-input__label");
         const btn = parentGroup.querySelector(".sage-input-group__button");
+        if (!label || !btn) return;
         const labelStyles = window.getComputedStyle(label);
         btn.style.top = `${parseInt(labelStyles.lineHeight) + parseInt(labelStyles.marginBottom) + inputBoxShadowWidth}px`;
       });

--- a/packages/sage-system/lib/panel-controls.js
+++ b/packages/sage-system/lib/panel-controls.js
@@ -301,6 +301,7 @@ Sage.panelControls = (() => {
 
     const elBulkActionsContainer = target.closest(`.${CLASSES.BULK_ACTIONS}`);
     const elToggleContainer = target.closest(`.${CLASSES.BULK_ACTIONS_TOGGLE}`);
+    if (!elBulkActionsContainer || !elToggleContainer) return null;
 
     // Ensure checkbox has no partial selection on
     elToggleContainer.classList.remove(CLASSES.CHECKBOX_PARTIAL_SELECTION);
@@ -308,7 +309,7 @@ Sage.panelControls = (() => {
 
     // Ensure --checked modifier is off
     elBulkActionsContainer.classList.remove(CLASSES.BULK_ACTIONS_CHECKED);
-    
+
     // If checked add --checked modifier
     if (target.checked) {
       elBulkActionsContainer.classList.add(CLASSES.BULK_ACTIONS_CHECKED);
@@ -367,6 +368,7 @@ Sage.panelControls = (() => {
 
   const handleExpandCollapseClick = (ev) =>  {
     const elExpandCollapseContainer = ev.target.closest(`.${CLASSES.EXPAND_COLLAPSE}`);
+    if (!elExpandCollapseContainer) return;
 
     // Toggle to new button including changing focus
     // First set which event should be triggered
@@ -375,11 +377,13 @@ Sage.panelControls = (() => {
     if (elExpandCollapseContainer.dataset[ATTRS.EXPAND_COLLAPSE_STATUS.JS] === DATA_EXPAND_COLLAPSE_STATUSES.EXPAND) {
       eventType = EVENTS.EXPAND_COLLAPSE.EXPAND;
       elExpandCollapseContainer.dataset[ATTRS.EXPAND_COLLAPSE_STATUS.JS] = DATA_EXPAND_COLLAPSE_STATUSES.COLLAPSE;
-      elRoot.querySelector(`.${CLASSES.COLLAPSE_BTN}`).focus();
+      const collapseBtn = elRoot && elRoot.querySelector(`.${CLASSES.COLLAPSE_BTN}`);
+      if (collapseBtn) collapseBtn.focus();
     } else {
       eventType = EVENTS.EXPAND_COLLAPSE.COLLAPSE;
       elExpandCollapseContainer.dataset[ATTRS.EXPAND_COLLAPSE_STATUS.JS] = DATA_EXPAND_COLLAPSE_STATUSES.EXPAND;
-      elRoot.querySelector(`.${CLASSES.EXPAND_BTN}`).focus();
+      const expandBtn = elRoot && elRoot.querySelector(`.${CLASSES.EXPAND_BTN}`);
+      if (expandBtn) expandBtn.focus();
     }
 
     dispatchEvent(eventType, {});

--- a/packages/sage-system/lib/popover.js
+++ b/packages/sage-system/lib/popover.js
@@ -31,7 +31,7 @@ Sage.popover = (function() {
     const elParent = evt.currentTarget;
     const elChild = elParent.children[0];
 
-    if (evt.target.hasAttribute(SELECTOR_TRIGGER) || evt.target.parentNode.hasAttribute(SELECTOR_TRIGGER)) {
+    if (evt.target.hasAttribute(SELECTOR_TRIGGER) || (evt.target.parentNode && evt.target.parentNode.hasAttribute(SELECTOR_TRIGGER))) {
       if (!elChild) return;
       if (isExpanded(elParent) || isExpanded(elChild.parentNode)) {
         closePopoverPanel(elParent);
@@ -64,7 +64,8 @@ Sage.popover = (function() {
   }
 
   function openPopoverPanel(elParent) {
-    elParent.querySelector(`[${SELECTOR_TRIGGER}]`).setAttribute(ATTRIBUTE_ARIA_EXPANDED, 'true');
+    const trigger = elParent.querySelector(`[${SELECTOR_TRIGGER}]`);
+    if (trigger) trigger.setAttribute(ATTRIBUTE_ARIA_EXPANDED, 'true');
     elParent.classList.add(CLASS_ACTIVE);
     let focusableEls = elParent.querySelectorAll(SELECTOR_FOCUSABLE_ELEMENTS);
     SELECTOR_LAST_FOCUSED = document.activeElement;
@@ -72,7 +73,8 @@ Sage.popover = (function() {
   }
 
   function closePopoverPanel(elParent) {
-    elParent.querySelector(`[${SELECTOR_TRIGGER}]`).setAttribute(ATTRIBUTE_ARIA_EXPANDED, 'false');
+    const trigger = elParent.querySelector(`[${SELECTOR_TRIGGER}]`);
+    if (trigger) trigger.setAttribute(ATTRIBUTE_ARIA_EXPANDED, 'false');
     elParent.classList.remove(CLASS_ACTIVE);
     elParent.removeEventListener('keydown', focusTrap);
     if (SELECTOR_LAST_FOCUSED) SELECTOR_LAST_FOCUSED.focus();

--- a/packages/sage-system/lib/popover.js
+++ b/packages/sage-system/lib/popover.js
@@ -30,7 +30,7 @@ Sage.popover = (function() {
 
     const elParent = evt.currentTarget;
     const elChild = elParent.children[0];
-    const popoverPanel = elChild.parentNode.querySelector(".sage-popover__panel");
+    if (!elChild) return;
 
     if (evt.target.hasAttribute(SELECTOR_TRIGGER) || evt.target.parentNode.hasAttribute(SELECTOR_TRIGGER)) {
       if (isExpanded(elParent) || isExpanded(elChild.parentNode)) {
@@ -47,6 +47,7 @@ Sage.popover = (function() {
 
   function handleKeydown(evt) {
     const elParent = evt.target.closest(`[${SELECTOR_PARENT}]`);
+    if (!elParent) return;
 
     // Enter key
     if (evt.keyCode === 13 && !isExpanded(elParent)) {
@@ -74,7 +75,7 @@ Sage.popover = (function() {
     elParent.querySelector(`[${SELECTOR_TRIGGER}]`).setAttribute(ATTRIBUTE_ARIA_EXPANDED, 'false');
     elParent.classList.remove(CLASS_ACTIVE);
     elParent.removeEventListener('keydown', focusTrap);
-    SELECTOR_LAST_FOCUSED.focus();
+    if (SELECTOR_LAST_FOCUSED) SELECTOR_LAST_FOCUSED.focus();
   }
 
   function focusTrap(evt) {

--- a/packages/sage-system/lib/popover.js
+++ b/packages/sage-system/lib/popover.js
@@ -30,9 +30,9 @@ Sage.popover = (function() {
 
     const elParent = evt.currentTarget;
     const elChild = elParent.children[0];
-    if (!elChild) return;
 
     if (evt.target.hasAttribute(SELECTOR_TRIGGER) || evt.target.parentNode.hasAttribute(SELECTOR_TRIGGER)) {
+      if (!elChild) return;
       if (isExpanded(elParent) || isExpanded(elChild.parentNode)) {
         closePopoverPanel(elParent);
       } else {

--- a/packages/sage-system/lib/select.js
+++ b/packages/sage-system/lib/select.js
@@ -12,6 +12,7 @@ Sage.select = (function() {
 
   function handleChange(evt) {
     const elSelectParent = evt.target.closest(elSelectClass);
+    if (!elSelectParent) return;
     updateValueSelectedState(evt.target.value, elSelectParent);
   }
 
@@ -36,6 +37,7 @@ Sage.select = (function() {
 
   function init(el) {
     var elSelect = el.querySelector('select');
+    if (!elSelect) return;
 
     disableSelectPromptOptions(elSelect);
     updateValueSelectedState(elSelect.value, el);

--- a/packages/sage-system/lib/tabs.js
+++ b/packages/sage-system/lib/tabs.js
@@ -82,7 +82,9 @@ Sage.tabs = (function() {
     let { tabsId, paneId } = evt.detail;
 
     let elTabsParent = document.querySelector(`[${SELECTOR_TABS}="${tabsId}"]`);
+    if (!elTabsParent) return;
     let elTab = elTabsParent.querySelector(`[${SELECTOR_TAB_ITEM}="${paneId}"]`);
+    if (!elTab) return;
     let tabsArray = Sage.util.nodelistToArray(elTabsParent.querySelectorAll(`[${SELECTOR_TAB_ITEM}]`));
 
     tabsArray.forEach((el) => {
@@ -100,7 +102,7 @@ Sage.tabs = (function() {
 
     let elPane = document.querySelector(`[${SELECTOR_TAB_PANE}="${paneId}"]`);
     // Ensure there is a matching pane
-    if (!elPane) {
+    if (!elPane || !elPane.parentElement) {
       return;
     }
 
@@ -115,6 +117,7 @@ Sage.tabs = (function() {
     evType = evType || EVENT_SELECT;
 
     let tabComponent = document.querySelector(`[${SELECTOR_TABS}="${tabsId}"]`);
+    if (!tabComponent) return;
 
     dispatchChangeEvent(tabComponent, evType, eventDetail)
   }


### PR DESCRIPTION
Linear: [COMMOPX-908](https://linear.app/kajabi/issue/COMMOPX-908/fix-unhandled-typeerrors-from-sage-popover-null-deref-audit-cleanup)

## Description

Originally a fix for one high-volume RUM error in \`Sage.popover\`; audit of related call sites turned up the same unguarded-null-deref pattern in 5 more components, so they're cleaned up in the same PR.

### Primary fix — popover (the RUM trigger)

\`Sage.popover.handleKeydown\`'s \`evt.target.closest('[data-js-popover]')\` returns \`null\` when a keypress bubbles up from outside any popover. The next line called \`isExpanded(null)\`, which threw \`Cannot read properties of null (reading 'classList')\`. This single bug is the source of **~1,510 events/hour** in Kajabi Admin RUM (DataDog issue \`06975da6-f8de-11ee-979a-da7ad0900002\`, fingerprint \`v11.AAC943F7EF7C400B781BBEFC8FED4C85\`).

\`handleClick\` and \`closePopoverPanel\` had the same shape — \`children[0]\` could be \`undefined\`, and \`SELECTOR_LAST_FOCUSED\` could be unset on first close — both guarded here. Also removed an unused \`popoverPanel\` local in \`handleClick\` that was assigned but never read.

### Audit cleanup — same pattern in other components

Same fix shape (early-return when DOM lookup returned null) applied to:

- **accordion-panel.js** — guard \`el.closest('.sage-expandable-card')\`, \`el.closest(SELECTOR_ACCORDION)\`, and per-item header lookup
- **select.js** — guard \`evt.target.closest(elSelectClass)\` in handleChange; guard \`el.querySelector('select')\` in init
- **inputgroup.js** — guard \`parentElement\` and \`.sage-input__field\` lookups in togglePasswordDisplay; guard closest() results in addButtonPadding and positionButtonOnError
- **tabs.js** — guard \`document.querySelector\` results in eventHandlerChange and dispatchChange; require \`elPane.parentElement\` before reading
- **panel-controls.js** — guard closest() results in updateBulkActionsToggleState and handleExpandCollapseClick; guard \`elRoot.querySelector\` focus calls

All early-return guards. No behavioral change when DOM is well-formed.

This matches the defensive pattern already used in \`f33da8631 fix(dropdown): prevent null reference errors on dynamic positioning\` and \`da9b7c319 fix(tooltip): ensure valid node before removal to prevent errors\`.

## Observability

- **DataDog RUM issue:** [\`06975da6-f8de-11ee-979a-da7ad0900002\`](https://app.datadoghq.com/rum/explorer?query=%40issue.id%3A06975da6-f8de-11ee-979a-da7ad0900002)
- **Application:** Kajabi Admin (\`@service: kajabi-admin\`, \`@application.id: 8dca32bf-6fd4-41ad-8dc8-48410773bf4f\`)
- **Volume:** ~1,510 events/hr in production
- **Browser:** ~97% Chrome, occasional Edge — Desktop only

## Testing in \`sage-lib\`

Open any sage-rails docs page exercising the affected components (popover, accordion, select, input group with toggle/buttons, tabs, panel-controls) and verify normal behavior is unchanged.

## Testing in \`kajabi-products\`

1. (**LOW**) Component behavior should be unchanged. Pages to spot-check after a version bump in monolith:
   - [ ] \`/admin/sites/{site_id}/offers\` — pricing/offer popovers, tabs, panel-controls
   - [ ] \`/admin/posts/{post_id}/edit\` — editor toolbar popovers, input groups
   - [ ] \`/admin/forms/{form_id}/edit\` — form selects, input groups, popovers
   - [ ] \`/admin/newsletters/{id}\` and \`/admin/newsletter_posts/{id}/edit\` — accordion, tabs
   - [ ] Any admin page using bulk-actions panel-controls
   - [ ] After deploying, watch the Kajabi Admin RUM dashboard — error volume for issue \`06975da6-f8de-11ee-979a-da7ad0900002\` should drop sharply (popover fix alone accounts for the bulk; audit fixes reduce the long tail).

## Related

- Linear: [COMMOPX-908](https://linear.app/kajabi/issue/COMMOPX-908/fix-unhandled-typeerrors-from-sage-popover-null-deref-audit-cleanup)
- DataDog RUM issue \`06975da6-f8de-11ee-979a-da7ad0900002\` (fingerprint \`v11.AAC943F7EF7C400B781BBEFC8FED4C85\`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive early returns only; no auth, data, or API changes, and intended behavior is unchanged when components are correctly mounted.
> 
> **Overview**
> Adds **early-return null guards** across `sage-system` so DOM lookups (`closest`, `querySelector`, `parentElement`, etc.) no longer throw when markup is missing or events bubble from outside a component.
> 
> **Popover** is the main fix: `handleKeydown` now exits when `closest('[data-js-popover]')` is null (the high-volume RUM `classList` error), plus safer click/trigger handling, optional restore of `SELECTOR_LAST_FOCUSED` on close, and removal of an unused `popoverPanel` variable in `handleClick`.
> 
> The same defensive pattern is applied in **accordion-panel**, **inputgroup**, **select**, **tabs**, and **panel-controls** (bulk actions, expand/collapse focus). Behavior when the DOM is well-formed should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a169fe8c9926025b3ddbfb9e7e5bb94ccd79ad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->