### PR TITLE
fix(sage-system): make Sage global init order-independent

### DIFF
--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import { generateId } from './utils/index';
 
 Sage.accordion = (function () {

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import { tns } from "tiny-slider/src/tiny-slider";
 
 Sage.carousel = (function() {

--- a/packages/sage-system/lib/defineSage.js
+++ b/packages/sage-system/lib/defineSage.js
@@ -1,2 +1,13 @@
 window.Sage = window.Sage || {};
 window.Sage.docs = window.Sage.docs || {}
+
+// Re-export the namespace so consumer modules can `import { Sage } from './defineSage'`.
+// This is what guarantees evaluation order: modules that assign onto the global at
+// load time (e.g. `Sage.toast = (...)()`) must run AFTER this file has created
+// `window.Sage`. Historically that ordering was only implied by the `require()` order
+// in index.js, which worked under the old (Webpack/Rollup 3) CJS pipeline. Bundlers
+// that hoist ES `import` statements above side-effect-only requires (Rollup 4 / Vite 6+)
+// break the implicit order, evaluating a consumer before the namespace exists and
+// throwing `ReferenceError: Sage is not defined`. Importing this binding creates an
+// explicit dependency edge so the bundler is forced to evaluate defineSage first.
+export const Sage = window.Sage;

--- a/packages/sage-system/lib/drawer.js
+++ b/packages/sage-system/lib/drawer.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import { forEach } from "lodash";
 
 Sage.drawerExpandCollapse = (() => {

--- a/packages/sage-system/lib/init.js
+++ b/packages/sage-system/lib/init.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import * as arrive from 'arrive/src/arrive.js';
 
 Sage.init = function(elementNamesToInitLegacy) {

--- a/packages/sage-system/lib/list.js
+++ b/packages/sage-system/lib/list.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 // NOTE: Uses SortableJS
 // https://github.com/SortableJS/Sortable
 import Sortable from 'sortablejs/modular/sortable.core.esm.js';

--- a/packages/sage-system/lib/sortable.js
+++ b/packages/sage-system/lib/sortable.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import Sortable from 'sortablejs/modular/sortable.core.esm.js';
 
 Sage.sortable = (function() {

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -1,3 +1,4 @@
+import { Sage } from '../defineSage';
 import {
   generateId,
   stringToHtmlFragment,


### PR DESCRIPTION
## Description

`@kajabi/sage-system` builds a shared global `Sage` namespace: `defineSage.js` creates it (`window.Sage = window.Sage || {}`) and ~30 sibling modules assign onto it at load time (`Sage.toast = (...)()`, `Sage.util = ...`, etc.). The creator-before-consumers order was only ever *implied* by the `require()` order in `index.js`, which held under the old CJS bundling pipeline.

Bundlers that hoist ES `import` statements above side-effect-only modules — **Rollup 4, which ships in Vite 6+** — break that implicit order. An ESM consumer module (e.g. `toast/toast.js`, which has top-level `import`s) gets evaluated *before* `defineSage.js` runs, so its top-level `Sage.toast = ...` reads a `Sage` global that doesn't exist yet:

```
ReferenceError: Sage is not defined
    at assets/system-….js  (Sage.toast = …)
```

Because `entrypoints/sage/system.js` loads on **every admin page** in `kajabi-products`, this single module-eval throw aborts the whole entry and takes **all** Sage JS down site-wide (modals, toasts, dropdowns, web components, Stimulus boot). This surfaced as nearly every feature spec failing on the Vite 6 upgrade branch while the server-rendered HTML still rendered.

This was a latent bug — Vite 6 just stopped getting lucky with module order.

## Solution

Make the namespace an **explicit dependency** instead of an implicit ordering assumption:

- `defineSage.js`: export the namespace — `export const Sage = window.Sage;`
- Add `import { Sage } from './defineSage'` to the ESM consumer modules that assign onto the global at top level (`accordion-panel`, `carousel`, `drawer`, `init`, `list`, `sortable`, `toast/toast`).

The import creates a hard dependency edge, so any bundler is *forced* to evaluate `defineSage` first. Order-independent and resilient to future Vite/Rollup hops. The ~22 pure-CJS consumer modules are unchanged (their `require()` order is still honored).

18 lines across 8 files.

## Testing in `sage-lib`

- `yarn build` (webpack) and the existing test suite should pass unchanged — this only adds an import edge; runtime behavior of each module is identical once loaded.
- The namespace surface is unchanged: after `sage/system` loads, `window.Sage` still exposes all members (`util, toast, modal, dropdown, init, tabs, sortable, accordion, drawerExpandCollapse, …`).

## Testing in `kajabi-products`

1. (**HIGH**) Fixes a site-wide JS failure on the Vite 6 upgrade branch where the `sage/system` entry threw `ReferenceError: Sage is not defined`, disabling all Sage-driven UI on every admin page.
   - [ ] On the Vite 6 branch with this version bumped in, load any admin page and confirm Sage interactions work: open a **modal**, trigger a **toast**, open a **dropdown** / user menu.
   - [ ] Confirm the previously-failing `ruby_feature_specs` suite goes green (coupons, podcasts, affiliates, contacts, automations, super-admin modals, etc.).
   - [ ] Smoke-test on a non-Vite-6 build to confirm no regression under the current bundler.

### Verification done
Reproduced and verified against a production (`--mode test`) Vite 6 build loaded in real headless Chrome:
- **Before:** `ReferenceError: Sage is not defined`, `window.Sage` empty.
- **After:** entry loads cleanly, all 29 Sage namespace members register.

## Related

- Surfaced by the kajabi-products Vite 4→6 upgrade (COMMOPX-717).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import edges only; no API or runtime logic changes beyond fixing module evaluation order.
> 
> **Overview**
> **Fixes site-wide `ReferenceError: Sage is not defined`** when `@kajabi/sage-system` is bundled with Rollup 4 / Vite 6+, where ES `import` hoisting can run ESM feature modules before the namespace exists.
> 
> `defineSage.js` now **exports** `Sage` (`export const Sage = window.Sage`) so consumers can depend on it explicitly. Seven modules that both use top-level `import`s and assign onto the global at load time—accordion, carousel, drawer, init, list, sortable, and toast—gain **`import { Sage } from './defineSage'`**, forcing the bundler to evaluate namespace setup first. Pure CJS siblings and runtime behavior after load are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf44c15f61f37b585d73b6ccbc7c90e47667d240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->