### PR TITLE
chore(claude): add optional post-to-PR mode to sage-run-gauntlet

### DIFF
--- a/.claude/skills/sage-run-gauntlet/SKILL.md
+++ b/.claude/skills/sage-run-gauntlet/SKILL.md
@@ -177,21 +177,32 @@ show per-section counts.
 
 ## After the Gauntlet
 
+Resolve the current branch's open PR once (used for labeling and posting):
+
+```bash
+PR_NUM=$(gh pr view --repo Kajabi/sage-lib --json number -q .number 2>/dev/null || true)
+```
+
+Always pass `--repo Kajabi/sage-lib` on `gh` PR commands so fork / non-default
+remote contexts target the upstream repo, not a fork with the same numeric id.
+
 ### Apply the `ran-gauntlet` label (required)
 
 Always add the `ran-gauntlet` label to the PR to signal to human reviewers
 that automated multi-agent review has already run on this branch:
 
 ```bash
-gh pr edit <PR#> --add-label ran-gauntlet
+if [ -n "$PR_NUM" ]; then
+  gh pr edit "$PR_NUM" --repo Kajabi/sage-lib --add-label ran-gauntlet
+fi
 ```
 
-Apply the label unconditionally — including when the gauntlet short-circuits
+Apply the label unconditionally when a PR exists — including when the gauntlet short-circuits
 to manual review for docs-only or config-only diffs. The signal is "the
 gauntlet step was performed on this branch," not "N agents executed."
 
-If no PR exists yet (common when running the gauntlet before PR creation),
-add the label at PR creation time or immediately after the PR is opened.
+If no PR exists yet (`PR_NUM` empty; common before `gh pr create`), defer
+labeling until PR creation or immediately after the PR is opened.
 
 ### Post results to the PR (optional)
 
@@ -199,17 +210,10 @@ By default the gauntlet output stays in the conversation between the
 developer running it and the agent — the assumption is that's the same
 person as the PR author, so a verbal-only result is enough.
 
-**Prerequisite (same as labeling):** resolve the current branch's open
-PR before posting. If no PR exists yet (common pre-`gh pr create`), **do
-not** run `gh pr review` or `gh pr comment` — keep findings in the
-conversation and post after the PR is opened (or when the user re-runs
-the gauntlet on the open PR).
-
-```bash
-PR_NUM=$(gh pr view --repo Kajabi/sage-lib --json number -q .number 2>/dev/null || true)
-```
-
-If `PR_NUM` is empty, skip posting entirely.
+**Prerequisite:** use the `PR_NUM` resolved above. If empty, **do not** run
+`gh pr review` or `gh pr comment` — keep findings in the conversation and
+post after the PR is opened (or when the user re-runs the gauntlet on the
+open PR).
 
 **Posting decision — apply in order (first match wins):**
 
@@ -271,21 +275,27 @@ applied. Findings ordered by severity; numbering is sequential across
 sections._
 EOF
 
