### PR TITLE
Revert PAT-bypass wiring in Publish workflow (fixes stuck release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish
 on:
   workflow_call:
-    secrets:
-      KAJABI_CI_GH_TOKEN:
-        required: true
   # Allows manually triggering a publish from the Actions tab or `gh workflow run`.
   # Dispatching against `main` runs the Lerna Publish path; against `develop`, the
   # canary path — both gate on github.ref, which dispatch sets to the chosen branch.
@@ -34,12 +31,6 @@ jobs:
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: "0"
-          token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
-
-      - name: Pin origin remote to PAT identity
-        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
-        env:
-          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
       # Setup Git Credentials to come from the Bot
       - name: Set Bot Email


### PR DESCRIPTION
## Description
Reverts the PAT-bypass wiring (`dc53ff4b5` — *"fix(release): pin origin remote to PAT to bypass branch protection"*) from the `Publish` workflow, while **preserving** the `workflow_dispatch` trigger added in #2193.

**The bug:** the latest `Publish` run on `main` ([26595956309](https://github.com/Kajabi/sage-lib/actions/runs/26595956309)) failed at the **Clone Sage-Lib Repo** step:
```
##[error]Input required and not supplied: token
```
The checkout required `secrets.KAJABI_CI_GH_TOKEN`, which is **not configured** (the repo only has `ACCESS_TOKEN`), so `actions/checkout` errored before lerna ran. This wiring reached `main` via the back-merge #2191 and the first run to actually exercise it (after `workflow_dispatch` was added) surfaced the failure.

**Why the revert is safe:** the PAT existed solely to bypass branch protection when lerna pushes the release commit + tag back to `main`. `main` **no longer has branch protection** (no classic protection, no rulesets — confirmed), so the default `GITHUB_TOKEN` can push directly, exactly as it did for every release before `dc53ff4b5` (#2178, #2169, #2161, …).

**Changes** (`-9` lines):
- remove `KAJABI_CI_GH_TOKEN` from `workflow_call.secrets`
- remove `token: KAJABI_CI_GH_TOKEN` from the checkout step (uses default `GITHUB_TOKEN`)
- remove the **Pin origin remote to PAT identity** step
- `workflow_dispatch` trigger retained

> ⚠️ If branch protection is ever re-enabled on `main`, `GITHUB_TOKEN` won't be able to bypass it and a properly-configured PAT will be needed again.

## Testing in `sage-lib`
- Merging this is a push to `main` → triggers `Publish` → the **Clone** step now succeeds with `GITHUB_TOKEN`, and lerna should push the release commit + `v6.2.31` tag (the orphaned `v6.2.31` tag was already deleted), cutting **6.2.31**.
- If it doesn't auto-fire, the `workflow_dispatch` button (Actions → Publish → Run workflow on `main`) is available as a manual trigger.
- No runtime/library code changed — this is CI-only.

## Testing in `kajabi-products`
1. (**LOW**) CI/release-pipeline-only change to `.github/workflows/publish.yml`; no shipped component, token, or style code is affected. No `kajabi-products` verification needed beyond confirming the `6.2.31` packages publish to the GitHub npm registry as expected.

## Related
- Supersedes #2195 (same fix done manually; this is a clean `git revert`)
- Builds on #2193 (`workflow_dispatch` trigger)
- Reverts `dc53ff4b5`
- Failing run: https://github.com/Kajabi/sage-lib/actions/runs/26595956309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to publish.yml; no library or runtime code, and main is described as unprotected so default token pushes should work as before.
> 
> **Overview**
> Reverts the **Publish** workflow’s PAT-based git checkout and remote wiring so releases can run again without a missing `KAJABI_CI_GH_TOKEN` secret.
> 
> The workflow no longer declares `KAJABI_CI_GH_TOKEN` on `workflow_call`, `actions/checkout` uses the default `GITHUB_TOKEN`, and the step that rewrote `origin` to an x-access-token URL is removed. **`workflow_dispatch`** and the existing push triggers on `main` / `develop` are unchanged.
> 
> This is CI-only; npm auth still uses `ACCESS_TOKEN` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f880541a94698202e9f5b6ae1edb5d443be7bae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->