### PR TITLE
New Version Bump

### DIFF
--- a/packages/sage-system/lib/accordion-panel.js
+++ b/packages/sage-system/lib/accordion-panel.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import { generateId } from './utils/index';
 
 Sage.accordion = (function () {

--- a/packages/sage-system/lib/carousel.js
+++ b/packages/sage-system/lib/carousel.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import { tns } from "tiny-slider/src/tiny-slider";
 
 Sage.carousel = (function() {

--- a/packages/sage-system/lib/defineSage.js
+++ b/packages/sage-system/lib/defineSage.js
@@ -1,2 +1,13 @@
 window.Sage = window.Sage || {};
 window.Sage.docs = window.Sage.docs || {}
+
+// Re-export the namespace so consumer modules can `import { Sage } from './defineSage'`.
+// This is what guarantees evaluation order: modules that assign onto the global at
+// load time (e.g. `Sage.toast = (...)()`) must run AFTER this file has created
+// `window.Sage`. Historically that ordering was only implied by the `require()` order
+// in index.js, which worked under the old (Webpack/Rollup 3) CJS pipeline. Bundlers
+// that hoist ES `import` statements above side-effect-only requires (Rollup 4 / Vite 6+)
+// break the implicit order, evaluating a consumer before the namespace exists and
+// throwing `ReferenceError: Sage is not defined`. Importing this binding creates an
+// explicit dependency edge so the bundler is forced to evaluate defineSage first.
+export const Sage = window.Sage;

--- a/packages/sage-system/lib/drawer.js
+++ b/packages/sage-system/lib/drawer.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import { forEach } from "lodash";
 
 Sage.drawerExpandCollapse = (() => {

--- a/packages/sage-system/lib/init.js
+++ b/packages/sage-system/lib/init.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import * as arrive from 'arrive/src/arrive.js';
 
 Sage.init = function(elementNamesToInitLegacy) {

--- a/packages/sage-system/lib/list.js
+++ b/packages/sage-system/lib/list.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 // NOTE: Uses SortableJS
 // https://github.com/SortableJS/Sortable
 import Sortable from 'sortablejs/modular/sortable.core.esm.js';

--- a/packages/sage-system/lib/sortable.js
+++ b/packages/sage-system/lib/sortable.js
@@ -1,3 +1,4 @@
+import { Sage } from './defineSage';
 import Sortable from 'sortablejs/modular/sortable.core.esm.js';
 
 Sage.sortable = (function() {

--- a/packages/sage-system/lib/toast/toast.js
+++ b/packages/sage-system/lib/toast/toast.js
@@ -1,3 +1,4 @@
+import { Sage } from '../defineSage';
 import {
   generateId,
   stringToHtmlFragment,


### PR DESCRIPTION
- LOW https://github.com/Kajabi/sage-lib/pull/2200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time module ordering fix with no intentional behavior changes; remaining `Sage.*` modules without the import may still break under the same bundlers until updated similarly.
> 
> **Overview**
> Fixes **`ReferenceError: Sage is not defined`** when `sage-system` is built with bundlers that hoist ES imports (Rollup 4 / Vite 6+), where feature modules could run before the global namespace existed.
> 
> **`defineSage.js`** now **re-exports** `export const Sage = window.Sage` after initializing `window.Sage`, so consumers get an explicit dependency edge instead of relying on `require()` order in `index.js`.
> 
> Seven modules that assign onto **`Sage` at load time** now start with **`import { Sage } from './defineSage'`** (toast uses `../defineSage`): accordion, carousel, drawer, init, sortable list, sortable, and toast. Runtime behavior of those features is unchanged; only module initialization order is guaranteed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6128d7dec53363fbf76833ff2cafddb78b7dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->