-gh pr review "$PR_NUM" --repo Kajabi/sage-lib --comment --body-file "$BODY_FILE" \
-  || gh pr comment "$PR_NUM" --repo Kajabi/sage-lib --body-file "$BODY_FILE"
+if ! gh pr review "$PR_NUM" --repo Kajabi/sage-lib --comment --body-file "$BODY_FILE" 2>gauntlet_review_err.log; then
+  if grep -qE '403|404|HTTP 403|HTTP 404|forbidden|not found|Resource not accessible|pull request write' gauntlet_review_err.log; then
+    gh pr comment "$PR_NUM" --repo Kajabi/sage-lib --body-file "$BODY_FILE"
+  else
+    cat gauntlet_review_err.log >&2
+    exit 1
+  fi
+fi
 ```
 
 The footer line is required — it tells human reviewers the comment was
 machine-generated and signals where to look for the criteria (the
 `ran-gauntlet` label). Do not claim the label was applied in the footer
-unless `gh pr edit … --add-label ran-gauntlet` actually ran (or will run
-immediately after posting on the same PR).
+unless `gh pr edit "$PR_NUM" --repo Kajabi/sage-lib --add-label ran-gauntlet`
+actually ran (or will run immediately after posting on the same PR).
 
 **Permissions:** `gh pr review --comment` requires you to be a
 collaborator on the repo or to have read+pull-request-write scopes on
-your `gh auth`. If it fails with a 403 / 404, the `||` fallback runs
-`gh pr comment` with the same `--repo` and `--body-file` (normal PR
-conversation comment instead of a formal review).
+your `gh auth`. Fall back to `gh pr comment` **only** when stderr matches
+403/404 or permission errors (see `grep` above). On any other failure,
+surface the error in the conversation and **do not** post a second comment.
 
 ### Present results and offer options
 

--- a/.claude/skills/sage-run-gauntlet/SKILL.md
+++ b/.claude/skills/sage-run-gauntlet/SKILL.md
@@ -177,10 +177,25 @@ show per-section counts.
 
 ## After the Gauntlet
 
-Resolve the current branch's open PR once (used for labeling and posting):
+Resolve the current branch's open PR once (used for labeling and posting).
+**Do not** treat `gh` failures the same as "no PR" — only an empty result with
+a "no pull requests found" style message means defer; auth/network errors must
+surface in the conversation and stop before label/post commands.
 
 ```bash
-PR_NUM=$(gh pr view --repo Kajabi/sage-lib --json number -q .number 2>/dev/null || true)
+PR_VIEW_ERR=$(mktemp)
+PR_NUM=$(gh pr view --repo Kajabi/sage-lib --json number -q .number 2>"$PR_VIEW_ERR")
+PR_VIEW_EXIT=$?
+if [ "$PR_VIEW_EXIT" -ne 0 ]; then
+  if grep -qiE 'no pull requests found|could not find pull request' "$PR_VIEW_ERR"; then
+    PR_NUM=""
+  else
+    cat "$PR_VIEW_ERR" >&2
+    rm -f "$PR_VIEW_ERR"
+    exit 1
+  fi
+fi
+rm -f "$PR_VIEW_ERR"
 ```
 
 Always pass `--repo Kajabi/sage-lib` on `gh` PR commands so fork / non-default
@@ -192,8 +207,11 @@ Always add the `ran-gauntlet` label to the PR to signal to human reviewers
 that automated multi-agent review has already run on this branch:
 
 ```bash
+LABEL_APPLIED=0
 if [ -n "$PR_NUM" ]; then
