### PR TITLE
feat(alert): add dismissLabel prop for i18n pass-through (pilot)

### DIFF
--- a/docs/lib/sage_rails/app/sage_components/sage_alert.rb
+++ b/docs/lib/sage_rails/app/sage_components/sage_alert.rb
@@ -3,6 +3,7 @@ class SageAlert < SageComponent
     color: [:optional, NilClass, Set.new(["default", "danger", "draft", "info", "locked", "success", "published", "warning", "reached", "exceeded", "approaching"])],
     desc: [:optional, NilClass, String],
     dismissable: [:optional, NilClass, TrueClass],
+    dismiss_label: [:optional, NilClass, String],
     icon_name: [:optional, NilClass, String],
     primary_action: [:optional, NilClass, {
       value: String,

--- a/docs/lib/sage_rails/app/views/sage_components/_sage_alert.html.erb
+++ b/docs/lib/sage_rails/app/views/sage_components/_sage_alert.html.erb
@@ -56,7 +56,7 @@
   <% if component.dismissable %>
     <div class="sage-alert__close">
       <%= sage_component SageButton, {
-        value: "Close",
+        value: component.dismiss_label || "Dismiss alert",
         icon: {
           style: "only",
           name: "remove"

--- a/packages/sage-react/lib/Alert/Alert.jsx
+++ b/packages/sage-react/lib/Alert/Alert.jsx
@@ -12,6 +12,7 @@ export const Alert = ({
   color,
   description,
   dismissable,
+  dismissLabel,
   icon,
   onDismiss,
   small,
@@ -86,7 +87,7 @@ export const Alert = ({
             subtle={true}
             value="Close"
             onClick={handleDismiss}
-            aria-label="Close Alert"
+            aria-label={dismissLabel}
           />
         </div>
       )}
@@ -102,6 +103,8 @@ Alert.defaultProps = {
   className: '',
   description: null,
   dismissable: false,
+  // i18n pass-through: English default; converges on Pine id `pds-alert.dismiss`.
+  dismissLabel: 'Close Alert',
   icon: null,
   onDismiss: null,
   small: false,
@@ -115,6 +118,7 @@ Alert.propTypes = {
   color: PropTypes.oneOf(Object.values(ALERT_COLORS)).isRequired,
   description: PropTypes.string,
   dismissable: PropTypes.bool,
+  dismissLabel: PropTypes.string,
   icon: PropTypes.oneOf(Object.values(SageTokens.ICONS)),
   onDismiss: PropTypes.func,
   small: PropTypes.bool,

--- a/packages/sage-react/lib/Alert/Alert.jsx
+++ b/packages/sage-react/lib/Alert/Alert.jsx
@@ -85,7 +85,7 @@ export const Alert = ({
             icon={SageTokens.ICONS.REMOVE}
             iconOnly={true}
             subtle={true}
-            value="Close"
+            value={dismissLabel}
             onClick={handleDismiss}
             aria-label={dismissLabel}
           />
@@ -104,7 +104,7 @@ Alert.defaultProps = {
   description: null,
   dismissable: false,
   // i18n pass-through: English default; converges on Pine id `pds-alert.dismiss`.
-  dismissLabel: 'Close Alert',
+  dismissLabel: 'Dismiss alert',
   icon: null,
   onDismiss: null,
   small: false,


### PR DESCRIPTION
## Description

Adds `dismissLabel` (React) / `dismiss_label` (Sage Rails) to `Alert` so the dismiss control's label and `aria-label` — hard-coded today (`"Close Alert"` in React, `"Close"` in Rails) — can be localized. Part of the cross-DS i18n pass-through initiative.

**Draft / pilot.** Sage is mid-migration to Pine, so this is the deliberately **minimal tier** — a prop with an English default, no new infra. The prop/key converges on Pine's `pine.alert.dismiss`, so the eventual Sage→Pine port is a rename, not a redesign. Because `Alert` renders under `kajabi-products`' `react-i18next` provider, a consumer can pass `dismissLabel={t('pine.alert.dismiss')}` today.

**One deliberate default change (ratified in the 2026-08-06 DS sync).** The dismiss copy converges on Pine's canonical **"Dismiss alert"**, replacing the three prior strings for one control (`"Close Alert"` in React, `"Close"` in Rails). So — unlike the rest of the initiative, which keeps defaults byte-for-byte — this PR *does* change the omitted-default screen-reader announcement for existing dismissable Alerts. Intentional and low-risk: both are valid dismiss labels, no test/snapshot asserts the old wording, and it makes the announcement consistent with Pine ahead of the migration. Consumers override via the prop.

## Testing in `sage-lib`

- `Alert` (React) and `SageAlert` (Rails) both expose the dismiss label as a prop; the default is `"Dismiss alert"`.
- Passing `dismissLabel` / `dismiss_label` overrides the dismiss control's label and `aria-label`.
- React: added to `Alert.propTypes` (`PropTypes.string`) + `Alert.defaultProps`, wired into the icon-only dismiss `Button` (`value` + `aria-label`). Rails: `dismiss_label` in the `SageAlert` schema, consumed by `_sage_alert.html.erb`.

## Testing in `kajabi-products`

1. (**LOW**) `Alert` gains an optional `dismissLabel` that overrides the dismiss-button `aria-label`. The default **deliberately converges** to `"Dismiss alert"` (was `"Close Alert"`) — verify a dismissable `Alert` still announces correctly to a screen reader, and that passing `dismissLabel` localizes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API on a UI component with defaults; only affects dismiss button labeling when callers opt in.
> 
> **Overview**
> Adds an optional **`dismissLabel`** / **`dismiss_label`** on Alert (React and Sage Rails) so the dismiss close control’s visible label and **`aria-label`** can be supplied by consumers (e.g. `react-i18next`), aligned with Pine’s `pds-alert.dismiss` id.
> 
> React **`Alert`** wires `dismissLabel` into the icon-only dismiss **`Button`** (`value` and `aria-label`); default copy is **`"Dismiss alert"`** (replacing hard-coded **"Close"** / **"Close Alert"**). Sage **`SageAlert`** mirrors this via schema + ERB for the dismiss **`SageButton`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0f82b64ada3890e4faa4ab4fa4220b2df31ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
