### PR TITLE
fix(release): pin origin remote to PAT to bypass branch protection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish
 on:
   workflow_call:
+    secrets:
+      KAJABI_CI_GH_TOKEN:
+        required: true
   push:
     branches:
       - main
@@ -27,6 +30,12 @@ jobs:
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: "0"
+          token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+
+      - name: Pin origin remote to PAT identity
+        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
+        env:
+          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
       # Setup Git Credentials to come from the Bot
       - name: Set Bot Email

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
+
+**Note:** Version bump only for package root
+
+
+
+
+
 ## [6.2.28](https://github.com/Kajabi/sage-lib/compare/v6.2.27...v6.2.28) (2026-01-29)
 
 **Note:** Version bump only for package root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.30](https://github.com/Kajabi/sage-lib/compare/v6.2.29...v6.2.30) (2026-04-28)
+
+**Note:** Version bump only for package root
+
+
+
+
+
 ## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
 
 **Note:** Version bump only for package root

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.30](https://github.com/Kajabi/sage-lib/compare/v6.2.29...v6.2.30) (2026-04-28)
+
+**Note:** Version bump only for package @kajabi/sage
+
+
+
+
+
 ## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
 
 **Note:** Version bump only for package @kajabi/sage

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
+
+**Note:** Version bump only for package @kajabi/sage
+
+
+
+
+
 ## [6.2.28](https://github.com/Kajabi/sage-lib/compare/v6.2.27...v6.2.28) (2026-01-29)
 
 **Note:** Version bump only for package @kajabi/sage

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (6.2.29)
+    sage_rails (6.2.30)
       classy_hash
       rails
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/sage_rails
   specs:
-    sage_rails (6.2.28)
+    sage_rails (6.2.29)
       classy_hash
       rails
 

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "6.2.29"
+  VERSION = "6.2.30"
 end

--- a/docs/lib/sage_rails/lib/sage_rails/version.rb
+++ b/docs/lib/sage_rails/lib/sage_rails/version.rb
@@ -1,3 +1,3 @@
 module SageRails
-  VERSION = "6.2.28"
+  VERSION = "6.2.29"
 end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "6.2.28",
+  "version": "6.2.29",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -38,7 +38,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^6.2.28",
+    "@kajabi/sage-packs": "^6.2.29",
     "@rails/webpacker": "5.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage",
-  "version": "6.2.29",
+  "version": "6.2.30",
   "description": "The Sage Design System (SDS) is our single source of truth, providing everything you need to build great products for our customers. It is the culmination of designers and developers working together to give teams the ability to ship high-quality products faster.",
   "main": "sage/pages/index",
   "directories": {
@@ -38,7 +38,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/plugin-transform-runtime": "^7.12.1",
-    "@kajabi/sage-packs": "^6.2.29",
+    "@kajabi/sage-packs": "^6.2.30",
     "@rails/webpacker": "5.2.2",
     "arrive": "^2.4.1",
     "core-js": "^3.6.5",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*",
     "docs"
   ],
-  "version": "6.2.29",
+  "version": "6.2.30",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*",
     "docs"
   ],