-  gh pr edit "$PR_NUM" --repo Kajabi/sage-lib --add-label ran-gauntlet
+  if gh pr edit "$PR_NUM" --repo Kajabi/sage-lib --add-label ran-gauntlet; then
+    LABEL_APPLIED=1
+  fi
 fi
 ```
 
@@ -201,8 +219,9 @@ Apply the label unconditionally when a PR exists — including when the gauntlet
 to manual review for docs-only or config-only diffs. The signal is "the
 gauntlet step was performed on this branch," not "N agents executed."
 
-If no PR exists yet (`PR_NUM` empty; common before `gh pr create`), defer
-labeling until PR creation or immediately after the PR is opened.
+If no PR exists yet (`PR_NUM` empty after the "no pull requests found" path;
+common before `gh pr create`), defer labeling until PR creation or immediately
+after the PR is opened.
 
 ### Post results to the PR (optional)
 
@@ -223,61 +242,48 @@ open PR).
 3. **Post** — User explicitly opted in ("post the findings to the PR,"
    "leave a review on the PR," "comment on the PR with the findings," or
    similar) and `PR_NUM` is set.
-4. **Do not post** — Findings are praise-only: no BLOCKER and no SHOULD
-   FIX items (label is enough signal).
-5. **Post** — Gauntlet ran on **someone else's PR** (compare
+4. **Post** — Gauntlet ran on **someone else's PR** (compare
    `gh pr view --repo Kajabi/sage-lib --json author -q .author.login` to
-   `gh api user -q .login`) **and** findings include at least one
-   BLOCKER or SHOULD FIX.
+   `gh api user -q .login`) **and** findings include at least one BLOCKER,
+   SHOULD FIX, or CONSIDER item (so the author sees actionable feedback).
+5. **Do not post** — Praise-only: no BLOCKER, SHOULD FIX, or CONSIDER
+   items (only "What's Good" / empty severity sections; label is enough).
 6. **Do not post** — All other cases (including the author's own PR,
-   including own open PRs with BLOCKER/SHOULD FIX — they already have
-   the conversation output).
+   including own open PRs with findings — they already have the
+   conversation output).
 
-This ordering resolves conflicts (e.g. someone else's PR with praise-only
-findings → step 4, no post; author's own PR with blockers → step 6, no
-post unless step 3).
+This ordering resolves conflicts (e.g. someone else's PR with CONSIDER-only
+→ step 4, post; praise-only on any PR → step 5, no post; author's own PR
+with blockers → step 6, no post unless step 3).
 
 **Format:** post the full structured output as a single `gh pr review`
 comment so sequential numbering, severity headers, and per-finding
 file:line refs are preserved. Inline per-line comments would fragment
 the output and lose cross-finding ordering.
 
-**Command:** write the body to a temp file so shell metacharacters in
-findings (quotes, `$`, backticks) cannot break the command. Use
-`--body-file` for both primary and fallback paths.
+**Command:** write the consolidated report from **Output Format** (above)
+verbatim into a temp file — same headings (`**Reviewers:**`, `---`, full
+per-finding `File` / `Issue` / `Fix` fields). Do **not** post the abbreviated
+placeholder version. Then append **one** footer line matching `LABEL_APPLIED`:
+
+- `LABEL_APPLIED=1`: `_Posted by sage-run-gauntlet. The ran-gauntlet label has been applied. Findings ordered by severity; numbering is sequential across sections._`
+- `LABEL_APPLIED=0`: `_Posted by sage-run-gauntlet. Findings ordered by severity; numbering is sequential across sections._`
+
+Use `--body-file` so shell metacharacters in findings cannot break the command.
 
 ```bash
 BODY_FILE=$(mktemp)
 trap 'rm -f "$BODY_FILE"' EXIT
 
-cat > "$BODY_FILE" <<'EOF'
-## Sage Gauntlet Results
-
-**Reviewers launched:** [list]
-**Files Reviewed:** [list]
-**Overall Assessment:** APPROVED | NEEDS CHANGES | BLOCKER
-
-### BLOCKERS ([count])
-…
-
-### SHOULD FIX ([count])
-…
-
-### CONSIDER ([count])
-…
-
-### What's Good
-…
-
----
-_Posted by `sage-run-gauntlet`. The `ran-gauntlet` label has also been
-applied. Findings ordered by severity; numbering is sequential across
-sections._
-EOF
+# 1. Write the full consolidated gauntlet report (Output Format) into BODY_FILE.
+# 2. Append the footer line for LABEL_APPLIED (see above).
 
 if ! gh pr review "$PR_NUM" --repo Kajabi/sage-lib --comment --body-file "$BODY_FILE" 2>gauntlet_review_err.log; then
-  if grep -qE '403|404|HTTP 403|HTTP 404|forbidden|not found|Resource not accessible|pull request write' gauntlet_review_err.log; then
-    gh pr comment "$PR_NUM" --repo Kajabi/sage-lib --body-file "$BODY_FILE"
+  if grep -qiE 'HTTP 403|HTTP 404|403 Forbidden|404 Not Found|Resource not accessible by integration|pull request write|does not have permission to' gauntlet_review_err.log; then
+    if ! gh pr comment "$PR_NUM" --repo Kajabi/sage-lib --body-file "$BODY_FILE" 2>gauntlet_comment_err.log; then
+      cat gauntlet_comment_err.log >&2
+      exit 1
+    fi
   else
     cat gauntlet_review_err.log >&2
     exit 1
