### PR TITLE
fix(docs): add yaml-dev to Alpine image for psych native build

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add \
   libxml2-dev \
   libxslt-dev \
   tzdata \
+  yaml-dev \
   # Install node and yarn
   && curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -54,8 +54,9 @@ RUN echo "-----> Using .npmrc from config"
 RUN npm config set @kajabi:registry https://npm.pkg.github.com
 RUN npm config set '//npm.pkg.github.com/:_authToken' '${GITHUB_TOKEN}'
 
-RUN bundle exec rails assets:precompile
 RUN yarn install --check-files
+
+RUN bundle exec rails assets:precompile
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Linear Ticket

Follow-up to [PE-3391](https://linear.app/kajabi/issue/PE-3391/upgrade-sage-lib-docs-site-off-ruby-27-rails-60-eol) (the Rails 7.2 / Ruby 3.3.9 upgrade, #2201).

## Description

The first staging deploy of the docs site after the Rails 7.2 upgrade failed while building `docs/Dockerfile`. `bundle install` died with a `Gem::Ext::BuildError` compiling **psych 5.4.0**, which the Ruby 3.3 / Rails 7.2 dependency graph pulls in. psych's native extension links against libyaml, but the Alpine `apk add` list was missing the `yaml-dev` headers.

This didn't surface on the old Ruby 2.7 / Rails 6.0 image because that dependency set didn't compile psych from source.

## Solution

Add `yaml-dev` to the Dockerfile's `apk add` list. nokogiri now resolves from a precompiled musl gem and sassc builds via `build-base`, so `yaml-dev` was the one remaining missing dev dependency for the image.

## Customer Impact

No customer-facing impact — build/deploy plumbing only. Unblocks deploying the upgraded docs site.

## QA Testing Guidelines

1. (**LOW**) Re-run the `Release-Deploy` workflow to staging from `develop` once merged.
   - [x] The `deploy-docs-site` job's "Build and push docs site" step completes (psych compiles, image pushes to ECR).
   - [x] https://sage-lib-documentation.staging.kajabi.farm/ loads with CSS/JS assets present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Dockerfile changes with no runtime app logic; risk is limited to whether the image still builds and precompiles assets correctly.
> 
> **Overview**
> Fixes the **docs site Docker image** failing on staging after the Ruby 3.3 / Rails 7.2 upgrade when **`bundle install`** compiles **psych** from source.
> 
> Adds **`yaml-dev`** to the Alpine `apk add` list so libyaml headers are available for psych’s native extension (the missing piece once nokogiri/sassc already had their deps).
> 
> Also **reorders the image build**: **`yarn install --check-files`** now runs **before** **`bundle exec rails assets:precompile`**, so JS/CSS dependencies are present when assets are compiled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9567b29a9a57efc7075496a3527a61316811da15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->