### PR TITLE
ci(publish): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     secrets:
       KAJABI_CI_GH_TOKEN:
         required: true
+  # Allows manually triggering a publish from the Actions tab or `gh workflow run`.
+  # Dispatching against `main` runs the Lerna Publish path; against `develop`, the
+  # canary path — both gate on github.ref, which dispatch sets to the chosen branch.
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What

Adds `workflow_dispatch` to the `Publish` workflow's triggers so it can be run manually from the **Actions tab** or via `gh workflow run Publish --ref <branch>` — no fresh push required.

```yaml
on:
  workflow_call:
    ...
  workflow_dispatch:   # ← new
  push:
    branches: [main, develop]
```

## Why

Two reasons:

1. **Permanent fix** — the release currently can only be triggered by a `push` to `main`/`develop`. When a release gets stuck (as 6.2.31 did) there's no clean way to re-run it; the only options are empty commits or direct pushes to `main`. `workflow_dispatch` gives a first-class manual trigger.

2. **Unblocks 6.2.31 right now** — merging this PR is itself a `push` to `main` (it carries a real file change, so it squashes to a real commit, unlike the earlier empty-commit attempt). That push fires `Publish`, which should cut 6.2.31 cleanly now that the orphaned `v6.2.31` tag is gone.

## Behavior note

The publish steps already gate on `github.ref` (`Lerna Publish` for `refs/heads/main`, canary for `refs/heads/develop`). `workflow_dispatch` sets `github.ref` to the dispatched branch, so dispatching against `main` runs the main publish path unchanged — no step logic needed to change.

## Merge

Squash-merge (matches the repo's release-PR convention). The squash commit has real content, so it lands a new commit on `main` and triggers `Publish`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change; publish behavior still depends on the same ref-gated Lerna steps as push events.
> 
> **Overview**
> Adds **`workflow_dispatch`** to the **Publish** workflow so releases can be started from the Actions UI or `gh workflow run` without a new push to `main`/`develop`.
> 
> Inline comments document that dispatch uses the selected branch’s **`github.ref`**, so existing **`if: github.ref == ...`** gates still pick **Lerna Publish** on `main` and the canary path on `develop`—no job or step changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4acfa72e8d8a52e12571c66ecac530a693b06b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->