@@ -285,17 +291,15 @@ if ! gh pr review "$PR_NUM" --repo Kajabi/sage-lib --comment --body-file "$BODY_
 fi
 ```
 
-The footer line is required — it tells human reviewers the comment was
-machine-generated and signals where to look for the criteria (the
-`ran-gauntlet` label). Do not claim the label was applied in the footer
-unless `gh pr edit "$PR_NUM" --repo Kajabi/sage-lib --add-label ran-gauntlet`
-actually ran (or will run immediately after posting on the same PR).
+The footer is required so human reviewers know the comment was
+machine-generated. Never claim the label was applied when `LABEL_APPLIED=0`.
 
 **Permissions:** `gh pr review --comment` requires you to be a
 collaborator on the repo or to have read+pull-request-write scopes on
 your `gh auth`. Fall back to `gh pr comment` **only** when stderr matches
-403/404 or permission errors (see `grep` above). On any other failure,
-surface the error in the conversation and **do not** post a second comment.
+the permission `grep` patterns above. On any other review failure, or if the
+fallback comment command fails, surface the error in the conversation and
+**do not** assume posting succeeded.
 
 ### Present results and offer options
 

--- a/.claude/skills/sage-run-gauntlet/SKILL.md
+++ b/.claude/skills/sage-run-gauntlet/SKILL.md
@@ -199,33 +199,54 @@ By default the gauntlet output stays in the conversation between the
 developer running it and the agent — the assumption is that's the same
 person as the PR author, so a verbal-only result is enough.
 
-**Opt in to posting** when any of the following is true:
+**Prerequisite (same as labeling):** resolve the current branch's open
+PR before posting. If no PR exists yet (common pre-`gh pr create`), **do
+not** run `gh pr review` or `gh pr comment` — keep findings in the
+conversation and post after the PR is opened (or when the user re-runs
+the gauntlet on the open PR).
 
-- The gauntlet is being run against **someone else's PR** (the original
-  author needs to see the findings).
-- The user explicitly asks: "post the gauntlet findings to the PR,"
-  "leave a review on the PR," "comment on the PR with the findings,"
-  or similar.
-- The findings include at least one BLOCKER or SHOULD FIX and the PR
-  is open for review (so the post is actionable, not just informational
-  noise).
+```bash
+PR_NUM=$(gh pr view --repo Kajabi/sage-lib --json number -q .number 2>/dev/null || true)
+```
 
-**Do not post by default** when:
+If `PR_NUM` is empty, skip posting entirely.
 
-- The gauntlet ran against the developer's own PR pre-push (they're
-  going to read the conversation output anyway).
-- All sections are empty / "What's Good" only (label is enough signal).
-- The user explicitly opted out ("don't post," "just tell me here").
+**Posting decision — apply in order (first match wins):**
+
+1. **Do not post** — User explicitly opted out ("don't post," "just tell
+   me here," or similar).
+2. **Do not post** — No open PR for the current branch (`PR_NUM` empty).
+3. **Post** — User explicitly opted in ("post the findings to the PR,"
+   "leave a review on the PR," "comment on the PR with the findings," or
+   similar) and `PR_NUM` is set.
+4. **Do not post** — Findings are praise-only: no BLOCKER and no SHOULD
+   FIX items (label is enough signal).
+5. **Post** — Gauntlet ran on **someone else's PR** (compare
+   `gh pr view --repo Kajabi/sage-lib --json author -q .author.login` to
+   `gh api user -q .login`) **and** findings include at least one
+   BLOCKER or SHOULD FIX.
+6. **Do not post** — All other cases (including the author's own PR,
+   including own open PRs with BLOCKER/SHOULD FIX — they already have
+   the conversation output).
+
+This ordering resolves conflicts (e.g. someone else's PR with praise-only
+findings → step 4, no post; author's own PR with blockers → step 6, no
+post unless step 3).
 
 **Format:** post the full structured output as a single `gh pr review`
 comment so sequential numbering, severity headers, and per-finding
 file:line refs are preserved. Inline per-line comments would fragment
 the output and lose cross-finding ordering.
 
-**Command:**
+**Command:** write the body to a temp file so shell metacharacters in
+findings (quotes, `$`, backticks) cannot break the command. Use
+`--body-file` for both primary and fallback paths.
 
 ```bash
