### PR TITLE
feat(ci): migrate CI workflows to Depot runners (PE-3158)

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint_test_build:
     name: Lint, Test, Build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     strategy:
       matrix:
         node-version: ${{ fromJSON(vars.NODE_VERSIONS) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
   publish:
     needs: [lint-test-build]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     # GITHUB_TOKEN needs write access to push lerna's release commit + tag to main.
     permissions:
       contents: write

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
   setup:
     needs: [lint-test-build]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     outputs:
       postfix: ${{ env.postfix }}
       gitsha: ${{ steps.gitsha.outputs.value }}
@@ -74,7 +74,7 @@ jobs:
 
   login:
     needs: [setup]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -105,7 +105,7 @@ jobs:
 
   deploy-docs-site:
     needs: [setup, login]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,7 +151,7 @@ jobs:
   # over the folder
   deploy-storybook-site:
     needs: [setup, login]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -198,7 +198,7 @@ jobs:
 
   deploy-sassdocs-site:
     needs: [setup, login]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

Switches the three heavy CI workflows — `lint-test-build.yml`, `publish.yml`, and `release-deploy.yml` (all 7 jobs) — from `ubuntu-latest` to `depot-ubuntu-24.04`.

## Why

This repo is the PE-3158 pilot with the most complete A/B data: across 6+ paired benchmark runs of the same Node/yarn workload, Depot was **~22–27% faster** and **~49% cheaper per run** than GitHub-hosted runners ([dashboard](https://app.datadoghq.com/dashboard/qtn-ivj-cus), `repo:Kajabi/sage-lib`). Install-heavy jobs like these are exactly where Depot's advantage concentrates.

Utility workflows (`label.yml`, `release-notification.yml`, `update-release.yml`, `tag-release-image.yml`) deliberately stay on `ubuntu-latest` — the terraform/kubernetes pilots showed sub-minute jobs get no speed benefit from Depot.

## Rollback

Revert this PR; nothing else changes. The `runner-comparison.yml` benchmark workflow is untouched and can keep collecting paired data as a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publish and ECR deploy paths still use the same AWS/Lerna/Docker steps but on a new runner provider; misconfiguration or Depot outages could block releases until reverted.
> 
> **Overview**
> Moves **lint/test/build**, **publish**, and **release/deploy** GitHub Actions jobs from `ubuntu-latest` to **`depot-ubuntu-24.04`**. That covers the reusable `lint-test-build` workflow plus the `publish` job and all five deploy-related jobs in `release-deploy` (`setup`, `login`, `deploy-docs-site`, `deploy-storybook-site`, `deploy-sassdocs-site`).
> 
> **No step logic, secrets, or job graphs change**—only where those workloads execute. Lighter workflows (e.g. labeling) are unchanged and stay on GitHub-hosted runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea93f883209a8d1c1eee7e7525b140c964b9b6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->