-  "version": "6.2.28",
+  "version": "6.2.29",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/sage-assets/CHANGELOG.md
+++ b/packages/sage-assets/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.30](https://github.com/Kajabi/sage-lib/compare/v6.2.29...v6.2.30) (2026-04-28)
+
+**Note:** Version bump only for package @kajabi/sage-assets
+
+
+
+
+
 ## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
 
 **Note:** Version bump only for package @kajabi/sage-assets

--- a/packages/sage-assets/CHANGELOG.md
+++ b/packages/sage-assets/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
+
+**Note:** Version bump only for package @kajabi/sage-assets
+
+
+
+
+
 ## [6.2.28](https://github.com/Kajabi/sage-lib/compare/v6.2.27...v6.2.28) (2026-01-29)
 
 **Note:** Version bump only for package @kajabi/sage-assets

--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-assets",
-  "version": "6.2.29",
+  "version": "6.2.30",
   "description": "Assets",
   "main": "dist/main.css",
   "repository": {

--- a/packages/sage-assets/package.json
+++ b/packages/sage-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-assets",
-  "version": "6.2.28",
+  "version": "6.2.29",
   "description": "Assets",
   "main": "dist/main.css",
   "repository": {

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.30](https://github.com/Kajabi/sage-lib/compare/v6.2.29...v6.2.30) (2026-04-28)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/CHANGELOG.md
+++ b/packages/sage-packs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
+
+**Note:** Version bump only for package @kajabi/sage-packs
+
+
+
+
+
 ## [6.2.28](https://github.com/Kajabi/sage-lib/compare/v6.2.27...v6.2.28) (2026-01-29)
 
 **Note:** Version bump only for package @kajabi/sage-packs

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "6.2.29",
+  "version": "6.2.30",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -31,8 +31,8 @@
     "url": "https://github.com/Kajabi/sage-lib/issues"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^6.2.29",
-    "@kajabi/sage-react": "^6.2.29",
+    "@kajabi/sage-assets": "^6.2.30",
+    "@kajabi/sage-react": "^6.2.30",
     "@kajabi/sage-system": "^6.2.28"
   },
   "devDependencies": {

--- a/packages/sage-packs/package.json
+++ b/packages/sage-packs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-packs",
-  "version": "6.2.28",
+  "version": "6.2.29",
   "description": "Sage Packs",
   "keywords": [
     "sage",
@@ -31,8 +31,8 @@
     "url": "https://github.com/Kajabi/sage-lib/issues"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^6.2.28",
-    "@kajabi/sage-react": "^6.2.28",
+    "@kajabi/sage-assets": "^6.2.29",
+    "@kajabi/sage-react": "^6.2.29",
     "@kajabi/sage-system": "^6.2.28"
   },
   "devDependencies": {

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.30](https://github.com/Kajabi/sage-lib/compare/v6.2.29...v6.2.30) (2026-04-28)
+
+**Note:** Version bump only for package @kajabi/sage-react
+
+
+
+
+
 ## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
 
 **Note:** Version bump only for package @kajabi/sage-react

--- a/packages/sage-react/CHANGELOG.md
+++ b/packages/sage-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.2.29](https://github.com/Kajabi/sage-lib/compare/v6.2.28...v6.2.29) (2026-02-25)
+
+**Note:** Version bump only for package @kajabi/sage-react
+
+
+
+
+
 ## [6.2.28](https://github.com/Kajabi/sage-lib/compare/v6.2.27...v6.2.28) (2026-01-29)
 
 **Note:** Version bump only for package @kajabi/sage-react

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "6.2.28",
+  "version": "6.2.29",
   "description": "React Components",
   "keywords": [
     "react",
@@ -84,7 +84,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^6.2.28",
+    "@kajabi/sage-assets": "^6.2.29",
     "@popperjs/core": "^2.11.8",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",

--- a/packages/sage-react/package.json
+++ b/packages/sage-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kajabi/sage-react",
-  "version": "6.2.29",
+  "version": "6.2.30",
   "description": "React Components",
   "keywords": [
     "react",
@@ -84,7 +84,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@kajabi/sage-assets": "^6.2.29",
+    "@kajabi/sage-assets": "^6.2.30",
     "@popperjs/core": "^2.11.8",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",


### PR DESCRIPTION
## Description

Ports the release auth fix from [ds-tokens#38](https://github.com/Kajabi/ds-tokens/pull/38) and [pine#727](https://github.com/Kajabi/pine/pull/727) to Sage's `Publish` workflow.

The org-level "Protect default branch" ruleset requires PRs and lists the `bots` team (which includes `kajabi-ci`) as a bypass actor. `actions/checkout@v4` persists credentials via a helper file under `$RUNNER_TEMP` rather than an inline `extraheader` — so `lerna publish`'s subsequent `git push` was falling back to the `github-actions[bot]` token, which is not a bypass actor.

### Changes to `.github/workflows/publish.yml`

1. **Checkout with PAT** — adds `token: KAJABI_CI_GH_TOKEN` to the publish job's `actions/checkout` step.
2. **Pin origin remote** — rewrites `origin` to embed the PAT directly so every subsequent `git push` (including those inside `lerna publish`) authenticates as the PAT bypass actor.
3. **`workflow_call` secrets** — declares `KAJABI_CI_GH_TOKEN` as a required secret for reusable workflow callers.

## Testing in `sage-lib`

- Confirm `KAJABI_CI_GH_TOKEN` exists in repo secrets (same secret used by ds-tokens and pine).
- After merge, verify the next `Publish` run on `main` succeeds at the lerna version-bump push step.
- Confirm the resulting commit is pushed by the PAT account, not `github-actions[bot]`.

## Testing in `kajabi-products`

N/A — CI workflow change only; no package or component changes.

## Related

- https://github.com/Kajabi/ds-tokens/pull/38
- https://github.com/Kajabi/pine/pull/727

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release automation pushes to protected branches using a privileged PAT; misconfiguration could block releases or widen push identity scope, but runtime app behavior is unchanged.
> 
> **Overview**
> Updates the **Publish** workflow so `lerna publish` can push version commits through default-branch protection.
> 
> `workflow_call` now requires a **`KAJABI_CI_GH_TOKEN`** secret. The publish job checks out with that PAT and **rewrites `origin`** to use `x-access-token` so later `git push` steps (including inside Lerna) run as the bypass-capable CI identity instead of `github-actions[bot]`.
> 
> The diff also includes **6.2.29 / 6.2.30** release housekeeping (changelogs, `lerna.json`, package versions, and `sage_rails` version in docs)—version-bump only, no product code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1287cc2d62a881bbcebdce1fc948156ecf796009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->