-gh pr review <PR#> --repo Kajabi/sage-lib --comment --body "$(cat <<'EOF'
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
+
+cat > "$BODY_FILE" <<'EOF'
 ## Sage Gauntlet Results
 
 **Reviewers launched:** [list]
@@ -245,22 +266,26 @@ gh pr review <PR#> --repo Kajabi/sage-lib --comment --body "$(cat <<'EOF'
 …
 
 ---
-_Posted by \`sage-run-gauntlet\`. The \`ran-gauntlet\` label has also
-been applied. Findings ordered by severity; numbering is sequential
-across sections._
+_Posted by `sage-run-gauntlet`. The `ran-gauntlet` label has also been
+applied. Findings ordered by severity; numbering is sequential across
+sections._
 EOF
-)"
+
+gh pr review "$PR_NUM" --repo Kajabi/sage-lib --comment --body-file "$BODY_FILE" \
+  || gh pr comment "$PR_NUM" --repo Kajabi/sage-lib --body-file "$BODY_FILE"
 ```
 
 The footer line is required — it tells human reviewers the comment was
 machine-generated and signals where to look for the criteria (the
-`ran-gauntlet` label).
+`ran-gauntlet` label). Do not claim the label was applied in the footer
+unless `gh pr edit … --add-label ran-gauntlet` actually ran (or will run
+immediately after posting on the same PR).
 
 **Permissions:** `gh pr review --comment` requires you to be a
 collaborator on the repo or to have read+pull-request-write scopes on
-your `gh auth`. If it fails with a 403 / 404, fall back to
-`gh pr comment <PR#> --body "…"` which creates a normal PR conversation
-comment instead of a formal review.
+your `gh auth`. If it fails with a 403 / 404, the `||` fallback runs
+`gh pr comment` with the same `--repo` and `--body-file` (normal PR
+conversation comment instead of a formal review).
 
 ### Present results and offer options
 

--- a/.claude/skills/sage-run-gauntlet/SKILL.md
+++ b/.claude/skills/sage-run-gauntlet/SKILL.md
@@ -193,6 +193,75 @@ gauntlet step was performed on this branch," not "N agents executed."
 If no PR exists yet (common when running the gauntlet before PR creation),
 add the label at PR creation time or immediately after the PR is opened.
 
+### Post results to the PR (optional)
+
+By default the gauntlet output stays in the conversation between the
+developer running it and the agent — the assumption is that's the same
+person as the PR author, so a verbal-only result is enough.
+
+**Opt in to posting** when any of the following is true:
+
+- The gauntlet is being run against **someone else's PR** (the original
+  author needs to see the findings).
+- The user explicitly asks: "post the gauntlet findings to the PR,"
+  "leave a review on the PR," "comment on the PR with the findings,"
+  or similar.
+- The findings include at least one BLOCKER or SHOULD FIX and the PR
+  is open for review (so the post is actionable, not just informational
+  noise).
+
+**Do not post by default** when:
+
+- The gauntlet ran against the developer's own PR pre-push (they're
+  going to read the conversation output anyway).
+- All sections are empty / "What's Good" only (label is enough signal).
+- The user explicitly opted out ("don't post," "just tell me here").
+
+**Format:** post the full structured output as a single `gh pr review`
+comment so sequential numbering, severity headers, and per-finding
+file:line refs are preserved. Inline per-line comments would fragment
+the output and lose cross-finding ordering.
+
+**Command:**
+
+```bash
+gh pr review <PR#> --repo Kajabi/sage-lib --comment --body "$(cat <<'EOF'
+## Sage Gauntlet Results
+
+**Reviewers launched:** [list]
+**Files Reviewed:** [list]
+**Overall Assessment:** APPROVED | NEEDS CHANGES | BLOCKER
+
+### BLOCKERS ([count])
+…
+
+### SHOULD FIX ([count])
+…
+
+### CONSIDER ([count])
+…
+
+### What's Good
+…
+
+---
+_Posted by \`sage-run-gauntlet\`. The \`ran-gauntlet\` label has also
+been applied. Findings ordered by severity; numbering is sequential
+across sections._
+EOF
+)"
+```
+
+The footer line is required — it tells human reviewers the comment was
+machine-generated and signals where to look for the criteria (the
+`ran-gauntlet` label).
+
+**Permissions:** `gh pr review --comment` requires you to be a
+collaborator on the repo or to have read+pull-request-write scopes on
+your `gh auth`. If it fails with a 403 / 404, fall back to
+`gh pr comment <PR#> --body "…"` which creates a normal PR conversation
+comment instead of a formal review.
+
 ### Present results and offer options
 
 1. **Fix blockers** — Address BLOCKER issues, optionally re-run gauntlet


