### PR TITLE
fix(publish): use GITHUB_TOKEN for checkout/push, drop unset PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish
 on:
   workflow_call:
-    secrets:
-      KAJABI_CI_GH_TOKEN:
-        required: true
   # Allows manually triggering a publish from the Actions tab or `gh workflow run`.
   # Dispatching against `main` runs the Lerna Publish path; against `develop`, the
   # canary path — both gate on github.ref, which dispatch sets to the chosen branch.
@@ -20,6 +17,9 @@ jobs:
   publish:
     needs: [lint-test-build]
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN needs write access to push lerna's release commit + tag to main.
+    permissions:
+      contents: write
 
     steps:
       # # Setup Auth token to push to github packages
@@ -34,12 +34,11 @@ jobs:
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: "0"
-          token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
-
-      - name: Pin origin remote to PAT identity
-        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
-        env:
-          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+          # Uses the default GITHUB_TOKEN. main has no branch protection, so the
+          # checkout credentials can push lerna's release commit + tag back directly.
+          # (If branch protection is ever re-enabled on main, restore a PAT here —
+          # see KAJABI_CI_GH_TOKEN / the removed "Pin origin remote to PAT" step —
+          # because GITHUB_TOKEN cannot bypass protection.)
 
       # Setup Git Credentials to come from the Bot
       - name: Set Bot Email


### PR DESCRIPTION
## The bug

The latest `Publish` run on `main` ([26595956309](https://github.com/Kajabi/sage-lib/actions/runs/26595956309)) failed at the **Clone Sage-Lib Repo** step:

```
##[error]Input required and not supplied: token
```

The checkout step required `secrets.KAJABI_CI_GH_TOKEN`, but that secret **isn't configured** (repo has only `ACCESS_TOKEN`). With no token value, `actions/checkout` errors immediately — before lerna runs.

This wiring (the PAT token + "Pin origin remote to PAT identity" step) was added in `dc53ff4b5` *(fix(release): pin origin remote to PAT to bypass branch protection)* and reached `main` via the back-merge #2191. The Publish workflow hadn't actually **run** on main with this wiring until the `workflow_dispatch` PR (#2193) triggered it — which is when the latent failure surfaced.

## Why we can just drop the PAT

The PAT existed solely to **bypass branch protection** when lerna pushes the release commit + tag back to `main`. But `main` **no longer has branch protection** — confirmed: no classic protection (404) and no rulesets. So the default `GITHUB_TOKEN` can push directly, exactly as it did for every release before `dc53ff4b5` (#2178, #2169, #2161, …).

## Changes

- **checkout**: drop `token: KAJABI_CI_GH_TOKEN` → use the auto-provisioned `GITHUB_TOKEN`
- remove the **Pin origin remote to PAT identity** step (would rewrite `origin` to an empty PAT and break the push)
- remove the now-unused `KAJABI_CI_GH_TOKEN` from `workflow_call.secrets`
- add `permissions: contents: write` to the publish job so `GITHUB_TOKEN` can push the commit + tag

Net: `+8 / −9` lines.

## Caveat

If branch protection is ever re-enabled on `main`, `GITHUB_TOKEN` won't be able to bypass it and a properly-configured PAT will be needed again. Noted inline in the file.

## Merge

Squash-merge. The merge is a push to `main` → triggers `Publish` → should finally cut **6.2.31** cleanly (orphaned `v6.2.31` tag already deleted). If it doesn't auto-fire, we now have the manual `workflow_dispatch` button from #2193.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to GitHub Actions auth; no application runtime, security, or data-path changes.
> 
> **Overview**
> Fixes the **Publish** workflow failing at checkout with `Input required and not supplied: token` because `KAJABI_CI_GH_TOKEN` was required but not set on the repo.
> 
> **Checkout and git push** now rely on the default **`GITHUB_TOKEN`** instead of a PAT: the explicit `token` on `actions/checkout` and the **Pin origin remote to PAT identity** step are removed, and the unused **`KAJABI_CI_GH_TOKEN`** entry is dropped from `workflow_call.secrets`. The publish job gets **`permissions: contents: write`** so Lerna can push the release commit and tag to `main` (valid while `main` has no branch protection; comments note restoring a PAT if protection returns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25459b902b3ac0029e10275dc9cc6ad1f351cab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->