### PR TITLE
chore(lefthook): use local commitlint instead of npx in commit-msg

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,5 +6,5 @@ pre-commit:
 commit-msg:
   commands:
     lint-commit:
-      # pinned local commitlint (see PR #2183)
+      # pinned local commitlint (not npx)
       run: node node_modules/@commitlint/cli/cli.js --edit

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,4 +6,12 @@ pre-commit:
 commit-msg:
   commands:
     lint-commit:
-      run: npx commitlint --edit
+      # Use the locally-installed commitlint (pinned by yarn.lock) instead of
+      # `npx commitlint`, which fetches the latest from the npm registry. The
+      # current latest (@commitlint/cli@20.x) throws `TypeError: format is not
+      # a function` on Node 22 regardless of message content, blocking every
+      # commit.
+      #
+      # Lerna's hoisted layout doesn't create node_modules/.bin/commitlint at
+      # the repo root, so the CLI is invoked directly via node + its cli.js.
+      run: node node_modules/@commitlint/cli/cli.js --edit

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,12 +6,5 @@ pre-commit:
 commit-msg:
   commands:
     lint-commit:
-      # Use the locally-installed commitlint (pinned by yarn.lock) instead of
-      # `npx commitlint`, which fetches the latest from the npm registry. The
-      # current latest (@commitlint/cli@20.x) throws `TypeError: format is not
-      # a function` on Node 22 regardless of message content, blocking every
-      # commit.
-      #
-      # Lerna's hoisted layout doesn't create node_modules/.bin/commitlint at
-      # the repo root, so the CLI is invoked directly via node + its cli.js.
+      # pinned local commitlint (see PR #2183)
       run: node node_modules/@commitlint/cli/cli.js --edit


### PR DESCRIPTION
## Summary

The `commit-msg` lefthook step ran `npx commitlint --edit`, which fetches the latest `@commitlint/cli` from the npm registry on every commit. The current latest (`@commitlint/cli@20.5.3`) throws `TypeError: format is not a function` on Node 22 *regardless of message content*, blocking every commit and forcing contributors to use `--no-verify`.

This switches to the locally-installed CLI pinned by `yarn.lock`. Lerna's hoisted layout doesn't create `node_modules/.bin/commitlint` at the repo root, so the binary is invoked directly via `node node_modules/@commitlint/cli/cli.js --edit`.

## Stacked on #2182

Branched off `chore/claude-gauntlet-skills`. Will need rebase if that merges first; targeting it as base so the PR diff stays focused on the `lefthook.yml` change.

## Test plan

- [x] **Smoke-tested locally** — `node node_modules/@commitlint/cli/cli.js --edit <good msg>` exits 0; same command on a malformed message ("missing type") correctly reports `subject-empty` + `type-empty`.
- [x] **Self-test** — This PR's own commit was authored through the patched hook (no `--no-verify`). The lefthook log shows `✔️ lint-commit (0.23 seconds)`, vs the previous behavior which crashed during the commitlint print-error path after ~5s.
- [ ] Open this PR and confirm CI passes.
- [ ] One reviewer commits something to this branch (good or bad message) to confirm the hook runs locally on their machine too.

## Notes

- Pinned version is `@commitlint/cli@11.0.0` per `node_modules/@commitlint/cli/package.json` — old but functional with the existing `commitlint.config.js` (`@commitlint/config-conventional`).
- A future upgrade to a modern commitlint can come as its own PR; out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line dev-tooling change in lefthook.yml with no runtime, auth, or production impact.
> 
> **Overview**
> The **`commit-msg`** lefthook hook no longer runs **`npx commitlint --edit`**, which pulled the latest CLI from npm and could break commits (e.g. recent `@commitlint/cli` failing on Node 22). It now runs the **repo-pinned** `@commitlint/cli` via **`node node_modules/@commitlint/cli/cli.js --edit`**, with a short comment noting the direct path is used because Lerna’s layout may not expose **`node_modules/.bin/commitlint`** at the root.
> 
> **`commitlint.config.js`** and conventional-commit rules are unchanged; only how the hook invokes commitlint changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e420ba6bcb403e619ab8e4bb014eb35ab8ffebe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->