### PR DESCRIPTION
## Summary

`sage-run-gauntlet` output currently lives only in the conversation between the developer and the agent. That works when the runner is the PR author, but not when running on someone else's PR — like running the gauntlet on #2181 yesterday, where the original author has no way to see the findings.

This adds an optional **Post results to the PR** mode under the existing **After the Gauntlet** section.

## Behavior

| Scenario | Default behavior |
|---|---|
| Running on your own PR pre-push | Don't post — you'll see results in the conversation |
| Running on someone else's PR | **Post** — original author needs to see findings |
| User explicitly says "post the findings" | Post |
| User explicitly says "don't post" / "just tell me here" | Don't post |
| Findings are empty / What's Good only | Don't post — label is enough |
| Findings include BLOCKER or SHOULD FIX on an open PR | Post |

Label-apply behavior is **unchanged** — always run, regardless of post-or-not.

## Format

Single `gh pr review --comment` body that preserves:
- Sequential numbering across BLOCKERS → SHOULD FIX → CONSIDER
- Per-finding file:line refs
- A footer noting machine-generation + the `ran-gauntlet` label

Inline per-line comments would fragment the output and break cross-finding ordering, so the skill explicitly chooses single-comment posting over inline.

Falls back to `gh pr comment` (general PR comment) if `gh pr review` returns 403/404 on collaborator scopes.

## Stack

- #2182 — `chore(claude):` add gauntlet skills (base: `develop`)
- #2183 — `chore(lefthook):` fix commit-msg hook (base: `chore/claude-gauntlet-skills`)
- #2184 — `chore(claude):` classify sage-system (base: `chore/fix-commit-msg-hook`)
- **this PR** — base: `chore/sage-system-classification`

Will need rebase if upstream merges first.

## Test plan

- [x] Lefthook `lint-commit` passes (0.38s, no `--no-verify`) — proves #2183 hook fix still works.
- [ ] **Demonstrate** by re-posting yesterday's gauntlet findings on #2181 using the new mode — see follow-up comment on this PR.

## Notes

- A parallel update to `pine-run-gauntlet` makes sense as a follow-up; out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a Claude skill; no runtime code, auth, or product behavior in sage-lib.
> 
> **Overview**
> Extends **`sage-run-gauntlet`** so agents can optionally publish consolidated gauntlet results to GitHub, not only in the local conversation.
> 
> **After the Gauntlet** now resolves the current branch’s PR once via `gh pr view` on **`Kajabi/sage-lib`**, distinguishes real “no PR” from auth/network failures, and tracks whether **`ran-gauntlet`** was applied (`LABEL_APPLIED`). Labeling is deferred when there is no open PR; otherwise it still runs unconditionally when a PR exists.
> 
> A new **Post results to the PR** section defines a **first-match-wins** policy: default is conversation-only on your own PR; post when the user opts in, when reviewing **someone else’s** PR with actionable findings (BLOCKER / SHOULD FIX / CONSIDER), with explicit opt-out and praise-only exceptions. Posting uses a single **`gh pr review --comment`** with the full structured report and a machine-generated footer (wording depends on label success), **`--body-file`** for safety, and **`gh pr comment`** only on permission-related failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fad9829c906d776a490869de556ad63318f44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->